### PR TITLE
refactor(skills): rename devops-orchestrate to devops-agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.35.5] — 2026-04-08
+
+### Changed
+
+- **skills** — renamed `/devops-orchestrate` to `/devops-agents` for clarity; updated all references, triggers, and extension paths
+
 ## [0.35.4] — 2026-04-08
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,7 +197,7 @@
 
 ### Added
 
-- **skills** — new `/devops-orchestrate` skill: explicitly evaluate which agents are useful for a task and orchestrate their parallel or sequential execution with wave-based planning
+- **skills** — new `/devops-agents` skill (formerly `/devops-orchestrate`): explicitly evaluate which agents are useful for a task and orchestrate their parallel or sequential execution with wave-based planning
 
 ## [0.27.0] — 2026-04-05
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Complete DevOps automation plugin for Claude Code. Hooks, skills, agents, and te
 ## Features
 
 - **13 Hooks** — automated guards and triggers across the full session lifecycle
-- **16 Skills** — devops-ship, devops-commit, devops-flow, devops-deep-research, devops-explain, devops-new-issue, devops-project-setup, devops-readme, devops-refresh-usage, devops-extend-skill, devops-repo-health, devops-claude-md-lint, devops-livebrief, devops-orchestrate, devops-self-update, devops-autonomous
+- **16 Skills** — devops-ship, devops-commit, devops-flow, devops-deep-research, devops-explain, devops-new-issue, devops-project-setup, devops-readme, devops-refresh-usage, devops-extend-skill, devops-repo-health, devops-claude-md-lint, devops-livebrief, devops-agents, devops-self-update, devops-autonomous
 - **10 Agents** — AI, Core, Designer, Feature, Frontend, Gamer, PO, QA, Research, Windows
 - **Completion Flow** — mandatory card after every task (8 variants), visual verification, ship recommendation
 - **Ship Enforcement** — intent detection, PR command blocking, automatic /devops-ship skill routing
@@ -135,7 +135,7 @@ SessionStart  ──>  PreToolUse  ──>  PostToolUse  ──>  UserPromptSubm
 | `/devops-self-update` | Explicit | Update the plugin to the latest version from GitHub |
 | `/devops-claude-md-lint` | Explicit | Audit CLAUDE.md files for size, structure, and token efficiency |
 | `/devops-livebrief` | Explicit | Interactive HTML page for analysis, plans, and prototypes |
-| `/devops-orchestrate` | Explicit | Evaluate agents and orchestrate parallel execution |
+| `/devops-agents` | Explicit | Evaluate agents and orchestrate parallel execution |
 | `/devops-autonomous` | Explicit | Fully autonomous agent orchestration while user is AFK |
 
 ### Agents (spawned for parallel work)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.35.4**
+**Version: 0.35.5**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.35.4",
+  "version": "0.35.5",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/skills/devops-agents/SKILL.md
+++ b/plugins/devops/skills/devops-agents/SKILL.md
@@ -1,11 +1,11 @@
 ---
-name: devops-orchestrate
-version: 0.1.0
+name: devops-agents
+version: 0.2.0
 description: >-
   Evaluate which agents are useful for a task and orchestrate their parallel or
   sequential execution. Use when the user explicitly wants orchestrated agent
   work instead of inline execution, or when a task clearly benefits from
-  multi-agent collaboration. Triggers on: "orchestrate", "orchestriere",
+  multi-agent collaboration. Triggers on: "agents", "orchestrate", "orchestriere",
   "agents einsetzen", "use agents", "parallel agents", "multi-agent",
   "lass agents das machen", "delegate to agents", "agent workflow".
   Do NOT trigger for: simple single-file edits, quick fixes, explanations
@@ -23,8 +23,8 @@ Evaluate which agents add value for `$ARGUMENTS`, then orchestrate their executi
 Check for optional overrides. Use **Glob** to verify each path exists before reading.
 Do NOT call Read on files that may not exist — skip missing files silently (no output).
 
-1. Global: `~/.claude/skills/orchestrate/SKILL.md` + `reference.md`
-2. Project: `{project}/.claude/skills/orchestrate/SKILL.md` + `reference.md`
+1. Global: `~/.claude/skills/devops-agents/SKILL.md` + `reference.md`
+2. Project: `{project}/.claude/skills/devops-agents/SKILL.md` + `reference.md`
 3. Merge: project > global > plugin defaults
 
 ## Step 1 — Task Analysis

--- a/plugins/devops/skills/devops-autonomous/SKILL.md
+++ b/plugins/devops/skills/devops-autonomous/SKILL.md
@@ -11,7 +11,7 @@ description: >-
   "ich geh kurz weg", "mach das alleine", "run this while I'm away",
   "autonom weiter", "ich bin gleich weg", "afk mode", "unattended mode",
   "mach weiter ohne mich", "autopilot". Do NOT trigger for normal orchestration
-  where the user stays present — use /devops-orchestrate instead.
+  where the user stays present — use /devops-agents instead.
 argument-hint: "[optional: task description]"
 allowed-tools: >-
   Bash(*), Read, Write, Edit, Glob, Grep, Agent,


### PR DESCRIPTION
## Summary\n- Renamed `/devops-orchestrate` skill to `/devops-agents` for clarity\n- Updated all references in README, CHANGELOG, devops-autonomous, and extension paths\n- Added \"agents\" as additional trigger keyword