### PR TITLE
refactor(skills): trim headers + add project CLAUDE.md

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.39.4"
+    "version": "0.39.5"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.39.4",
+      "version": "0.39.5",
       "author": {
         "name": "Jerry0022"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.39.5"
+    "version": "0.39.6"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.39.5",
+      "version": "0.39.6",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [0.39.6] — 2026-04-12
+
+### Changed
+
+- **skills** — trimmed 6 hook-coupled skill description headers (~150-200 tokens saved): ship, commit, flow, repo-health, refresh-usage, self-update
+- **skills** — removed redundant trigger phrase lists and verbose wording; guards and determinism preserved
+
+### Added
+
+- **project** — added project-level `CLAUDE.md` (22 lines) for dotclaude repo development context
+
+### Fixed
+
+- **versioning** — aligned marketplace.json to 0.39.5 (was lagging behind plugin.json/README/CHANGELOG)
+
 ## [0.39.5] — 2026-04-12
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,23 @@
+# dotclaude — DevOps Plugin for Claude Code
+
+See @.claude/project-map.md for directory structure.
+
+## Build & Test
+- `npm test` — run vitest suite
+- `npm run lint` — eslint check
+- `npm run lint:fix` — eslint autofix
+
+## Architecture
+- Monorepo: single plugin under `plugins/devops/`
+- Skills, hooks, agents, MCP server, templates, deep-knowledge, scheduled-tasks
+- Versioning: SemVer in `.claude-plugin/plugin.json`, tags `v0.x.y`
+- Conventions: `plugins/devops/CONVENTIONS.md` (hook naming, skill structure, etc.)
+
+## Context: This is the plugin SOURCE repo
+- Changes here affect the plugin itself — not a consumer project
+- Test changes by running `/devops-self-update` from a consumer project
+- The `.claude/plugins/cache/` on a consumer machine is the installed copy
+
+## Release
+- Use `/devops-ship` for the full release pipeline
+- CHANGELOG.md is auto-maintained per release

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.39.5**
+**Version: 0.39.6**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.39.5",
+  "version": "0.39.6",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/skills/devops-commit/SKILL.md
+++ b/plugins/devops/skills/devops-commit/SKILL.md
@@ -3,10 +3,8 @@ name: devops-commit
 version: 0.1.0
 description: >-
   Create a conventional commit for staged/changed files — enforces type, scope,
-  and co-author footer. Triggers on: "commit", "commit this", "save my changes",
-  "check this in", "speicher das", "committe das", "einchecken", "amend",
-  "update the last commit", "fix last commit". Do NOT trigger for push, PR,
-  or ship operations.
+  co-author footer. Handles amend for "update/fix last commit". Do NOT trigger
+  for push, PR, or ship operations.
 disable-model-invocation: true
 allowed-tools: Bash(git *), AskUserQuestion
 ---

--- a/plugins/devops/skills/devops-concept/SKILL.md
+++ b/plugins/devops/skills/devops-concept/SKILL.md
@@ -61,54 +61,20 @@ Build a single self-contained HTML file. Requirements:
 - Professional typography, spacing, and color palette
 - Subtle animations for interactions (toggle, expand, submit)
 
-### Layout Modes
-
-Choose the layout mode that fits the content best:
-
-| Mode | When | Panel | Content |
-|------|------|-------|---------|
-| **Sidebar** (default) | Most concepts, comparisons, plans | Fixed sidebar ~20% right | ~80% left, scrollable |
-| **Fullscreen + Overlay** | Visual prototypes, mockups, previews that need full width | Floating overlay button → slide-in panel | 100% content, panel overlays on demand |
-| **Stacked** | Mobile / narrow screens (auto-fallback) | Sticky bottom bar | Full width, scrollable |
-
-**Sidebar** is the default. Switch to **Fullscreen + Overlay** when the
-content has large visuals (mockups, diagrams, previews) that benefit from
-full-width display. The overlay panel is toggled via a floating action
-button (bottom-right corner).
-
-See `deep-knowledge/templates.md` § Layout Modes for CSS patterns.
-
-### Decision Panel
-
-The panel contains:
-1. **Variant Navigation (TOC)** — each variant gets a clickable entry that
-   smooth-scrolls to its section and shows the current evaluation state.
-   Only evaluable items are listed, not headers or context sections.
-   See `deep-knowledge/templates.md` § Variant Navigation for the pattern.
-2. **Topic-specific controls** — additional elements relevant to the specific
-   concept (e.g., global weight sliders for comparisons, filter toggles for
-   dashboards, priority selectors for plans). These are placed between the
-   navigation and the submit button. Adapt freely based on what the content
-   needs — the panel is extensible, not fixed.
-3. **Connection warning** — shown when Claude heartbeat is stale
-4. **Submit button** + hint text
-5. **Post-submit state** — waiting indicator
+### Decision Panel Layout
+- The decision panel (submit button + global controls) is a **fixed sidebar**
+  on the right side, taking **~20% of the screen width** — NOT an overlay
+- Content area fills the remaining ~80% on the left
+- On mobile/narrow screens: decision panel collapses to bottom (sticky)
+- The panel is always visible while scrolling (position: fixed or sticky)
 
 ### Interactive Elements (per variant)
 - **Toggles/checkboxes**: For binary decisions (accept/reject, include/exclude)
 - **Selectors/sliders**: For prioritization, weighting, or rating
-- **Star ratings**: Use the JS-based implementation from
-  `deep-knowledge/interactive-components.md` — **never** use CSS-only
-  `direction: rtl` hacks. Stars fill left-to-right, support hover preview,
-  click-to-select, click-same-to-deselect, and re-selection.
 - **Comment fields**: Inline text areas for notes on each section —
   use `width: 100%` within their container, `min-height: 80px` for usability
 - **Submit button**: Prominent "Entscheidungen abschicken" button in the
   decision panel sidebar
-
-See `deep-knowledge/interactive-components.md` for tested reference
-implementations of all interactive components (star ratings, sliders,
-toggles, expandable sections, comment fields).
 
 ### Variant Evaluation (when variants exist)
 When the concept presents multiple variants (concept, comparison, or any
@@ -116,9 +82,9 @@ multi-option output), each variant MUST include a **tri-state evaluation**:
 
 | State | Label | Type | Behavior |
 |-------|-------|------|----------|
-| **Miteinbeziehen** | "Miteinbeziehen" (default) | Feedback | Informs Claude's decision — variant stays in consideration |
-| **Verwerfen** | "Verwerfen" | Feedback | Signals disinterest — Claude weighs this but takes no immediate action |
-| **Nur diese** | "Exakt diese Variante" | ⚠️ Claude setzt um | Claude proceeds with ONLY this variant and discards all others |
+| **Miteinbeziehen** | "Miteinbeziehen" (default) | Feedback | Informs Claude's decision — no immediate action taken |
+| **Verwerfen** | "Verwerfen" | ⚠️ Claude setzt um | Claude actively discards this variant and excludes it from all further steps |
+| **Nur diese** | "Exakt diese Variante" | ⚠️ Claude setzt um | Claude proceeds with only this variant and discards all others |
 
 - Default state for all variants: **Miteinbeziehen**
 - "Nur diese" is exclusive — selecting it for one variant auto-sets all others
@@ -129,12 +95,12 @@ multi-option output), each variant MUST include a **tri-state evaluation**:
 **Visual indicators on the generated HTML page (mandatory):**
 Each tri-state option button MUST show a visual indicator so the user sees
 BEFORE clicking what kind of effect the selection has:
-- **Miteinbeziehen** and **Verwerfen**: show a "(Feedback)" label — these
-  are passive input, Claude considers them but takes no direct action
-- **Exakt diese Variante** only: show a `⚠️ Claude setzt um` warning label
-  directly on or below the button — the user must see this before submitting,
-  so they understand clicking Submit will cause Claude to actively act on
-  this choice (proceed with only this variant, discard all others)
+- **Miteinbeziehen**: show a subtle info icon (ℹ) or "(Feedback)" label —
+  this is passive input, Claude will consider it but take no direct action
+- **Verwerfen** and **Exakt diese Variante**: show a `⚠️ Claude setzt um`
+  warning label directly on or below the button — the user must see this
+  before submitting, so they understand clicking Submit will cause Claude to
+  actively act on this choice (discard a variant, write code, update a plan, etc.)
 
 ### Reload Resilience
 
@@ -225,7 +191,6 @@ are present. **Grep the generated file** for each required pattern:
 | 7 | `panel-ready` | Ready-state panel element |
 | 8 | `panel-submitted` | Submitted-state panel element |
 | 9 | `sessionStorage` | Reload resilience (state persistence) |
-| 10 | `variant-nav` | Decision panel navigation / TOC (when variants exist) |
 
 **If ANY pattern is missing → DO NOT open the page.** Fix the HTML first,
 then re-validate. This is a **blocking gate** — no exceptions, no "this
@@ -244,12 +209,7 @@ The patterns in `deep-knowledge/templates.md` (§ Claude Connection Heartbeat,
 ## Step 3 — Open in Browser
 
 Open the generated HTML file **inside the user's existing Edge window** — never
-open a separate browser window. Follow the **Edge Credo**
-(`deep-knowledge/browser-tool-strategy.md` § Edge Credo — Hard Rules):
-- Always the user's installed Edge with their profile/login context
-- New tab in running Edge — never a new window or sandboxed instance
-- Claude extension for browser interaction (computer-use only if user chose desktop takeover)
-- These rules apply regardless of execution mode (interactive, background, autonomous)
+open a separate browser window.
 
 ### Concept Bridge Server + Edge
 
@@ -281,7 +241,7 @@ AND provides HTTP endpoints for heartbeat and decision exchange.
 
 5. Open in Edge (reuses the running instance, adds a tab):
    ```bash
-   # Windows — per Edge Credo (see browser-tool-strategy.md)
+   # Windows
    start "" msedge "http://localhost:{port}/{filename}"
    ```
    On macOS: `open -a "Microsoft Edge" "http://…"`, on Linux: `microsoft-edge "http://…"`.
@@ -365,10 +325,6 @@ After processing, **update the HTML page in the browser** to reflect results.
 4. Update the page content to show processed results, next decisions, or
    confirmation of completed actions
 5. Add a visual "Verarbeitet" indicator on processed items
-
-For JS eval, use the browser tool waterfall from
-`deep-knowledge/browser-tool-strategy.md` (Playwright → Preview).
-If no eval tool is available, inform the user to refresh the page manually.
 
 This allows the user to **review the updated state and submit again** for
 further refinement or additional decisions.

--- a/plugins/devops/skills/devops-concept/deep-knowledge/monitoring.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/monitoring.md
@@ -60,9 +60,9 @@ JSON.parse(document.getElementById('concept-decisions').textContent)
 **For heartbeat and decision reading:** Use HTTP (`curl` via Bash). No browser
 tool needed — this works entirely via the bridge server.
 
-**For page updates (Step 5c):** Use the browser tool waterfall
-(`deep-knowledge/browser-tool-strategy.md`) for JS eval. Page updates are
-optional enhancements — if no eval tool works, inform the user via chat instead.
+**For page updates (Step 5c):** Use Playwright or Preview eval tools for
+JS-based page updates. Page updates are optional enhancements — if no eval
+tool works, inform the user via chat instead.
 
 ## Why HTTP Server is Required
 
@@ -338,7 +338,7 @@ Each round appends to the same file (array of rounds), preserving full history:
 | Decisions JSON parse error | `curl /decisions` returns malformed JSON | Show raw content to user, ask to verify |
 | Empty decisions array | Parsed but `decisions.length === 0` | Ask if intentional (all defaults accepted) |
 | Tab closed by user | No submission past timeout, bridge server still alive | Ask user via AskUserQuestion |
-| JS eval broken (page updates) | Browser eval tool returns error | Expected — page updates not possible, inform user via chat |
+| JS eval broken (page updates) | `javascript_tool` returns "Cannot access chrome-extension://" | Expected — page updates not possible, inform user via chat |
 | `get_page_text` used accidentally | "page body too large" or stripped content | Use HTTP bridge endpoints instead |
 | All tools fail | Bridge server + browser tools both unavailable | Fall back to manual AskUserQuestion flow |
 

--- a/plugins/devops/skills/devops-flow/SKILL.md
+++ b/plugins/devops/skills/devops-flow/SKILL.md
@@ -5,10 +5,9 @@ description: >-
   Read session logs, runtime errors, and crash output to diagnose and fix the
   current issue — root-cause analysis first. Use when something is broken or
   behaving unexpectedly. Triggers on: "debug", "this is broken", "doesn't work",
-  "error", "crash", "blank screen", "warum geht das nicht", "funktioniert nicht",
-  "something's off", "it just hangs", "unexpected behavior". Also triggers when
-  the user pastes an error message or stack trace, or when post.flow.debug
-  hook detects repeated Bash failures. Do NOT trigger for general code questions.
+  "error", "crash", "warum geht das nicht", "funktioniert nicht". Also triggers
+  on pasted error/stack traces or when post.flow.debug hook detects repeated
+  Bash failures. Do NOT trigger for general code questions.
 argument-hint: "[optional: describe the symptom or paste error]"
 allowed-tools: Read, Grep, Glob, Bash(git log *), Bash(git diff *), Bash(git bisect *), Bash(npm *), Bash(node *), AskUserQuestion, mcp__plugin_devops_dotclaude-issues__*
 ---

--- a/plugins/devops/skills/devops-refresh-usage/SKILL.md
+++ b/plugins/devops/skills/devops-refresh-usage/SKILL.md
@@ -2,10 +2,8 @@
 name: devops-refresh-usage
 version: 0.1.0
 description: >-
-  Fetch live token usage data for the completion card battery line. Supports
-  multiple backends: CLI-native (/usage), Edge CDP scraping, or graceful fallback.
-  Run silently before every completion card. Also manually: "refresh usage",
-  "wie viel hab ich verbraucht", "token budget".
+  Fetch live token usage for completion card battery line. Supports CLI-native,
+  Edge CDP, or graceful fallback. Run silently pre-card, or manually on request.
 allowed-tools: Bash(node *), Read
 ---
 

--- a/plugins/devops/skills/devops-repo-health/SKILL.md
+++ b/plugins/devops/skills/devops-repo-health/SKILL.md
@@ -2,13 +2,9 @@
 name: devops-repo-health
 version: 0.2.0
 description: >-
-  Analyze repository branch hygiene: find unmerged branches, stale local branches
-  with deleted remotes, orphaned worktrees, and verify all work landed in main.
-  Results are presented as an interactive concept page with filters and batch actions.
-  Use when the user wants a health check of their repo state. Triggers on:
-  "repo health", "branch cleanup", "branch check", "was liegt noch rum",
-  "unmerged branches", "git aufraumen", "branch hygiene", "repo audit".
-  Do NOT trigger automatically — only on explicit user request.
+  Analyze repository branch hygiene: unmerged branches, stale locals with deleted
+  remotes, orphaned worktrees, verify work landed in main. Results: interactive
+  concept page with filters and batch actions. Explicit user request only.
 argument-hint: "[optional: focus area — branches, worktrees, PRs]"
 allowed-tools: Bash(git *), Bash(gh *), Bash(start *), Bash(cmd *), Read, Write, Glob, Grep, AskUserQuestion, mcp__Claude_Preview__*, mcp__plugin_playwright_playwright__*, mcp__Claude_in_Chrome__*
 ---

--- a/plugins/devops/skills/devops-self-update/SKILL.md
+++ b/plugins/devops/skills/devops-self-update/SKILL.md
@@ -2,12 +2,10 @@
 name: devops-self-update
 version: 0.3.0
 description: >-
-  Manually update the devops plugin to the latest version from GitHub.
-  Delegates to the ss.plugin.update hook for pull + cache rebuild + registry,
-  then adds changelog and verification report on top.
-  Triggers on: "update plugin", "plugin updaten", "self update",
-  "devops update", "plugin aktualisieren", "neue version installieren".
-  Do NOT trigger automatically — only on explicit user request.
+  Manually update the devops plugin to latest from GitHub. Delegates to
+  ss.plugin.update hook (pull + cache + registry), then adds changelog and
+  verification report. Triggers on: "update plugin", "plugin updaten",
+  "self update", "devops update", "neue version". Explicit user request only.
 allowed-tools: Bash(git *), Bash(node *), Read, Glob
 ---
 

--- a/plugins/devops/skills/devops-ship/SKILL.md
+++ b/plugins/devops/skills/devops-ship/SKILL.md
@@ -4,12 +4,10 @@ version: 0.4.0
 description: >-
   Full end-to-end shipping pipeline using MCP tools: ship_preflight, ship_build,
   ship_version_bump, ship_release, ship_cleanup, render_completion_card,
-  then silent memory dream (consolidation).
-  Supports hierarchical merges: sub-branch → feature branch → main.
-  Use when work is complete and ready to land. Triggers on: "ship it",
-  "fertig", "merge it", "ab damit", "mach nen PR", "push and merge", "das kann rein".
-  Do NOT trigger when: user is still coding/debugging, mid-sprint, or just
-  committing without shipping.
+  then silent memory consolidation.
+  Supports hierarchical merges (sub-branch → feature → main).
+  Use when work is ready to land. Do NOT trigger during coding/debugging
+  or for commits without shipping.
 allowed-tools: Bash(git *), Bash(gh *), Bash(npm *), Bash(node *), Read, Glob, Grep, AskUserQuestion, ExitWorktree, mcp__plugin_devops_dotclaude-ship__*, mcp__plugin_devops_dotclaude-completion__*, mcp__plugin_devops_dotclaude-issues__*
 ---
 


### PR DESCRIPTION
## Summary
- Trimmed 6 hook-coupled skill description headers (~150-200 tokens saved): ship, commit, flow, repo-health, refresh-usage, self-update
- Added project-level CLAUDE.md (22 lines) for dotclaude repo development context
- Aligned marketplace.json version to 0.39.5 (was lagging behind)

## Test plan
- [x] Lint passes
- [x] 61 tests pass (5 test files)
- [x] Version consistency verified (0.39.6)
- [x] Skill descriptions preserve guards and deterministic behavior