### PR TITLE
fix(usage): script filename + path desync in refresh-usage

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.38.4"
+    "version": "0.38.5"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.38.4",
+      "version": "0.38.5",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.38.6] — 2026-04-11
+
+### Fixed
+
+- **refresh-usage** — SKILL.md referenced non-existent `devops-refresh-usage-headless.js` (actual: `refresh-usage-headless.js`), causing every manual refresh to fail silently with MODULE_NOT_FOUND
+- **refresh-usage** — SKILL.md write path was `scripts/usage-live.json` but scraper writes to `~/.claude/usage-live.json`, causing path desync and permanent "unavailable" state
+- **marketplace** — sync marketplace.json version to 0.38.5
+
 ## [0.38.5] — 2026-04-11
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.38.5**
+**Version: 0.38.6**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.38.5",
+  "version": "0.38.6",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/skills/devops-refresh-usage/SKILL.md
+++ b/plugins/devops/skills/devops-refresh-usage/SKILL.md
@@ -27,23 +27,23 @@ Do NOT call Read on files that may not exist — skip missing files silently (no
 **NEVER show `[no data]` without exhausting ALL fallbacks first.**
 Run this chain top-to-bottom. Stop at first success.
 
-The script path is `${CLAUDE_PLUGIN_ROOT}/scripts/devops-refresh-usage-headless.js` (use the plugin root, NOT a relative path).
+The script path is `${CLAUDE_PLUGIN_ROOT}/scripts/refresh-usage-headless.js` (use the plugin root, NOT a relative path).
 
 ### 1a. Try Edge CDP directly
 
 ```bash
-node "${CLAUDE_PLUGIN_ROOT}/scripts/devops-refresh-usage-headless.js" --quiet --check-only
+node "${CLAUDE_PLUGIN_ROOT}/scripts/refresh-usage-headless.js" --quiet --check-only
 ```
 - Exit 0 → CDP ready → scrape:
   ```bash
-  node "${CLAUDE_PLUGIN_ROOT}/scripts/devops-refresh-usage-headless.js" --quiet --summary
+  node "${CLAUDE_PLUGIN_ROOT}/scripts/refresh-usage-headless.js" --quiet --summary
   ```
   → Done. Read `~/.claude/usage-live.json`.
 
 ### 1b. Edge not running (exit 7) → auto-start
 
 ```bash
-node "${CLAUDE_PLUGIN_ROOT}/scripts/devops-refresh-usage-headless.js" --auto-start --quiet --summary
+node "${CLAUDE_PLUGIN_ROOT}/scripts/refresh-usage-headless.js" --auto-start --quiet --summary
 ```
 - Starts Edge with CDP in background, scrapes, done.
 - No user interaction needed.
@@ -51,12 +51,12 @@ node "${CLAUDE_PLUGIN_ROOT}/scripts/devops-refresh-usage-headless.js" --auto-sta
 ### 1c. Edge running without CDP (exit 5) → activate CDP
 
 ```bash
-node "${CLAUDE_PLUGIN_ROOT}/scripts/devops-refresh-usage-headless.js" --activate-cdp --quiet
+node "${CLAUDE_PLUGIN_ROOT}/scripts/refresh-usage-headless.js" --activate-cdp --quiet
 ```
 - Restarts Edge with CDP flag (restores tabs via `--restore-last-session`).
 - Then scrape:
   ```bash
-  node "${CLAUDE_PLUGIN_ROOT}/scripts/devops-refresh-usage-headless.js" --quiet --summary
+  node "${CLAUDE_PLUGIN_ROOT}/scripts/refresh-usage-headless.js" --quiet --summary
   ```
 - This is autonomous — do NOT ask the user for permission. Edge restart is fast and restores all tabs.
 
@@ -78,7 +78,7 @@ Only after ALL of 1a–1e fail: show `[no data]` with the specific reason (e.g.,
 
 ## Step 2 — Parse and store
 
-Write results to `scripts/usage-live.json`:
+Write results to `~/.claude/usage-live.json`:
 
 ```json
 {
@@ -111,4 +111,4 @@ ratio > 1.3  → 🪫 + "Hoher Verbrauch — neue Session oder Haiku empfohlen"
 - **Silent execution** — CDP operations are invisible. Edge restart is autonomous (restores tabs).
 - **Playwright fallback is acceptable** — if CDP fails, opening a browser tab to scrape is fine.
 - **Delta computation**: Read `usage-live.json` before and after refresh. Delta = new_pct - old_pct.
-- **Script path**: Always use `${CLAUDE_PLUGIN_ROOT}/scripts/devops-refresh-usage-headless.js`, never a relative path.
+- **Script path**: Always use `${CLAUDE_PLUGIN_ROOT}/scripts/refresh-usage-headless.js`, never a relative path.


### PR DESCRIPTION
## Summary
- Fix SKILL.md referencing non-existent `devops-refresh-usage-headless.js` (actual: `refresh-usage-headless.js`) — every manual refresh failed silently with MODULE_NOT_FOUND
- Fix write path mismatch (`scripts/usage-live.json` vs actual `~/.claude/usage-live.json`) causing permanent "unavailable" state
- Sync marketplace.json version from 0.38.4 to 0.38.5 (pre-existing mismatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)