### PR TITLE
fix(hooks): direct MCP call for render_completion_card

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.36.1"
+    "version": "0.36.2"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.36.1",
+      "version": "0.36.2",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.36.3] — 2026-04-10
+
+### Fixed
+
+- **hooks** — completion card hooks now call `render_completion_card` MCP tool directly instead of via ToolSearch; ToolSearch only searches deferred tools, causing silent resolution failures when the tool is already loaded
+- **hooks** — aligned `marketplace.json` version (was stuck at 0.36.1 while other files had 0.36.2)
+
 ## [0.36.2] — 2026-04-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.36.2**
+**Version: 0.36.3**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.36.2",
+  "version": "0.36.3",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/hooks/post-tool-use/post.flow.completion.js
+++ b/plugins/devops/hooks/post-tool-use/post.flow.completion.js
@@ -74,8 +74,8 @@ process.stdin.on('end', () => {
   lines.push(
     '',
     'COMPLETION CARD — when ALL work is done:',
-    'Resolve via ToolSearch: select:mcp__plugin_devops_dotclaude-completion__render_completion_card',
-    'Then call `render_completion_card` MCP tool (dotclaude-completion server).',
+    'Call `mcp__plugin_devops_dotclaude-completion__render_completion_card` directly (already loaded MCP tool).',
+    'Only if the direct call fails with "tool not found", fall back to ToolSearch: select:mcp__plugin_devops_dotclaude-completion__render_completion_card',
     `Pass: variant, summary (max ~10 words, user language), lang:(use "de" if user writes German, "en" otherwise), session_id:"${hook.session_id || ''}",`,
     '  plus changes, tests, state, cta, userTest as applicable.',
     'Variant: shipped=ship succeeded, blocked=build/gate/merge failed,',

--- a/plugins/devops/hooks/stop/stop.flow.guard.js
+++ b/plugins/devops/hooks/stop/stop.flow.guard.js
@@ -42,8 +42,8 @@ process.stdin.on('end', () => {
   if (workHappened && !cardRendered) {
     process.stdout.write([
       '[stop.flow.guard] CARRY-OVER: Work completed but no completion card rendered.',
-      'Resolve the tool via ToolSearch: select:mcp__plugin_devops_dotclaude-completion__render_completion_card',
-      'Then call `render_completion_card` MCP tool NOW as the FIRST thing — before any other output.',
+      'Call `mcp__plugin_devops_dotclaude-completion__render_completion_card` directly (already loaded MCP tool) NOW as the FIRST thing — before any other output.',
+      'Only if the direct call fails with "tool not found", fall back to ToolSearch: select:mcp__plugin_devops_dotclaude-completion__render_completion_card',
       'IMPORTANT: The tool result is hidden in a collapsed UI element. You MUST copy the',
       'returned markdown and output it VERBATIM as your own text — the user cannot see tool results.',
       'VERBATIM = character-for-character: preserve every emoji, symbol, formatting character.',


### PR DESCRIPTION
## Summary\n- Completion card hooks now call `render_completion_card` MCP tool directly instead of via ToolSearch\n- ToolSearch only searches deferred tools — when the tool is already loaded, resolution silently fails\n- Also fixed `marketplace.json` version drift (was stuck at 0.36.1)\n\nCloses #41