### PR TITLE
chore: ignore .claude/project-map.md

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.35.3"
+    "version": "0.35.6"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.35.3",
+      "version": "0.35.6",
       "author": {
         "name": "Jerry0022"
       },

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ node_modules/
 .claude/templates/
 .claude/scripts/
 .claude/scheduled-tasks/
+.claude/project-map.md
 
 # Secrets
 .credentials.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.35.6] — 2026-04-08
+
+### Changed
+
+- **gitignore** — ignore `.claude/project-map.md` (auto-generated, not distributable)
+
 ## [0.35.5] — 2026-04-08
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.35.5**
+**Version: 0.35.6**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.35.5",
+  "version": "0.35.6",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary\n- Ignore auto-generated `.claude/project-map.md` in `.gitignore` to prevent false \"uncommitted files\" warnings at session start