### PR TITLE
fix(agents): remove auto-ship from agent orchestration

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.39.7"
+    "version": "0.39.8"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.39.7",
+      "version": "0.39.8",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.39.9] — 2026-04-12
+
+### Fixed
+
+- **devops-agents** — removed automatic `/devops-ship` from agent orchestration; agents now only commit and push, shipping is the user's explicit decision
+
 ## [0.39.8] — 2026-04-12
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.39.8**
+**Version: 0.39.9**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.39.8",
+  "version": "0.39.9",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/skills/devops-agents/SKILL.md
+++ b/plugins/devops/skills/devops-agents/SKILL.md
@@ -131,8 +131,7 @@ For each wave:
    - **"Work autonomously. Do NOT use AskUserQuestion. Make reasonable decisions independently. Document all decisions in your commit messages."**
 3. **Continue with other work** or inform the user that agents are working
 4. **Collect results** when notified of completion
-5. **Merge** — ship each sub-branch via `/devops-ship` (sequential within wave)
-6. **Handoff** — pass completed contracts/findings to next wave
+5. **Handoff** — pass completed contracts/findings to next wave
 
 ### Wave Execution — Interactive Mode
 
@@ -149,8 +148,7 @@ For each wave:
    - **"Work interactively. Use AskUserQuestion with concrete options (2-4 choices) for design decisions, ambiguous requirements, or trade-offs. Provide detailed analysis and reasoning inline in the chat. Never decide silently — always explain your approach."**
 3. **Collect results** — wait for all agents in the wave to complete
 4. **Present interim results** — after each wave, summarize findings and decisions inline with analysis text
-5. **Merge** — ship each sub-branch via `/devops-ship` (sequential within wave)
-6. **Handoff** — pass completed contracts/findings to next wave
+5. **Handoff** — pass completed contracts/findings to next wave
 
 ### Single-Agent Shortcut
 
@@ -167,14 +165,15 @@ After all waves complete:
 1. Summarize what each agent accomplished
 2. List any unresolved findings or open questions
 3. Show final branch/PR state
-4. Trigger completion flow
+4. Remind the user to run `/devops-ship` manually when ready to merge
+5. Trigger completion flow
 
 ## Rules
 
 - **Never skip the plan step** — always present and confirm before executing
 - **Never run agents silently** — announce each agent launch
 - **Respect wave dependencies** — Core before Frontend, QA after all code changes
-- **Ship sub-branches sequentially** — parallel work is fine, parallel shipping is not
+- **Never ship automatically** — agents commit and push only. The user decides when to run `/devops-ship`
 - **Follow handoff protocol** — every agent-to-agent transition uses structured handoffs
 - If the user says "just do it" without agents → respect that, don't orchestrate
 - If only 1 domain is affected → consider if a single inline execution is simpler


### PR DESCRIPTION
## Summary
- Removed automatic `/devops-ship` calls from both background and interactive agent execution modes
- Agents now only commit and push — shipping is the user's explicit decision
- Added "Never ship automatically" rule to agent orchestration skill
- Aligned marketplace.json version (was lagging behind at 0.39.7)

Closes #69