### PR TITLE
feat(browser): centralized browser tool strategy (#46)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.36.2"
+    "version": "0.36.4"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.36.2",
+      "version": "0.36.4",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,18 @@
 # Changelog
 
-## [0.36.4] — 2026-04-10
+## [0.36.4] — 2026-04-11
 
 ### Added
 
+- **deep-knowledge** — centralized browser tool strategy: Edge Claude-in-Chrome extension as primary tool, silent waterfall fallback (Chrome MCP → Playwright → Preview), hard error block with fix instructions when no tool available, computer-use explicitly banned for browser interaction (read-only tier)
 - **deep-knowledge** — "Erstmal in Ruhe durchlesen" rule: when AskUserQuestion follows substantial inline results, the first option must offer a read-first escape with subtext clarifying nothing will change until the user continues; re-presents questions without that option after selection
-
-## [0.36.3] — 2026-04-10
-
-### Added
-
 - **agents** — execution mode selection: users choose between background (autonomous) and interactive (inline Q&A) agent work before orchestration begins
+
+### Changed
+
+- **autonomous** — browser priming (Step 3b) now references central strategy with `$BROWSER_TOOL` variable instead of inline waterfall
+- **concept** — monitoring and polling use central browser tool strategy instead of duplicated priority lists
+- **desktop-testing** — added warning to prefer browser tool strategy over computer-use for web UI
 
 ### Fixed
 

--- a/plugins/devops/deep-knowledge/INDEX.md
+++ b/plugins/devops/deep-knowledge/INDEX.md
@@ -8,6 +8,7 @@ Quick-reference for all deep-knowledge topics. Read this FIRST to find the right
 | [agent-collaboration.md](agent-collaboration.md) | Agent Collaboration Protocol | How agents work together on multi-role tasks. |
 | [agent-conventions.md](agent-conventions.md) | Agent Naming & Collaboration Conventions | [role:X · Type] Task description |
 | [agent-proactivity.md](agent-proactivity.md) | Proactive Agent Orchestration | Cross-cutting rule for when to involve specialized agents without explicit us... |
+| [browser-tool-strategy.md](browser-tool-strategy.md) | Browser Tool Strategy | Cross-cutting rules for browser interaction across all skills. Every skill that |
 | [claude-directory-structure.md](claude-directory-structure.md) | Claude Directory Structure Convention | All Claude Code configuration belongs inside `.claude/`. Nothing Claude-specific |
 | [code-defaults.md](code-defaults.md) | Code Defaults | Standard coding conventions enforced across all projects using the devops plu... |
 | [codex-integration.md](codex-integration.md) | Codex Integration | Cross-cutting reference for all points where `codex-plugin-cc` skills are |

--- a/plugins/devops/deep-knowledge/browser-tool-strategy.md
+++ b/plugins/devops/deep-knowledge/browser-tool-strategy.md
@@ -1,0 +1,99 @@
+# Browser Tool Strategy
+
+Cross-cutting rules for browser interaction across all skills. Every skill that
+needs to read, navigate, click, or evaluate JavaScript in a browser MUST follow
+this strategy. Do NOT duplicate browser tool selection logic in individual skills.
+
+## Primary Tool: Claude-in-Chrome Extension in Edge
+
+The **Claude-in-Chrome MCP** (`mcp__Claude_in_Chrome__*`) is the primary and
+preferred browser tool. It runs as a browser extension in **Microsoft Edge**
+(Chromium-based, fully compatible). It provides full DOM-based read+write access:
+navigation, clicking, typing, JavaScript evaluation, form filling, tab management.
+
+**Key properties:**
+- No desktop takeover — runs in the browser process, not via mouse/keyboard
+- Works in both foreground and background/autonomous mode
+- User can continue working while Claude interacts with browser tabs
+- Full read+write: navigate, click, type, evaluate JS, read DOM, fill forms
+
+## Waterfall: Silent Fallback
+
+If the primary tool is not connected, fall through silently. No warnings, no
+"extension not connected" messages. Use the **first tool that responds**:
+
+| Priority | Tool | Probe call | Variable value |
+|----------|------|-----------|----------------|
+| 1 | Claude-in-Chrome | `tabs_context_mcp` | `chrome-mcp` |
+| 2 | Playwright | `browser_snapshot` | `playwright` |
+| 3 | Preview | `preview_screenshot` | `preview` |
+
+Set `$BROWSER_TOOL` to the value from the first successful probe. Skills
+reference `$BROWSER_TOOL` to pick the right calls.
+
+If **none** respond → this is a hard error. Do not fall back to computer-use
+for browser tasks. Display:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+⚠️  BROWSER TOOL NICHT VERFÜGBAR
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Kein Browser-Tool konnte verbunden werden.
+
+Geprüft:
+  ✗ Claude-in-Chrome Extension (Edge) — nicht erreichbar
+  ✗ Playwright MCP — nicht erreichbar
+  ✗ Preview MCP — nicht erreichbar
+
+Fix:
+  1. Edge öffnen → Extension-Icon klicken → prüfen ob "Connected"
+  2. Falls nicht: edge://extensions → Claude Extension → "Neu laden"
+  3. Falls immer noch nicht: Edge komplett neu starten
+  4. Claude Code Session ggf. neu starten (WebSocket-Reconnect)
+
+Browser-Aufgaben können ohne aktives Tool nicht ausgeführt werden.
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+Then abort the browser-dependent part of the task. Do NOT attempt to use
+`computer-use` for browser interaction — browsers are locked to **read-only tier**
+in computer-use (screenshots only, no clicks or typing).
+
+## Silent Edge Restart (optional recovery)
+
+Before showing the error, attempt ONE silent recovery if Edge is not responding:
+
+```bash
+# Only if no Edge process is running at all
+tasklist | grep -qi msedge || start msedge --restore-last-session
+```
+
+Wait 5 seconds, then retry `tabs_context_mcp`. If still no response → show the
+error block above.
+
+## Computer-Use: Native Apps Only
+
+`computer-use` is **exclusively** for native desktop applications (file explorer,
+system settings, desktop apps). Never use it for:
+- Browser navigation or clicking
+- Web page interaction
+- Form filling in web apps
+- Reading web page content
+
+Browsers have read-only tier in computer-use — visible in screenshots but all
+interaction (clicks, typing) is blocked by the MCP server.
+
+## Tool Mapping Reference
+
+For skills that need to call browser tools, use `$BROWSER_TOOL` to select:
+
+| Action | chrome-mcp | playwright | preview |
+|--------|-----------|------------|---------|
+| Open URL | `tabs_create_mcp` + `navigate` | `browser_navigate` | `preview_start` |
+| Screenshot | `computer` (screenshot) | `browser_take_screenshot` | `preview_screenshot` |
+| Click | `computer` (click) | `browser_click` | `preview_click` |
+| Type text | `form_input` | `browser_fill_form` / `browser_type` | `preview_fill` |
+| Eval JS | `javascript_tool` | `browser_evaluate` | `preview_eval` |
+| Read page | `get_page_text` | `browser_snapshot` | `preview_snapshot` |
+| Read DOM | `read_page` | `browser_snapshot` | `preview_snapshot` |

--- a/plugins/devops/deep-knowledge/desktop-testing.md
+++ b/plugins/devops/deep-knowledge/desktop-testing.md
@@ -3,6 +3,10 @@
 Rules for when and how Claude takes over the desktop to run visual UI tests
 automatically using the Computer Use MCP tools.
 
+**Important:** For browser-based UI testing, prefer the Browser Tool Strategy
+(`browser-tool-strategy.md`) over computer-use. Computer-use has read-only tier
+for browsers (no clicks/typing). Only use computer-use for native desktop apps.
+
 ## When to Offer
 
 All three conditions must be true:

--- a/plugins/devops/skills/devops-autonomous/SKILL.md
+++ b/plugins/devops/skills/devops-autonomous/SKILL.md
@@ -72,11 +72,12 @@ Browser-based testing (Playwright, Preview) runs regardless of this choice — i
 operates in its own window and doesn't occupy the desktop. This question only
 controls whether computer-use (mouse/keyboard takeover) is used for **native apps**.
 
-**Edge/Chrome browser exception:** Even in "Hintergrund" mode, Claude is allowed to
-open, navigate, read, and interact with browser tabs via the **Claude-in-Chrome MCP**
-(`mcp__Claude_in_Chrome__*`). This is DOM-based — no mouse/keyboard takeover, no
-desktop occupation. The user can keep working while Claude autonomously tests, reads,
-and interacts with web pages in a browser tab. Prime these tools in Step 3b.
+**Browser interaction in background mode:** Even in "Hintergrund" mode, Claude has
+full read+write browser access via `$BROWSER_TOOL` (set in Step 3b). The waterfall
+(Chrome MCP → Playwright → Preview) ensures a working tool is always selected.
+All three are DOM/protocol-based — no mouse/keyboard takeover, no desktop occupation.
+**Never fall back to computer-use for browser tasks** — it only has read-tier access
+to browsers (screenshots only, no clicks or typing).
 
 In `analyze` mode, desktop is only used for visual inspection (screenshots), never for interaction.
 
@@ -102,12 +103,11 @@ Call `mcp__computer-use__request_access` with the list of applications needed
 Then take a test `mcp__computer-use__screenshot` to confirm access works.
 
 ### 3b — Browser Tools
-**Claude-in-Chrome** (`mcp__Claude_in_Chrome__*`): Always prime — runs in both
-desktop and background mode. Trigger a lightweight call (e.g., `tabs_context_mcp`)
-to confirm the extension is connected. This is the primary browser interface in
-background mode (DOM-based, no desktop takeover).
-**Playwright / Preview**: If the task involves web UI, additionally trigger a
-lightweight call (e.g., `browser_snapshot` or `preview_screenshot`) to prime.
+
+Follow the **Browser Tool Strategy** (`deep-knowledge/browser-tool-strategy.md`):
+Run the waterfall probe (Chrome MCP → Playwright → Preview), set `$BROWSER_TOOL`
+to the first responder. If none respond → show the error block from the strategy
+doc and abort browser-dependent work. Never use computer-use for browser tasks.
 
 ### 3c — File & Shell Tools
 Run a harmless `Bash` command (e.g., `echo "permission primed"`), `Read` a file,
@@ -121,8 +121,8 @@ trigger a lightweight read-only call to each to prime the permission.
 ### 3e — Confirmation Checklist
 Display a checklist of all primed permissions:
 ```
-✅ Computer-Use: {app1, app2} genehmigt
-✅ Browser: Playwright/Preview bereit
+✅ Browser: {$BROWSER_TOOL} aktiv (Chrome MCP / Playwright / Preview)
+✅ Computer-Use: {app1, app2} genehmigt  (nur wenn Desktop-Modus)
 ✅ Dateisystem: Lesen/Schreiben genehmigt
 ✅ Shell: Bash genehmigt
 ✅ MCP Tools: {list} genehmigt
@@ -178,8 +178,9 @@ tests, linters, installing dev deps.
 
 ### Live Testing (implement mode only)
 
-After implementation: run build, run tests, then use Preview/Playwright/computer-use
-to open the app, screenshot key flows, verify visually. Track progress via TodoWrite.
+After implementation: run build, run tests, then use `$BROWSER_TOOL` (from Step 3b)
+to open the app, screenshot key flows, verify visually. For native desktop apps
+(not browser), use computer-use if desktop mode was chosen. Track progress via TodoWrite.
 
 ## Step 6 — Error Handling
 

--- a/plugins/devops/skills/devops-concept/SKILL.md
+++ b/plugins/devops/skills/devops-concept/SKILL.md
@@ -148,13 +148,10 @@ After opening, inform the user:
 
 ## Step 4 — Monitor for Feedback
 
-Poll the browser page for the submit signal. Use the best available tool:
-
-**Priority order:**
-1. `mcp__Claude_in_Chrome__javascript_tool` — if browser MCP connected (works with Edge)
-2. `mcp__plugin_playwright_playwright__browser_evaluate` — if Playwright available
-3. `mcp__Claude_Preview__preview_eval` — if Preview available
-4. **Fallback**: Ask user to confirm manually via `AskUserQuestion`
+Poll the browser page for the submit signal. Use `$BROWSER_TOOL` as determined
+by the **Browser Tool Strategy** (`deep-knowledge/browser-tool-strategy.md`).
+Use the tool mapping table to pick the right eval call.
+If no browser tool is available → ask user to confirm manually via `AskUserQuestion`.
 
 **Polling logic:**
 - Check: `document.body.classList.contains('concept-submitted')`

--- a/plugins/devops/skills/devops-concept/deep-knowledge/monitoring.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/monitoring.md
@@ -34,55 +34,29 @@ Decision data lives in a hidden JSON block:
 JSON.parse(document.getElementById('concept-decisions').textContent)
 ```
 
-## Tool Priority
+## Tool Selection
 
-Use the first available tool in this order:
+Follow the **Browser Tool Strategy** (`deep-knowledge/browser-tool-strategy.md`)
+for tool selection. Use the waterfall to set `$BROWSER_TOOL`, then use the tool
+mapping table to pick the correct call for each action.
 
-### 1. Claude in Chrome/Edge (`mcp__Claude_in_Chrome__*`)
+### Concept-Specific Calls
 
-Best option — direct access to page DOM. Works with Edge (Chromium-based).
+Using `$BROWSER_TOOL`, execute:
 
 **Check submission:**
-```
-javascript_tool: "document.body.classList.contains('concept-submitted')"
-```
+- chrome-mcp: `javascript_tool("document.body.classList.contains('concept-submitted')")`
+- playwright: `browser_evaluate("document.body.classList.contains('concept-submitted')")`
+- preview: `preview_eval("document.body.classList.contains('concept-submitted')")`
 
 **Read decisions:**
-```
-javascript_tool: "document.getElementById('concept-decisions').textContent"
-```
+- chrome-mcp: `javascript_tool("document.getElementById('concept-decisions').textContent")`
+- playwright: `browser_evaluate("document.getElementById('concept-decisions').textContent")`
+- preview: `preview_eval("document.getElementById('concept-decisions').textContent")`
 
-### 2. Playwright (`mcp__plugin_playwright_playwright__*`)
+### Manual Fallback (no browser tool available)
 
-Second best — headless or attached browser.
-
-**Navigate to file:**
-```
-browser_navigate: "file:///{filepath}"
-```
-
-**Check submission:**
-```
-browser_evaluate: "document.body.classList.contains('concept-submitted')"
-```
-
-**Read decisions:**
-```
-browser_evaluate: "document.getElementById('concept-decisions').textContent"
-```
-
-### 3. Claude Preview (`mcp__Claude_Preview__*`)
-
-Works for preview-based workflows.
-
-**Check submission:**
-```
-preview_eval: "document.body.classList.contains('concept-submitted')"
-```
-
-### 4. Manual Fallback
-
-If no browser tool is available:
+If the browser tool strategy waterfall fails entirely:
 
 ```
 AskUserQuestion:


### PR DESCRIPTION
## Summary

- Add `deep-knowledge/browser-tool-strategy.md` as single source of truth for browser tool selection
- Edge Claude-in-Chrome extension is primary, silent waterfall to Playwright/Preview
- Hard error block with fix instructions when no browser tool available
- Computer-use explicitly banned for browser interaction (read-only tier)
- Consolidated changelog entries from version drift (0.36.3/0.36.4 → unified 0.36.4)

## Intermediate PRs
- #45 — feat(agents): background/interactive execution mode
- #44 — fix(hooks): direct MCP call for render_completion_card
- #43 — feat(hooks): worktree branch guard for main protection