### PR TITLE
feat(hooks): idle guard for self-calibration (#28)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.35.11] — 2026-04-09
+
+### Added
+
+- **hooks** — idle guard for self-calibration cron: skip cycle when no user prompt occurred since the last run, preventing token waste in idle sessions (#28)
+- **hooks** — new `prompt.flow.useractivity` hook touches a session-scoped flag on every user prompt for cross-session isolation
+
 ## [0.35.10] — 2026-04-09
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.35.10**
+**Version: 0.35.11**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.35.10",
+  "version": "0.35.11",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/hooks/hooks.json
+++ b/plugins/devops/hooks/hooks.json
@@ -54,6 +54,7 @@
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/user-prompt-submit/prompt.issue.detect.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/user-prompt-submit/prompt.ship.detect.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/user-prompt-submit/prompt.flow.selfcalibration.js" },
+          { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/user-prompt-submit/prompt.flow.useractivity.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/user-prompt-submit/prompt.flow.appstart.js" }
         ]
       }

--- a/plugins/devops/hooks/session-start/ss.flow.selfcalibration.js
+++ b/plugins/devops/hooks/session-start/ss.flow.selfcalibration.js
@@ -15,6 +15,7 @@ require('../lib/plugin-guard');
 const fs   = require('fs');
 const path = require('path');
 const { runOnce } = require('../lib/run-once');
+const { sessionFile } = require('../lib/session-id');
 
 const PLUGIN_DIR  = path.resolve(__dirname, '..', '..');
 const TASKS_DIR   = path.join(PLUGIN_DIR, 'scheduled-tasks');
@@ -26,6 +27,8 @@ const TASKS_DIR   = path.join(PLUGIN_DIR, 'scheduled-tasks');
 // latest cache at cron fire time.
 const home = process.env.HOME || process.env.USERPROFILE || '';
 const PLUGIN_GLOB_BASE = path.join(home, '.claude', 'plugins', 'cache').replace(/\\/g, '/');
+
+const FLAG_PREFIX = 'dotclaude-devops-user-active';
 
 const TASK_DEFINITIONS = [
   {
@@ -84,15 +87,23 @@ process.stdin.on('end', () => {
 
   if (tasks.length === 0) process.exit(0);
 
+  // Set the initial user-active flag so the first immediate execution runs.
+  const flagPath = sessionFile(FLAG_PREFIX, sessionId).replace(/\\/g, '/');
+  try {
+    fs.writeFileSync(sessionFile(FLAG_PREFIX, sessionId), String(Date.now()), 'utf8');
+  } catch {}
+
   const lines = [
     'BLOCKING — execute BEFORE responding to the user message:',
     '',
   ];
 
   for (const t of tasks) {
+    const idleGuard = `IDLE GUARD: First, run Bash to check if the file "${flagPath}" exists (test -f "${flagPath}"). If it does NOT exist, output nothing and stop — do NOT proceed with the task. If it DOES exist, delete it (rm "${flagPath}") and continue.`;
+
     const cronPrompt = t.cronDiscoveryDir
-      ? `Execute the ${t.id} scheduled task as defined in the plugin. List the directory ${t.cronDiscoveryDir} to find the current version, then Read {version}/scheduled-tasks/${t.id}/SKILL.md — use the match to derive the plugin root (parent of scheduled-tasks/).`
-      : `Execute the ${t.id} scheduled task as defined in the plugin. Read ${t.resolvedSkillPath} — use the file's parent of scheduled-tasks/ as the plugin root.`;
+      ? `${idleGuard} Execute the ${t.id} scheduled task as defined in the plugin. List the directory ${t.cronDiscoveryDir} to find the current version, then Read {version}/scheduled-tasks/${t.id}/SKILL.md — use the match to derive the plugin root (parent of scheduled-tasks/).`
+      : `${idleGuard} Execute the ${t.id} scheduled task as defined in the plugin. Read ${t.resolvedSkillPath} — use the file's parent of scheduled-tasks/ as the plugin root.`;
     lines.push(
       `Register cron via CronCreate: cron="${t.cron}", recurring=${t.recurring}, prompt="${cronPrompt}"`,
       `Then immediately execute it once: Read ${t.resolvedSkillPath} and run Step 0 (Completion Flow Internalization).`,

--- a/plugins/devops/hooks/user-prompt-submit/prompt.flow.selfcalibration.js
+++ b/plugins/devops/hooks/user-prompt-submit/prompt.flow.selfcalibration.js
@@ -21,6 +21,7 @@ require('../lib/plugin-guard');
 const fs   = require('fs');
 const path = require('path');
 const { runOnce } = require('../lib/run-once');
+const { sessionFile } = require('../lib/session-id');
 
 const PLUGIN_DIR  = path.resolve(__dirname, '..', '..');
 const TASKS_DIR   = path.join(PLUGIN_DIR, 'scheduled-tasks');
@@ -32,6 +33,8 @@ const TASKS_DIR   = path.join(PLUGIN_DIR, 'scheduled-tasks');
 // latest cache at cron fire time.
 const home = process.env.HOME || process.env.USERPROFILE || '';
 const PLUGIN_GLOB_BASE = path.join(home, '.claude', 'plugins', 'cache').replace(/\\/g, '/');
+
+const FLAG_PREFIX = 'dotclaude-devops-user-active';
 
 const TASK_DEFINITIONS = [
   {
@@ -90,15 +93,26 @@ process.stdin.on('end', () => {
 
   if (tasks.length === 0) process.exit(0);
 
+  // Set the initial user-active flag so the first immediate execution runs.
+  // Subsequent flags are set by prompt.flow.useractivity.js on every user prompt.
+  const flagPath = sessionFile(FLAG_PREFIX, sessionId).replace(/\\/g, '/');
+  try {
+    fs.writeFileSync(sessionFile(FLAG_PREFIX, sessionId), String(Date.now()), 'utf8');
+  } catch {}
+
   const lines = [
     'BLOCKING — execute BEFORE responding to the user message:',
     '',
   ];
 
   for (const t of tasks) {
+    // Idle guard: check the session-scoped flag file before running the task.
+    // If no user prompt arrived since the last cycle, skip entirely.
+    const idleGuard = `IDLE GUARD: First, run Bash to check if the file "${flagPath}" exists (test -f "${flagPath}"). If it does NOT exist, output nothing and stop — do NOT proceed with the task. If it DOES exist, delete it (rm "${flagPath}") and continue.`;
+
     const cronPrompt = t.cronDiscoveryDir
-      ? `Execute the ${t.id} scheduled task as defined in the plugin. List the directory ${t.cronDiscoveryDir} to find the current version, then Read {version}/scheduled-tasks/${t.id}/SKILL.md — use the match to derive the plugin root (parent of scheduled-tasks/).`
-      : `Execute the ${t.id} scheduled task as defined in the plugin. Read ${t.resolvedSkillPath} — use the file's parent of scheduled-tasks/ as the plugin root.`;
+      ? `${idleGuard} Execute the ${t.id} scheduled task as defined in the plugin. List the directory ${t.cronDiscoveryDir} to find the current version, then Read {version}/scheduled-tasks/${t.id}/SKILL.md — use the match to derive the plugin root (parent of scheduled-tasks/).`
+      : `${idleGuard} Execute the ${t.id} scheduled task as defined in the plugin. Read ${t.resolvedSkillPath} — use the file's parent of scheduled-tasks/ as the plugin root.`;
     lines.push(
       `Register cron via CronCreate: cron="${t.cron}", recurring=${t.recurring}, prompt="${cronPrompt}"`,
       `Then immediately execute it once: Read ${t.resolvedSkillPath} and run Step 0 (Completion Flow Internalization).`,

--- a/plugins/devops/hooks/user-prompt-submit/prompt.flow.useractivity.js
+++ b/plugins/devops/hooks/user-prompt-submit/prompt.flow.useractivity.js
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+/**
+ * @hook prompt.flow.useractivity
+ * @version 0.1.0
+ * @event UserPromptSubmit
+ * @plugin devops
+ * @description Touch a session-scoped flag file on every user prompt.
+ *   The self-calibration cron checks this flag before running: if no
+ *   user prompt arrived since the last cycle, the cycle is skipped.
+ *   This prevents idle sessions from burning tokens on repeated
+ *   self-calibration runs with zero value.
+ *
+ *   The flag path includes the session_id so parallel sessions
+ *   (different worktrees, different windows) are fully isolated.
+ */
+
+require('../lib/plugin-guard');
+
+const fs   = require('fs');
+const { sessionFile } = require('../lib/session-id');
+
+const FLAG_PREFIX = 'dotclaude-devops-user-active';
+
+let inputData = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', d => { inputData += d; });
+process.stdin.on('end', () => {
+  let sessionId;
+  try {
+    const input = JSON.parse(inputData);
+    sessionId = input.session_id;
+  } catch {}
+
+  // Touch the flag file — content doesn't matter, existence is the signal.
+  const flagPath = sessionFile(FLAG_PREFIX, sessionId);
+  try {
+    fs.writeFileSync(flagPath, String(Date.now()), 'utf8');
+  } catch {
+    // Non-critical — worst case the next calibration cycle runs anyway.
+  }
+});


### PR DESCRIPTION
## Summary
- Skip self-calibration cron cycles when no user prompt occurred since the last run
- New `prompt.flow.useractivity` hook touches a session-scoped flag on every user prompt
- Idle guard baked into cron prompt with session_id isolation for parallel worktrees

Closes #28