### PR TITLE
fix(ship): resolve build-id script path dynamically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.36.7] — 2026-04-11
+
+### Fixed
+
+- **ship** — resolve build-id script path dynamically: after mid-session plugin cache rebuild, `__dirname` pointed to deleted old cache version causing `build-id.js` ENOENT; replaced static import-time resolution with lazy `pluginRoot()` fallback chain (env var → static path → cache parent scan)
+
 ## [0.36.6] — 2026-04-11
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.36.6**
+**Version: 0.36.7**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.36.6",
+  "version": "0.36.7",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/mcp-server/ship/tools/build.js
+++ b/plugins/devops/mcp-server/ship/tools/build.js
@@ -8,15 +8,55 @@
 
 import { z } from "zod";
 import { execSync } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { join, resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const PLUGIN_ROOT = resolve(__dirname, "..", "..", "..");
-const BUILD_ID_SCRIPT = join(PLUGIN_ROOT, "scripts", "build-id.js");
-const DK_INDEX_SCRIPT = join(PLUGIN_ROOT, "scripts", "gen-dk-index.js");
-const PROJECT_MAP_SCRIPT = join(PLUGIN_ROOT, "scripts", "gen-project-map.js");
+
+/**
+ * Resolve plugin root at call time — survives cache rebuilds while MCP server is running.
+ *
+ * The problem: __dirname is set at import time and points to the cache version that existed
+ * when the MCP server started. If the plugin updates mid-session, the old cache is deleted
+ * and __dirname points to a non-existent path. process.cwd() has the same issue.
+ *
+ * Solution: walk up from __dirname to the cache parent dir, then find the current version.
+ * Cache layout: .claude/plugins/cache/dotclaude/devops/{version}/
+ */
+function pluginRoot() {
+  // 1. Env var (authoritative if set)
+  if (process.env.CLAUDE_PLUGIN_ROOT && existsSync(process.env.CLAUDE_PLUGIN_ROOT)) {
+    return process.env.CLAUDE_PLUGIN_ROOT;
+  }
+  // 2. Static path still valid (no update happened)
+  const staticRoot = resolve(__dirname, "..", "..", "..");
+  if (existsSync(join(staticRoot, "scripts", "build-id.js"))) {
+    return staticRoot;
+  }
+  // 3. Cache was rebuilt — find current version in parent directory
+  //    staticRoot was e.g. .../cache/dotclaude/devops/0.36.4/
+  //    parent is          .../cache/dotclaude/devops/
+  const cacheParent = dirname(staticRoot);
+  try {
+    const versions = readdirSync(cacheParent).filter(
+      v => existsSync(join(cacheParent, v, "scripts", "build-id.js"))
+    );
+    if (versions.length > 0) {
+      // Pick the latest version (lexicographic sort works for semver with same digit count)
+      versions.sort();
+      return join(cacheParent, versions[versions.length - 1]);
+    }
+  } catch { /* cacheParent doesn't exist or isn't readable */ }
+  // 4. Give up — return stale path, caller will get existsSync guard
+  return staticRoot;
+}
+function scriptPath(name) { return join(pluginRoot(), "scripts", name); }
+
+// Lazy accessors — resolved at call time, not import time
+const BUILD_ID_SCRIPT = () => scriptPath("build-id.js");
+const DK_INDEX_SCRIPT = () => scriptPath("gen-dk-index.js");
+const PROJECT_MAP_SCRIPT = () => scriptPath("gen-project-map.js");
 
 export const schema = z.object({
   buildCmd: z.string().nullable().default(null).describe("Build command (null = auto-detect from package.json)"),
@@ -63,7 +103,7 @@ function run(cmd, cwd) {
 function getBuildId(cwd) {
   try {
     return execSync(
-      `"${process.execPath}" "${BUILD_ID_SCRIPT}"`,
+      `"${process.execPath}" "${BUILD_ID_SCRIPT()}"`,
       { cwd, encoding: "utf8", timeout: 10_000 }
     ).trim();
   } catch (err) {
@@ -91,14 +131,14 @@ export async function handler(params) {
 
   // Regenerate deep-knowledge INDEX.md (idempotent, skips if unchanged)
   // 1. Plugin's own deep-knowledge
-  run(`"${process.execPath}" "${DK_INDEX_SCRIPT}"`, cwd);
+  run(`"${process.execPath}" "${DK_INDEX_SCRIPT()}"`, cwd);
   // 2. Project's deep-knowledge (if it exists)
   const projectDk = join(cwd, "deep-knowledge");
   if (existsSync(projectDk)) {
     run(`"${process.execPath}" "${DK_INDEX_SCRIPT}" "${projectDk}"`, cwd);
   }
   // 3. Project map (full codebase index)
-  run(`"${process.execPath}" "${PROJECT_MAP_SCRIPT}" "${cwd}"`, cwd);
+  run(`"${process.execPath}" "${PROJECT_MAP_SCRIPT()}" "${cwd}"`, cwd);
 
   // Build (skip if no build script detected/provided)
   if (buildCmd) {


### PR DESCRIPTION
## Summary
- After mid-session plugin cache rebuild, `__dirname` points to deleted old cache version, causing `build-id.js` ENOENT (silently returns `no-build-id`)
- Replace static import-time path resolution with lazy `pluginRoot()` fallback chain: env var → static path (if still valid) → cache parent directory scan for current version
- Script path constants changed from static strings to lazy functions resolved at call time

## Test plan
- [ ] Ship after a plugin update in the same session — build-id should resolve correctly
- [ ] Ship without plugin update — no behavior change (static path still valid)

🤖 Generated with [Claude Code](https://claude.com/claude-code)