### PR TITLE
feat(tokens): project-map awareness for search ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [0.35.8] — 2026-04-09
 
+### Added
+
+- **deep-knowledge** — project-map awareness: teach Claude to consult `.claude/project-map.md` before running full-repo Grep/Glob searches
+- **hooks** — token guard now shows "Hint: Read .claude/project-map.md" when blocking broad Grep/Glob operations
+
 ### Fixed
 
 - **mcp** — add cache fallback for usage fetch: when CDP scrape chain fails, use cached `usage-live.json` data (if within 5h reset window) instead of showing "Usage data unavailable"

--- a/plugins/devops/deep-knowledge/tool-selection.md
+++ b/plugins/devops/deep-knowledge/tool-selection.md
@@ -15,5 +15,27 @@ Always prefer Claude Code's dedicated tools over Bash equivalents:
 - Batch Bash calls with `&&` when multiple sequential commands are needed.
 - Use Unix shell syntax (forward slashes, /dev/null) even on Windows.
 
+## Project Map as Search Index
+
+Before running a full-repo Grep or Glob (no `path` parameter), **always** read
+`.claude/project-map.md` first. The project map is a lightweight index of the
+codebase structure — it tells you which directories and files exist and what they
+contain.
+
+Use it to derive the correct `path` parameter:
+
+1. Read `.claude/project-map.md` (cheap — small file)
+2. Find the relevant directory for your search term
+3. Run Grep/Glob with that directory as `path`
+
+This avoids the token guard blocking full-repo searches and produces faster,
+more precise results.
+
+**Example:** Searching for "livebrief" → project map shows
+`skills/devops-livebrief/` exists → `Grep(pattern: "livebrief", path: "plugins/devops/skills/devops-livebrief")`.
+
+**When to skip:** If the project has no `.claude/project-map.md`, fall back to
+scoped searches using your best guess, or use the Explore agent for broad searches.
+
 ## Priority
 Functionality > aesthetics. Get the job done with the right tool, don't optimize for pretty output.

--- a/plugins/devops/hooks/pre-tool-use/pre.tokens.guard.js
+++ b/plugins/devops/hooks/pre-tool-use/pre.tokens.guard.js
@@ -222,6 +222,14 @@ process.stdin.on('end', () => {
     }
   }
 
+  // Project map hint for broad searches
+  if (toolName === 'Grep' || toolName === 'Glob') {
+    const projectMap = path.join(cwd, '.claude', 'project-map.md');
+    if (fs.existsSync(projectMap)) {
+      console.error(`\nHint: Read .claude/project-map.md to find the right path first.`);
+    }
+  }
+
   console.error(line);
   console.error('To proceed, retry the same operation.');
   console.error('');


### PR DESCRIPTION
## Summary
- Add project-map consultation guidance to `deep-knowledge/tool-selection.md` — Claude now checks `.claude/project-map.md` before broad Grep/Glob
- Token guard hook shows project-map hint when blocking full-repo searches

## Test plan
- [ ] Trigger a full-repo Grep without path → verify hint appears in error
- [ ] Verify Claude consults project-map before searching in new sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)