### PR TITLE
fix(hooks): eliminate self-calibration over-execution (#48)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.36.5] — 2026-04-11
+
+### Fixed
+
+- **hooks** — eliminate self-calibration over-execution: disable SessionStart hook (no-op), add 60s debounce to useractivity flag, add 8-minute cooldown guard in cron prompt, unify runOnce key — reduces idle-session calibration from up to 6x/hour to maximum 1x
+
 ## [0.36.4] — 2026-04-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.36.4**
+**Version: 0.36.5**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.36.4",
+  "version": "0.36.5",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/hooks/session-start/ss.flow.selfcalibration.js
+++ b/plugins/devops/hooks/session-start/ss.flow.selfcalibration.js
@@ -1,114 +1,18 @@
 #!/usr/bin/env node
 /**
  * @hook ss.flow.selfcalibration
- * @version 0.6.0
+ * @version 0.7.0
  * @event SessionStart
  * @plugin devops
- * @deprecated Moved to UserPromptSubmit (prompt.flow.selfcalibration.js).
- *   Kept as fallback for older runtimes that don't support UserPromptSubmit.
- *   The UserPromptSubmit variant fires right before Claude processes the first
- *   user message, giving the instructions higher priority.
+ * @deprecated DISABLED. Registration moved to UserPromptSubmit
+ *   (prompt.flow.selfcalibration.js). This hook is kept as a no-op placeholder
+ *   so older plugin registries don't error on missing file. It produces no
+ *   output and exits immediately.
+ *
+ *   Previously this was a "fallback for older runtimes" but it caused
+ *   double-registration: both SS and UPS hooks used different runOnce keys,
+ *   so both would fire and register duplicate crons.
  */
 
-require('../lib/plugin-guard');
-
-const fs   = require('fs');
-const path = require('path');
-const { runOnce } = require('../lib/run-once');
-const { sessionFile } = require('../lib/session-id');
-
-const PLUGIN_DIR  = path.resolve(__dirname, '..', '..');
-const TASKS_DIR   = path.join(PLUGIN_DIR, 'scheduled-tasks');
-
-// Stable base path for version-agnostic discovery.
-// The cache may be rebuilt mid-session by ss.plugin.update, which deletes the
-// old versioned dir. Baking __dirname into the cron prompt would point to a
-// deleted path. Instead, we emit a glob pattern so Claude can resolve the
-// latest cache at cron fire time.
-const home = process.env.HOME || process.env.USERPROFILE || '';
-const PLUGIN_GLOB_BASE = path.join(home, '.claude', 'plugins', 'cache').replace(/\\/g, '/');
-
-const FLAG_PREFIX = 'dotclaude-devops-user-active';
-
-const TASK_DEFINITIONS = [
-  {
-    id: 'self-calibration',
-    cron: '*/10 * * * *',
-    recurring: true,
-    description: 'Periodic self-audit and skill internalization',
-  },
-];
-
-let inputData = '';
-process.stdin.setEncoding('utf8');
-process.stdin.on('data', d => { inputData += d; });
-process.stdin.on('end', () => {
-  let sessionId;
-  try {
-    const input = JSON.parse(inputData);
-    sessionId = input.session_id;
-  } catch {}
-
-  // Once-per-session guard
-  if (!runOnce('ss-flow-selfcalibration', sessionId)) process.exit(0);
-
-  // Build compact, high-priority registration instruction.
-  // Paths must survive mid-session cache rebuilds (ss.plugin.update deletes
-  // the old versioned dir). When running from cache, emit a glob with a
-  // wildcard version. When running from repo (dev), use the direct path.
-  const normalizedPluginDir = PLUGIN_DIR.replace(/\\/g, '/');
-  const normalizedCacheBase = PLUGIN_GLOB_BASE;
-  const inCache = normalizedPluginDir.startsWith(normalizedCacheBase + '/');
-
-  const tasks = [];
-  for (const task of TASK_DEFINITIONS) {
-    const skillPath = path.join(TASKS_DIR, task.id, 'SKILL.md');
-    try {
-      fs.readFileSync(skillPath, 'utf8');
-    } catch {
-      continue;
-    }
-
-    // Resolved path for immediate execution (known to exist right now).
-    const resolvedSkillPath = skillPath.replace(/\\/g, '/');
-
-    // For cron: version may change mid-session, so emit the parent dir
-    // and let Claude list + pick the version (more reliable than glob on Windows).
-    let cronDiscoveryDir;
-    if (inCache) {
-      const rel = normalizedPluginDir.slice(normalizedCacheBase.length + 1);
-      const parts = rel.split('/'); // ["dotclaude", "devops", "0.35.2"]
-      cronDiscoveryDir = `${normalizedCacheBase}/${parts[0]}/${parts[1]}`;
-    } else {
-      cronDiscoveryDir = null; // dev path is stable
-    }
-    tasks.push({ ...task, resolvedSkillPath, cronDiscoveryDir });
-  }
-
-  if (tasks.length === 0) process.exit(0);
-
-  // Set the initial user-active flag so the first immediate execution runs.
-  const flagPath = sessionFile(FLAG_PREFIX, sessionId).replace(/\\/g, '/');
-  try {
-    fs.writeFileSync(sessionFile(FLAG_PREFIX, sessionId), String(Date.now()), 'utf8');
-  } catch {}
-
-  const lines = [
-    'BLOCKING — execute BEFORE responding to the user message:',
-    '',
-  ];
-
-  for (const t of tasks) {
-    const idleGuard = `IDLE GUARD: First, run Bash to check if the file "${flagPath}" exists (test -f "${flagPath}"). If it does NOT exist, output nothing and stop — do NOT proceed with the task. If it DOES exist, delete it (rm "${flagPath}") and continue.`;
-
-    const cronPrompt = t.cronDiscoveryDir
-      ? `${idleGuard} Execute the ${t.id} scheduled task as defined in the plugin. List the directory ${t.cronDiscoveryDir} to find the current version, then Read {version}/scheduled-tasks/${t.id}/SKILL.md — use the match to derive the plugin root (parent of scheduled-tasks/).`
-      : `${idleGuard} Execute the ${t.id} scheduled task as defined in the plugin. Read ${t.resolvedSkillPath} — use the file's parent of scheduled-tasks/ as the plugin root.`;
-    lines.push(
-      `Register cron via CronCreate: cron="${t.cron}", recurring=${t.recurring}, prompt="${cronPrompt}"`,
-      `Then immediately execute it once: Read ${t.resolvedSkillPath} and run Step 0 (Completion Flow Internalization).`,
-    );
-  }
-
-  process.stdout.write(lines.join('\n') + '\n');
-});
+// No-op — all logic lives in prompt.flow.selfcalibration.js
+process.exit(0);

--- a/plugins/devops/hooks/user-prompt-submit/prompt.flow.selfcalibration.js
+++ b/plugins/devops/hooks/user-prompt-submit/prompt.flow.selfcalibration.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * @hook prompt.flow.selfcalibration
- * @version 0.6.0
+ * @version 0.7.0
  * @event UserPromptSubmit
  * @plugin devops
  * @description Register the self-calibration cron task once per session.
@@ -10,8 +10,17 @@
  *   priority than SessionStart system-reminders, which Claude may deprioritize
  *   in favor of the user's task.
  *
+ *   SINGLE REGISTRATION POINT (v0.7.0): This is now the ONLY hook that
+ *   registers the cron. The SessionStart variant (ss.flow.selfcalibration.js)
+ *   is disabled (no-op). This eliminates the double-registration bug where
+ *   both hooks used different runOnce keys and both fired.
+ *
+ *   SHARED GUARD KEY (v0.7.0): Uses a single runOnce key
+ *   'flow-selfcalibration' (no ss-/prompt- prefix) so even if the old
+ *   SessionStart hook is somehow re-enabled, it can't run alongside this one.
+ *
  *   If the task is not yet registered (CronList is empty for this task),
- *   also execute it immediately — no waiting for the first 30-minute tick.
+ *   also execute it immediately — no waiting for the first 10-minute tick.
  *   If the task already exists in CronList, skip everything (no duplicate
  *   registration, no immediate run).
  */
@@ -55,8 +64,10 @@ process.stdin.on('end', () => {
     sessionId = input.session_id;
   } catch {}
 
-  // Once-per-session guard — only inject on the very first user prompt
-  if (!runOnce('prompt-flow-selfcalibration', sessionId)) process.exit(0);
+  // Once-per-session guard — only inject on the very first user prompt.
+  // Uses a shared key (no ss-/prompt- prefix) so both SessionStart and
+  // UserPromptSubmit variants share the same guard — prevents double-fire.
+  if (!runOnce('flow-selfcalibration', sessionId)) process.exit(0);
 
   // Build compact, high-priority registration instruction.
   // Paths must survive mid-session cache rebuilds (ss.plugin.update deletes
@@ -105,10 +116,16 @@ process.stdin.on('end', () => {
     '',
   ];
 
+  // Cooldown marker: prevents multiple cron fires within the same 10-min window.
+  // The cron writes this after each successful run; next fire checks age.
+  const cooldownPath = sessionFile('dotclaude-devops-calibration-lastrun', sessionId).replace(/\\/g, '/');
+
   for (const t of tasks) {
     // Idle guard: check the session-scoped flag file before running the task.
     // If no user prompt arrived since the last cycle, skip entirely.
-    const idleGuard = `IDLE GUARD: First, run Bash to check if the file "${flagPath}" exists (test -f "${flagPath}"). If it does NOT exist, output nothing and stop — do NOT proceed with the task. If it DOES exist, delete it (rm "${flagPath}") and continue.`;
+    // Cooldown guard: even if the flag exists, skip if last run was <8 minutes ago
+    // (provides buffer below the 10-min cron interval to prevent overlapping runs).
+    const idleGuard = `IDLE GUARD: Run Bash with this script: FLAG="${flagPath}"; COOL="${cooldownPath}"; if [ ! -f "$FLAG" ]; then echo "SKIP"; exit 0; fi; if [ -f "$COOL" ]; then LAST=$(cat "$COOL"); NOW=$(date +%s); DIFF=$((NOW - LAST)); if [ "$DIFF" -lt 480 ]; then echo "COOLDOWN"; exit 0; fi; fi; rm -f "$FLAG"; echo "$NOW" > "$COOL"; echo "RUN". — If output is SKIP or COOLDOWN, output nothing and stop. If output is RUN, continue with the task.`;
 
     const cronPrompt = t.cronDiscoveryDir
       ? `${idleGuard} Execute the ${t.id} scheduled task as defined in the plugin. List the directory ${t.cronDiscoveryDir} to find the current version, then Read {version}/scheduled-tasks/${t.id}/SKILL.md — use the match to derive the plugin root (parent of scheduled-tasks/).`

--- a/plugins/devops/hooks/user-prompt-submit/prompt.flow.useractivity.js
+++ b/plugins/devops/hooks/user-prompt-submit/prompt.flow.useractivity.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * @hook prompt.flow.useractivity
- * @version 0.1.0
+ * @version 0.2.0
  * @event UserPromptSubmit
  * @plugin devops
  * @description Touch a session-scoped flag file on every user prompt.
@@ -9,6 +9,11 @@
  *   user prompt arrived since the last cycle, the cycle is skipped.
  *   This prevents idle sessions from burning tokens on repeated
  *   self-calibration runs with zero value.
+ *
+ *   DEDUPLICATION (v0.2.0): If the flag file already exists and was written
+ *   less than 60 seconds ago, skip the write. This prevents rapid-fire
+ *   re-touches when context compression or system-reminders re-trigger
+ *   UserPromptSubmit hooks without a real user prompt in between.
  *
  *   The flag path includes the session_id so parallel sessions
  *   (different worktrees, different windows) are fully isolated.
@@ -20,6 +25,7 @@ const fs   = require('fs');
 const { sessionFile } = require('../lib/session-id');
 
 const FLAG_PREFIX = 'dotclaude-devops-user-active';
+const DEBOUNCE_MS = 60_000; // 60 seconds
 
 let inputData = '';
 process.stdin.setEncoding('utf8');
@@ -31,11 +37,23 @@ process.stdin.on('end', () => {
     sessionId = input.session_id;
   } catch {}
 
-  // Touch the flag file — content doesn't matter, existence is the signal.
   const flagPath = sessionFile(FLAG_PREFIX, sessionId);
+
+  // Debounce: if flag was touched recently, don't re-touch.
+  // This prevents synthetic prompt events (context compression, system-reminder
+  // re-injection) from resetting the idle guard and causing extra cron runs.
+  try {
+    const stat = fs.statSync(flagPath);
+    if (Date.now() - stat.mtimeMs < DEBOUNCE_MS) {
+      process.exit(0); // Already fresh — skip
+    }
+  } catch {
+    // File doesn't exist — proceed to create it
+  }
+
   try {
     fs.writeFileSync(flagPath, String(Date.now()), 'utf8');
   } catch {
-    // Non-critical — worst case the next calibration cycle runs anyway.
+    // Non-critical — worst case the next calibration cycle is skipped.
   }
 });


### PR DESCRIPTION
## Summary
- Disable SessionStart self-calibration hook (no-op) to prevent double-registration with UserPromptSubmit
- Add 60s debounce to useractivity flag to block synthetic re-touches from context compression
- Add 8-minute cooldown guard in cron prompt to cap execution frequency
- Unify runOnce key to shared `flow-selfcalibration` preventing parallel guard bypass

Reduces idle-session self-calibration from up to 6x/hour to maximum 1x.

## Test plan
- [x] Lint passes
- [x] 61 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)