### PR TITLE
fix(i18n): umlaut substitutes in completion card CTAs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.35.10] — 2026-04-09
+
+### Fixed
+
+- **i18n** — replace ASCII umlaut substitutes in completion card CTAs (`AENDERN` → `ÄNDERN`, `zurueck` → `zurück`)
+
 ## [0.35.9] — 2026-04-09
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.35.9**
+**Version: 0.35.10**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.35.9",
+  "version": "0.35.10",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/mcp-server/index.js
+++ b/plugins/devops/mcp-server/index.js
@@ -153,9 +153,9 @@ const CTA = {
     fallback:        '## \ud83d\udccb DONE \u2014 Anything ELSE?',
   },
   de: {
-    'shipped-bump':  '## \ud83d\ude80 SHIPPED. {vOld} \u2192 {vNew} ({bump}) \u2014 LEHN dich zurueck, alles erledigt',
-    'shipped-plain': '## \ud83d\ude80 SHIPPED. {version} \u2014 LEHN dich zurueck, alles erledigt',
-    ready:           '## \ud83d\udce6 READY. {info} \u2014 SHIP oder AENDERN?',
+    'shipped-bump':  '## \ud83d\ude80 SHIPPED. {vOld} \u2192 {vNew} ({bump}) \u2014 LEHN dich zurück, alles erledigt',
+    'shipped-plain': '## \ud83d\ude80 SHIPPED. {version} \u2014 LEHN dich zurück, alles erledigt',
+    ready:           '## \ud83d\udce6 READY. {info} \u2014 SHIP oder ÄNDERN?',
     blocked:         '## \u26d4 BLOCKED. {reason} \u2014 FIX oder SKIP?',
     test:            '## \ud83e\uddea DONE. {info} \u2014 SHIP nach deinem TEST?',
     'minimal-start': '## \ud83e\uddea STARTED. {description} \u2014 VIEL SPASS',

--- a/plugins/devops/templates/completion-card.md
+++ b/plugins/devops/templates/completion-card.md
@@ -324,9 +324,9 @@ Format: `## {icon} {STATUS}. {short-info} — {sentence with VERB}`
 
 | # | Variant | CTA |
 |---|---------|-----|
-| 1 | shipped (with bump) | `## 🚀 SHIPPED. {{vOld}} → {{vNew}} ({{bump}}) — LEHN dich zurueck, alles erledigt` |
-| 1 | shipped (no bump) | `## 🚀 SHIPPED. {{version}} — LEHN dich zurueck, alles erledigt` |
-| 2 | ready | `## 📦 READY. {{info}} — SHIP oder AENDERN?` |
+| 1 | shipped (with bump) | `## 🚀 SHIPPED. {{vOld}} → {{vNew}} ({{bump}}) — LEHN dich zurück, alles erledigt` |
+| 1 | shipped (no bump) | `## 🚀 SHIPPED. {{version}} — LEHN dich zurück, alles erledigt` |
+| 2 | ready | `## 📦 READY. {{info}} — SHIP oder ÄNDERN?` |
 | 3 | blocked | `## ⛔ BLOCKED. {{reason}} — FIX oder SKIP?` |
 | 4 | test | `## 🧪 DONE. {{info}} — SHIP nach deinem TEST?` |
 | 5 | minimal-start | `## 🧪 STARTED. {{user-facing-description}} — VIEL SPASS` |


### PR DESCRIPTION
## Summary
- Replace ASCII umlaut substitutes in completion card CTA strings: `AENDERN` → `ÄNDERN`, `zurueck` → `zurück`
- Fixes both template (`completion-card.md`) and runtime (`mcp-server/index.js`)

Closes #33