### PR TITLE
fix(concept): validation gate + monitoring improvements

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.38.0"
+    "version": "0.38.1"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.38.0",
+      "version": "0.38.1",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.38.2] — 2026-04-11
+
+### Added
+
+- **concept** — post-generation validation gate: 9-pattern grep checklist blocks opening pages without heartbeat, connection warning, panel states, or sessionStorage
+- **concept** — localhost HTTP serving for concept pages (Chrome MCP cannot handle file:// URLs)
+
+### Fixed
+
+- **concept** — heartbeat initial grace period: 2s → 30s (Claude needs time for browser tool waterfall before first heartbeat)
+- **concept** — document file:// URL limitation and MCP tab group isolation in monitoring.md
+- **marketplace** — sync marketplace.json version 0.38.0 → 0.38.1
+
 ## [0.38.1] — 2026-04-11
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.38.1**
+**Version: 0.38.2**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.38.1",
+  "version": "0.38.2",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/skills/devops-concept/SKILL.md
+++ b/plugins/devops/skills/devops-concept/SKILL.md
@@ -175,22 +175,49 @@ The patterns in `deep-knowledge/templates.md` (§ Claude Connection Heartbeat,
 
 ## Step 3 — Open in Browser
 
-Open the generated HTML file as a **new tab in the existing Edge browser**.
-If Edge is not running, launch it with the file.
+Open the generated HTML file **inside the user's existing Edge window** — never
+open a separate browser window.
+
+### Preferred: Serve via localhost + Chrome MCP (monitorable)
+
+The Chrome MCP `navigate` tool **always prepends `https://`** to URLs, which
+breaks `file://` paths. And `start "" msedge` opens tabs **outside the MCP tab
+group**, making them invisible to monitoring. The workaround:
+
+1. Start a local HTTP server in the concept directory:
+   ```bash
+   cd "{concept-dir}" && python -m http.server {random-port} &
+   ```
+   Use a random port (8700-8999) to avoid conflicts.
+
+2. Open via Chrome MCP (stays in the MCP tab group, monitorable):
+   ```
+   tabs_context_mcp(createIfEmpty: true)  → get/create tab group
+   navigate(url: "http://localhost:{port}/{filename}", tabId: $TAB_ID)
+   ```
+
+3. After monitoring ends, kill the HTTP server:
+   ```bash
+   kill %1  # or track the PID
+   ```
+
+### Fallback: Direct Edge launch (not monitorable)
+
+If Chrome MCP is unavailable, fall back to direct launch. This opens in the
+user's existing Edge instance but **cannot be monitored** — use AskUserQuestion
+flow instead.
 
 ```bash
-# Windows — opens as new tab in running Edge, or launches Edge
+# Windows — reuses running Edge, adds tab (not a new window)
 start "" msedge "{filepath}"
 ```
 
 On macOS: `open -a "Microsoft Edge" "{filepath}"`, on Linux: `microsoft-edge "{filepath}"`.
 
-**Important:** Always target Edge specifically — never use the system default
-browser or Chrome. The `start "" msedge` command reuses the running Edge instance
-and adds a tab (no new window). The empty `""` is required on Windows — without
-it, `cmd.exe` interprets the first quoted argument as a window title.
+The empty `""` is required on Windows — without it, `cmd.exe` interprets
+the first quoted argument as a window title.
 
-After opening, inform the user:
+### After opening, inform the user:
 
 > Concept geöffnet. Triff deine Entscheidungen auf der Seite und klick
 > "Entscheidungen abschicken" wenn du fertig bist — ich übernehme dann.

--- a/plugins/devops/skills/devops-concept/SKILL.md
+++ b/plugins/devops/skills/devops-concept/SKILL.md
@@ -142,6 +142,37 @@ Write to: `{project}/.claude/devops-concept/{timestamp}-{slug}.html`
 - Create the directory if it doesn't exist
 - Add `.claude/devops-concept/` to `.gitignore` if not already there
 
+### Post-Generation Validation (mandatory gate)
+
+After writing the HTML file, validate that all mandatory interactive patterns
+are present. **Grep the generated file** for each required pattern:
+
+| # | Pattern to grep | Purpose |
+|---|----------------|---------|
+| 1 | `concept-decisions` | Decision data JSON container |
+| 2 | `concept-submitted` | CSS class for monitoring detection signal |
+| 3 | `connection-warning` | Disconnection warning element |
+| 4 | `checkClaudeConnection` | Heartbeat checker function |
+| 5 | `HEARTBEAT_STALE_MS` | Heartbeat staleness threshold |
+| 6 | `claudeHeartbeat` | Heartbeat dataset target |
+| 7 | `panel-ready` | Ready-state panel element |
+| 8 | `panel-submitted` | Submitted-state panel element |
+| 9 | `sessionStorage` | Reload resilience (state persistence) |
+
+**If ANY pattern is missing → DO NOT open the page.** Fix the HTML first,
+then re-validate. This is a **blocking gate** — no exceptions, no "this
+page doesn't need it". Every concept page needs monitoring, every monitored
+page needs the heartbeat guard.
+
+**Common failures this gate catches:**
+- Heartbeat system omitted → submit button stays clickable without monitoring
+- Connection warning missing → user gets no feedback when Claude disconnects
+- Panel states missing → no visual transition on submit/reset cycle
+- sessionStorage missing → user selections lost on F5
+
+The patterns in `deep-knowledge/templates.md` (§ Claude Connection Heartbeat,
+§ Submit Handler, § State Persistence) provide the reference implementations.
+
 ## Step 3 — Open in Browser
 
 Open the generated HTML file as a **new tab in the existing Edge browser**.

--- a/plugins/devops/skills/devops-concept/deep-knowledge/monitoring.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/monitoring.md
@@ -40,6 +40,17 @@ Follow the **Browser Tool Strategy** (`deep-knowledge/browser-tool-strategy.md`)
 for tool selection. Use the waterfall to set `$BROWSER_TOOL`, then use the tool
 mapping table to pick the correct call for each action.
 
+## Known Limitation: `file://` URLs
+
+Browser tools (Chrome MCP, Playwright) **cannot open or interact with `file://`
+URLs**. Chrome MCP's `navigate` tool always prepends `https://`, and Playwright
+blocks the `file:` protocol entirely. Additionally, tabs opened via `start ""
+msedge` land **outside the MCP tab group** and are invisible to monitoring.
+
+**Required workaround:** Serve concept pages via a local HTTP server (see
+SKILL.md Step 3). This makes the page accessible at `http://localhost:<port>/`
+which all browser tools can handle.
+
 ## Pre-Monitoring Setup
 
 Before starting the monitoring loop, establish and validate the browser connection:
@@ -47,6 +58,9 @@ Before starting the monitoring loop, establish and validate the browser connecti
 1. Run the **Browser Tool Strategy waterfall** (`deep-knowledge/browser-tool-strategy.md`)
    to set `$BROWSER_TOOL`
 2. If `$BROWSER_TOOL` is `chrome-mcp`:
+   - The concept page must already be open via `navigate` in the MCP tab group
+     (opened in Step 3 via localhost HTTP server). Do NOT look for tabs opened
+     via `start "" msedge` — those are outside the MCP group.
    - Call `tabs_context_mcp` to get the current tab group
    - Identify the concept page tab (by URL or title) and store its ID as `$TAB_ID`
    - **Validate the type:** `$TAB_ID` must be a number — if it was captured as a

--- a/plugins/devops/skills/devops-concept/deep-knowledge/templates.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/templates.md
@@ -623,8 +623,10 @@ function checkClaudeConnection() {
 
 // Check every 5 seconds
 setInterval(checkClaudeConnection, 5000);
-// Initial check after 2 seconds (give Claude time for first heartbeat)
-setTimeout(checkClaudeConnection, 2000);
+// Initial grace period: 30 seconds — Claude needs time to run the browser
+// tool waterfall, find the tab, and inject the first heartbeat. A 2-second
+// grace period causes the button to be disabled before Claude can even start.
+setTimeout(checkClaudeConnection, 30000);
 ```
 
 **Claude-side heartbeat injection** (executed by Claude via eval on each poll):


### PR DESCRIPTION
## Summary
- Post-generation validation gate: 9-pattern grep checklist blocks concept pages missing heartbeat, connection warning, panel states, or sessionStorage
- Localhost HTTP serving for concept pages (Chrome MCP cannot handle file:// URLs)
- Heartbeat initial grace: 2s → 30s (Claude needs time for browser tool waterfall)
- Document file:// URL limitation and MCP tab group isolation
- Sync marketplace.json version 0.38.0 → 0.38.1

## Test plan
- [x] Lint passes
- [x] 61 tests pass (5 suites)
- [x] Validation gate verified: 8/9 patterns missing on old HTML, 9/9 on fixed HTML