### PR TITLE
feat(concept): HTTP bridge for heartbeat + decisions (#62)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.38.5"
+    "version": "0.38.6"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.38.5",
+      "version": "0.38.6",
       "author": {
         "name": "Jerry0022"
       },

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ memory/
 # Package locks (scripts use minimal deps)
 package-lock.json
 .claude/devops-concept/
+__pycache__/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.39.0] — 2026-04-11
+
+### Added
+
+- **concept** — HTTP bridge server (`concept-server.py`) for heartbeat and decision exchange, bypassing Chrome MCP JS injection limitation entirely
+- **concept** — page heartbeat now polls `GET /heartbeat` via fetch instead of requiring `document.body.dataset.claudeHeartbeat` injection
+- **concept** — submit handler POSTs decisions to `/decisions` endpoint, Claude reads via `GET /decisions`
+- **concept** — `POST /reset` endpoint for clearing decisions between rounds
+
+### Changed
+
+- **concept** — SKILL.md Step 3 uses bridge server instead of `python -m http.server`
+- **concept** — SKILL.md Step 4 uses HTTP polling + CronCreate heartbeat instead of JS eval monitoring
+- **concept** — monitoring.md rewritten for HTTP-based protocol (JS eval only needed for optional page updates)
+- **concept** — validation gate: `claudeHeartbeat` pattern replaced with `pollHeartbeat`
+
 ## [0.38.6] — 2026-04-11
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.38.6**
+**Version: 0.39.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.38.6",
+  "version": "0.39.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/scripts/concept-server.py
+++ b/plugins/devops/scripts/concept-server.py
@@ -1,0 +1,102 @@
+"""
+Concept Bridge Server — HTTP-based heartbeat and decision bridge.
+
+Replaces `python -m http.server` with a custom server that adds:
+- GET/POST /heartbeat — Claude signals presence via curl, page polls via fetch
+- GET/POST /decisions — Page submits decisions via POST, Claude reads via GET
+
+This bypasses Chrome MCP JS injection limitations entirely. The page
+communicates with Claude through HTTP endpoints instead of requiring
+JavaScript eval injection into the browser tab.
+
+Usage:
+    python concept-server.py <port> [directory]
+
+Example:
+    python concept-server.py 8742 /path/to/.claude/devops-concept
+"""
+
+import http.server
+import json
+import os
+import sys
+import time
+import threading
+
+_heartbeat_ts = 0
+_decisions = '{"submitted": false, "decisions": [], "comments": []}'
+_lock = threading.Lock()
+
+
+class ConceptBridgeHandler(http.server.SimpleHTTPRequestHandler):
+
+    def do_GET(self):
+        if self.path == '/heartbeat':
+            with _lock:
+                ts = _heartbeat_ts
+            self._json_response({"ts": ts})
+        elif self.path == '/decisions':
+            with _lock:
+                data = _decisions
+            self._send_raw_json(data)
+        else:
+            super().do_GET()
+
+    def do_POST(self):
+        global _heartbeat_ts, _decisions
+        if self.path == '/heartbeat':
+            with _lock:
+                _heartbeat_ts = int(time.time() * 1000)
+                ts = _heartbeat_ts
+            self._json_response({"ok": True, "ts": ts})
+        elif self.path == '/decisions':
+            length = int(self.headers.get('Content-Length', 0))
+            body = self.rfile.read(length).decode()
+            with _lock:
+                _decisions = body
+            self._json_response({"ok": True})
+        elif self.path == '/reset':
+            with _lock:
+                _decisions = '{"submitted": false, "decisions": [], "comments": []}'
+            self._json_response({"ok": True})
+        else:
+            self.send_error(404)
+
+    def do_OPTIONS(self):
+        self.send_response(204)
+        self._cors_headers()
+        self.end_headers()
+
+    def _json_response(self, data):
+        body = json.dumps(data).encode()
+        self.send_response(200)
+        self.send_header('Content-Type', 'application/json')
+        self._cors_headers()
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _send_raw_json(self, raw):
+        self.send_response(200)
+        self.send_header('Content-Type', 'application/json')
+        self._cors_headers()
+        self.end_headers()
+        self.wfile.write(raw.encode())
+
+    def _cors_headers(self):
+        self.send_header('Access-Control-Allow-Origin', '*')
+        self.send_header('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
+        self.send_header('Access-Control-Allow-Headers', 'Content-Type')
+        self.send_header('Cache-Control', 'no-cache, no-store')
+
+    def log_message(self, fmt, *args):
+        pass  # suppress per-request logging
+
+
+if __name__ == '__main__':
+    port = int(sys.argv[1]) if len(sys.argv) > 1 else 8700
+    directory = sys.argv[2] if len(sys.argv) > 2 else '.'
+    os.chdir(directory)
+    with http.server.HTTPServer(('', port), ConceptBridgeHandler) as httpd:
+        print(f"Concept bridge server on http://localhost:{port}/")
+        print(f"Serving: {os.getcwd()}")
+        httpd.serve_forever()

--- a/plugins/devops/skills/devops-concept/SKILL.md
+++ b/plugins/devops/skills/devops-concept/SKILL.md
@@ -13,7 +13,7 @@ description: >-
   Do NOT trigger for: simple code explanations, debugging
   (use /devops-flow), or static documentation (use /devops-readme).
 argument-hint: "[topic, analysis result, plan, or concept to visualize]"
-allowed-tools: Read, Write, Glob, Grep, Bash(start *), Bash(cmd *), AskUserQuestion, mcp__Claude_Preview__*, mcp__plugin_playwright_playwright__*, mcp__Claude_in_Chrome__*, mcp__plugin_devops_dotclaude-completion__*
+allowed-tools: Read, Write, Glob, Grep, Bash(start *), Bash(cmd *), Bash(python *), Bash(curl *), Bash(kill *), AskUserQuestion, CronCreate, CronDelete, mcp__Claude_Preview__*, mcp__plugin_playwright_playwright__*, mcp__Claude_in_Chrome__*, mcp__plugin_devops_dotclaude-completion__*
 ---
 
 # Concept
@@ -164,7 +164,7 @@ are present. **Grep the generated file** for each required pattern:
 | 3 | `connection-warning` | Disconnection warning element |
 | 4 | `checkClaudeConnection` | Heartbeat checker function |
 | 5 | `HEARTBEAT_STALE_MS` | Heartbeat staleness threshold |
-| 6 | `claudeHeartbeat` | Heartbeat dataset target |
+| 6 | `pollHeartbeat` | HTTP heartbeat polling function |
 | 7 | `panel-ready` | Ready-state panel element |
 | 8 | `panel-submitted` | Submitted-state panel element |
 | 9 | `sessionStorage` | Reload resilience (state persistence) |
@@ -188,28 +188,46 @@ The patterns in `deep-knowledge/templates.md` (§ Claude Connection Heartbeat,
 Open the generated HTML file **inside the user's existing Edge window** — never
 open a separate browser window.
 
-### Preferred: Serve via localhost + Chrome MCP (monitorable)
+### Preferred: Concept Bridge Server (HTTP-based monitoring)
 
-The Chrome MCP `navigate` tool **always prepends `https://`** to URLs, which
-breaks `file://` paths. And `start "" msedge` opens tabs **outside the MCP tab
-group**, making them invisible to monitoring. The workaround:
+The **concept bridge server** (`scripts/concept-server.py`) replaces the plain
+`python -m http.server`. It serves static files AND provides HTTP endpoints for
+heartbeat and decision exchange — no Chrome MCP JS injection needed.
 
-1. Start a local HTTP server in the concept directory:
+1. Find the bridge server script:
    ```bash
-   cd "{concept-dir}" && python -m http.server {random-port} &
+   PLUGIN_ROOT=$(ls -d ~/.claude/plugins/cache/dotclaude/devops/*/scripts/concept-server.py 2>/dev/null | head -1)
    ```
-   Use a random port (8700-8999) to avoid conflicts.
 
-2. Open via Chrome MCP (stays in the MCP tab group, monitorable):
+2. Start the bridge server in the concept directory:
+   ```bash
+   python "$PLUGIN_ROOT" {random-port} "{concept-dir}" &
+   ```
+   Use a random port (8700-8999) to avoid conflicts. Store the port as `$PORT`.
+
+3. Set up the heartbeat cron (keeps the connection indicator green):
+   ```
+   CronCreate(cron: "* * * * *", prompt: "Run: curl -s -X POST http://localhost:{port}/heartbeat > /dev/null")
+   ```
+   This fires every ~60s. For tighter heartbeat, also send an initial POST
+   immediately and on each monitoring poll via Bash.
+
+4. Send the first heartbeat immediately:
+   ```bash
+   curl -s -X POST http://localhost:{port}/heartbeat
+   ```
+
+5. Open via Chrome MCP (stays in the MCP tab group, visible to the user):
    ```
    tabs_context_mcp(createIfEmpty: true)  → get/create tab group
    navigate(url: "http://localhost:{port}/{filename}", tabId: $TAB_ID)
    ```
 
-3. After monitoring ends, kill the HTTP server:
+6. After monitoring ends, clean up:
    ```bash
    kill %1  # or track the PID
    ```
+   Also delete the heartbeat cron via `CronDelete`.
 
 ### Fallback: Direct Edge launch (not monitorable)
 
@@ -232,37 +250,37 @@ the first quoted argument as a window title.
 > Concept geöffnet. Triff deine Entscheidungen auf der Seite und klick
 > "Entscheidungen abschicken" wenn du fertig bist — ich übernehme dann.
 
-## Step 4 — Establish Monitoring Connection
+## Step 4 — Monitor via HTTP Bridge
 
-After opening the page in Edge, immediately establish the monitoring connection:
+The bridge server handles all communication — no JS eval injection needed.
 
-1. Run the **Browser Tool Strategy waterfall** (`deep-knowledge/browser-tool-strategy.md`)
-   → set `$BROWSER_TOOL`
-2. If `chrome-mcp`: call `tabs_context_mcp`, identify the concept tab, store its ID as
-   `$TAB_ID` — **must be a number** (coerce with `Number()` if captured as string)
-3. If `playwright` or `preview`: tab management is implicit, no explicit `$TAB_ID` needed
-4. If the waterfall fails entirely: skip browser monitoring, fall back to manual
-   `AskUserQuestion` flow (see `deep-knowledge/monitoring.md` § Manual Fallback (no browser tool available))
+**Heartbeat** is handled by the cron job set up in Step 3. Additionally,
+send a heartbeat POST on each manual poll cycle:
 
-See `deep-knowledge/monitoring.md` for the full polling protocol.
+```bash
+curl -s -X POST http://localhost:$PORT/heartbeat
+```
 
-**Polling logic:**
-- Before each poll, validate `$TAB_ID` is still alive (chrome-mcp only) —
-  see `deep-knowledge/monitoring.md` § Per-Poll Validation (chrome-mcp only)
-- **First on each poll**: inject heartbeat via
-  `document.body.dataset.claudeHeartbeat = Date.now()` — this keeps the
-  submit button enabled and the connection warning hidden
-- Then check: `document.body.classList.contains('concept-submitted')` via the
-  eval-based tool for `$BROWSER_TOOL`
-- If true → read decisions from `#concept-decisions` JSON using the same eval tool
-- If false → wait and retry (max 5 minutes, check every 15 seconds)
-- If eval fails but tab alive → page reload detected, wait and retry
-  (see `deep-knowledge/monitoring.md` § Page Reload Detection)
-- If timeout → ask user if they need more time or want to skip
+**Polling for decisions** — check if the user has submitted:
 
-**NEVER use `get_page_text` or equivalent read-page tools to read decisions** —
-always use eval-based tools (`javascript_tool` / `browser_evaluate` / `preview_eval`).
-See `deep-knowledge/monitoring.md` § Tool Selection for the reason.
+```bash
+curl -s http://localhost:$PORT/decisions
+```
+
+Parse the JSON response. If `submitted` is `true` → process decisions (Step 5).
+If `false` → wait and retry.
+
+**Polling schedule:**
+- **Initial wait**: 10 seconds after opening
+- **Poll interval**: 15 seconds (via conversation-driven checks or cron)
+- **Timeout**: 5 minutes → ask user via AskUserQuestion
+- On each poll, also POST `/heartbeat` to keep the connection indicator green
+
+**Browser tool strategy** (optional enhancement, not required):
+- If Chrome MCP or Playwright is available, it can still be used for
+  tab-alive checks and page content updates (Step 5c)
+- But heartbeat and decision reading work entirely via HTTP — no JS eval needed
+- If the browser tool waterfall fails, monitoring still works via HTTP
 
 **Important:** While waiting, do NOT block the conversation. Inform the
 user that you're monitoring and they can continue chatting. If the user
@@ -347,5 +365,6 @@ Append to the response: "Soll ich das als Concept-Seite aufbereiten?"
 - Comment fields are optional — include only where comments add value
 - Design quality matters — this is a deliverable, not a debug dump
 - German UI labels (buttons, headers) unless project language says otherwise
-- The HTML must work offline — no fetch calls, no server dependency
+- The HTML must be self-contained — no CDN or external fetch calls.
+  Bridge server fetch calls (`/heartbeat`, `/decisions`) are the only exception
 - Keep file size reasonable (< 500KB) — inline only what's needed

--- a/plugins/devops/skills/devops-concept/deep-knowledge/monitoring.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/monitoring.md
@@ -6,15 +6,21 @@ How Claude monitors the concept page for user decisions, processes them
 ## Monitoring Architecture
 
 ```
-[Claude generates HTML] → [Opens in browser] → [User interacts]
-                                                       ↓
-[Claude polls page state] ←←←←←←←←←←←←←←←←← [User clicks Submit]
-         ↓
-[Parse decisions JSON] → [Process decisions] → [Update page in browser]
-         ↑                                              ↓
-         └←←←←←←←← [User reviews update] ←←←←←←←←←←←←┘
-                     [User can submit again]
+[Claude generates HTML] → [Bridge Server serves page] → [User interacts]
+                                                               ↓
+                         ┌─── HTTP ───┐                [User clicks Submit]
+                         │             │                       ↓
+Claude ──POST /heartbeat─→ Bridge     ←─POST /decisions── Page JS
+Claude ──GET /decisions──→ Server     ←─GET /heartbeat─── Page JS
+                         │             │
+                         └─────────────┘
+
+[Claude reads decisions via HTTP] → [Process] → [Update page via browser tool]
 ```
+
+The **concept bridge server** (`scripts/concept-server.py`) acts as the
+communication hub. Both Claude and the page talk to the server via HTTP —
+no Chrome MCP JS injection needed for heartbeat or decision exchange.
 
 This is an **iterative loop**, not a one-shot. After each submission,
 Claude processes the feedback, updates the page, and monitors again.
@@ -22,7 +28,22 @@ The loop continues until the user is done (closes page or says "fertig").
 
 ## Detection Signal
 
-The submit action adds a CSS class to `<body>`:
+### Primary: HTTP Bridge (preferred)
+
+Claude polls the bridge server for submitted decisions:
+
+```bash
+curl -s http://localhost:$PORT/decisions
+```
+
+Returns JSON with `"submitted": true` when the user has clicked Submit.
+The page POSTs decisions to `/decisions` on submit (see `templates.md`
+§ Submit Handler).
+
+### Fallback: JS eval (when bridge server unavailable)
+
+If the bridge server is not running (legacy concept pages, direct file open),
+fall back to the JS eval approach:
 
 ```javascript
 document.body.classList.contains('concept-submitted')  // → true when submitted
@@ -36,9 +57,12 @@ JSON.parse(document.getElementById('concept-decisions').textContent)
 
 ## Tool Selection
 
-Follow the **Browser Tool Strategy** (`deep-knowledge/browser-tool-strategy.md`)
-for tool selection. Use the waterfall to set `$BROWSER_TOOL`, then use the tool
-mapping table to pick the correct call for each action.
+**For heartbeat and decision reading:** Use HTTP (`curl` via Bash). No browser
+tool needed — this works regardless of Chrome MCP or Playwright availability.
+
+**For page updates (Step 5c):** Follow the **Browser Tool Strategy**
+(`deep-knowledge/browser-tool-strategy.md`) for JS eval. Page updates are
+optional enhancements — if no eval tool works, inform the user via chat instead.
 
 ## Known Limitation: `file://` URLs
 
@@ -53,101 +77,93 @@ which all browser tools can handle.
 
 ## Pre-Monitoring Setup
 
-Before starting the monitoring loop, establish and validate the browser connection:
+### 1. Verify bridge server is running
 
+The bridge server should already be started in SKILL.md Step 3. Verify:
+
+```bash
+curl -s http://localhost:$PORT/heartbeat
+```
+
+If this returns `{"ts": ...}` → bridge is running. If it fails → the server
+didn't start; debug before proceeding.
+
+### 2. Start heartbeat cron
+
+Set up a recurring heartbeat so the page knows Claude is monitoring:
+
+```
+CronCreate(cron: "* * * * *", prompt: "Run silently: curl -s -X POST http://localhost:{port}/heartbeat > /dev/null. Output nothing.")
+```
+
+Also send the first heartbeat immediately:
+
+```bash
+curl -s -X POST http://localhost:$PORT/heartbeat
+```
+
+Store the cron job ID as `$HEARTBEAT_CRON_ID` for cleanup.
+
+### 3. Optionally establish browser tool (for page updates only)
+
+Browser tools are **not required** for heartbeat or decision reading (those
+work via HTTP). They are only needed for live page updates in Step 5c.
+
+If you want live page updates:
 1. Run the **Browser Tool Strategy waterfall** (`deep-knowledge/browser-tool-strategy.md`)
-   to set `$BROWSER_TOOL`
-2. If `$BROWSER_TOOL` is `chrome-mcp`:
-   - The concept page must already be open via `navigate` in the MCP tab group
-     (opened in Step 3 via localhost HTTP server). Do NOT look for tabs opened
-     via `start "" msedge` — those are outside the MCP group.
-   - Call `tabs_context_mcp` to get the current tab group
-   - Identify the concept page tab (by URL or title) and store its ID as `$TAB_ID`
-   - **Validate the type:** `$TAB_ID` must be a number — if it was captured as a
-     string, coerce immediately: `$TAB_ID = Number($TAB_ID)`
-   - A string tabId causes MCP validation errors on every subsequent call
-3. If `$BROWSER_TOOL` is `playwright` or `preview`:
-   - Tab management is implicit — no explicit `$TAB_ID` needed
-4. If the waterfall fails entirely:
-   - Skip browser-based monitoring
-   - Fall back to the manual AskUserQuestion flow (see below)
-5. **Validate JS eval capability** (mandatory — immediately after step 1-3):
-   - Run a test heartbeat injection using `$BROWSER_TOOL`'s eval tool
-   - If it **succeeds** → `$EVAL_TOOL = $BROWSER_TOOL` (same tool for everything)
-   - If it **fails** → the tool has a **split capability** (tab management works,
-     JS eval doesn't). This is a known failure mode with Chrome MCP where
-     `tabs_context_mcp`, `navigate`, and `read_page` work but `javascript_tool`
-     returns "Cannot access chrome-extension:// URL" errors.
-   - On failure: fall through the eval waterfall independently:
+2. Store `$BROWSER_TOOL` and `$TAB_ID` if chrome-mcp
+3. If the waterfall fails → page updates won't be live, but monitoring still
+   works fully via HTTP
 
-     | Priority | Eval tool | Test call |
-     |----------|-----------|-----------|
-     | 1 | `$BROWSER_TOOL`'s eval | (already failed) |
-     | 2 | playwright `browser_evaluate` | Inject test heartbeat on the same localhost URL |
-     | 3 | preview `preview_eval` | Inject test heartbeat on the concept page |
+### HTTP Bridge Monitoring
 
-   - Set `$EVAL_TOOL` to the first eval tool that succeeds
-   - `$BROWSER_TOOL` stays unchanged — it still handles tab management, navigation,
-     and `read_page`. Only JS eval operations use `$EVAL_TOOL`.
-   - If NO eval tool works → fall back to the manual AskUserQuestion flow.
-     The submit button will be disabled (heartbeat never arrives) — this is
-     correct behavior, the page accurately reflects that monitoring is not active.
+**Heartbeat** (keeps the connection indicator green on the page):
+```bash
+curl -s -X POST http://localhost:$PORT/heartbeat
+```
+Sent by the cron job every ~60s, and additionally on each manual poll cycle.
 
-   **Why this matters:** The waterfall probe (`tabs_context_mcp`) only tests
-   connectivity, not JS eval capability. A tool can be partially functional —
-   tab management works but eval is broken. Without this validation step, the
-   monitoring loop silently fails: heartbeat never arrives, submit button stays
-   disabled, and the user sees a "Claude ist nicht verbunden" warning with no
-   explanation from Claude's side.
+**Check submission** (poll for user decisions):
+```bash
+curl -s http://localhost:$PORT/decisions
+```
+Returns JSON. Check the `submitted` field:
+- `true` → user has submitted, read the decisions from the same response
+- `false` → not yet submitted, wait and retry
 
-### Concept-Specific Calls
+**Read decisions** — they're in the same JSON response from `GET /decisions`:
+```json
+{"submitted": true, "decisions": [...], "comments": [...]}
+```
 
-Using `$EVAL_TOOL` (not `$BROWSER_TOOL` — see step 5 above), execute all JS
-eval operations. Tab management (alive checks, navigation) still uses `$BROWSER_TOOL`.
+No browser eval needed. No Chrome MCP JS injection needed. No split-capability
+issues. The bridge server handles everything.
 
-**Heartbeat injection (every poll, BEFORE checking submission):**
-- chrome-mcp: `javascript_tool("document.body.dataset.claudeHeartbeat = Date.now()")`
-- playwright: `browser_evaluate("document.body.dataset.claudeHeartbeat = Date.now()")`
-- preview: `preview_eval("document.body.dataset.claudeHeartbeat = Date.now()")`
+**Reset after processing** — tell the bridge server to clear decisions:
+```bash
+curl -s -X POST http://localhost:$PORT/reset
+```
 
-This tells the page that Claude is actively monitoring. The page's JS uses
-this to enable/disable the submit button and show a connection warning when
-the heartbeat goes stale (>45 seconds). See `templates.md` § Claude Connection
-Heartbeat. **Always inject the heartbeat first** — even before checking
-`concept-submitted`, because the heartbeat keeps the UI in a valid state.
+### Legacy Fallback: JS Eval (for page updates)
 
-**Check submission:**
-- chrome-mcp: `javascript_tool("document.body.classList.contains('concept-submitted')")`
-- playwright: `browser_evaluate("document.body.classList.contains('concept-submitted')")`
-- preview: `preview_eval("document.body.classList.contains('concept-submitted')")`
+For live page updates (Step 5c — updating content after processing decisions),
+browser eval tools are still useful:
 
-**Read decisions:**
-- chrome-mcp: `javascript_tool("document.getElementById('concept-decisions').textContent")`
-- playwright: `browser_evaluate("document.getElementById('concept-decisions').textContent")`
-- preview: `preview_eval("document.getElementById('concept-decisions').textContent")`
+- chrome-mcp: `javascript_tool("...")`
+- playwright: `browser_evaluate("...")`
+- preview: `preview_eval("...")`
 
-**Split-capability limitation:** When `$EVAL_TOOL` differs from `$BROWSER_TOOL`,
-the eval tool (Playwright/Preview) runs in its own browser instance — it cannot
-inject heartbeats into the user's Edge tab, and it cannot see user interactions
-there. The two browser contexts are completely separate.
-
-**Therefore, in split-capability mode, fall back to AskUserQuestion polling:**
-1. Inform the user that live monitoring is eingeschränkt
-2. Use AskUserQuestion to detect submission (see § Manual Fallback below)
-3. When user confirms → ask them to copy the decisions JSON from the
-   DevTools console: `document.getElementById('concept-decisions').textContent`
-4. The heartbeat guard will disable the submit button in Edge (expected —
-   Claude cannot inject heartbeats). Inform the user to use the DevTools
-   console to re-enable: `document.getElementById('submit-btn').disabled = false`
+If no eval tool works, inform the user via chat what was processed instead
+of updating the page live. The page can be manually refreshed.
 
 **WARNING:** NEVER use `get_page_text`, `browser_snapshot`, or `preview_snapshot`
 to read decisions. Concept pages contain large inline CSS/JS (self-contained HTML).
 These "read page" tools strip scripts and may fail with "page body too large".
-Always use the eval-based tools above for structured data extraction.
 
-### Manual Fallback (no browser tool available)
+### Manual Fallback (bridge server AND browser tools unavailable)
 
-If the browser tool strategy waterfall fails entirely:
+If both the bridge server and browser tools are unavailable (very rare — would
+require the HTTP server to crash):
 
 ```
 AskUserQuestion:
@@ -158,7 +174,7 @@ AskUserQuestion:
     - "Abbrechen"
 ```
 
-If user picks "Ja" but no browser tool can read the page, ask the user to
+If user picks "Ja" but no tool can read decisions, ask the user to
 copy-paste the JSON from the page's developer console:
 
 ```
@@ -183,54 +199,29 @@ Monitoring MUST NOT block the conversation:
 3. If the user says "fertig" / "done" / "abgeschickt" → immediately read decisions
 4. If the user asks for something unrelated → pause monitoring, handle request
 
-### Per-Poll Validation (chrome-mcp only)
+### Per-Poll Validation
 
-Before each poll attempt:
-1. Call `tabs_context_mcp`
-2. Verify `$TAB_ID` is still in the returned tab list
-3. If missing → tab was closed → stop monitoring, inform user:
-   > "Die Concept-Seite wurde geschlossen. Monitoring beendet."
-4. If `tabs_context_mcp` itself fails → extension disconnected → attempt reconnection
-   per the Mid-Session Reconnection Protocol in `deep-knowledge/browser-tool-strategy.md`
+On each poll cycle:
 
-This check ensures monitoring stops ONLY when the tab is actually closed,
-never because the extension had a transient hiccup.
+1. **Send heartbeat**: `curl -s -X POST http://localhost:$PORT/heartbeat`
+2. **Check decisions**: `curl -s http://localhost:$PORT/decisions`
+3. If curl fails → bridge server may have crashed → attempt restart
 
-### Page Reload Detection
+**Optional tab-alive check** (if Chrome MCP is available):
+- Call `tabs_context_mcp` and verify `$TAB_ID` is still in the list
+- If missing → tab closed → stop monitoring, inform user
+- If Chrome MCP is not available → skip this check (monitoring via HTTP continues)
 
-A page reload (F5 or user-triggered) keeps the tab alive but temporarily makes
-the page unreachable. This is **not** a tool failure — it's a transient state.
+### Page Reload Handling
 
-**Detection signal:** The eval call fails (error, timeout, or returns
-`undefined`/`null`) BUT `tabs_context_mcp` confirms `$TAB_ID` is still in the
-list. This means the tab exists but the page content is not ready.
+A page reload (F5) is **not a problem** with the HTTP bridge:
+- The bridge server keeps running independently of the page
+- Heartbeat cron keeps posting → page reconnects automatically after reload
+- `sessionStorage` preserves user selections (see `templates.md` § State Persistence)
+- The `concept-submitted` class resets (correct — user can re-submit)
+- Decisions in the bridge server persist across reloads
 
-**Recovery protocol:**
-
-1. Eval fails → call `tabs_context_mcp`
-2. `$TAB_ID` still in list → **page reload detected** (not tab closed, not
-   extension disconnected)
-3. Wait **3 seconds** (page needs time to load and execute inline JS)
-4. Retry eval — if it succeeds, resume normal polling
-5. If still failing → wait another **3 seconds**, retry once more
-6. If still failing after 3 retries (total ~9 seconds) → re-run the full
-   waterfall probe as a last resort, then retry
-7. **NEVER stop monitoring** due to a reload — the tab is alive, the page
-   will come back
-
-**Key distinction from other failures:**
-
-| Symptom | Diagnosis | Action |
-|---------|-----------|--------|
-| Eval fails + tab missing | Tab closed | Stop monitoring |
-| Eval fails + `tabs_context_mcp` fails | Extension disconnected | Reconnection protocol |
-| Eval fails + tab still alive | **Page reload** | Wait and retry (this section) |
-
-After a successful retry, the page is back to its initial state. This is
-expected behavior — `sessionStorage` persistence in the HTML ensures user
-selections survive the reload (see `deep-knowledge/templates.md` § State
-Persistence). The `concept-submitted` class will be `false` (correct — the
-user hasn't re-submitted), so normal polling continues.
+**No special recovery needed** — the HTTP bridge makes page reloads transparent.
 
 **Do NOT use sleep loops.** Instead, check the page state:
 - When the user sends a message that could indicate completion
@@ -308,28 +299,33 @@ Map decisions back to the original context:
 
 ### Live Page Update (after each round)
 
-After processing a submission, Claude MUST update the browser page:
+After processing a submission, Claude MUST reset the bridge server and
+update the browser page:
 
-1. **Reset submission state and decision panel:**
+1. **Reset bridge server state:**
+   ```bash
+   curl -s -X POST http://localhost:$PORT/reset
+   ```
+
+2. **Reset page UI** (via browser eval if available):
    ```javascript
-   // Via browser tool (javascript_tool / browser_evaluate / preview_eval)
    document.body.classList.remove('concept-submitted');
    document.getElementById('concept-decisions').textContent =
      JSON.stringify({submitted: false, round: N+1, decisions: [], comments: []});
-   // Switch panel back from "submitted" to "ready" state
    document.getElementById('panel-submitted').style.display = 'none';
    document.getElementById('panel-ready').style.display = 'block';
    document.getElementById('submit-btn').disabled = false;
    document.getElementById('submit-btn').textContent = 'Entscheidungen abschicken';
    ```
+   If no browser eval tool is available, inform the user to refresh the page.
 
-2. **Update content to reflect processed state:**
+3. **Update content to reflect processed state** (via browser eval if available):
    - Mark processed items visually (checkmark, "Verarbeitet" badge)
    - Show results of the processing (e.g., generated code, updated plan)
    - Add new decision points if the processing revealed further choices
    - Gray out discarded variants
 
-3. **Resume monitoring** — return to the polling loop for the next round
+4. **Resume monitoring** — return to the polling loop for the next round
 
 ### Persistence
 
@@ -353,25 +349,21 @@ Each round appends to the same file (array of rounds), preserving full history:
 
 | Error | Symptom | Recovery |
 |-------|---------|----------|
-| tabId type error | MCP validation: "expected number, received string" | Coerce `$TAB_ID = Number($TAB_ID)`, retry |
-| Extension disconnected | Tool call times out or returns connection error | Re-run waterfall probe, update `$BROWSER_TOOL` and `$TAB_ID` |
-| Tab closed by user | `tabs_context_mcp` succeeds but `$TAB_ID` not in list | Stop monitoring, inform user: "Die Concept-Seite wurde geschlossen. Monitoring beendet." |
-| **Page reload** | Eval fails but `$TAB_ID` still in tab list | **Wait 3s → retry up to 3 times** (see § Page Reload Detection). NEVER stop monitoring — the page will come back. |
-| **JS eval broken, tab alive** | `javascript_tool` returns "Cannot access chrome-extension://" but `tabs_context_mcp` and `read_page` work | **Split-capability** — Chrome MCP partially functional. Run eval waterfall (§ Pre-Monitoring Setup step 5) to find a working `$EVAL_TOOL`. If none works → AskUserQuestion fallback. |
-| JS eval returns null/undefined | Element not found on page | Retry once (page might still be loading), then show raw error |
-| JSON parse error | `JSON.parse()` throws | Show raw content to user, ask to verify |
+| Bridge server not responding | `curl /heartbeat` fails or times out | Check if server process is alive, restart if needed |
+| Bridge server crashed | Connection refused on all endpoints | Re-run `python concept-server.py $PORT "$DIR" &` |
+| Heartbeat cron stopped | Page shows "nicht verbunden" despite server running | Send manual `curl -s -X POST /heartbeat`, re-create cron |
+| Decisions JSON parse error | `curl /decisions` returns malformed JSON | Show raw content to user, ask to verify |
 | Empty decisions array | Parsed but `decisions.length === 0` | Ask if intentional (all defaults accepted) |
-| `get_page_text` used accidentally | "page body too large" or stripped content | Switch to `javascript_tool`/`browser_evaluate`/`preview_eval` — NEVER use `get_page_text` for concept pages |
-| All tools fail | Waterfall exhausted | Fall back to manual AskUserQuestion flow |
+| Tab closed by user | Chrome MCP `tabs_context_mcp` shows tab missing | Stop monitoring, inform user: "Die Concept-Seite wurde geschlossen." |
+| JS eval broken (page updates) | `javascript_tool` returns "Cannot access chrome-extension://" | Expected — page updates not possible, inform user via chat |
+| `get_page_text` used accidentally | "page body too large" or stripped content | Use HTTP bridge endpoints instead |
+| All tools fail | Bridge server + browser tools both unavailable | Fall back to manual AskUserQuestion flow |
 
 ### Retry Protocol
 
-1. **Single tool failure**: Check tab alive first (§ Page Reload Detection)
-   - Tab alive → page reload — wait 3s, retry up to 3 times
-   - Tab missing → tab closed — stop monitoring, inform user
-   - `tabs_context_mcp` fails → extension disconnected — go to step 2
-2. **Repeated failure after reload recovery (3x)**: Re-probe waterfall, switch `$BROWSER_TOOL`
-3. **Waterfall failure**: Manual fallback (AskUserQuestion + console.log)
+1. **Bridge server failure**: Restart the server, re-create heartbeat cron
+2. **Browser tool failure** (for page updates): Inform user, continue monitoring via HTTP
+3. **Both fail**: Manual fallback (AskUserQuestion + console.log)
 4. **NEVER silently stop monitoring** — always inform the user why monitoring ended
 
 ## Security

--- a/plugins/devops/skills/devops-concept/deep-knowledge/templates.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/templates.md
@@ -541,11 +541,22 @@ function collectDecisions() {
 
 ### Submit Handler
 ```javascript
-document.getElementById('submit-btn').addEventListener('click', () => {
+document.getElementById('submit-btn').addEventListener('click', async () => {
   const data = collectDecisions();
   const container = document.getElementById('concept-decisions');
   container.textContent = JSON.stringify(data);
   document.body.classList.add('concept-submitted');
+
+  // POST decisions to bridge server — Claude reads via GET /decisions
+  try {
+    await fetch('/decisions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data)
+    });
+  } catch (e) {
+    // Fallback: decisions are still in the DOM for JS eval reading
+  }
 
   // Switch panel to "submitted" state
   document.getElementById('panel-ready').style.display = 'none';
@@ -585,26 +596,38 @@ document.getElementById('theme-toggle').addEventListener('click', () => {
 });
 ```
 
-### Claude Connection Heartbeat
+### Claude Connection Heartbeat (HTTP Bridge)
 
-Claude sets a heartbeat timestamp on the page during each monitoring poll.
-The page checks whether the heartbeat is fresh and updates the UI accordingly.
+The heartbeat uses the **HTTP Bridge** — the concept bridge server
+(`scripts/concept-server.py`) exposes `/heartbeat` endpoints that both Claude
+and the page communicate through. This bypasses Chrome MCP JS injection
+entirely.
 
 **How it works:**
-- Claude runs `document.body.dataset.claudeHeartbeat = Date.now()` via eval
-  on every poll cycle (every 15 seconds)
-- The page's JS checks this value every 5 seconds
+- Claude sends `curl -s -X POST localhost:{port}/heartbeat` every 10 seconds
+  (via CronCreate or the monitoring loop)
+- The page polls `GET /heartbeat` every 5 seconds via `fetch()`
 - If the heartbeat is older than 45 seconds (3 missed polls) or missing →
   the submit button is disabled and a warning is shown
 - If the heartbeat is fresh → submit is enabled, warning hidden
 
 ```javascript
-// --- Claude Connection Heartbeat ---
+// --- Claude Connection Heartbeat (HTTP Bridge) ---
 const HEARTBEAT_STALE_MS = 45000; // 3 missed polls = disconnected
+let _lastHeartbeatTs = 0;
+
+async function pollHeartbeat() {
+  try {
+    const res = await fetch('/heartbeat', { cache: 'no-store' });
+    const data = await res.json();
+    _lastHeartbeatTs = data.ts || 0;
+  } catch (e) {
+    // Server unreachable — heartbeat stays stale
+  }
+}
 
 function checkClaudeConnection() {
-  const hb = document.body.dataset.claudeHeartbeat;
-  const isConnected = hb && (Date.now() - Number(hb)) < HEARTBEAT_STALE_MS;
+  const isConnected = _lastHeartbeatTs && (Date.now() - _lastHeartbeatTs) < HEARTBEAT_STALE_MS;
   const warning = document.getElementById('connection-warning');
   const btn = document.getElementById('submit-btn');
   const panelSubmitted = document.getElementById('panel-submitted');
@@ -621,18 +644,23 @@ function checkClaudeConnection() {
   }
 }
 
-// Check every 5 seconds
-setInterval(checkClaudeConnection, 5000);
-// Initial grace period: 30 seconds — Claude needs time to run the browser
-// tool waterfall, find the tab, and inject the first heartbeat. A 2-second
-// grace period causes the button to be disabled before Claude can even start.
-setTimeout(checkClaudeConnection, 30000);
+// Poll heartbeat every 5 seconds, check connection after each poll
+setInterval(async () => { await pollHeartbeat(); checkClaudeConnection(); }, 5000);
+// Initial grace period: 30 seconds — Claude needs time to start the bridge
+// server, set up the heartbeat cron, and send the first POST.
+setTimeout(async () => { await pollHeartbeat(); checkClaudeConnection(); }, 30000);
 ```
 
-**Claude-side heartbeat injection** (executed by Claude via eval on each poll):
-```javascript
-document.body.dataset.claudeHeartbeat = Date.now();
+**Claude-side heartbeat** (executed by Claude via Bash or CronCreate):
+```bash
+curl -s -X POST http://localhost:{port}/heartbeat
 ```
 
-This single line is injected by Claude's monitoring loop on every poll cycle.
-See `monitoring.md` § Heartbeat Injection for integration into the polling protocol.
+No browser JS injection needed. See `monitoring.md` § HTTP Bridge Monitoring
+for integration into the monitoring protocol.
+
+**Legacy fallback:** If the bridge server is not available (e.g., someone opens
+a concept HTML file directly), the heartbeat check gracefully degrades — the
+`fetch('/heartbeat')` call fails silently, the heartbeat stays stale, and the
+submit button remains disabled. The user can still use the page for read-only
+review.


### PR DESCRIPTION
## Summary
- Add concept bridge server (`concept-server.py`) with `/heartbeat`, `/decisions`, `/reset` endpoints
- Replace Chrome MCP JS injection heartbeat with HTTP-based polling via `fetch()`
- Submit handler now POSTs decisions to bridge server — Claude reads via `curl`
- Rewrite monitoring protocol for HTTP-first approach (JS eval only for optional page updates)

Fixes the "Claude ist nicht verbunden" error caused by Chrome MCP's inability to inject JavaScript into localhost pages.

## Test plan
- [x] Server starts and serves static files
- [x] Heartbeat flow: POST updates timestamp, GET returns it
- [x] Decisions flow: POST stores, GET retrieves, POST /reset clears
- [x] CORS headers present on all endpoints
- [x] Lint + 61 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)