### PR TITLE
feat(deep-knowledge): add read-first option rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.36.4] — 2026-04-10
+
+### Added
+
+- **deep-knowledge** — "Erstmal in Ruhe durchlesen" rule: when AskUserQuestion follows substantial inline results, the first option must offer a read-first escape with subtext clarifying nothing will change until the user continues; re-presents questions without that option after selection
+
 ## [0.36.3] — 2026-04-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.36.3**
+**Version: 0.36.4**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.36.3",
+  "version": "0.36.4",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/deep-knowledge/decision-format.md
+++ b/plugins/devops/deep-knowledge/decision-format.md
@@ -27,6 +27,15 @@ structured format with risk markers and a clear recommendation.
 - Risk levels are relative to the specific decision context
 - If all options have equal risk, say so explicitly
 - For AskUserQuestion: use the `description` field for risk/strength info
+- For AskUserQuestion after inline results: if the preceding output contains
+  substantial inline content (analysis, report, long text), the **first option
+  of the first question** must always be **"Erstmal in Ruhe durchlesen"** with
+  description: "Es wird nichts implementiert oder weiter geändert, bis du
+  weiter sagst." — the options overlay often covers the results, and the user
+  needs a one-click way to dismiss and read first. When the user selects this
+  option, re-present the same questions **without** the "Erstmal in Ruhe
+  durchlesen" option (they already read). This applies only to the first
+  question; follow-up questions don't need this option.
 
 ## When to use
 


### PR DESCRIPTION
## Summary\n- Adds \"Erstmal in Ruhe durchlesen\" rule to `decision-format.md`: when AskUserQuestion follows substantial inline results, first option must offer a read-first escape\n- Subtext clarifies nothing will be implemented until user continues\n- Re-presents questions without read-first option after user selects it\n\nCloses #45