### PR TITLE
fix(hooks): stale remote refs and version-locked cron paths

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.35.2"
+    "version": "0.35.3"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.35.2",
+      "version": "0.35.3",
       "author": {
         "name": "Jerry0022"
       },


### PR DESCRIPTION
## Summary
- **ss.git.check**: `git fetch --quiet` before unpushed detection prevents false positives from stale remote-tracking refs
- **selfcalibration hooks**: version-agnostic glob in cron prompt survives mid-session cache rebuilds
- **marketplace.json**: aligned to v0.35.2 (missed in #21)

Closes #22