### PR TITLE
feat(hooks): session-start cron for git sync (#72)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [0.40.0] — 2026-04-12
+
+### Added
+
+- **hooks/ss.git.sync** — session-start hook registers a CronCreate job (every 10 min) to fetch remote main and merge parent chain into the current branch; keeps worktrees in sync even without user prompts
+- **scripts/git-sync** — extracted standalone sync logic (fetch, parent-chain merge, auto-resolve with `--ours`) shared by cron and prompt hook
+
+### Changed
+
+- **hooks/prompt.git.sync** — delegates to shared `scripts/git-sync.js` instead of inlining the sync logic; throttle (15 min) preserved as overlap guard
+
+### Fixed
+
+- **versioning** — aligned marketplace.json to 0.39.9 (was lagging at 0.39.8)
+
 ## [0.39.9] — 2026-04-12
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.39.9**
+**Version: 0.40.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.39.9",
+  "version": "0.40.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/hooks/hooks.json
+++ b/plugins/devops/hooks/hooks.json
@@ -8,6 +8,7 @@
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-start/ss.mcp.deps.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-start/ss.tokens.scan.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-start/ss.git.check.js" },
+          { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-start/ss.git.sync.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-start/ss.team.changelog.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-start/ss.flow.selfcalibration.js", "_deprecated": "moved to UserPromptSubmit — kept as fallback for older runtimes" }
         ]

--- a/plugins/devops/hooks/session-start/ss.git.sync.js
+++ b/plugins/devops/hooks/session-start/ss.git.sync.js
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+/**
+ * @hook ss.git.sync
+ * @version 0.1.0
+ * @event SessionStart
+ * @plugin devops
+ * @description Registers a recurring git sync cron job (every 10 minutes).
+ *   The cron runs scripts/git-sync.js to fetch remote main and merge
+ *   the parent chain into the current worktree branch.
+ *   One-time registration — the cron persists for the session lifetime.
+ */
+
+require('../lib/plugin-guard');
+
+const { execSync } = require('child_process');
+const path = require('path');
+
+const cwd = process.cwd();
+
+function git(cmd) {
+  try {
+    return execSync(`git ${cmd}`, {
+      cwd,
+      encoding: 'utf8',
+      timeout: 5000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+// Only register in a git repo on a non-main branch with a remote
+if (git('rev-parse --is-inside-work-tree') !== 'true') process.exit(0);
+if (!git('remote')) process.exit(0);
+
+const branch = git('rev-parse --abbrev-ref HEAD');
+if (!branch || branch === 'main') process.exit(0);
+
+// Resolve absolute path to the shared sync script (forward slashes for bash)
+const scriptPath = path.resolve(__dirname, '../../scripts/git-sync.js').replace(/\\/g, '/');
+
+process.stdout.write(
+  `Register a recurring git-sync cron job for this session. ` +
+  `Call CronCreate with cron "*/10 * * * *" (recurring: true) ` +
+  `and prompt: 'Silently run via Bash: node "${scriptPath}". ` +
+  `Only mention output to the user if there are unresolvable merge conflicts (lines containing ✗). ` +
+  `Otherwise do not produce any output.'\n`
+);

--- a/plugins/devops/hooks/user-prompt-submit/prompt.git.sync.js
+++ b/plugins/devops/hooks/user-prompt-submit/prompt.git.sync.js
@@ -1,15 +1,12 @@
 #!/usr/bin/env node
 /**
  * @hook prompt.git.sync
- * @version 0.2.0
+ * @version 0.3.0
  * @event UserPromptSubmit
  * @plugin devops
- * @description Periodic git pull/merge on user prompt — keeps the branch
- *   up-to-date with main AND parent branches during long sessions.
- *   Supports full branch hierarchy: for feat/auth/sub, merges main,
- *   then feat, then feat/auth into the current branch.
- *   Conflict resolution: auto-resolves with --ours before aborting.
- *   Throttled to run at most every 15 minutes.
+ * @description Throttled git sync on user prompt — delegates to scripts/git-sync.js.
+ *   Complements the session-start cron (ss.git.sync) with immediate sync
+ *   on user interaction. Throttled to 15 minutes to avoid overlap with cron.
  */
 
 require('../lib/plugin-guard');
@@ -35,117 +32,20 @@ try {
 // Update throttle timestamp immediately
 try { fs.writeFileSync(THROTTLE_FILE, Date.now().toString()); } catch {}
 
-const cwd = process.cwd();
-const MAIN = 'main';
-
-function git(cmd) {
-  try {
-    return execSync(`git ${cmd}`, {
-      cwd,
-      encoding: 'utf8',
-      timeout: 15000,
-      stdio: ['pipe', 'pipe', 'pipe'],
-    }).trim();
-  } catch {
-    return null;
+// Delegate to shared sync script
+const scriptPath = path.resolve(__dirname, '../../scripts/git-sync.js');
+try {
+  const output = execSync(`node "${scriptPath}"`, {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+    timeout: 30000,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  if (output.trim()) {
+    process.stderr.write(output);
   }
-}
-
-// Only run in a git repo
-if (git('rev-parse --is-inside-work-tree') !== 'true') {
-  process.exit(0);
-}
-
-const remote = git('remote');
-if (!remote) process.exit(0);
-const origin = remote.split('\n')[0];
-
-const branch = git('rev-parse --abbrev-ref HEAD');
-if (!branch || branch === MAIN) process.exit(0);
-
-// Build parent chain from branch name hierarchy.
-// For "feat/auth/login" → [main, feat, feat/auth]
-function getParentChain(branchName) {
-  const parts = branchName.split('/');
-  const parents = [MAIN];
-  for (let i = 1; i < parts.length; i++) {
-    parents.push(parts.slice(0, i).join('/'));
+} catch (err) {
+  if (err.stdout && err.stdout.trim()) {
+    process.stderr.write(err.stdout);
   }
-  return parents;
-}
-
-// Try merging source into HEAD. On conflict, auto-resolve with --ours
-// (keep current branch's version). Only abort if resolution fails.
-function tryMerge(source) {
-  const behind = git(`rev-list --count HEAD..${source}`);
-  if (!behind || parseInt(behind) === 0) return null; // already up to date
-
-  const count = parseInt(behind);
-
-  // Normal merge
-  if (git(`merge ${source} --no-edit --quiet`) !== null) {
-    return { source, commits: count };
-  }
-
-  // Merge conflicted — try to auto-resolve each file with --ours
-  const conflictOutput = git('diff --name-only --diff-filter=U');
-  if (!conflictOutput) {
-    // No conflict markers but merge still failed → unknown error, abort
-    git('merge --abort');
-    return { source, commits: count, failed: true };
-  }
-
-  const files = conflictOutput.split('\n').filter(Boolean);
-
-  for (const file of files) {
-    if (git(`checkout --ours -- "${file}"`) === null) {
-      git('merge --abort');
-      return { source, commits: count, failed: true };
-    }
-    git(`add -- "${file}"`);
-  }
-
-  // Complete the merge with resolved files
-  if (git('commit --no-edit') !== null) {
-    return { source, commits: count, autoResolved: files };
-  }
-
-  git('merge --abort');
-  return { source, commits: count, failed: true };
-}
-
-// Fetch main
-if (git(`fetch ${origin} ${MAIN} --quiet`) === null) {
-  process.exit(0);
-}
-git(`fetch ${origin} ${MAIN}:${MAIN} --quiet`);
-
-// Build parent chain, fetch each from origin, keep only existing branches
-const parents = getParentChain(branch).filter(p => {
-  if (p === MAIN) return true;
-  // Fetch and update local ref from origin (fast-forward)
-  git(`fetch ${origin} ${p}:${p} --quiet`);
-  return git(`rev-parse --verify ${p}`) !== null;
-});
-
-// Merge each parent into current branch (root → closest parent)
-const messages = [];
-for (const parent of parents) {
-  const result = tryMerge(parent);
-  if (!result) continue;
-
-  if (result.failed) {
-    messages.push(`✗ ${parent} → ${branch}: Konflikt, nicht lösbar`);
-  } else if (result.autoResolved) {
-    messages.push(
-      `⚠ ${parent} → ${branch}: ${result.commits} commit(s), ` +
-      `${result.autoResolved.length} Konflikt(e) auto-resolved (--ours)`
-    );
-  } else {
-    messages.push(`✓ ${parent} → ${branch}: ${result.commits} commit(s)`);
-  }
-}
-
-if (messages.length) {
-  process.stderr.write(`[prompt.git.sync] ${messages.join(' | ')}\n`);
 }

--- a/plugins/devops/scripts/git-sync.js
+++ b/plugins/devops/scripts/git-sync.js
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+/**
+ * @script git-sync
+ * @version 0.1.0
+ * @plugin devops
+ * @description Core git sync logic — fetch remote, merge parent chain into
+ *   current branch. Supports branch hierarchy (feat/auth/login merges
+ *   main → feat → feat/auth). Auto-resolves conflicts with --ours.
+ *   Standalone: called by prompt.git.sync hook and session-start cron.
+ */
+
+const { execSync } = require('child_process');
+
+const cwd = process.cwd();
+const MAIN = 'main';
+
+function git(cmd) {
+  try {
+    return execSync(`git ${cmd}`, {
+      cwd,
+      encoding: 'utf8',
+      timeout: 15000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+// Only run in a git repo
+if (git('rev-parse --is-inside-work-tree') !== 'true') {
+  process.exit(0);
+}
+
+const remote = git('remote');
+if (!remote) process.exit(0);
+const origin = remote.split('\n')[0];
+
+const branch = git('rev-parse --abbrev-ref HEAD');
+if (!branch || branch === MAIN) process.exit(0);
+
+// Build parent chain from branch name hierarchy.
+// For "feat/auth/login" → [main, feat, feat/auth]
+function getParentChain(branchName) {
+  const parts = branchName.split('/');
+  const parents = [MAIN];
+  for (let i = 1; i < parts.length; i++) {
+    parents.push(parts.slice(0, i).join('/'));
+  }
+  return parents;
+}
+
+// Try merging source into HEAD. On conflict, auto-resolve with --ours
+// (keep current branch's version). Only abort if resolution fails.
+function tryMerge(source) {
+  const behind = git(`rev-list --count HEAD..${source}`);
+  if (!behind || parseInt(behind) === 0) return null; // already up to date
+
+  const count = parseInt(behind);
+
+  // Normal merge
+  if (git(`merge ${source} --no-edit --quiet`) !== null) {
+    return { source, commits: count };
+  }
+
+  // Merge conflicted — try to auto-resolve each file with --ours
+  const conflictOutput = git('diff --name-only --diff-filter=U');
+  if (!conflictOutput) {
+    // No conflict markers but merge still failed → unknown error, abort
+    git('merge --abort');
+    return { source, commits: count, failed: true };
+  }
+
+  const files = conflictOutput.split('\n').filter(Boolean);
+
+  for (const file of files) {
+    if (git(`checkout --ours -- "${file}"`) === null) {
+      git('merge --abort');
+      return { source, commits: count, failed: true };
+    }
+    git(`add -- "${file}"`);
+  }
+
+  // Complete the merge with resolved files
+  if (git('commit --no-edit') !== null) {
+    return { source, commits: count, autoResolved: files };
+  }
+
+  git('merge --abort');
+  return { source, commits: count, failed: true };
+}
+
+// Fetch main
+if (git(`fetch ${origin} ${MAIN} --quiet`) === null) {
+  process.exit(0);
+}
+git(`fetch ${origin} ${MAIN}:${MAIN} --quiet`);
+
+// Build parent chain, fetch each from origin, keep only existing branches
+const parents = getParentChain(branch).filter(p => {
+  if (p === MAIN) return true;
+  // Fetch and update local ref from origin (fast-forward)
+  git(`fetch ${origin} ${p}:${p} --quiet`);
+  return git(`rev-parse --verify ${p}`) !== null;
+});
+
+// Merge each parent into current branch (root → closest parent)
+const messages = [];
+for (const parent of parents) {
+  const result = tryMerge(parent);
+  if (!result) continue;
+
+  if (result.failed) {
+    messages.push(`✗ ${parent} → ${branch}: Konflikt, nicht lösbar`);
+  } else if (result.autoResolved) {
+    messages.push(
+      `⚠ ${parent} → ${branch}: ${result.commits} commit(s), ` +
+      `${result.autoResolved.length} Konflikt(e) auto-resolved (--ours)`
+    );
+  } else {
+    messages.push(`✓ ${parent} → ${branch}: ${result.commits} commit(s)`);
+  }
+}
+
+if (messages.length) {
+  process.stdout.write(`[git-sync] ${messages.join(' | ')}\n`);
+}


### PR DESCRIPTION
## Summary
- Extract git sync core logic into shared `scripts/git-sync.js`
- Add `ss.git.sync.js` session-start hook that registers a CronCreate job (every 10 min) to keep worktree branches in sync with main — even without user prompts
- Refactor `prompt.git.sync.js` to delegate to the shared script
- Fix marketplace.json version lag (0.39.8 → 0.39.9)

## Test plan
- [x] `npm run lint` passes
- [x] `npm test` — 61/61 tests pass
- [x] `scripts/git-sync.js` runs standalone (exit 0, no output when up-to-date)
- [x] `ss.git.sync.js` outputs CronCreate registration prompt on non-main branches
- [x] `ss.git.sync.js` exits silently on main branch