### PR TITLE
feat(hooks): worktree branch guard for main protection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.36.2] — 2026-04-10
+
+### Added
+
+- **hooks** — worktree branch guard: prevents working on main/master inside linked worktrees; outputs BLOCKING instruction to create a new branch first; silent when not in a worktree
+
 ## [0.36.1] — 2026-04-10
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.36.1**
+**Version: 0.36.2**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.36.1",
+  "version": "0.36.2",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/hooks/hooks.json
+++ b/plugins/devops/hooks/hooks.json
@@ -55,7 +55,8 @@
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/user-prompt-submit/prompt.ship.detect.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/user-prompt-submit/prompt.flow.selfcalibration.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/user-prompt-submit/prompt.flow.useractivity.js" },
-          { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/user-prompt-submit/prompt.flow.appstart.js" }
+          { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/user-prompt-submit/prompt.flow.appstart.js" },
+          { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/user-prompt-submit/prompt.worktree.branch-guard.js" }
         ]
       }
     ]

--- a/plugins/devops/hooks/user-prompt-submit/prompt.worktree.branch-guard.js
+++ b/plugins/devops/hooks/user-prompt-submit/prompt.worktree.branch-guard.js
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+/**
+ * @hook prompt.worktree.branch-guard
+ * @version 0.1.0
+ * @event UserPromptSubmit
+ * @plugin devops
+ * @description Prevents working on main/master inside a linked worktree.
+ *   Only fires when the session is inside a git worktree (.git is a file,
+ *   not a directory). If the current branch is main or master, outputs a
+ *   BLOCKING instruction telling Claude to create a new branch first.
+ *   Does nothing if not in a worktree — the user intentionally works on main.
+ */
+
+require('../lib/plugin-guard');
+
+const { execSync } = require('child_process');
+const path = require('path');
+
+const cwd = process.cwd();
+
+function git(cmd) {
+  try {
+    return execSync(`git ${cmd}`, {
+      cwd,
+      encoding: 'utf8',
+      timeout: 5000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+// Only run in a git repo
+if (git('rev-parse --is-inside-work-tree') !== 'true') {
+  process.exit(0);
+}
+
+// Check if this is a linked worktree (not the main working tree).
+// In a linked worktree, --git-dir and --git-common-dir resolve to
+// different paths (git-dir points into .git/worktrees/<name>).
+const gitDir = git('rev-parse --git-dir');
+const commonDir = git('rev-parse --git-common-dir');
+if (!gitDir || !commonDir) process.exit(0);
+
+const isLinkedWorktree =
+  path.resolve(cwd, gitDir) !== path.resolve(cwd, commonDir);
+
+if (!isLinkedWorktree) {
+  // Not in a worktree — user intentionally works on main. Do nothing.
+  process.exit(0);
+}
+
+const branch = git('rev-parse --abbrev-ref HEAD');
+if (!branch) process.exit(0);
+
+if (branch === 'main' || branch === 'master') {
+  const worktreeName = path.basename(cwd);
+  process.stdout.write(
+    `BLOCKING — You are in a worktree but on branch "${branch}". ` +
+    `Create a new branch BEFORE doing any work: ` +
+    `git checkout -b claude/${worktreeName}`
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a `UserPromptSubmit` hook that blocks work on `main`/`master` when inside a linked worktree
- Silent when not in a worktree (user intentionally works on main) or already on a feature branch
- Prevents parallel session conflicts when multiple worktrees accidentally share the main branch