### PR TITLE
feat(hooks): add pre.ship.guard to block manual PR ops via Bash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.32.0] — 2026-04-07
+
+### Added
+
+- **hooks** — `pre.ship.guard`: PreToolUse hook that blocks `gh pr create`, `gh pr merge`, and `gh api .../pulls/.../merge` via Bash, enforcing all shipping through `/devops-ship`
+
 ## [0.31.1] — 2026-04-07
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.31.1**
+**Version: 0.32.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.31.1",
+  "version": "0.32.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/hooks/hooks.json
+++ b/plugins/devops/hooks/hooks.json
@@ -18,6 +18,12 @@
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/pre-tool-use/pre.tokens.guard.js" }
         ],
         "matcher": "Read|Bash|Glob|Grep"
+      },
+      {
+        "hooks": [
+          { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/pre-tool-use/pre.ship.guard.js" }
+        ],
+        "matcher": "Bash"
       }
     ],
     "PostToolUse": [

--- a/plugins/devops/hooks/pre-tool-use/pre.ship.guard.js
+++ b/plugins/devops/hooks/pre-tool-use/pre.ship.guard.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+/**
+ * @hook pre.ship.guard
+ * @version 0.1.0
+ * @event PreToolUse
+ * @plugin devops
+ * @description Block manual PR creation/merging via Bash.
+ *   These operations MUST go through /devops-ship MCP tools.
+ *   Detects: gh pr create, gh pr merge, gh api .../pulls/.../merge
+ *   Does NOT block: git push (needed for branch work before shipping).
+ */
+
+require('../lib/plugin-guard');
+
+const BLOCKED_PATTERNS = [
+  /gh\s+pr\s+create/,
+  /gh\s+pr\s+merge/,
+  /gh\s+api\s+.*pulls.*\/merge/,
+];
+
+let inputData = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', d => { inputData += d; });
+process.stdin.on('end', () => {
+  let hook;
+  try { hook = JSON.parse(inputData); }
+  catch { process.exit(0); }
+
+  const cmd = (hook.tool_input || {}).command || '';
+
+  const blocked = BLOCKED_PATTERNS.some(re => re.test(cmd));
+  if (!blocked) process.exit(0);
+
+  process.stderr.write(
+    'BLOCKED: Manual PR creation/merging detected. ' +
+    'Use /devops-ship for shipping. ' +
+    'The ship pipeline ensures build-ID, safety checks, version bumps, and proper completion cards.\n'
+  );
+  process.exit(2);
+});


### PR DESCRIPTION
## Summary

- New `pre.ship.guard` PreToolUse hook blocks `gh pr create`, `gh pr merge`, and `gh api .../pulls/.../merge` via Bash
- Enforces that all shipping goes through the `/devops-ship` pipeline (ship_preflight → ship_build → ship_version_bump → ship_release)
- `git push` is not blocked — branch work before shipping is unaffected
- Registered in `hooks.json` as a second `PreToolUse` entry with `matcher: "Bash"`