### PR TITLE
refactor(skills): rename autonomous-mode to devops-autonomous

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,7 +90,7 @@
 
 ### Added
 
-- **skills** — new `/autonomous-mode` skill: fully autonomous agent orchestration while user is AFK — task intake, permission priming, desktop/background test mode, safety guardrails (no push/ship), structured report with completion card, optional PC shutdown
+- **skills** — new `/devops-autonomous` skill: fully autonomous agent orchestration while user is AFK — task intake, permission priming, desktop/background test mode, safety guardrails (no push/ship), structured report with completion card, optional PC shutdown
 
 ## [0.28.1] — 2026-04-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.32.2] — 2026-04-08
+
+### Changed
+
+- **skills** — rename `autonomous-mode` → `devops-autonomous` for consistent `devops-` prefix across all skills
+
 ## [0.32.1] — 2026-04-08
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Complete DevOps automation plugin for Claude Code. Hooks, skills, agents, and te
 ## Features
 
 - **13 Hooks** — automated guards and triggers across the full session lifecycle
-- **16 Skills** — devops-ship, devops-commit, devops-flow, devops-deep-research, devops-explain, devops-new-issue, devops-project-setup, devops-readme, devops-refresh-usage, devops-extend-skill, devops-repo-health, devops-claude-md-lint, devops-livebrief, devops-orchestrate, devops-self-update, autonomous-mode
+- **16 Skills** — devops-ship, devops-commit, devops-flow, devops-deep-research, devops-explain, devops-new-issue, devops-project-setup, devops-readme, devops-refresh-usage, devops-extend-skill, devops-repo-health, devops-claude-md-lint, devops-livebrief, devops-orchestrate, devops-self-update, devops-autonomous
 - **10 Agents** — AI, Core, Designer, Feature, Frontend, Gamer, PO, QA, Research, Windows
 - **Completion Flow** — mandatory card after every task (8 variants), visual verification, ship recommendation
 - **Ship Enforcement** — intent detection, PR command blocking, automatic /devops-ship skill routing
@@ -136,7 +136,7 @@ SessionStart  ──>  PreToolUse  ──>  PostToolUse  ──>  UserPromptSubm
 | `/devops-claude-md-lint` | Explicit | Audit CLAUDE.md files for size, structure, and token efficiency |
 | `/devops-livebrief` | Explicit | Interactive HTML page for analysis, plans, and prototypes |
 | `/devops-orchestrate` | Explicit | Evaluate agents and orchestrate parallel execution |
-| `/autonomous-mode` | Explicit | Fully autonomous agent orchestration while user is AFK |
+| `/devops-autonomous` | Explicit | Fully autonomous agent orchestration while user is AFK |
 
 ### Agents (spawned for parallel work)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.32.1**
+**Version: 0.32.2**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.32.1",
+  "version": "0.32.2",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/skills/devops-autonomous/SKILL.md
+++ b/plugins/devops/skills/devops-autonomous/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: autonomous-mode
+name: devops-autonomous
 version: 0.1.0
 description: >-
   Activate fully autonomous agent orchestration for when the user is leaving
@@ -7,11 +7,11 @@ description: >-
   (implementation, computer-use desktop interaction, live browser/app testing).
   Delivers a structured report and completion card when done.
   Optionally shuts down the PC after completion.
-  Triggers on: "autonomous mode", "autonomer modus", "ich geh kurz weg",
-  "mach das alleine", "run this while I'm away", "autonom weiter",
-  "ich bin gleich weg", "afk mode", "unattended mode", "mach weiter ohne mich",
-  "autopilot". Do NOT trigger for normal orchestration where the user stays
-  present — use /devops-orchestrate instead.
+  Triggers on: "devops-autonomous", "autonomous", "autonomer modus",
+  "ich geh kurz weg", "mach das alleine", "run this while I'm away",
+  "autonom weiter", "ich bin gleich weg", "afk mode", "unattended mode",
+  "mach weiter ohne mich", "autopilot". Do NOT trigger for normal orchestration
+  where the user stays present — use /devops-orchestrate instead.
 argument-hint: "[optional: task description]"
 allowed-tools: >-
   Bash(*), Read, Write, Edit, Glob, Grep, Agent,
@@ -25,15 +25,15 @@ allowed-tools: >-
   mcp__plugin_devops_dotclaude-issues__*
 ---
 
-# Autonomous Mode
+# Devops Autonomous
 
 User is leaving the PC. Collect the task, prime permissions, confirm, then work independently.
 
 ## Step 0 — Load Extensions
 
 Silently check (do not surface "not found"):
-1. `~/.claude/skills/autonomous-mode/SKILL.md` + `reference.md`
-2. `{project}/.claude/skills/autonomous-mode/SKILL.md` + `reference.md`
+1. `~/.claude/skills/devops-autonomous/SKILL.md` + `reference.md`
+2. `{project}/.claude/skills/devops-autonomous/SKILL.md` + `reference.md`
 3. Merge: project > global > plugin defaults
 
 ## Step 1 — Task Intake
@@ -110,7 +110,7 @@ to open the app, screenshot key flows, verify visually. Track progress via TodoW
 Save `AUTONOMOUS-REPORT.md` to project root:
 
 ```markdown
-# Autonomous Mode Report
+# Autonomous Report
 **Task**: {goal} | **Status**: COMPLETED | PARTIAL | BLOCKED
 **Duration**: {time} | **Branch**: {branch}
 
@@ -135,6 +135,6 @@ Card is the last visible output.
 
 Only if user chose "Ja" AND status is COMPLETED:
 ```bash
-shutdown /s /t 60 /c "Autonomous mode completed. Shutting down in 60s. Run 'shutdown /a' to abort."
+shutdown /s /t 60 /c "Autonomous task completed. Shutting down in 60s. Run 'shutdown /a' to abort."
 ```
 If BLOCKED or PARTIAL: skip shutdown — user must intervene.


### PR DESCRIPTION
## Summary
- Rename `autonomous-mode` skill to `devops-autonomous` for consistent `devops-` prefix across all skills
- Update all references: SKILL.md frontmatter, triggers, extension paths, README, CHANGELOG