### PR TITLE
feat(autonomous): Claude-in-Chrome browser control in background mode

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.35.12"
+    "version": "0.35.13"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.35.12",
+      "version": "0.35.13",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.35.14] — 2026-04-09
+
+### Added
+
+- **autonomous** — allow Claude-in-Chrome (Edge) browser control in background mode; DOM-based tab interaction without desktop takeover
+
+### Fixed
+
+- **marketplace** — aligned `marketplace.json` version to v0.35.13 (missed in prior release)
+
 ## [0.35.13] — 2026-04-09
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.35.13**
+**Version: 0.35.14**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.35.13",
+  "version": "0.35.14",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/skills/devops-autonomous/SKILL.md
+++ b/plugins/devops/skills/devops-autonomous/SKILL.md
@@ -18,7 +18,8 @@ allowed-tools: >-
   AskUserQuestion, CronCreate, CronDelete, CronList,
   EnterWorktree, ExitWorktree, TodoWrite,
   WebFetch, WebSearch,
-  mcp__computer-use__*, mcp__Claude_Preview__*,
+  mcp__computer-use__*, mcp__Claude_in_Chrome__*,
+  mcp__Claude_Preview__*,
   mcp__plugin_playwright_playwright__*,
   mcp__plugin_devops_dotclaude-completion__*,
   mcp__plugin_devops_dotclaude-ship__*,
@@ -61,7 +62,14 @@ Save the choice as `$EXEC_MODE` (`analyze` | `implement`). This controls Step 5.
 
 Browser-based testing (Playwright, Preview) runs regardless of this choice — it
 operates in its own window and doesn't occupy the desktop. This question only
-controls whether computer-use (mouse/keyboard takeover) is used for native apps.
+controls whether computer-use (mouse/keyboard takeover) is used for **native apps**.
+
+**Edge/Chrome browser exception:** Even in "Hintergrund" mode, Claude is allowed to
+open, navigate, read, and interact with browser tabs via the **Claude-in-Chrome MCP**
+(`mcp__Claude_in_Chrome__*`). This is DOM-based — no mouse/keyboard takeover, no
+desktop occupation. The user can keep working while Claude autonomously tests, reads,
+and interacts with web pages in a browser tab. Prime these tools in Step 3b.
+
 In `analyze` mode, desktop is only used for visual inspection (screenshots), never for interaction.
 
 **Question 3 — Shutdown:**
@@ -82,8 +90,12 @@ Call `mcp__computer-use__request_access` with the list of applications needed
 Then take a test `mcp__computer-use__screenshot` to confirm access works.
 
 ### 3b — Browser Tools
-If the task involves web UI: trigger a lightweight Playwright or Preview call
-(e.g., `browser_snapshot` or `preview_screenshot`) to prime browser permissions.
+**Claude-in-Chrome** (`mcp__Claude_in_Chrome__*`): Always prime — runs in both
+desktop and background mode. Trigger a lightweight call (e.g., `tabs_context_mcp`)
+to confirm the extension is connected. This is the primary browser interface in
+background mode (DOM-based, no desktop takeover).
+**Playwright / Preview**: If the task involves web UI, additionally trigger a
+lightweight call (e.g., `browser_snapshot` or `preview_screenshot`) to prime.
 
 ### 3c — File & Shell Tools
 Run a harmless `Bash` command (e.g., `echo "permission primed"`), `Read` a file,


### PR DESCRIPTION
## Summary
- Allow Claude-in-Chrome (Edge) DOM-based browser tab control in autonomous background mode — no desktop takeover needed
- Always prime Claude-in-Chrome MCP tools during permission priming (Step 3b)
- Add `mcp__Claude_in_Chrome__*` to allowed-tools
- Fix `marketplace.json` version alignment (missed in v0.35.13)