### PR TITLE
fix(hooks): skip cost guard for non-token-consuming commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,9 +100,11 @@ Milestones do **not** use `sprint:N` labels. Issue-to-milestone assignment is ha
 - Avoid reading files listed as expensive (>20,000 tokens) unless absolutely necessary.
 - Use targeted skills (`/ipc-validate`, `/angular-health`, `/rsi-style`) instead of reading raw large files.
 - Confirm with the user before any operation estimated to cost ≥2% of the session limit (~20,000 tokens).
+- **Token cost = Claude processing cost only.** The cost hook guards against operations where Claude must *read and analyze* large output. Commands that Claude merely *executes* without processing content (git push, git fetch, git add, git commit, gh pr create, rm, mkdir, cp, mv, etc.) have zero token cost and must never be blocked — even if they reference large files by name. The hook's `noTokenCostPattern` allowlist handles this automatically.
+- When the cost hook blocks an operation, it lists the specific large files and their sizes/token estimates so you can report them to the user.
 
 ### Strategic budget awareness
-The SessionStart hook displays live rate limit data (5h window + weekly). **Actively use this data** when planning work:
+The completion card displays live rate limit data (5h window + weekly) after every task. **Actively use this data** when planning work:
 
 - Before any action likely to consume **>2% of the weekly limit** (broad codebase exploration, large Explore agents, full-repo grep, multi-file rewrites), pause and evaluate:
   1. **Prompt justifies it** (complex implementation, broad concept, large milestone) → proceed, this is what tokens are for.
@@ -137,6 +139,8 @@ Second change or action
 file1 — what changed
 file2 — what changed
 
+📊 5h: <pct>% (+<delta>%) | Weekly: <pct>% (+<delta>%) | Sonnet: <pct>% (+<delta>%)
+
 ---
 ```
 
@@ -152,13 +156,21 @@ file2 — what changed
 
 **Ship methods:** `direct push` (pushed without PR), `Pull-Request-Merge (PR #N)` (merged via PR).
 
+**Usage line (always last line before closing `---`):**
+- **Always** run `/refresh-usage` (no caching — always scrape live data) right before rendering the completion card.
+- Read `usage-live.json` **before** the refresh to capture the previous state. After the refresh, read the new state. Compute the delta (`new_pct - old_pct`) for each metric.
+- Format: `📊 5h: <pct>% (+<delta>%) | Weekly: <pct>% (+<delta>%) | Sonnet: <pct>% (+<delta>%)`
+- If the delta is 0, show `(+0%)`. If the previous file was missing (first refresh of the session), show `(—)` instead of a delta.
+- If the refresh fails, show `📊 [no data]` — do not block the completion card.
+- This is the **only** place where usage is displayed — no session start display, no background refresh.
+
 **Rules:**
 - The completion card is **always** the last thing in the response — nothing after it.
 - Use `##` heading for the title line — gives it visual weight and spacing.
 - Use a backslash `\` on its own line after the status line to force a visual break before the plain-text details (blank lines alone get swallowed by the renderer).
 - The summary is in the user's language (German), max ~10 words.
 - Branch info is omitted for branchless tasks.
-- Plain text (no bold, no inline code, no bullet markers) for actions and files — this renders in the terminal's default gray, visually subdued compared to the bold title and status line. Actions first, then files below (separated by a blank line). End the entire card with a `---` line at the very bottom. For non-code tasks, omit the files section.
+- Plain text (no bold, no inline code, no bullet markers) for actions and files — this renders in the terminal's default gray, visually subdued compared to the bold title and status line. Actions first, then files below (separated by a blank line). The usage line comes after files (or after actions if no files). End the entire card with a `---` line at the very bottom. For non-code tasks, omit the files section but still show the usage line.
 - Keep it factual — no commentary or praise.
 
 ## Agent Naming Convention
@@ -614,28 +626,6 @@ On Windows, each Bash tool call can open a visible CMD window that steals focus 
 
 ## Session Startup — Automatic Tasks
 
-### 1. Usage display (visible — Claude's first output)
-
-At the very start of every session, **before responding to the user's first message**, read `~/.claude/scripts/usage-live.json` and output the usage summary as a **fenced code block** directly in chat. This makes it always visible — not hidden inside collapsed hook output.
-
-**Format:**
-```
-────────────────────────────────────────
-📊 USAGE [LIVE <age>]
-5h: <pct>% — resets in <duration>
-Weekly: <pct>% | Sonnet: <pct>% — resets <day> <time>
-Status: <status>
-────────────────────────────────────────
-```
-
-- `<age>`: if timestamp is <1 min old → `just now`, otherwise `Xm ago`
-- `<status>`: `Budget healthy` / `CONSERVE — weekly >70%` / `SLOW DOWN — 5h limit near` (≥80%)
-- If the file is missing or unreadable: output `📊 USAGE [no data] — Run /refresh-usage`
-
-### 2. Refresh live usage data (background)
-
-Execute `/refresh-usage` as a **background agent** at session start if `~/.claude/scripts/usage-live.json` is missing or older than 10 minutes. The skill checks Edge CDP (port 9223) — if CDP is available, it scrapes invisibly (background tab, no focus steal). If CDP is not available, it asks the user (AskUserQuestion) before restarting Edge. Edge only needs one visible restart per PC session; after that, CDP stays active.
-
-### 3. Branch & worktree sweep (hook)
+### 1. Branch & worktree sweep (hook)
 
 Handled automatically by the `sweep-branches.js` SessionStart hook — no manual action needed. The hook cleans up garbage (orphaned worktrees, gone branches, stale refs) while preserving branches with remote counterparts. See §Session-start sweep for details.

--- a/plugins/blocklist.json
+++ b/plugins/blocklist.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-03-23T20:49:14.247Z",
+  "fetchedAt": "2026-03-24T22:57:05.014Z",
   "plugins": [
     {
       "plugin": "code-review@claude-plugins-official",

--- a/scripts/precheck-cost.js
+++ b/scripts/precheck-cost.js
@@ -5,7 +5,12 @@
  * If estimated token cost >= 2% of the estimated 5-hour session window limit,
  * blocks the operation and asks for confirmation.
  *
- * First call  → creates flag file, exits 2 (blocked with warning)
+ * IMPORTANT: This hook only guards against Claude TOKEN processing costs.
+ * Commands that Claude merely executes without processing large output
+ * (git push, git fetch, gh pr create, rm, mkdir, etc.) are always allowed
+ * because they don't consume tokens for Claude to analyze.
+ *
+ * First call  → creates flag file, exits 2 (blocked with warning + file list)
  * Second call → flag exists → deletes flag, exits 0 (allowed through)
  */
 
@@ -74,20 +79,31 @@ process.stdin.on('end', () => {
 
   else if (toolName === 'Bash') {
     const cmd = toolInput.command || '';
+    // Commands that don't produce output Claude needs to process — no token cost.
+    // These are "fire and forget" executions where Claude just checks the exit code.
+    // Pattern for commands that don't produce output Claude needs to process.
+    const noTokenCostPattern = /^\s*(git\s+(push|fetch|remote|prune|worktree\s+(add|remove|prune)|branch\s+-[dD]|checkout|switch|pull|merge|rebase|tag|stash|rm|add|commit)|gh\s+(pr\s+(create|merge|close)|issue\s+(create|close)|project\s+item-add|api\s+graphql)|npm\s+publish|rm\s|mkdir\s|cp\s|mv\s)/;
+    // Check each segment in a &&/; chain — if ALL segments are no-cost, allow.
+    const segments = cmd.split(/\s*(?:&&|;)\s*/);
+    const allNoTokenCost = segments.every(seg => noTokenCostPattern.test(seg));
+    if (allNoTokenCost) {
+      process.exit(0); // no Claude processing needed → allow
+    }
+
     // Check if command references a known expensive file
     const expensiveFiles = cfg.expensiveFiles || [];
-    let maxKnownCost = 0;
-    let matchedFile = '';
+    const matchedFiles = [];
     for (const ef of expensiveFiles) {
-      if (cmd.includes(ef.path || ef) && (ef.estimatedTokens || 20000) > maxKnownCost) {
-        maxKnownCost = ef.estimatedTokens || 20000;
-        matchedFile = ef.path || ef;
+      const fp = ef.path || ef;
+      if (cmd.includes(fp)) {
+        matchedFiles.push({ path: fp, tokens: ef.estimatedTokens || 20000 });
       }
     }
-    // Also flag broad npm install / ci (moderate cost from node exec)
-    if (maxKnownCost > 0) {
-      estimatedTokens = maxKnownCost;
-      description = `Bash referencing large file: ${matchedFile}`;
+    if (matchedFiles.length > 0) {
+      estimatedTokens = matchedFiles.reduce((sum, f) => sum + f.tokens, 0);
+      description = `Bash referencing large file(s)`;
+      // Store matched files for the warning output
+      toolInput._matchedFiles = matchedFiles;
     } else {
       process.exit(0); // can't estimate arbitrary bash → allow
     }
@@ -146,6 +162,24 @@ process.stdin.on('end', () => {
   console.error(`Operation:  ${description}`);
   console.error(`Est. cost:  ~${estimatedTokens.toLocaleString()} tokens  (${pct}% of ${(LIMIT/1000).toFixed(0)}K session window)`);
   console.error(`Threshold:  ${THRESHOLD.toLocaleString()} tokens (${(cfg.confirmThresholdPct * 100).toFixed(0)}% of session limit)`);
+
+  // List the large files that triggered this warning
+  if (toolName === 'Read') {
+    const fp = toolInput.file_path || '';
+    const absP = path.isAbsolute(fp) ? fp : path.join(process.cwd(), fp);
+    try {
+      const bytes = fs.statSync(absP).size;
+      const kb = (bytes / 1024).toFixed(1);
+      console.error(`\nLarge file:`);
+      console.error(`  ${path.relative(process.cwd(), absP).replace(/\\/g, '/')}  (${kb} KB → ~${estimatedTokens.toLocaleString()} tokens)`);
+    } catch {}
+  } else if (toolName === 'Bash' && toolInput._matchedFiles) {
+    console.error(`\nLarge files referenced:`);
+    for (const f of toolInput._matchedFiles) {
+      console.error(`  ${f.path}  (~${f.tokens.toLocaleString()} tokens)`);
+    }
+  }
+
   console.error(line);
   console.error(`To proceed, reply: "yes, proceed"`);
   console.error(`I will retry the operation once you confirm.`);

--- a/skills/refresh-usage/SKILL.md
+++ b/skills/refresh-usage/SKILL.md
@@ -8,34 +8,31 @@ Scrapes live token usage from claude.ai via Edge CDP (Chrome DevTools Protocol).
 
 ## When to run
 
-- **Automatically** at session start as a background agent, if `~/.claude/scripts/usage-live.json` is missing or older than 10 minutes.
+- **Automatically** before every completion card (Task Completion Signal) — always, no caching.
 - **Manually** when the user asks for fresh usage data.
 
 ## Steps
 
-1. Check if `~/.claude/scripts/usage-live.json` exists and is less than 10 minutes old.
-   - If fresh: skip, no refresh needed. Exit silently.
+1. Run `node ~/.claude/scripts/refresh-usage-headless.js --quiet --check-only` to test if CDP is available.
 
-2. Run `node ~/.claude/scripts/refresh-usage-headless.js --quiet --check-only` to test if CDP is available.
-
-3. **CDP available** (exit code 0):
-   Run `node ~/.claude/scripts/refresh-usage-headless.js --quiet --summary` to scrape in the background.
-   - Exit code 0: success — the script prints a formatted usage box to stdout. Display it directly to the user as-is (do NOT read usage-live.json separately or reformat).
+2. **CDP available** (exit code 0):
+   Run `node ~/.claude/scripts/refresh-usage-headless.js --quiet --summary` to scrape.
+   - Exit code 0: success — the script updates `usage-live.json`. Read the file for the new values.
    - Exit code 2: not logged in — inform user: "Bitte bei claude.ai einloggen, dann /refresh-usage erneut."
-   - Exit code 3/4: scrape failed — silently skip, will retry next session.
+   - Exit code 3/4: scrape failed — show `📊 [no data]` in the completion card.
 
-4. **CDP not available** (exit code 5):
+3. **CDP not available** (exit code 5):
    Ask the user via AskUserQuestion:
    - Label: "Edge CDP aktivieren"
    - Description: "Edge wird einmal sichtbar neu gestartet mit CDP-Port 9223. Danach läuft alles unsichtbar im Background."
    - Options: "Ja, Edge neu starten" / "Nein, überspringen"
 
    If approved: run `node ~/.claude/scripts/refresh-usage-headless.js --quiet --activate-cdp`
-   If declined: skip silently.
+   If declined: show `📊 [no data]` in the completion card.
 
 ## Important
 
 - Never restart Edge without explicit user consent (AskUserQuestion).
-- This skill runs as a **background agent** at session start — do not block the main conversation.
-- Usage display is handled by Claude directly (reads usage-live.json, outputs as chat text) — not by a hook.
+- **No caching** — always scrape fresh data, regardless of file age.
 - Edge only needs to be restarted once per PC session. After that, CDP stays active.
+- Usage display is handled exclusively by the completion card (§Task Completion Signal) — not at session start.


### PR DESCRIPTION
## Summary
- Fix cost hook blocking git push/fetch/add/commit and similar commands that don't consume Claude tokens
- Add file size and token estimate details to the block warning output
- Sync pending global config changes (CLAUDE.md completion card, blocklist, refresh-usage skill)

## Changes
- `scripts/precheck-cost.js` — noTokenCostPattern allowlist for fire-and-forget commands, chain-aware matching, file list in warnings
- `CLAUDE.md` — document token-cost-only principle in §Token Awareness
- `plugins/blocklist.json` — sync from global
- `skills/refresh-usage/SKILL.md` — sync from global