### PR TITLE
fix(completion): add missing opening --- to usage card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.31.1] — 2026-04-07
+
+### Fixed
+
+- **completion-card** — opening `---` separator now always rendered before the usage meter; previously the card started without a top delimiter when usage data was available, leaving the usage section visually unframed
+
 ## [0.31.0] — 2026-04-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.31.0**
+**Version: 0.31.1**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/mcp-server/index.js
+++ b/plugins/devops/mcp-server/index.js
@@ -296,12 +296,12 @@ function renderCard(input, meterText, buildId) {
   const parts = [];
 
   // Block A — What was done
+  parts.push('---');
   if (config.usage && meterText) {
+    parts.push('');
     parts.push(meterText);
     if (healthLine) parts.push(healthLine);
     parts.push('');
-    parts.push('---');
-  } else {
     parts.push('---');
   }
   parts.push('');

--- a/plugins/devops/templates/completion-card.md
+++ b/plugins/devops/templates/completion-card.md
@@ -37,6 +37,8 @@ Sections within a block may be omitted per variant rules — but the block order
 All variables in `{{...}}`. Sections wrapped in `{{#if}}` are conditional per variant.
 
 ```markdown
+---
+
 {{#if usage}}
 ```
 5h  {{bar-5h}}  {{pct-5h}} ({{delta-5h}})  · Reset {{reset-5h}}{{pace-warn-5h}}
@@ -45,14 +47,10 @@ All variables in `{{...}}`. Sections wrapped in `{{#if}}` are conditional per va
 Wk  {{bar-wk}}  {{pct-wk}} ({{delta-wk}})  · Reset {{reset-wk}}{{pace-warn-wk}}
     {{elapsed-arrow-wk}}
 ```
-{{else}}
-```
-⚠ Usage data unavailable — monitoring issue
-```
-{{/if}}
 
 ---
 
+{{/if}}
 ## ✨✨✨ {{summary}} · {{build-id}} ✨✨✨
 
 {{#if changes}}


### PR DESCRIPTION
## Summary

- Completion card now always starts with `---` separator, even when usage data is present
- Previously the usage meter code block appeared without a top delimiter, leaving the card visually unframed at the top

## Details

The `renderCard` function conditionally added `---` only when usage was **absent**. When usage was present, the card started directly with the code block — skipping the opening separator entirely. Now `---` is always the first element, with the usage block immediately following when applicable.

Template (`completion-card.md`) updated to reflect the correct 3-separator layout: open → between usage and title → close.