### PR TITLE
docs(browser): add Edge Credo hard rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [0.39.3] — 2026-04-12
+
+### Added
+
+- **browser-tool-strategy** — Edge Credo: 5 hard rules for browser interaction (Edge only, Claude extension first, user profile context, tab reuse, identical rules in background mode)
+- **browser-tool-strategy** — computer-use for browser allowed only on explicit desktop takeover request
+
+### Changed
+
+- **devops-concept** — Step 3 references Edge Credo for browser opening
+- **devops-autonomous** — Step 3b and background mode section reference Edge Credo
+- **devops-burn** — Burn-Guidance includes Edge Credo section
+- **devops-repo-health** — Step 8 references Edge Credo for browser interaction
+- **desktop-testing** — replaced "Google Chrome" with Edge-only reference
+
 ## [0.39.2] — 2026-04-11
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.39.2**
+**Version: 0.39.3**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/deep-knowledge/browser-tool-strategy.md
+++ b/plugins/devops/deep-knowledge/browser-tool-strategy.md
@@ -4,6 +4,90 @@ Cross-cutting rules for browser interaction across all skills. Every skill that
 needs to read, navigate, click, or evaluate JavaScript in a browser MUST follow
 this strategy. Do NOT duplicate browser tool selection logic in individual skills.
 
+---
+
+## Edge Credo — Hard Rules
+
+These rules are **absolute and non-negotiable**. Every skill, agent, hook, and
+autonomous flow MUST comply. No exceptions, no silent fallback to other browsers.
+
+### 1. Edge Only — No Other Browser
+
+Microsoft Edge is the **exclusive** browser. Never launch, control, or interact
+with Chrome, Firefox, or any other browser. The Chrome MCP extension
+(`mcp__Claude_in_Chrome__*`) is installed **in Edge** — its name contains
+"Chrome" because it's a Chromium extension, but it runs in Edge.
+
+### 2. Claude Extension First — Computer-Use for Browser Only on Explicit Request
+
+**Default:** All browser interaction goes through the **Claude-in-Chrome
+extension** running in Edge (or the Playwright/Preview fallback chain).
+
+**Exception:** Computer-use (`mcp__computer-use__*`) MAY be used for browser
+interaction **only** when the user explicitly requests desktop takeover:
+- User chooses "Desktop übernehmen" in `/devops-autonomous` Step 2
+- User explicitly asks for computer-use / desktop control
+- User explicitly invokes a flow that requires mouse/keyboard on the browser
+
+In all other cases — especially background mode, concept monitoring, autonomous
+background testing, silent operations — **never** use computer-use for browser
+interaction. Use the Claude extension or the waterfall fallback chain instead.
+
+**If the Claude extension is not connected and desktop takeover was NOT
+requested:** follow the waterfall fallback (Playwright → Preview). Do NOT
+silently fall back to computer-use mouse clicks on the Edge window.
+
+### 3. User's Installed Edge — Always With User Context
+
+Always use the user's **installed Edge instance** with their active profile
+(login sessions, cookies, extensions, saved passwords). Never:
+- Create a sandboxed or anonymous browser window via MCP
+- Launch a headless Edge instance without user context
+- Open a separate Edge profile or InPrivate window
+- Use Playwright's own browser instance for user-facing pages
+
+The user's context (logged-in state on claude.ai, GitHub, etc.) is essential.
+MCP-created browser windows run without this context and break authentication.
+
+### 4. Tab Reuse — No New Windows
+
+When Edge is already running:
+- **Open a new tab** in the existing Edge window — never a new Edge window
+- Use `tabs_create_mcp` (Chrome MCP) or `start "" msedge "{url}"` (which
+  adds a tab to the running instance, not a new window)
+
+When Edge is NOT running:
+- Launch a new Edge instance: `start "" msedge "{url}"`
+- This is the ONLY case where a new Edge window is acceptable
+
+**Never use `--new-window` or `--app=` flags** — they create isolated windows
+outside the user's normal tab context.
+
+### 5. Background and Autonomous Mode — Same Rules
+
+These rules apply identically regardless of execution context:
+- **Foreground** (user is present, interactive)
+- **Background** (concept monitoring, autonomous testing, burn mode)
+- **Autonomous** (user is AFK, `/devops-autonomous`)
+- **Headless/silent** (refresh-usage CDP scraping, health checks)
+
+Background mode does NOT mean "use a different browser" or "use computer-use
+instead". The Claude extension works in background — it operates via DOM/protocol,
+not mouse/keyboard, so it doesn't interfere with the user's work.
+
+### Quick Reference — What to Use When
+
+| Scenario | Default tool | Desktop-Takeover tool | Without takeover: NEVER use |
+|----------|-------------|----------------------|----------------------------|
+| Open URL in browser | Chrome MCP `navigate` / `start "" msedge` | Computer-use | Computer-use |
+| Read page content | Chrome MCP `get_page_text` / `read_page` | Computer-use screenshot | Computer-use |
+| Click in browser | Chrome MCP `computer` (click) | Computer-use `left_click` | Computer-use |
+| Fill form in browser | Chrome MCP `form_input` | Computer-use `type` | Computer-use |
+| Run JS in browser | Chrome MCP `javascript_tool` | Chrome MCP (still preferred) | — |
+| Test native desktop app | Computer-use (always) | Computer-use (always) | — |
+
+---
+
 ## Primary Tool: Claude-in-Chrome Extension in Edge
 
 The **Claude-in-Chrome MCP** (`mcp__Claude_in_Chrome__*`) is the primary and

--- a/plugins/devops/deep-knowledge/desktop-testing.md
+++ b/plugins/devops/deep-knowledge/desktop-testing.md
@@ -58,7 +58,7 @@ Warning (in question text, MANDATORY):
 
 Call `request_access` with the required applications:
 
-- The browser running the app (typically "Google Chrome" or "Microsoft Edge")
+- **Microsoft Edge** (the ONLY browser — see `browser-tool-strategy.md` § Edge Credo)
 - Any other application visible in the test (if known)
 
 Reason: "Automatische visuelle Tests der UI-Änderungen durchführen"

--- a/plugins/devops/skills/devops-autonomous/SKILL.md
+++ b/plugins/devops/skills/devops-autonomous/SKILL.md
@@ -108,7 +108,9 @@ full read+write browser access via `$BROWSER_TOOL` (set in Step 3b). The waterfa
 (Chrome MCP → Playwright → Preview) ensures a working tool is always selected.
 All three are DOM/protocol-based — no mouse/keyboard takeover, no desktop occupation.
 **Never fall back to computer-use for browser tasks** — it only has read-tier access
-to browsers (screenshots only, no clicks or typing).
+to browsers (screenshots only, no clicks or typing). The **Edge Credo** applies
+identically in background mode — same Edge instance, same user context, same tab
+reuse rules (see `deep-knowledge/browser-tool-strategy.md` § Edge Credo).
 
 In `analyze` mode, desktop is only used for visual inspection (screenshots), never for interaction.
 
@@ -135,7 +137,13 @@ Then take a test `mcp__computer-use__screenshot` to confirm access works.
 
 ### 3b — Browser Tools
 
-Follow the **Browser Tool Strategy** (`deep-knowledge/browser-tool-strategy.md`):
+Follow the **Browser Tool Strategy** (`deep-knowledge/browser-tool-strategy.md`),
+including the **Edge Credo** (§ Edge Credo — Hard Rules):
+- Edge only, Claude extension by default — computer-use for browser only if user chose "Desktop übernehmen"
+- Always use the user's installed Edge with their profile/login context
+- New tab in existing Edge window — never a new Edge window
+- These rules apply in BOTH foreground and background/autonomous mode
+
 Run the waterfall probe (Chrome MCP → Playwright → Preview), set `$BROWSER_TOOL`
 to the first responder. If none respond → show the error block from the strategy
 doc and abort browser-dependent work. Never use computer-use for browser tasks.

--- a/plugins/devops/skills/devops-burn/SKILL.md
+++ b/plugins/devops/skills/devops-burn/SKILL.md
@@ -216,6 +216,10 @@ BURN MODE ACTIVE — Maximale Parallelisierung.
 
 ## Burn-Guidance
 
+### Browser — Edge Credo
+- Alle Browser-Interaktion folgt dem Edge Credo (deep-knowledge/browser-tool-strategy.md § Edge Credo)
+- Edge only, Claude Extension only, User-Context, Tab-Reuse — auch im Burn-Modus
+
 ### Parallelisierung
 - IMMER die maximale Agent-Anzahl nutzen (full devops roster: core, frontend,
   ai, windows, designer, qa, po, research — je nach Relevanz)

--- a/plugins/devops/skills/devops-concept/SKILL.md
+++ b/plugins/devops/skills/devops-concept/SKILL.md
@@ -186,7 +186,12 @@ The patterns in `deep-knowledge/templates.md` (§ Claude Connection Heartbeat,
 ## Step 3 — Open in Browser
 
 Open the generated HTML file **inside the user's existing Edge window** — never
-open a separate browser window.
+open a separate browser window. Follow the **Edge Credo**
+(`deep-knowledge/browser-tool-strategy.md` § Edge Credo — Hard Rules):
+- Always the user's installed Edge with their profile/login context
+- New tab in running Edge — never a new window or sandboxed instance
+- Claude extension for browser interaction (computer-use only if user chose desktop takeover)
+- These rules apply regardless of execution mode (interactive, background, autonomous)
 
 ### Preferred: Concept Bridge Server (HTTP-based monitoring)
 

--- a/plugins/devops/skills/devops-repo-health/SKILL.md
+++ b/plugins/devops/skills/devops-repo-health/SKILL.md
@@ -242,7 +242,9 @@ Write to: `{project}/.claude/devops-concept/{date}-repo-health.html`
 ## Step 8 — Open & Monitor
 
 Open the page in the browser and monitor for the submit signal.
-Follow `/devops-concept` Step 3 (Open) and Step 4 (Monitor).
+Follow `/devops-concept` Step 3 (Open) and Step 4 (Monitor), respecting the
+**Edge Credo** (`deep-knowledge/browser-tool-strategy.md` § Edge Credo):
+new tab in running Edge, user's profile context, Claude extension for interaction.
 
 ```bash
 start "" msedge "{filepath}"


### PR DESCRIPTION
## Summary
- Adds **Edge Credo** (5 hard rules) to `browser-tool-strategy.md` as the authoritative browser interaction policy
- Computer-use for browser allowed only on explicit desktop takeover
- All browser-dependent skills (concept, autonomous, burn, repo-health) now reference the Edge Credo
- Removed "Google Chrome" from desktop-testing.md

## Edge Credo Rules
1. Edge only — no other browser
2. Claude extension first — computer-use for browser only on explicit request
3. User's installed Edge with profile context — never sandboxed/anonymous
4. Tab reuse — new tab if Edge running, new instance only if not
5. Background/autonomous mode — identical rules apply