### PR TITLE
fix(skills): use short names for extension lookup paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.33.2] — 2026-04-08
+
+### Fixed
+
+- **skills** — all 16 SKILL.md Step 0 extension lookup paths used `devops-{name}/` prefix but CONVENTIONS.md and projects use short names (`ship/`, `new-issue/`, etc.); user extensions were silently never loaded
+
 ## [0.33.1] — 2026-04-08
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.33.1**
+**Version: 0.33.2**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.33.1",
+  "version": "0.33.2",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/CONVENTIONS.md
+++ b/plugins/devops/CONVENTIONS.md
@@ -197,7 +197,7 @@ ha-finance/
 The plugin's `/devops-ship` reads these before executing and integrates the rules.
 
 **Eat-your-own-dogfood:** This plugin's own repo (`devops/`) uses
-the same mechanism. Project-specific ship rules live in `.claude/skills/devops-ship/`
+the same mechanism. Project-specific ship rules live in `.claude/skills/ship/`
 within this repo — no separate `/devops-ship-dotclaude` skill needed.
 
 ## Script Conventions

--- a/plugins/devops/skills/devops-autonomous/SKILL.md
+++ b/plugins/devops/skills/devops-autonomous/SKILL.md
@@ -32,8 +32,8 @@ User is leaving the PC. Collect the task, prime permissions, confirm, then work 
 ## Step 0 — Load Extensions
 
 Silently check (do not surface "not found"):
-1. `~/.claude/skills/devops-autonomous/SKILL.md` + `reference.md`
-2. `{project}/.claude/skills/devops-autonomous/SKILL.md` + `reference.md`
+1. `~/.claude/skills/autonomous/SKILL.md` + `reference.md`
+2. `{project}/.claude/skills/autonomous/SKILL.md` + `reference.md`
 3. Merge: project > global > plugin defaults
 
 ## Step 1 — Task Intake

--- a/plugins/devops/skills/devops-claude-md-lint/SKILL.md
+++ b/plugins/devops/skills/devops-claude-md-lint/SKILL.md
@@ -20,8 +20,8 @@ Audit CLAUDE.md files for token efficiency.
 
 Silently check for optional overrides (do not surface "not found" in output):
 
-1. Global skill extension: `~/.claude/skills/devops-claude-md-lint/SKILL.md` + `reference.md`
-2. Project skill extension: `{project}/.claude/skills/devops-claude-md-lint/SKILL.md` + `reference.md`
+1. Global skill extension: `~/.claude/skills/claude-md-lint/SKILL.md` + `reference.md`
+2. Project skill extension: `{project}/.claude/skills/claude-md-lint/SKILL.md` + `reference.md`
 3. Merge: project > global > plugin defaults
 
 ## Step 1 — Locate CLAUDE.md files

--- a/plugins/devops/skills/devops-commit/SKILL.md
+++ b/plugins/devops/skills/devops-commit/SKILL.md
@@ -19,8 +19,8 @@ Create a well-formed conventional commit.
 
 Silently check for optional overrides (do not surface "not found" in output):
 
-1. Global skill extension: `~/.claude/skills/devops-commit/SKILL.md` + `reference.md`
-2. Project skill extension: `{project}/.claude/skills/devops-commit/SKILL.md` + `reference.md`
+1. Global skill extension: `~/.claude/skills/commit/SKILL.md` + `reference.md`
+2. Project skill extension: `{project}/.claude/skills/commit/SKILL.md` + `reference.md`
 3. Merge: project > global > plugin defaults
 
 **Note on `disable-model-invocation: true`:** This skill is only triggered by

--- a/plugins/devops/skills/devops-deep-research/SKILL.md
+++ b/plugins/devops/skills/devops-deep-research/SKILL.md
@@ -22,8 +22,8 @@ Research the topic `$ARGUMENTS` thoroughly and return a structured report.
 
 Silently check for optional overrides (do not surface "not found" in output):
 
-1. Global skill extension: `~/.claude/skills/devops-deep-research/SKILL.md` + `reference.md`
-2. Project skill extension: `{project}/.claude/skills/devops-deep-research/SKILL.md` + `reference.md`
+1. Global skill extension: `~/.claude/skills/deep-research/SKILL.md` + `reference.md`
+2. Project skill extension: `{project}/.claude/skills/deep-research/SKILL.md` + `reference.md`
 3. Merge: project > global > plugin defaults
 
 ## Step 1 — Depth check

--- a/plugins/devops/skills/devops-explain/SKILL.md
+++ b/plugins/devops/skills/devops-explain/SKILL.md
@@ -21,8 +21,8 @@ Explain `$ARGUMENTS` clearly, tailored to the user's expertise level.
 
 Silently check for optional overrides (do not surface "not found" in output):
 
-1. Global skill extension: `~/.claude/skills/devops-explain/SKILL.md` + `reference.md`
-2. Project skill extension: `{project}/.claude/skills/devops-explain/SKILL.md` + `reference.md`
+1. Global skill extension: `~/.claude/skills/explain/SKILL.md` + `reference.md`
+2. Project skill extension: `{project}/.claude/skills/explain/SKILL.md` + `reference.md`
 3. Merge: project > global > plugin defaults
 
 ## Step 1 — Scope assessment

--- a/plugins/devops/skills/devops-extend-skill/SKILL.md
+++ b/plugins/devops/skills/devops-extend-skill/SKILL.md
@@ -18,8 +18,8 @@ Scaffold or adapt a project-level extension for any devops skill.
 
 Silently check for optional overrides (do not surface "not found" in output):
 
-1. Global skill extension: `~/.claude/skills/devops-extend-skill/SKILL.md` + `reference.md`
-2. Project skill extension: `{project}/.claude/skills/devops-extend-skill/SKILL.md` + `reference.md`
+1. Global skill extension: `~/.claude/skills/extend-skill/SKILL.md` + `reference.md`
+2. Project skill extension: `{project}/.claude/skills/extend-skill/SKILL.md` + `reference.md`
 3. Merge: project > global > plugin defaults
 
 ## Step 1 — Detect project root

--- a/plugins/devops/skills/devops-flow/SKILL.md
+++ b/plugins/devops/skills/devops-flow/SKILL.md
@@ -22,8 +22,8 @@ Diagnose and fix the issue: `$ARGUMENTS`
 
 Silently check for optional overrides (do not surface "not found" in output):
 
-1. Global skill extension: `~/.claude/skills/devops-flow/SKILL.md` + `reference.md`
-2. Project skill extension: `{project}/.claude/skills/devops-flow/SKILL.md` + `reference.md`
+1. Global skill extension: `~/.claude/skills/flow/SKILL.md` + `reference.md`
+2. Project skill extension: `{project}/.claude/skills/flow/SKILL.md` + `reference.md`
 3. Merge: project > global > plugin defaults
 
 Project extensions define framework-specific log paths (e.g., Electron logs in

--- a/plugins/devops/skills/devops-livebrief/SKILL.md
+++ b/plugins/devops/skills/devops-livebrief/SKILL.md
@@ -25,8 +25,8 @@ and monitor for user decisions.
 
 Silently check for optional overrides (do not surface "not found" in output):
 
-1. Global skill extension: `~/.claude/skills/devops-livebrief/SKILL.md` + `reference.md`
-2. Project skill extension: `{project}/.claude/skills/devops-livebrief/SKILL.md` + `reference.md`
+1. Global skill extension: `~/.claude/skills/livebrief/SKILL.md` + `reference.md`
+2. Project skill extension: `{project}/.claude/skills/livebrief/SKILL.md` + `reference.md`
 3. Merge: project > global > plugin defaults
 
 ## Step 1 — Determine Variant

--- a/plugins/devops/skills/devops-livebrief/reference.md
+++ b/plugins/devops/skills/devops-livebrief/reference.md
@@ -4,8 +4,8 @@ What users can override in their global or project-level extensions.
 
 ## Extension Paths
 
-- Global: `~/.claude/skills/devops-livebrief/SKILL.md` + `reference.md`
-- Project: `{project}/.claude/skills/devops-livebrief/SKILL.md` + `reference.md`
+- Global: `~/.claude/skills/livebrief/SKILL.md` + `reference.md`
+- Project: `{project}/.claude/skills/livebrief/SKILL.md` + `reference.md`
 
 ## What to Override
 

--- a/plugins/devops/skills/devops-new-issue/SKILL.md
+++ b/plugins/devops/skills/devops-new-issue/SKILL.md
@@ -20,8 +20,8 @@ Create issues and milestones with enforced formatting and optional board integra
 
 Silently check for optional overrides (do not surface "not found" in output):
 
-1. Global skill extension: `~/.claude/skills/devops-new-issue/SKILL.md` + `reference.md`
-2. Project skill extension: `{project}/.claude/skills/devops-new-issue/SKILL.md` + `reference.md`
+1. Global skill extension: `~/.claude/skills/new-issue/SKILL.md` + `reference.md`
+2. Project skill extension: `{project}/.claude/skills/new-issue/SKILL.md` + `reference.md`
 3. Merge: project > global > plugin defaults
 
 **Project extensions define:**

--- a/plugins/devops/skills/devops-orchestrate/SKILL.md
+++ b/plugins/devops/skills/devops-orchestrate/SKILL.md
@@ -22,8 +22,8 @@ Evaluate which agents add value for `$ARGUMENTS`, then orchestrate their executi
 
 Silently check for optional overrides (do not surface "not found" in output):
 
-1. Global skill extension: `~/.claude/skills/devops-orchestrate/SKILL.md` + `reference.md`
-2. Project skill extension: `{project}/.claude/skills/devops-orchestrate/SKILL.md` + `reference.md`
+1. Global skill extension: `~/.claude/skills/orchestrate/SKILL.md` + `reference.md`
+2. Project skill extension: `{project}/.claude/skills/orchestrate/SKILL.md` + `reference.md`
 3. Merge: project > global > plugin defaults
 
 ## Step 1 — Task Analysis

--- a/plugins/devops/skills/devops-project-setup/SKILL.md
+++ b/plugins/devops/skills/devops-project-setup/SKILL.md
@@ -20,8 +20,8 @@ Audit or initialize a project's repository structure.
 
 Silently check for optional overrides (do not surface "not found" in output):
 
-1. Global skill extension: `~/.claude/skills/devops-project-setup/SKILL.md` + `reference.md`
-2. Project skill extension: `{project}/.claude/skills/devops-project-setup/SKILL.md` + `reference.md`
+1. Global skill extension: `~/.claude/skills/project-setup/SKILL.md` + `reference.md`
+2. Project skill extension: `{project}/.claude/skills/project-setup/SKILL.md` + `reference.md`
 3. Merge: project > global > plugin defaults
 
 ## Arguments

--- a/plugins/devops/skills/devops-readme/SKILL.md
+++ b/plugins/devops/skills/devops-readme/SKILL.md
@@ -19,8 +19,8 @@ Generate a modern, informative README.md for the current project.
 
 Silently check for optional overrides (do not surface "not found" in output):
 
-1. Global skill extension: `~/.claude/skills/devops-readme/SKILL.md` + `reference.md`
-2. Project skill extension: `{project}/.claude/skills/devops-readme/SKILL.md` + `reference.md`
+1. Global skill extension: `~/.claude/skills/readme/SKILL.md` + `reference.md`
+2. Project skill extension: `{project}/.claude/skills/readme/SKILL.md` + `reference.md`
 3. Merge: project > global > plugin defaults
 
 ## Arguments

--- a/plugins/devops/skills/devops-refresh-usage/SKILL.md
+++ b/plugins/devops/skills/devops-refresh-usage/SKILL.md
@@ -17,8 +17,8 @@ Fetch live token usage for the completion card's battery line.
 
 Silently check for optional overrides (do not surface "not found" in output):
 
-1. Global skill extension: `~/.claude/skills/devops-refresh-usage/SKILL.md` + `reference.md`
-2. Project skill extension: `{project}/.claude/skills/devops-refresh-usage/SKILL.md` + `reference.md`
+1. Global skill extension: `~/.claude/skills/refresh-usage/SKILL.md` + `reference.md`
+2. Project skill extension: `{project}/.claude/skills/refresh-usage/SKILL.md` + `reference.md`
 3. Merge: project > global > plugin defaults
 
 ## Step 1 — Fetch data (aggressive fallback chain)

--- a/plugins/devops/skills/devops-ship/SKILL.md
+++ b/plugins/devops/skills/devops-ship/SKILL.md
@@ -42,8 +42,8 @@ This guard only applies to the **current chat session**, not external CI or othe
 
 Silently check for optional overrides (do not surface "not found" in output):
 
-1. Global skill extension: `~/.claude/skills/devops-ship/SKILL.md` + `reference.md`
-2. Project skill extension: `{project}/.claude/skills/devops-ship/SKILL.md` + `reference.md`
+1. Global skill extension: `~/.claude/skills/ship/SKILL.md` + `reference.md`
+2. Project skill extension: `{project}/.claude/skills/ship/SKILL.md` + `reference.md`
 3. Merge: project > global > plugin defaults
 
 Project extensions define: quality gate commands, deploy targets, version files, CI specifics.

--- a/plugins/devops/skills/devops-ship/reference.md
+++ b/plugins/devops/skills/devops-ship/reference.md
@@ -5,7 +5,7 @@
 Create project-specific ship rules in your project:
 
 ```
-{project}/.claude/skills/devops-ship/
+{project}/.claude/skills/ship/
 ├── SKILL.md        ← Override or add steps
 └── reference.md    ← Project-specific context
 ```


### PR DESCRIPTION
## Summary
- All 16 SKILL.md Step 0 extension paths used `devops-{name}/` (e.g. `skills/devops-ship/`) for user extensions
- CONVENTIONS.md documents short names (e.g. `skills/ship/`)
- Projects already use short names — extensions were silently never loaded
- Fixed all SKILL.md + reference.md files to match the documented convention

## Files changed (17)
- 15x `skills/devops-*/SKILL.md` — Step 0 lookup paths
- `skills/devops-livebrief/reference.md` — extension path examples
- `skills/devops-ship/reference.md` — extension path example
- `CONVENTIONS.md` — eat-your-own-dogfood example