### PR TITLE
fix(codex): mandatory context loading for integration points

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.39.9"
+    "version": "0.40.1"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.39.9",
+      "version": "0.40.1",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.40.1] — 2026-04-12
+
+### Fixed
+
+- **codex-integration** — skills (ship, flow, deep-research) and agents (QA, research) now load `codex-integration.md` at startup instead of relying on buried mid-flow references that were silently skipped
+
 ## [0.40.0] — 2026-04-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.40.0**
+**Version: 0.40.1**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.40.0",
+  "version": "0.40.1",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/agents/qa.md
+++ b/plugins/devops/agents/qa.md
@@ -14,6 +14,10 @@ tools: ["Bash", "Read", "Glob", "Grep", "preview_screenshot", "preview_snapshot"
 
 Verify that changes work correctly. Run in parallel with implementation.
 
+## Context
+
+Before starting, read `{PLUGIN_ROOT}/deep-knowledge/codex-integration.md` §4 (QA Agent). If codex-plugin-cc is installed, Codex adversarial review is **mandatory** for complex changes — not optional.
+
 ## Responsibilities
 
 - Run unit tests and report results

--- a/plugins/devops/agents/research.md
+++ b/plugins/devops/agents/research.md
@@ -14,6 +14,10 @@ tools: ["WebSearch", "WebFetch", "Read", "Grep", "Glob"]
 
 Deep-dive into a topic and return structured findings.
 
+## Context
+
+Before starting, read `{PLUGIN_ROOT}/deep-knowledge/codex-integration.md` §5 (Research Agent). If codex-plugin-cc is installed, parallel delegation to Codex is **mandatory** for 3+ research angles — not optional.
+
 ## Responsibilities
 
 - Break topic into 3-5 research angles

--- a/plugins/devops/skills/devops-deep-research/SKILL.md
+++ b/plugins/devops/skills/devops-deep-research/SKILL.md
@@ -27,6 +27,8 @@ Do NOT call Read on files that may not exist — skip missing files silently (no
 2. Project: `{project}/.claude/skills/deep-research/SKILL.md` + `reference.md`
 3. Merge: project > global > plugin defaults
 
+4. Codex context: Read `{PLUGIN_ROOT}/deep-knowledge/codex-integration.md` — this skill auto-delegates sub-questions to Codex for parallel research (§5 in that doc). Detect Codex availability now so Step 3 can act on it.
+
 ## Step 1 — Depth check
 
 Before spawning a full research agent, assess:

--- a/plugins/devops/skills/devops-flow/SKILL.md
+++ b/plugins/devops/skills/devops-flow/SKILL.md
@@ -28,6 +28,8 @@ Do NOT call Read on files that may not exist — skip missing files silently (no
 Project extensions define framework-specific log paths (e.g., Electron logs in
 `%APPDATA%/<app>/logs/`, Angular dev server console, etc.).
 
+4. Codex context: Read `{PLUGIN_ROOT}/deep-knowledge/codex-integration.md` — this skill auto-invokes `/codex:rescue` on unclear root cause (§2 in that doc). Detect Codex availability now so Step 6 can act on it.
+
 ## Step 1 — Triage: what broke?
 
 If `$ARGUMENTS` is empty or vague, ask ONE focused question via `AskUserQuestion`:

--- a/plugins/devops/skills/devops-ship/SKILL.md
+++ b/plugins/devops/skills/devops-ship/SKILL.md
@@ -52,6 +52,8 @@ Do NOT call Read on files that may not exist — skip missing files silently (no
 
 Project extensions define: quality gate commands, deploy targets, version files, CI specifics.
 
+4. Codex context: Read `{PLUGIN_ROOT}/deep-knowledge/codex-integration.md` — this skill has a **mandatory** Codex review gate (§1 in that doc). Detect Codex availability now so Step 2 can act on it.
+
 ## Step 1 — Pre-Flight Safety Gate
 
 Call `ship_preflight` MCP tool (dotclaude-ship server).


### PR DESCRIPTION
## Summary
- Skills (ship, flow, deep-research) and agents (QA, research) now load `codex-integration.md` at startup
- Fixes silent skipping of Codex integration points that were buried in mid-flow references
- Codex review gate, rescue invocation, and parallel delegation are now enforced early in skill/agent lifecycle