### PR TITLE
fix(skills): restore trigger phrases removed by header trim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.40.3] — 2026-04-13
+
+### Fixed
+
+- **skills** — restore trigger phrases in ship, repo-health, refresh-usage, and flow skill descriptions that were accidentally removed during header trim (6fd39b0); removes ambiguous triggers ("fertig", "something's off") per Codex review
+
 ## [0.40.2] — 2026-04-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.40.2**
+**Version: 0.40.3**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.40.2",
+  "version": "0.40.3",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/skills/devops-commit/SKILL.md
+++ b/plugins/devops/skills/devops-commit/SKILL.md
@@ -3,8 +3,7 @@ name: devops-commit
 version: 0.1.0
 description: >-
   Create a conventional commit for staged/changed files — enforces type, scope,
-  co-author footer. Triggers on: "commit", "commit this", "speicher das",
-  "committe das", "einchecken". Handles amend for "update/fix last commit".
+  co-author footer. Handles amend for "update/fix last commit".
   Do NOT trigger for push, PR, or ship operations.
 disable-model-invocation: true
 allowed-tools: Bash(git *), AskUserQuestion

--- a/plugins/devops/skills/devops-commit/SKILL.md
+++ b/plugins/devops/skills/devops-commit/SKILL.md
@@ -3,8 +3,9 @@ name: devops-commit
 version: 0.1.0
 description: >-
   Create a conventional commit for staged/changed files — enforces type, scope,
-  co-author footer. Handles amend for "update/fix last commit". Do NOT trigger
-  for push, PR, or ship operations.
+  co-author footer. Triggers on: "commit", "commit this", "speicher das",
+  "committe das", "einchecken". Handles amend for "update/fix last commit".
+  Do NOT trigger for push, PR, or ship operations.
 disable-model-invocation: true
 allowed-tools: Bash(git *), AskUserQuestion
 ---

--- a/plugins/devops/skills/devops-flow/SKILL.md
+++ b/plugins/devops/skills/devops-flow/SKILL.md
@@ -5,8 +5,8 @@ description: >-
   Read session logs, runtime errors, and crash output to diagnose and fix the
   current issue — root-cause analysis first. Use when something is broken or
   behaving unexpectedly. Triggers on: "debug", "this is broken", "doesn't work",
-  "error", "crash", "blank screen", "warum geht das nicht", "funktioniert nicht",
-  "something's off", "it just hangs". Also triggers on pasted error/stack traces
+  "error", "crash", "blank screen", "warum geht das nicht", "funktioniert nicht".
+  Also triggers on pasted error/stack traces
   or when post.flow.debug hook detects repeated Bash failures.
   Do NOT trigger for general code questions.
 argument-hint: "[optional: describe the symptom or paste error]"

--- a/plugins/devops/skills/devops-flow/SKILL.md
+++ b/plugins/devops/skills/devops-flow/SKILL.md
@@ -5,9 +5,10 @@ description: >-
   Read session logs, runtime errors, and crash output to diagnose and fix the
   current issue — root-cause analysis first. Use when something is broken or
   behaving unexpectedly. Triggers on: "debug", "this is broken", "doesn't work",
-  "error", "crash", "warum geht das nicht", "funktioniert nicht". Also triggers
-  on pasted error/stack traces or when post.flow.debug hook detects repeated
-  Bash failures. Do NOT trigger for general code questions.
+  "error", "crash", "blank screen", "warum geht das nicht", "funktioniert nicht",
+  "something's off", "it just hangs". Also triggers on pasted error/stack traces
+  or when post.flow.debug hook detects repeated Bash failures.
+  Do NOT trigger for general code questions.
 argument-hint: "[optional: describe the symptom or paste error]"
 allowed-tools: Read, Grep, Glob, Bash(git log *), Bash(git diff *), Bash(git bisect *), Bash(npm *), Bash(node *), AskUserQuestion, mcp__plugin_devops_dotclaude-issues__*
 ---

--- a/plugins/devops/skills/devops-refresh-usage/SKILL.md
+++ b/plugins/devops/skills/devops-refresh-usage/SKILL.md
@@ -3,7 +3,8 @@ name: devops-refresh-usage
 version: 0.1.0
 description: >-
   Fetch live token usage for completion card battery line. Supports CLI-native,
-  Edge CDP, or graceful fallback. Run silently pre-card, or manually on request.
+  Edge CDP, or graceful fallback. Run silently pre-card, or manually:
+  "refresh usage", "wie viel hab ich verbraucht", "token budget".
 allowed-tools: Bash(node *), Read
 ---
 

--- a/plugins/devops/skills/devops-repo-health/SKILL.md
+++ b/plugins/devops/skills/devops-repo-health/SKILL.md
@@ -4,7 +4,9 @@ version: 0.2.0
 description: >-
   Analyze repository branch hygiene: unmerged branches, stale locals with deleted
   remotes, orphaned worktrees, verify work landed in main. Results: interactive
-  concept page with filters and batch actions. Explicit user request only.
+  concept page with filters and batch actions. Triggers on: "repo health",
+  "branch cleanup", "was liegt noch rum", "git aufräumen", "branch hygiene".
+  Explicit user request only.
 argument-hint: "[optional: focus area — branches, worktrees, PRs]"
 allowed-tools: Bash(git *), Bash(gh *), Bash(start *), Bash(cmd *), Read, Write, Glob, Grep, AskUserQuestion, mcp__Claude_Preview__*, mcp__plugin_playwright_playwright__*, mcp__Claude_in_Chrome__*
 ---

--- a/plugins/devops/skills/devops-ship/SKILL.md
+++ b/plugins/devops/skills/devops-ship/SKILL.md
@@ -6,8 +6,9 @@ description: >-
   ship_version_bump, ship_release, ship_cleanup, render_completion_card,
   then silent memory consolidation.
   Supports hierarchical merges (sub-branch → feature → main).
-  Use when work is ready to land. Do NOT trigger during coding/debugging
-  or for commits without shipping.
+  Use when work is ready to land. Triggers on: "ship it", "fertig",
+  "ab damit", "push and merge", "das kann rein".
+  Do NOT trigger during coding/debugging or for commits without shipping.
 allowed-tools: Bash(git *), Bash(gh *), Bash(npm *), Bash(node *), Read, Glob, Grep, AskUserQuestion, ExitWorktree, mcp__plugin_devops_dotclaude-ship__*, mcp__plugin_devops_dotclaude-completion__*, mcp__plugin_devops_dotclaude-issues__*
 ---
 

--- a/plugins/devops/skills/devops-ship/SKILL.md
+++ b/plugins/devops/skills/devops-ship/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   ship_version_bump, ship_release, ship_cleanup, render_completion_card,
   then silent memory consolidation.
   Supports hierarchical merges (sub-branch → feature → main).
-  Use when work is ready to land. Triggers on: "ship it", "fertig",
+  Use when work is ready to land. Triggers on: "ship it",
   "ab damit", "push and merge", "das kann rein".
   Do NOT trigger during coding/debugging or for commits without shipping.
 allowed-tools: Bash(git *), Bash(gh *), Bash(npm *), Bash(node *), Read, Glob, Grep, AskUserQuestion, ExitWorktree, mcp__plugin_devops_dotclaude-ship__*, mcp__plugin_devops_dotclaude-completion__*, mcp__plugin_devops_dotclaude-issues__*


### PR DESCRIPTION
## Summary
- Restore trigger phrases in skill descriptions (ship, repo-health, refresh-usage, flow) that were accidentally removed during the header trim refactor (6fd39b0)
- Remove ambiguous triggers per Codex review: "fertig" (conflicts with concept acknowledgement), vague flow phrases ("something's off", "it just hangs")
- devops-commit left without triggers since it has `disable-model-invocation: true`

## Test plan
- [ ] Verify `/devops-ship` triggers on "ship it", "ab damit", "das kann rein"
- [ ] Verify `/devops-flow` triggers on "debug", "error", "funktioniert nicht"
- [ ] Verify `/devops-repo-health` triggers on "repo health", "branch cleanup"