### PR TITLE
feat(concept): localStorage persistence, offline queue, no timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.39.7] — 2026-04-12
+
+### Changed
+
+- **devops-concept** — state persistence upgraded from `sessionStorage` to `localStorage` with 24h TTL (survives tab close, browser restart, accidental reloads)
+- **devops-concept** — submit button stays enabled when Claude is disconnected (warning banner is sufficient)
+- **devops-concept** — removed 5-minute monitoring timeout and 20-poll limit; concept pages now run indefinitely until user ends session
+
+### Added
+
+- **devops-concept** — offline submit queue: decisions cached in `localStorage` when bridge server is unreachable, auto-delivered on reconnect via `retryPendingSubmission()`
+
 ## [0.39.6] — 2026-04-12
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.39.6**
+**Version: 0.39.7**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.39.6",
+  "version": "0.39.7",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/skills/devops-concept/SKILL.md
+++ b/plugins/devops/skills/devops-concept/SKILL.md
@@ -104,13 +104,18 @@ BEFORE clicking what kind of effect the selection has:
 
 ### Reload Resilience
 
-The HTML page MUST persist interactive element state via `sessionStorage` so
-that user selections survive a page reload (F5). Include the state persistence
-pattern from `deep-knowledge/templates.md` § State Persistence in every
-generated concept page. Theme preference is also persisted to prevent flash.
+The HTML page MUST persist interactive element state via `localStorage` (with
+a 24-hour TTL) so that user selections survive page reloads, accidental tab
+closes, and even browser restarts. Include the state persistence pattern from
+`deep-knowledge/templates.md` § State Persistence in every generated concept
+page. Theme preference is also persisted to prevent flash.
 
 The `concept-submitted` class is NOT persisted — after a reload the page is
 back to "not yet submitted" (correct behavior, the user can re-submit).
+
+Additionally, the offline submit queue (`localStorage` key `{slug}-pending`)
+caches decisions submitted while Claude is disconnected and auto-delivers
+them when the connection is restored (see `templates.md` § Offline Submit Queue).
 
 ### Feedback Mechanism
 
@@ -190,7 +195,7 @@ are present. **Grep the generated file** for each required pattern:
 | 6 | `pollHeartbeat` | HTTP heartbeat polling function |
 | 7 | `panel-ready` | Ready-state panel element |
 | 8 | `panel-submitted` | Submitted-state panel element |
-| 9 | `sessionStorage` | Reload resilience (state persistence) |
+| 9 | `localStorage` | Reload resilience (state persistence with TTL) |
 
 **If ANY pattern is missing → DO NOT open the page.** Fix the HTML first,
 then re-validate. This is a **blocking gate** — no exceptions, no "this
@@ -201,7 +206,7 @@ page needs the heartbeat guard.
 - Heartbeat system omitted → submit button stays clickable without monitoring
 - Connection warning missing → user gets no feedback when Claude disconnects
 - Panel states missing → no visual transition on submit/reset cycle
-- sessionStorage missing → user selections lost on F5
+- localStorage missing → user selections lost on reload or tab close
 
 The patterns in `deep-knowledge/templates.md` (§ Claude Connection Heartbeat,
 § Submit Handler, § State Persistence) provide the reference implementations.
@@ -283,7 +288,8 @@ If `false` → wait and retry.
 **Polling schedule:**
 - **Initial wait**: 10 seconds after opening
 - **Poll interval**: 15 seconds (via conversation-driven checks or cron)
-- **Timeout**: 5 minutes → ask user via AskUserQuestion
+- **No timeout** — monitoring runs indefinitely until the user ends it
+  (says "fertig"/"done", closes the page, or closes Claude)
 - On each poll, also POST `/heartbeat` to keep the connection indicator green
 
 **Important:** While waiting, do NOT block the conversation. Inform the

--- a/plugins/devops/skills/devops-concept/deep-knowledge/monitoring.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/monitoring.md
@@ -169,8 +169,9 @@ console.log(document.getElementById('concept-decisions').textContent)
 - **Initial wait**: 10 seconds after opening (give the page time to load and
   the user time to orient)
 - **Poll interval**: 15 seconds
-- **Timeout**: 5 minutes (300 seconds)
-- **Max polls**: 20 attempts
+- **Timeout**: NONE — monitoring runs indefinitely until the user explicitly
+  ends it (says "fertig"/"done", closes the page, or closes Claude). The
+  heartbeat cron keeps the connection alive. Never impose artificial timeouts.
 
 ### Non-Blocking Behavior
 
@@ -200,7 +201,7 @@ On each poll cycle:
 A page reload (F5) is **not a problem** with the HTTP bridge:
 - The bridge server keeps running independently of the page
 - Heartbeat cron keeps posting → page reconnects automatically after reload
-- `sessionStorage` preserves user selections (see `templates.md` § State Persistence)
+- `localStorage` preserves user selections (see `templates.md` § State Persistence)
 - The `concept-submitted` class resets (correct — user can re-submit)
 - Decisions in the bridge server persist across reloads
 
@@ -211,18 +212,18 @@ A page reload (F5) is **not a problem** with the HTTP bridge:
 - When the user explicitly says they're done
 - Periodically if the conversation is idle (via cron or tool-based check)
 
-### Timeout Handling
+### No Timeout Policy
 
-After 5 minutes without submission:
+There is **no timeout**. The user decides when to submit — whether that takes
+2 minutes or 2 hours. Claude keeps the heartbeat cron alive and responds
+whenever the user submits or sends a chat message.
 
-```
-AskUserQuestion:
-  question: "Die Concept-Seite ist seit 5 Minuten offen. Wie soll ich weiter?"
-  options:
-    - "Brauche mehr Zeit" → extend by 5 minutes
-    - "Ergebnisse jetzt auslesen" → read current state even if not submitted
-    - "Abbrechen" → proceed without decisions
-```
+The monitoring loop ends ONLY when:
+- The user says "fertig" / "done" / "abbrechen" in chat
+- The user closes the browser tab (detected when bridge server stays alive
+  but no submissions arrive and the user confirms in chat)
+- The user closes Claude Desktop
+- The heartbeat cron expires after 7 days (platform limit, effectively infinite)
 
 ## Decision Processing
 
@@ -337,7 +338,8 @@ Each round appends to the same file (array of rounds), preserving full history:
 | Heartbeat cron stopped | Page shows "nicht verbunden" despite server running | Send manual `curl -s -X POST /heartbeat`, re-create cron |
 | Decisions JSON parse error | `curl /decisions` returns malformed JSON | Show raw content to user, ask to verify |
 | Empty decisions array | Parsed but `decisions.length === 0` | Ask if intentional (all defaults accepted) |
-| Tab closed by user | No submission past timeout, bridge server still alive | Ask user via AskUserQuestion |
+| Tab closed by user | Bridge server alive but no activity | Ask user via AskUserQuestion when they send a chat message |
+| Offline submission | User submitted while Claude was disconnected | Decisions cached in localStorage, auto-delivered on reconnect via `retryPendingSubmission()` |
 | JS eval broken (page updates) | `javascript_tool` returns "Cannot access chrome-extension://" | Expected — page updates not possible, inform user via chat |
 | `get_page_text` used accidentally | "page body too large" or stripped content | Use HTTP bridge endpoints instead |
 | All tools fail | Bridge server + browser tools both unavailable | Fall back to manual AskUserQuestion flow |

--- a/plugins/devops/skills/devops-concept/deep-knowledge/templates.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/templates.md
@@ -696,17 +696,20 @@ concept variants (see above): Verwerfen / Miteinbeziehen / Exakt diese.
 
 ### State Persistence
 
-Interactive element state MUST survive page reloads via `sessionStorage`.
-This prevents the user from losing their selections when they press F5.
+Interactive element state MUST survive page reloads AND accidental tab closes
+via `localStorage` with a time-to-live (TTL). This prevents the user from
+losing selections, comments, and ratings.
 
 **Storage key:** `concept-state-{slug}` (derived from the page's filename slug)
+**TTL:** 24 hours — auto-clears stale state from previous days
 
 ```javascript
-// --- State Persistence ---
+// --- State Persistence (localStorage + TTL) ---
 const STORAGE_KEY = 'concept-state-' + location.pathname.split('/').pop().replace('.html', '');
+const STATE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
 
 function saveState() {
-  const state = {};
+  const state = { _savedAt: Date.now() };
   // Save toggles, checkboxes, radios
   document.querySelectorAll('input[type="checkbox"], input[type="radio"]').forEach(el => {
     if (el.name || el.id) state['input:' + (el.name || el.id) + ':' + el.value] = el.checked;
@@ -725,18 +728,24 @@ function saveState() {
   });
   // Save theme preference
   state['theme'] = document.documentElement.getAttribute('data-theme');
-  sessionStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
 }
 
 function restoreState() {
-  const raw = sessionStorage.getItem(STORAGE_KEY);
+  const raw = localStorage.getItem(STORAGE_KEY);
   if (!raw) return;
   try {
     const state = JSON.parse(raw);
+    // TTL check — discard state older than 24 hours
+    if (state._savedAt && (Date.now() - state._savedAt) > STATE_TTL_MS) {
+      localStorage.removeItem(STORAGE_KEY);
+      return;
+    }
     // Restore theme first (prevents flash)
     if (state.theme) document.documentElement.setAttribute('data-theme', state.theme);
     // Restore inputs
     Object.entries(state).forEach(([key, value]) => {
+      if (key.startsWith('_')) return; // skip metadata keys
       const [type, ...rest] = key.split(':');
       if (type === 'input') {
         const [name, val] = [rest.slice(0, -1).join(':'), rest[rest.length - 1]];
@@ -766,8 +775,9 @@ document.addEventListener('input', saveState);
 ```
 
 **Rules:**
-- Use `sessionStorage` (not `localStorage`) — state is per-tab, per-session,
-  and auto-clears when the tab is closed. No stale state across sessions.
+- Use `localStorage` with a 24-hour TTL — survives tab close, browser restart,
+  and accidental reloads. Stale state auto-clears after 24h so old concept
+  sessions don't pollute new ones
 - Save on every `change` and `input` event — not just on submit
 - Restore runs on `DOMContentLoaded` — before the user sees the page
 - The `concept-submitted` class is deliberately NOT persisted — after a reload
@@ -848,6 +858,10 @@ document.getElementById('submit-btn').addEventListener('click', async () => {
   container.textContent = JSON.stringify(data);
   document.body.classList.add('concept-submitted');
 
+  // Switch panel to "submitted" state immediately (optimistic UI)
+  document.getElementById('panel-ready').style.display = 'none';
+  document.getElementById('panel-submitted').style.display = 'block';
+
   // POST decisions to bridge server — Claude reads via GET /decisions
   try {
     await fetch('/decisions', {
@@ -856,16 +870,29 @@ document.getElementById('submit-btn').addEventListener('click', async () => {
       body: JSON.stringify(data)
     });
   } catch (e) {
-    // Fallback: decisions are still in the DOM for JS eval reading
+    // Bridge server unreachable — cache decisions for retry
+    localStorage.setItem(STORAGE_KEY + '-pending', JSON.stringify(data));
   }
 
-  // Switch panel to "submitted" state
-  document.getElementById('panel-ready').style.display = 'none';
-  document.getElementById('panel-submitted').style.display = 'block';
-
-  // Clear sessionStorage submitted flag so reload restores "ready" state
   saveState();
 });
+
+// --- Offline Submit Queue ---
+// If the user submitted while disconnected, retry delivery when the bridge
+// server comes back. Checked after each successful heartbeat poll.
+async function retryPendingSubmission() {
+  const pendingKey = STORAGE_KEY + '-pending';
+  const pending = localStorage.getItem(pendingKey);
+  if (!pending) return;
+  try {
+    const res = await fetch('/decisions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: pending
+    });
+    if (res.ok) localStorage.removeItem(pendingKey);
+  } catch (e) { /* still offline — will retry next heartbeat cycle */ }
+}
 ```
 
 ### Panel State Reset
@@ -939,9 +966,14 @@ function checkClaudeConnection() {
   if (isConnected) {
     if (warning) warning.style.display = 'none';
     if (btn) btn.disabled = false;
+    // Retry any pending offline submission now that we're connected
+    retryPendingSubmission();
   } else {
     if (warning) warning.style.display = 'flex';
-    if (btn) btn.disabled = true;
+    // Submit button stays ENABLED even when disconnected — decisions are
+    // cached in localStorage and auto-delivered when Claude reconnects.
+    // The warning banner is enough to inform the user.
+    if (btn) btn.disabled = false;
   }
 }
 


### PR DESCRIPTION
## Summary\n- Upgrade concept page state persistence from sessionStorage to localStorage with 24h TTL — survives tab close, browser restart, Ctrl+Shift+T recovery\n- Add offline submit queue: decisions cached in localStorage when Claude is disconnected, auto-delivered on reconnect\n- Remove 5-minute monitoring timeout — concept pages run indefinitely until user explicitly ends session\n- Submit button stays enabled during disconnect (warning banner is sufficient info)