### PR TITLE
fix(usage): session reset timer shows 0h 0m when <1h remains

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.35.7"
+    "version": "0.35.12"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.35.7",
+      "version": "0.35.12",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.35.13] — 2026-04-09
+
+### Fixed
+
+- **usage** — session reset timer showed "0h 0m left" when less than 1 hour remained; regex now handles minutes-only format
+- **usage** — `formatResetShort` null guard returns "—" instead of coercing null to "0h 0m"
+- **usage** — null-safe elapsed percentage calculation for progress bar
+
 ## [0.35.12] — 2026-04-09
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.35.12**
+**Version: 0.35.13**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.35.12",
+  "version": "0.35.13",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/mcp-server/index.js
+++ b/plugins/devops/mcp-server/index.js
@@ -57,6 +57,7 @@ function formatDelta(delta) {
 }
 
 function formatResetShort(minutes) {
+  if (minutes == null || isNaN(minutes)) return '—';
   if (minutes >= 1440) {
     const d = Math.floor(minutes / 1440);
     const h = Math.floor((minutes % 1440) / 60);
@@ -87,7 +88,7 @@ function renderUsageMeter(usageData, delta5h, deltaWk) {
   const w = usageData.weekly;
   const lines = [];
 
-  const elapsed5hPct = ((300 - s.resetInMinutes) / 300) * 100;
+  const elapsed5hPct = s.resetInMinutes != null ? ((300 - s.resetInMinutes) / 300) * 100 : 0;
   lines.push(renderUsageLine('5h', s.pct, elapsed5hPct, delta5h, s.resetInMinutes));
 
   if (w) {
@@ -111,7 +112,7 @@ function renderUsageMeterForCard(usageData, delta5h, deltaWk) {
   const w = usageData.weekly;
   const lines = ['```'];
 
-  const elapsed5hPct = ((300 - s.resetInMinutes) / 300) * 100;
+  const elapsed5hPct = s.resetInMinutes != null ? ((300 - s.resetInMinutes) / 300) * 100 : 0;
   lines.push(renderUsageLine('5h', s.pct, elapsed5hPct, delta5h, s.resetInMinutes));
 
   if (w) {

--- a/plugins/devops/scripts/refresh-usage-headless.js
+++ b/plugins/devops/scripts/refresh-usage-headless.js
@@ -88,12 +88,19 @@ function parseUsageText(text) {
   const pctMatches = [...text.matchAll(/(?:\d{1,2}:\d{2})?(\d{1,3}) % (?:verwendet|used)/g)];
   const pcts = pctMatches.map(m => parseInt(m[1]));
 
+  // Match session reset: "Zurücksetzung in 2 Std. 30 Min." or just "30 Min." (< 1h left)
   const resetMatch = text.match(
-    /(?:Zurücksetzung in|Resets? in)\s+(\d+)\s*(?:Std\.|hr)\.?\s*(\d+)?\s*(?:Min\.|min)?/
+    /(?:Zurücksetzung in|Resets? in)\s+(?:(\d+)\s*(?:Std\.|hr)\.?\s*)?(\d+)\s*(?:Min\.|min)/
+  );
+  // Fallback: hours-only format "Zurücksetzung in 2 Std." (no minutes)
+  const resetMatchHoursOnly = !resetMatch && text.match(
+    /(?:Zurücksetzung in|Resets? in)\s+(\d+)\s*(?:Std\.|hr)/
   );
   const resetMinutes = resetMatch
     ? (parseInt(resetMatch[1]) || 0) * 60 + (parseInt(resetMatch[2]) || 0)
-    : null;
+    : resetMatchHoursOnly
+      ? (parseInt(resetMatchHoursOnly[1]) || 0) * 60
+      : null;
 
   const weeklyMatch = text.match(
     /(?:Alle Modelle|All Models)[\s\S]*?(?:Zurücksetzung|Reset)\s+(\w+)\.?,?\s*(\d{1,2}:\d{2})/


### PR DESCRIPTION
## Summary
- Session reset regex required hours part, failing when <1h remained (minutes-only format)
- `formatResetShort(null)` coerced null to 0 → showed "0h 0m left" instead of fallback
- Added null guards for elapsed percentage calculation