### PR TITLE
feat(hooks): add team changelog session-start hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.33.0] — 2026-04-08
+
+### Added
+
+- **hooks** — `ss.team.changelog`: session-start hook that shows a summary of changes by other contributors on remote `main` since the user's last commit; auto-detects identity via `git config` and GitHub noreply cross-matching; silent when no foreign commits
+
 ## [0.32.2] — 2026-04-08
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.32.2**
+**Version: 0.33.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.32.2",
+  "version": "0.33.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/hooks/hooks.json
+++ b/plugins/devops/hooks/hooks.json
@@ -8,6 +8,7 @@
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-start/ss.mcp.deps.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-start/ss.tokens.scan.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-start/ss.git.check.js" },
+          { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-start/ss.team.changelog.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-start/ss.flow.selfcalibration.js", "_deprecated": "moved to UserPromptSubmit — kept as fallback for older runtimes" }
         ]
       }

--- a/plugins/devops/hooks/session-start/ss.team.changelog.js
+++ b/plugins/devops/hooks/session-start/ss.team.changelog.js
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+/**
+ * @hook ss.team.changelog
+ * @version 0.1.0
+ * @event SessionStart
+ * @plugin devops
+ * @description Show a summary of changes made by other contributors on remote main
+ *   since the user's last commit. Only triggers when the latest commit on
+ *   origin/<main> is NOT by the current git user. Silent otherwise.
+ */
+
+require('../lib/plugin-guard');
+
+const { execSync } = require('child_process');
+
+function run(cmd, cwd) {
+  try {
+    return execSync(cmd, { cwd, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'], timeout: 15000 }).trim();
+  } catch {
+    return '';
+  }
+}
+
+const cwd = process.cwd();
+
+// Detect main branch from remote HEAD
+const mainBranch = (
+  run('git symbolic-ref refs/remotes/origin/HEAD', cwd)
+    .replace('refs/remotes/origin/', '') || 'main'
+);
+
+// Fetch latest remote state (only the main branch, quiet)
+if (!run(`git fetch origin ${mainBranch} --quiet`, cwd) && run(`git fetch origin ${mainBranch}`, cwd) === '') {
+  // fetch may return empty on success — continue regardless
+}
+
+// Get local user identity
+const userName = run('git config user.name', cwd).toLowerCase();
+const userEmail = run('git config user.email', cwd).toLowerCase();
+
+if (!userName && !userEmail) process.exit(0);
+
+// Structured git log: hash · author · email · ISO date · subject
+// Uses %x1f (unit separator) to avoid conflicts with commit message content
+const rawLog = run(
+  `git log origin/${mainBranch} --format="%H%x1f%an%x1f%ae%x1f%ai%x1f%s" -50`,
+  cwd,
+);
+if (!rawLog) process.exit(0);
+
+const commits = rawLog.split('\n').filter(Boolean).map(line => {
+  const parts = line.split('\x1f');
+  return {
+    hash: parts[0],
+    name: parts[1] || '',
+    email: (parts[2] || '').toLowerCase(),
+    date: parts[3] || '',
+    subject: parts.slice(4).join('\x1f'),
+  };
+});
+
+/**
+ * Extract GitHub username from a noreply email address.
+ * Handles both old (<user>@users.noreply.github.com) and
+ * new (<id>+<user>@users.noreply.github.com) formats.
+ */
+function ghUsernameFromEmail(email) {
+  const m = email.match(/^(?:\d+\+)?(.+)@users\.noreply\.github\.com$/i);
+  return m ? m[1].toLowerCase() : null;
+}
+
+/** Match commit author against local git identity. */
+function isMe(commit) {
+  if (userEmail && commit.email === userEmail) return true;
+  if (userName && commit.name.toLowerCase() === userName) return true;
+  // Cross-match GitHub noreply username against git user.name
+  const commitGhUser = ghUsernameFromEmail(commit.email);
+  if (commitGhUser && commitGhUser === userName) return true;
+  const myGhUser = ghUsernameFromEmail(userEmail);
+  if (myGhUser && myGhUser === commit.name.toLowerCase()) return true;
+  if (myGhUser && commitGhUser && myGhUser === commitGhUser) return true;
+  return false;
+}
+
+// If the latest commit is by the user — nothing to show
+if (commits.length === 0 || isMe(commits[0])) process.exit(0);
+
+// Collect commits by others until we hit one by the user
+const otherCommits = [];
+for (const commit of commits) {
+  if (isMe(commit)) break;
+  otherCommits.push(commit);
+}
+if (otherCommits.length === 0) process.exit(0);
+
+// Group by author (preserve insertion order)
+const byAuthor = new Map();
+for (const c of otherCommits) {
+  if (!byAuthor.has(c.name)) byAuthor.set(c.name, []);
+  byAuthor.get(c.name).push(c);
+}
+
+// Date formatting helpers
+function fmtDate(iso) {
+  return new Date(iso).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}
+
+function dateRange(list) {
+  const dates = list.map(c => new Date(c.date).getTime());
+  const min = fmtDate(new Date(Math.min(...dates)).toISOString());
+  const max = fmtDate(new Date(Math.max(...dates)).toISOString());
+  return min === max ? min : `${min} – ${max}`;
+}
+
+// Build output
+const overall = dateRange(otherCommits);
+const out = [
+  `Team changes landed on \`${mainBranch}\` while you were away. Show the user this summary as-is:`,
+  '',
+  '---',
+  `**Team changes on \`${mainBranch}\`** · ${overall}`,
+  '---',
+  '',
+];
+
+for (const [author, authorCommits] of byAuthor) {
+  out.push(`**${author}** · ${dateRange(authorCommits)}`);
+  for (const c of authorCommits) {
+    out.push(`- ${c.subject}`);
+  }
+  out.push('');
+}
+
+out.push('---');
+
+process.stdout.write(out.join('\n'));


### PR DESCRIPTION
## Summary
- New `ss.team.changelog` session-start hook that shows a formatted summary of changes by other contributors on remote `main` since the user's last commit
- Auto-detects user identity via `git config` + GitHub noreply email cross-matching (old and new formats)
- Silent when the latest `origin/main` commit is by the current user — no noise
- Grouped by author with date ranges and one bullet per commit

## Test plan
- [x] Lint passes
- [x] 59/59 tests pass
- [x] Identity matching verified for local name, local email, GitHub noreply (old+new format)
- [x] Output formatting verified with simulated multi-author data

🤖 Generated with [Claude Code](https://claude.com/claude-code)