### PR TITLE
refactor(concept): git-tracked concepts + heartbeat fix

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.39.3"
+    "version": "0.39.4"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.39.3",
+      "version": "0.39.4",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [0.39.5] — 2026-04-12
+
+### Changed
+
+- **devops-concept** — concept files now saved to `docs/concepts/` (git-tracked) instead of `.claude/devops-concept/`
+- **devops-concept** — fixed naming pattern: `{timestamp}-{slug}-v{version}.html` with auto-versioning
+- **devops-concept** — clear versioning vs. in-place update rules (feedback loop = same file, new session = version bump)
+- **devops-concept** — tab redirect via `meta http-equiv="refresh"` on version bump
+- **devops-concept** — removed direct Chrome MCP references, uses global browser-tool-strategy waterfall
+
+### Fixed
+
+- **devops-concept** — heartbeat flicker: `HEARTBEAT_STALE_MS` raised from 45s to 90s (safely covers 60s cron interval)
+- **devops-concept** — corrected heartbeat docs: cron fires every 60s, not 10s
+
 ## [0.39.4] — 2026-04-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.39.4**
+**Version: 0.39.5**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.39.4",
+  "version": "0.39.5",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/skills/devops-concept/SKILL.md
+++ b/plugins/devops/skills/devops-concept/SKILL.md
@@ -13,7 +13,7 @@ description: >-
   Do NOT trigger for: simple code explanations, debugging
   (use /devops-flow), or static documentation (use /devops-readme).
 argument-hint: "[topic, analysis result, plan, or concept to visualize]"
-allowed-tools: Read, Write, Glob, Grep, Bash(start *), Bash(cmd *), Bash(python *), Bash(curl *), Bash(kill *), AskUserQuestion, CronCreate, CronDelete, mcp__Claude_Preview__*, mcp__plugin_playwright_playwright__*, mcp__Claude_in_Chrome__*, mcp__plugin_devops_dotclaude-completion__*
+allowed-tools: Read, Write, Glob, Grep, Bash(start *), Bash(cmd *), Bash(python *), Bash(curl *), Bash(kill *), AskUserQuestion, CronCreate, CronDelete, mcp__Claude_Preview__*, mcp__plugin_playwright_playwright__*, mcp__plugin_devops_dotclaude-completion__*
 ---
 
 # Concept
@@ -179,12 +179,35 @@ signal Claude monitors.
 
 ### File Location
 
-Write to: `{project}/.claude/devops-concept/{timestamp}-{slug}.html`
+Write to: `docs/concepts/{timestamp}-{slug}-v{version}.html`
 
-- `{timestamp}`: ISO date (`2026-04-05`)
-- `{slug}`: kebab-case summary of the topic (max 40 chars)
-- Create the directory if it doesn't exist
-- Add `.claude/devops-concept/` to `.gitignore` if not already there
+**Fixed naming pattern** (all three segments mandatory, in this order):
+
+| Segment | Format | Example |
+|---------|--------|---------|
+| `{timestamp}` | ISO date `YYYY-MM-DD` | `2026-04-12` |
+| `{slug}` | kebab-case topic summary, max 40 chars | `auth-middleware-redesign` |
+| `{version}` | Integer starting at `1`, incremented per revision of the same slug | `1` |
+
+Full example: `docs/concepts/2026-04-12-auth-middleware-redesign-v1.html`
+
+- Create the `docs/concepts/` directory if it doesn't exist
+- This directory is **git-tracked** — concepts are project artifacts meant
+  to be shared with other repo users
+- To determine the next version: glob for `docs/concepts/*-{slug}-v*.html`,
+  parse the highest existing version number, and increment by 1.
+  If no match exists, start at `v1`
+
+### Versioning vs. In-Place Update
+
+| Situation | Action | Version |
+|-----------|--------|---------|
+| Feedback loop iteration (Step 5c) | Update the **same file** in-place, refresh the existing tab | No bump — stays `v1` |
+| New concept session for the same topic (user revisits later) | Create a **new file** with incremented version | Bump → `v2`, `v3`, … |
+| Fundamental rework after feedback (user says "nochmal neu") | Create a **new file** with incremented version | Bump → next `vN` |
+
+**Rule of thumb:** within an active feedback loop, never bump the version.
+A version bump only happens when a new file is created.
 
 ### Post-Generation Validation (mandatory gate)
 
@@ -228,11 +251,10 @@ open a separate browser window. Follow the **Edge Credo**
 - Claude extension for browser interaction (computer-use only if user chose desktop takeover)
 - These rules apply regardless of execution mode (interactive, background, autonomous)
 
-### Preferred: Concept Bridge Server (HTTP-based monitoring)
+### Concept Bridge Server + Edge
 
-The **concept bridge server** (`scripts/concept-server.py`) replaces the plain
-`python -m http.server`. It serves static files AND provides HTTP endpoints for
-heartbeat and decision exchange — no Chrome MCP JS injection needed.
+The **concept bridge server** (`scripts/concept-server.py`) serves static files
+AND provides HTTP endpoints for heartbeat and decision exchange.
 
 1. Find the bridge server script:
    ```bash
@@ -257,33 +279,21 @@ heartbeat and decision exchange — no Chrome MCP JS injection needed.
    curl -s -X POST http://localhost:{port}/heartbeat
    ```
 
-5. Open via Chrome MCP (stays in the MCP tab group, visible to the user):
+5. Open in Edge (reuses the running instance, adds a tab):
+   ```bash
+   # Windows — per Edge Credo (see browser-tool-strategy.md)
+   start "" msedge "http://localhost:{port}/{filename}"
    ```
-   tabs_context_mcp(createIfEmpty: true)  → get/create tab group
-   navigate(url: "http://localhost:{port}/{filename}", tabId: $TAB_ID)
-   ```
+   On macOS: `open -a "Microsoft Edge" "http://…"`, on Linux: `microsoft-edge "http://…"`.
+
+   The empty `""` is required on Windows — without it, `cmd.exe` interprets
+   the first quoted argument as a window title.
 
 6. After monitoring ends, clean up:
    ```bash
    kill %1  # or track the PID
    ```
    Also delete the heartbeat cron via `CronDelete`.
-
-### Fallback: Direct Edge launch (not monitorable)
-
-If Chrome MCP is unavailable, fall back to direct launch. This opens in the
-user's existing Edge instance but **cannot be monitored** — use AskUserQuestion
-flow instead.
-
-```bash
-# Windows — reuses running Edge, adds tab (not a new window)
-start "" msedge "{filepath}"
-```
-
-On macOS: `open -a "Microsoft Edge" "{filepath}"`, on Linux: `microsoft-edge "{filepath}"`.
-
-The empty `""` is required on Windows — without it, `cmd.exe` interprets
-the first quoted argument as a window title.
 
 ### After opening, inform the user:
 
@@ -316,12 +326,6 @@ If `false` → wait and retry.
 - **Timeout**: 5 minutes → ask user via AskUserQuestion
 - On each poll, also POST `/heartbeat` to keep the connection indicator green
 
-**Browser tool strategy** (optional enhancement, not required):
-- If Chrome MCP or Playwright is available, it can still be used for
-  tab-alive checks and page content updates (Step 5c)
-- But heartbeat and decision reading work entirely via HTTP — no JS eval needed
-- If the browser tool waterfall fails, monitoring still works via HTTP
-
 **Important:** While waiting, do NOT block the conversation. Inform the
 user that you're monitoring and they can continue chatting. If the user
 sends a message while monitoring, pause monitoring and respond normally.
@@ -352,7 +356,9 @@ User submits → Claude reads → Claude processes → Claude updates page → U
    - For concepts: develop chosen variant, archive alternatives
    - For comparisons: proceed with selected winner
 ### 5c. Update the Page
-After processing, **update the HTML page in the browser** to reflect results:
+After processing, **update the HTML page in the browser** to reflect results.
+
+**In-place update (same version, normal case):**
 1. Reset `submitted` to `false` in `#concept-decisions`
 2. Remove `concept-submitted` class from `<body>`
 3. Re-enable the submit button
@@ -360,8 +366,31 @@ After processing, **update the HTML page in the browser** to reflect results:
    confirmation of completed actions
 5. Add a visual "Verarbeitet" indicator on processed items
 
+For JS eval, use the browser tool waterfall from
+`deep-knowledge/browser-tool-strategy.md` (Playwright → Preview).
+If no eval tool is available, inform the user to refresh the page manually.
+
 This allows the user to **review the updated state and submit again** for
 further refinement or additional decisions.
+
+**New version (version bump, e.g. after "nochmal neu"):**
+When a new version file is created while the old tab is still open:
+1. Write the new HTML file (`docs/concepts/…-v{N+1}.html`)
+2. The bridge server already serves all files in `docs/concepts/` — the new
+   file is immediately accessible at `http://localhost:{port}/{new-filename}`
+3. **Redirect the existing tab** by overwriting the old HTML file with a
+   minimal redirect page:
+   ```html
+   <!DOCTYPE html>
+   <html><head>
+     <meta http-equiv="refresh" content="0;url=http://localhost:{port}/{new-filename}">
+   </head><body>
+     <p>Neue Version: <a href="http://localhost:{port}/{new-filename}">{new-filename}</a></p>
+   </body></html>
+   ```
+   The user's tab auto-navigates to the new version within 1 second.
+4. Do NOT leave the old tab in "Entscheidungen übermittelt" state — the user
+   must never be stuck waiting on a tab that Claude is no longer monitoring
 
 ### 5d. Resume Monitoring
 Return to Step 4 (monitor for next submission). The loop continues until:
@@ -370,7 +399,7 @@ Return to Step 4 (monitor for next submission). The loop continues until:
 - There are no more decisions to make (all items processed)
 
 ### 5e. Persist
-Write a cumulative summary to `{project}/.claude/devops-concept/{same-slug}-decisions.json`
+Write a cumulative summary to `docs/concepts/{same-timestamp}-{same-slug}-v{same-version}-decisions.json`
 after each iteration (append, don't overwrite previous rounds).
 
 ## Step 6 — Completion

--- a/plugins/devops/skills/devops-concept/deep-knowledge/monitoring.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/monitoring.md
@@ -20,7 +20,7 @@ Claude ──GET /decisions──→ Server     ←─GET /heartbeat─── Pa
 
 The **concept bridge server** (`scripts/concept-server.py`) acts as the
 communication hub. Both Claude and the page talk to the server via HTTP —
-no Chrome MCP JS injection needed for heartbeat or decision exchange.
+no browser tool injection needed for heartbeat or decision exchange.
 
 This is an **iterative loop**, not a one-shot. After each submission,
 Claude processes the feedback, updates the page, and monitors again.
@@ -58,22 +58,17 @@ JSON.parse(document.getElementById('concept-decisions').textContent)
 ## Tool Selection
 
 **For heartbeat and decision reading:** Use HTTP (`curl` via Bash). No browser
-tool needed — this works regardless of Chrome MCP or Playwright availability.
+tool needed — this works entirely via the bridge server.
 
-**For page updates (Step 5c):** Follow the **Browser Tool Strategy**
+**For page updates (Step 5c):** Use the browser tool waterfall
 (`deep-knowledge/browser-tool-strategy.md`) for JS eval. Page updates are
 optional enhancements — if no eval tool works, inform the user via chat instead.
 
-## Known Limitation: `file://` URLs
+## Why HTTP Server is Required
 
-Browser tools (Chrome MCP, Playwright) **cannot open or interact with `file://`
-URLs**. Chrome MCP's `navigate` tool always prepends `https://`, and Playwright
-blocks the `file:` protocol entirely. Additionally, tabs opened via `start ""
-msedge` land **outside the MCP tab group** and are invisible to monitoring.
-
-**Required workaround:** Serve concept pages via a local HTTP server (see
-SKILL.md Step 3). This makes the page accessible at `http://localhost:<port>/`
-which all browser tools can handle.
+Concept pages must be served via the bridge server (`http://localhost:<port>/`)
+rather than opened as `file://` URLs. The bridge server provides heartbeat and
+decision endpoints that the page relies on for Claude connectivity.
 
 ## Pre-Monitoring Setup
 
@@ -104,17 +99,6 @@ curl -s -X POST http://localhost:$PORT/heartbeat
 
 Store the cron job ID as `$HEARTBEAT_CRON_ID` for cleanup.
 
-### 3. Optionally establish browser tool (for page updates only)
-
-Browser tools are **not required** for heartbeat or decision reading (those
-work via HTTP). They are only needed for live page updates in Step 5c.
-
-If you want live page updates:
-1. Run the **Browser Tool Strategy waterfall** (`deep-knowledge/browser-tool-strategy.md`)
-2. Store `$BROWSER_TOOL` and `$TAB_ID` if chrome-mcp
-3. If the waterfall fails → page updates won't be live, but monitoring still
-   works fully via HTTP
-
 ### HTTP Bridge Monitoring
 
 **Heartbeat** (keeps the connection indicator green on the page):
@@ -136,8 +120,7 @@ Returns JSON. Check the `submitted` field:
 {"submitted": true, "decisions": [...], "comments": [...]}
 ```
 
-No browser eval needed. No Chrome MCP JS injection needed. No split-capability
-issues. The bridge server handles everything.
+No browser eval needed. The bridge server handles everything.
 
 **Reset after processing** — tell the bridge server to clear decisions:
 ```bash
@@ -149,7 +132,6 @@ curl -s -X POST http://localhost:$PORT/reset
 For live page updates (Step 5c — updating content after processing decisions),
 browser eval tools are still useful:
 
-- chrome-mcp: `javascript_tool("...")`
 - playwright: `browser_evaluate("...")`
 - preview: `preview_eval("...")`
 
@@ -207,10 +189,11 @@ On each poll cycle:
 2. **Check decisions**: `curl -s http://localhost:$PORT/decisions`
 3. If curl fails → bridge server may have crashed → attempt restart
 
-**Optional tab-alive check** (if Chrome MCP is available):
-- Call `tabs_context_mcp` and verify `$TAB_ID` is still in the list
-- If missing → tab closed → stop monitoring, inform user
-- If Chrome MCP is not available → skip this check (monitoring via HTTP continues)
+**Tab-alive check** (via HTTP):
+- If `curl /heartbeat` or `curl /decisions` fails with connection refused →
+  bridge server crashed → attempt restart
+- If bridge server responds but page never submits past timeout → user may
+  have closed the tab → ask via AskUserQuestion
 
 ### Page Reload Handling
 
@@ -330,7 +313,7 @@ update the browser page:
 ### Persistence
 
 Write processed decisions to:
-`{project}/.claude/devops-concept/{same-timestamp}-{same-slug}-decisions.json`
+`docs/concepts/{same-timestamp}-{same-slug}-v{same-version}-decisions.json`
 
 Each round appends to the same file (array of rounds), preserving full history:
 
@@ -354,8 +337,8 @@ Each round appends to the same file (array of rounds), preserving full history:
 | Heartbeat cron stopped | Page shows "nicht verbunden" despite server running | Send manual `curl -s -X POST /heartbeat`, re-create cron |
 | Decisions JSON parse error | `curl /decisions` returns malformed JSON | Show raw content to user, ask to verify |
 | Empty decisions array | Parsed but `decisions.length === 0` | Ask if intentional (all defaults accepted) |
-| Tab closed by user | Chrome MCP `tabs_context_mcp` shows tab missing | Stop monitoring, inform user: "Die Concept-Seite wurde geschlossen." |
-| JS eval broken (page updates) | `javascript_tool` returns "Cannot access chrome-extension://" | Expected — page updates not possible, inform user via chat |
+| Tab closed by user | No submission past timeout, bridge server still alive | Ask user via AskUserQuestion |
+| JS eval broken (page updates) | Browser eval tool returns error | Expected — page updates not possible, inform user via chat |
 | `get_page_text` used accidentally | "page body too large" or stripped content | Use HTTP bridge endpoints instead |
 | All tools fail | Bridge server + browser tools both unavailable | Fall back to manual AskUserQuestion flow |
 

--- a/plugins/devops/skills/devops-concept/deep-knowledge/templates.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/templates.md
@@ -901,20 +901,20 @@ document.getElementById('theme-toggle').addEventListener('click', () => {
 
 The heartbeat uses the **HTTP Bridge** — the concept bridge server
 (`scripts/concept-server.py`) exposes `/heartbeat` endpoints that both Claude
-and the page communicate through. This bypasses Chrome MCP JS injection
-entirely.
+and the page communicate through.
 
 **How it works:**
-- Claude sends `curl -s -X POST localhost:{port}/heartbeat` every 10 seconds
-  (via CronCreate or the monitoring loop)
+- Claude sends `curl -s -X POST localhost:{port}/heartbeat` every 60 seconds
+  (via CronCreate) plus on each monitoring poll cycle (~15s when active)
 - The page polls `GET /heartbeat` every 5 seconds via `fetch()`
-- If the heartbeat is older than 45 seconds (3 missed polls) or missing →
-  the submit button is disabled and a warning is shown
+- If the heartbeat is older than 90 seconds → the submit button is disabled
+  and a warning is shown (90s threshold safely covers the 60s cron interval
+  with buffer for timing jitter)
 - If the heartbeat is fresh → submit is enabled, warning hidden
 
 ```javascript
 // --- Claude Connection Heartbeat (HTTP Bridge) ---
-const HEARTBEAT_STALE_MS = 45000; // 3 missed polls = disconnected
+const HEARTBEAT_STALE_MS = 90000; // 90s — safely covers 60s cron interval + buffer
 let _lastHeartbeatTs = 0;
 
 async function pollHeartbeat() {


### PR DESCRIPTION
## Summary\n- Move concept files from `.claude/devops-concept/` to `docs/concepts/` (git-tracked, shareable)\n- Fixed naming pattern: `{timestamp}-{slug}-v{version}.html` with auto-versioning\n- Clear versioning vs. in-place update rules for feedback loop\n- Tab redirect via meta-refresh on version bump\n- Remove direct Chrome MCP references, use global browser-tool-strategy waterfall\n- Fix heartbeat flicker: HEARTBEAT_STALE_MS 45s → 90s (covers 60s cron interval)