### PR TITLE
fix(completion-card): remove delta marker suffixes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.35.13"
+    "version": "0.36.1"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.35.13",
+      "version": "0.36.1",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.36.1] — 2026-04-10
+
+### Fixed
+
+- **completion-card** — removed delta marker suffixes (! / !!) from usage meter; delta is now a clean (+N%) without trailing noise
+
 ## [0.36.0] — 2026-04-10
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.36.0**
+**Version: 0.36.1**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.36.0",
+  "version": "0.36.1",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/templates/completion-card.md
+++ b/plugins/devops/templates/completion-card.md
@@ -101,10 +101,10 @@ If `usage-live.json` is missing: show error message instead of bars.
 **Example rendering:**
 
 ```
-5h  ▓▓▓▓▓▓▓▓░░░░   67% (+1%   )  · Reset 1h 42m
+5h  ▓▓▓▓▓▓▓▓░░░░   67% (+1%)  · Reset 1h 42m
           ↑
 
-Wk  ▓▓▓░░░░░░░░░   25% (+8% !!)  · Reset 4d 11h  ⚠ Sonnet or new session
+Wk  ▓▓▓░░░░░░░░░   25% (+8%)  · Reset 4d 11h  ⚠ Sonnet or new session
         ↑
 ```
 
@@ -144,16 +144,8 @@ arrow_line = " " × (4 + arrow_pos) + "↑"
 
 Only show the delta parenthetical when a previous `usage-live.json` snapshot exists **and** is less than 8 hours old. If no previous snapshot exists or it is stale (>8h), omit the parenthetical entirely — pad with 8 spaces to preserve column alignment.
 
-When shown, delta uses color coding (marker suffix in code block):
-
-| Delta | Marker | Example |
-|-------|--------|---------|
-| +0 – 1% | no marker | `(+1%   )` |
-| +2 – 5% | `!` suffix | `(+4% ! )` |
-| +6%+ | `!!` suffix | `(+8% !!)` |
-
-Delta field is always 8 characters wide: `(+N% XX)`, right-padded with spaces inside.
-When omitted, 8 spaces are used instead to keep `· Reset` aligned.
+Delta field is always 5 characters wide: `(+N%)`, no trailing markers.
+When omitted, 5 spaces are used instead to keep `· Reset` aligned.
 
 **Implementation:** Pass `delta5h: null` / `deltaWk: null` in the render-card input JSON when no valid previous snapshot is available. The renderer will omit the parenthetical and pad for alignment.
 
@@ -186,7 +178,7 @@ Gap           3 chr   "   "
 Pct           3 chr   right-aligned, space-padded
 Pct-suffix    1 chr   "%"
 Space         1 chr   " "
-Delta         8 chr   "(+N% XX)"
+Delta         5 chr   "(+N%)"
 Gap           2 chr   "  "
 Separator     2 chr   "· "
 Reset-label   6 chr   "Reset "


### PR DESCRIPTION
## Summary
- Remove `!` / `!!` marker suffixes from delta percentage in usage meter
- Delta field is now a clean `(+N%)` without trailing noise
- Simplifies column alignment (8 → 5 chars)