### PR TITLE
fix(ship): require cwd on all ship MCP tools (#48)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.36.6] — 2026-04-11
+
+### Fixed
+
+- **ship** — require `cwd` on all 5 ship MCP tools: the MCP server runs in the plugin directory, not the target repo; silent `process.cwd()` fallback caused `gh pr create` to operate on the wrong repository when invoked from worktrees or other projects; schema now enforces required `cwd`, handler throws hard error if missing, SKILL.md examples updated
+
 ## [0.36.5] — 2026-04-11
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.36.5**
+**Version: 0.36.6**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.36.5",
+  "version": "0.36.6",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/mcp-server/ship/tools/build.js
+++ b/plugins/devops/mcp-server/ship/tools/build.js
@@ -23,7 +23,7 @@ export const schema = z.object({
   lintCmd: z.string().nullable().default(null).describe("Lint command (null = auto-detect from package.json)"),
   testCmd: z.string().nullable().default(null).describe("Test command (null = auto-detect from package.json)"),
   buildIdOnly: z.boolean().default(false).describe("Skip build, only compute build-ID"),
-  cwd: z.string().optional().describe("Working directory override (e.g. worktree path). Falls back to process.cwd()."),
+  cwd: z.string().describe("Working directory of the target repo (required — must be passed by the caller)"),
 });
 
 /**
@@ -73,7 +73,8 @@ function getBuildId(cwd) {
 }
 
 export async function handler(params) {
-  const cwd = params.cwd || process.cwd();
+  const cwd = params.cwd;
+  if (!cwd) throw new Error("cwd is required — MCP server runs in the plugin directory, not the target repo");
   const { buildIdOnly } = params;
 
   if (buildIdOnly) {

--- a/plugins/devops/mcp-server/ship/tools/cleanup.js
+++ b/plugins/devops/mcp-server/ship/tools/cleanup.js
@@ -10,12 +10,12 @@ import { git, gitStrict, isWorktree, getWorktreeBranches } from "../lib/git.js";
 export const schema = z.object({
   branch: z.string().describe("Feature branch to delete"),
   base: z.string().default("main").describe("Base branch (should already be checked out)"),
-  cwd: z.string().nullable().default(null).describe("Working directory override (agent cwd) for worktree detection"),
+  cwd: z.string().describe("Working directory of the target repo (required — must be passed by the caller)"),
 });
 
 export async function handler(params) {
-  const { branch, base, cwd: agentCwd } = params;
-  const cwd = agentCwd || process.cwd();
+  const { branch, base, cwd } = params;
+  if (!cwd) throw new Error("cwd is required — MCP server runs in the plugin directory, not the target repo");
   const opts = { cwd };
   const intermediate = base !== "main";
   const cleaned = [];

--- a/plugins/devops/mcp-server/ship/tools/preflight.js
+++ b/plugins/devops/mcp-server/ship/tools/preflight.js
@@ -9,12 +9,13 @@ import { readVersion, verifyVersionFiles } from "../lib/version.js";
 
 export const schema = z.object({
   base: z.string().default("main").describe("Base branch to ship into (auto-detected from sub-branch naming if 'main')"),
-  cwd: z.string().optional().describe("Working directory override (e.g. worktree path). Falls back to process.cwd()."),
+  cwd: z.string().describe("Working directory of the target repo (required — must be passed by the caller)"),
 });
 
 export async function handler(params) {
   let { base } = params;
-  const cwd = params.cwd || process.cwd();
+  const cwd = params.cwd;
+  if (!cwd) throw new Error("cwd is required — MCP server runs in the plugin directory, not the target repo");
   const opts = { cwd };
   const checks = [];
   const errors = [];

--- a/plugins/devops/mcp-server/ship/tools/release.js
+++ b/plugins/devops/mcp-server/ship/tools/release.js
@@ -16,12 +16,13 @@ export const schema = z.object({
   releaseNotes: z.string().nullable().default(null).describe("GitHub release notes (CHANGELOG mirror) — ignored for intermediate merges"),
   prerelease: z.boolean().default(false).describe("Mark as pre-release (for 0.x versions)"),
   commitMessage: z.string().nullable().default(null).describe("If set, stage all and commit with this message before pushing"),
-  cwd: z.string().optional().describe("Working directory override (e.g. worktree path). Falls back to process.cwd()."),
+  cwd: z.string().describe("Working directory of the target repo (required — must be passed by the caller)"),
 });
 
 export async function handler(params) {
   const { base, title, body, tag, releaseNotes, prerelease, commitMessage } = params;
-  const cwd = params.cwd || process.cwd();
+  const cwd = params.cwd;
+  if (!cwd) throw new Error("cwd is required — MCP server runs in the plugin directory, not the target repo");
   const opts = { cwd };
   const branch = currentBranch(opts);
   const intermediate = base !== "main";

--- a/plugins/devops/mcp-server/ship/tools/version-bump.js
+++ b/plugins/devops/mcp-server/ship/tools/version-bump.js
@@ -8,12 +8,13 @@ import { readVersion, bumpVersion, updateVersionFiles, verifyVersionFiles } from
 
 export const schema = z.object({
   bump: z.enum(["patch", "minor", "major", "none"]).describe("Semantic version bump type"),
-  cwd: z.string().optional().describe("Working directory override (e.g. worktree path). Falls back to process.cwd()."),
+  cwd: z.string().describe("Working directory of the target repo (required — must be passed by the caller)"),
 });
 
 export async function handler(params) {
   const { bump } = params;
-  const cwd = params.cwd || process.cwd();
+  const cwd = params.cwd;
+  if (!cwd) throw new Error("cwd is required — MCP server runs in the plugin directory, not the target repo");
 
   // Read current version
   const { version: vOld, type: projectType, file: sourceFile } = readVersion(cwd);

--- a/plugins/devops/skills/devops-ship/SKILL.md
+++ b/plugins/devops/skills/devops-ship/SKILL.md
@@ -18,6 +18,11 @@ allowed-tools: Bash(git *), Bash(gh *), Bash(npm *), Bash(node *), Read, Glob, G
 Ship completed work via PR using the `dotclaude-ship` MCP server tools.
 Supports two modes: **direct** (branch → main) and **intermediate** (sub-branch → feature branch).
 
+> **CRITICAL — `cwd` is required on every MCP tool call.**
+> The ship MCP server runs in the plugin directory, NOT the target repo.
+> Every `ship_*` tool call MUST include `cwd` set to the current working directory of this Claude session.
+> Omitting `cwd` will cause the tool to operate on the wrong repository.
+
 ## Pre-Step — Session Activity Guard
 
 Before anything else, check whether this session still has work in progress.
@@ -51,15 +56,17 @@ Project extensions define: quality gate commands, deploy targets, version files,
 
 ## Step 1 — Pre-Flight Safety Gate
 
-Call `ship_preflight` MCP tool (dotclaude-ship server):
+Call `ship_preflight` MCP tool (dotclaude-ship server).
+**CRITICAL:** Always pass `cwd` — the MCP server runs in the plugin directory, not the target repo.
+Use the current working directory of the Claude session as `cwd`.
 ```
-ship_preflight({ base: "main" })
+ship_preflight({ base: "main", cwd: "<current working directory>" })
 ```
 
 The tool **auto-detects** the correct base branch:
 - If on a sub-branch like `feat/42-video-filters/core`, it detects `feat/42-video-filters` as the parent and uses it as base.
 - If no parent branch is found, it ships to `main` (default).
-- You can override by passing an explicit base: `ship_preflight({ base: "feat/42" })`.
+- You can override by passing an explicit base: `ship_preflight({ base: "feat/42", cwd: "<cwd>" })`.
 
 Check the result:
 - `autoDetectedBase` — non-null if a parent branch was detected (confirms intermediate merge).
@@ -70,9 +77,9 @@ The tool checks: clean tree, commits ahead, all pushed, version consistency (ski
 
 ## Step 2 — Build + Quality Gates
 
-Call `ship_build` MCP tool:
+Call `ship_build` MCP tool (always pass `cwd`):
 ```
-ship_build({ buildCmd: "npm run build", lintCmd: "npm run lint" })
+ship_build({ buildCmd: "npm run build", lintCmd: "npm run lint", cwd: "<cwd>" })
 ```
 
 Pass project-specific commands from extensions if available.
@@ -105,9 +112,9 @@ Determine bump type based on changes:
 **Before calling ship_version_bump**, update CHANGELOG.md with the new version entry.
 The MCP tool updates JSON files and README — CHANGELOG is editorial and must be done by Claude.
 
-Then call `ship_version_bump` MCP tool:
+Then call `ship_version_bump` MCP tool (always pass `cwd`):
 ```
-ship_version_bump({ bump: "minor" })
+ship_version_bump({ bump: "minor", cwd: "<cwd>" })
 ```
 
 Returns: `{ success, vOld, vNew, filesUpdated, verified, mismatches }`.
@@ -128,7 +135,8 @@ ship_release({
   commitMessage: "chore(release): v0.18.0",
   tag: "v0.18.0",
   releaseNotes: "...",
-  prerelease: false
+  prerelease: false,
+  cwd: "<cwd>"
 })
 ```
 
@@ -140,7 +148,8 @@ ship_release({
   body: "## Summary\n...",
   commitMessage: null,
   tag: null,
-  releaseNotes: null
+  releaseNotes: null,
+  cwd: "<cwd>"
 })
 ```
 
@@ -175,14 +184,14 @@ This preserves the audit trail through squash-merges. Without these references, 
 If `ExitWorktree` **fails** (e.g. directory locked by another process): **STOP**. Do not proceed to cleanup.
 Report the error to the user. The merge already landed on GitHub — cleanup can be retried later.
 
-Then call `ship_cleanup` MCP tool with the `base` from Step 1:
+Then call `ship_cleanup` MCP tool with the `base` from Step 1 (always pass `cwd`):
 ```
-ship_cleanup({ branch: "claude/feature-branch", base: "main" })
+ship_cleanup({ branch: "claude/feature-branch", base: "main", cwd: "<cwd>" })
 ```
 
 For intermediate merges:
 ```
-ship_cleanup({ branch: "feat/42-video-filters/core", base: "feat/42-video-filters" })
+ship_cleanup({ branch: "feat/42-video-filters/core", base: "feat/42-video-filters", cwd: "<cwd>" })
 ```
 
 The tool deletes the sub-branch but **preserves the feature branch** for further sub-branch merges or final ship to main.


### PR DESCRIPTION
## Summary
- Ship MCP server runs in plugin directory, not the target repo — all 5 tools silently fell back to `process.cwd()`, causing `gh pr create` to operate on the wrong repository from worktrees/other projects
- Schema: `cwd` changed from optional to required on preflight, build, version-bump, release, cleanup
- Handler: silent fallback replaced with hard error message
- SKILL.md: global cwd rule added, all examples updated with `cwd` parameter

## Test plan
- [ ] Run `/devops-ship` from a worktree — should pass cwd correctly
- [ ] Call any ship tool without cwd — should get clear error instead of silent wrong-repo behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)