### PR TITLE
fix(ship): skip --delete-branch in worktree context

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.34.1"
+    "version": "0.35.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.34.1",
+      "version": "0.35.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.35.1] — 2026-04-08
+
+### Fixed
+
+- **ship** — `mergePR()` now skips `--delete-branch` flag when running inside a git worktree, preventing `gh` from failing on local branch switch; branch cleanup deferred to `ship_cleanup` as designed
+- **marketplace** — synced `marketplace.json` version to v0.35.0 (was stuck at v0.34.1)
+
 ## [0.35.0] — 2026-04-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.35.0**
+**Version: 0.35.1**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.35.0",
+  "version": "0.35.1",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/mcp-server/ship/lib/github.js
+++ b/plugins/devops/mcp-server/ship/lib/github.js
@@ -46,12 +46,13 @@ export function createPR({ title, body, base = "main", head }, opts) {
  * @param {number} prNumber
  * @param {string} base - Base branch name (e.g. "main", "develop")
  * @param {object} [opts]
+ * @param {object} [flags]
+ * @param {boolean} [flags.skipDeleteBranch=false] - Skip --delete-branch (e.g. in worktrees where local branch switch fails)
  */
-export function mergePR(prNumber, base = "main", opts) {
-  gh(
-    ["pr", "merge", String(prNumber), "--squash", "--delete-branch", "--admin"],
-    opts,
-  );
+export function mergePR(prNumber, base = "main", opts, flags = {}) {
+  const args = ["pr", "merge", String(prNumber), "--squash", "--admin"];
+  if (!flags.skipDeleteBranch) args.push("--delete-branch");
+  gh(args, opts);
   // Verify the PR is actually in MERGED state (retry up to 3 times with 2s backoff
   // to handle transient network errors or GitHub eventual consistency)
   let state = null;

--- a/plugins/devops/mcp-server/ship/tools/release.js
+++ b/plugins/devops/mcp-server/ship/tools/release.js
@@ -82,9 +82,11 @@ export async function handler(params) {
     }
     result.pr = { number: pr.number, url: pr.url, title };
 
-    // Merge PR (squash + delete branch)
+    // Merge PR (squash + delete branch; skip --delete-branch in worktrees
+    // where gh tries to switch to base locally — cleanup handles branch deletion)
     gitStrict(`fetch origin ${base}`, opts);
-    const mergeSha = mergePR(pr.number, base, opts);
+    const worktree = isWorktree(opts);
+    const mergeSha = mergePR(pr.number, base, opts, { skipDeleteBranch: worktree });
     result.merged = base;
     result.mergeSha = mergeSha;
 


### PR DESCRIPTION
## Summary
- `mergePR()` now skips `--delete-branch` when inside a git worktree, preventing `gh` from failing on local branch switch
- Branch cleanup deferred to `ship_cleanup` as designed
- Synced `marketplace.json` version (was stuck at v0.34.1)

Closes #19