### PR TITLE
fix(codex): replace phantom skill refs with actual skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.40.2"
+    "version": "0.40.3"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.40.2",
+      "version": "0.40.3",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.40.4] — 2026-04-13
+
+### Fixed
+
+- **codex** — replace phantom skill references (`/codex:review`, `/codex:adversarial-review`, `/codex:cancel`) with actual available skills (`/codex:rescue`, `/codex:setup`) across ship SKILL, QA agent, codex-integration deep-knowledge, INSTALL, README, and architecture diagram
+- **version** — align marketplace.json with current release version
+
 ## [0.40.3] — 2026-04-13
 
 ### Fixed

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -77,12 +77,8 @@ Then start a new session and run `/codex:setup` to configure authentication.
 
 | Skill | Purpose |
 |---|---|
-| `/codex:review` | Read-only code review against diffs |
-| `/codex:adversarial-review` | Devil's advocate review — challenges design trade-offs |
-| `/codex:rescue` | Delegate investigation or fix tasks to Codex |
-| `/codex:status` | Monitor running Codex jobs |
-| `/codex:result` | Retrieve completed job output |
-| `/codex:cancel` | Cancel active Codex tasks |
+| `/codex:rescue` | Delegate investigation, review, or fix tasks to Codex |
+| `/codex:setup` | Check Codex CLI readiness and configure review gate |
 
 ### How it works with devops
 
@@ -91,9 +87,8 @@ No extra configuration needed — install both and all skills are available.
 
 Typical combined workflows:
 
-- **Ship with review:** `/codex:review` → check feedback → `/devops-ship`
+- **Ship with review:** `/codex:rescue` for pre-ship code review → `/devops-ship`
 - **Delegate investigation:** `/codex:rescue` as alternative to `/devops-deep-research`
-- **Adversarial QA:** `/codex:adversarial-review` alongside the QA agent
 
 ### Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.40.3**
+**Version: 0.40.4**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/README.md
+++ b/README.md
@@ -195,8 +195,8 @@ Install [codex-plugin-cc](https://github.com/openai/codex-plugin-cc) alongside
 this plugin for AI-powered code review and task delegation via OpenAI Codex.
 Both plugins coexist as independent skill providers — no configuration needed.
 
-Combined workflows: `/codex:review` before `/devops-ship`, `/codex:rescue` as
-alternative to `/devops-deep-research`, `/codex:adversarial-review` alongside QA.
+Combined workflows: `/codex:rescue` for pre-ship code review, parallel investigation
+as alternative to `/devops-deep-research`, and QA-integrated review for complex changes.
 
 See [INSTALL.md](INSTALL.md#optional-codex-integration) for setup instructions.
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.40.3",
+  "version": "0.40.4",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/agents/qa.md
+++ b/plugins/devops/agents/qa.md
@@ -16,7 +16,7 @@ Verify that changes work correctly. Run in parallel with implementation.
 
 ## Context
 
-Before starting, read `{PLUGIN_ROOT}/deep-knowledge/codex-integration.md` §4 (QA Agent). If codex-plugin-cc is installed, Codex adversarial review is **mandatory** for complex changes — not optional.
+Before starting, read `{PLUGIN_ROOT}/deep-knowledge/codex-integration.md` §4 (QA Agent). If codex-plugin-cc is installed, Codex review via `/codex:rescue` is **mandatory** for complex changes — not optional.
 
 ## Responsibilities
 
@@ -25,7 +25,7 @@ Before starting, read `{PLUGIN_ROOT}/deep-knowledge/codex-integration.md` §4 (Q
 - Take screenshots of UI changes
 - Check console logs for errors
 - Generate build-ID after successful build
-- **Automatically run** `/codex:adversarial-review` for complex or high-risk changes (multi-file, architectural, security-sensitive). Skip for trivial single-file fixes. If codex-plugin-cc is not installed → skip silently.
+- **Automatically run** `/codex:rescue` for complex or high-risk changes (multi-file, architectural, security-sensitive). Skip for trivial single-file fixes. If codex-plugin-cc is not installed → skip silently.
 - Report findings in structured format
 
 ## Output format

--- a/plugins/devops/deep-knowledge/codex-integration.md
+++ b/plugins/devops/deep-knowledge/codex-integration.md
@@ -28,10 +28,9 @@ a hard gate), so automatic execution carries no risk of blocking workflows.
 ### 1. /devops-ship — Pre-PR Code Review (Step 2, Quality Gates)
 
 **When:** After build + lint + tests pass, before commit/push/PR.
-**Skill:** `/codex:review` (standard) or `/codex:adversarial-review` (major bumps).
+**Skill:** `/codex:rescue` (delegates diff review to Codex).
 **Behavior:**
-- patch/minor bump → **automatically run** `/codex:review` on the diff (read-only)
-- major bump → **automatically run** `/codex:adversarial-review` (challenges design trade-offs)
+- **Automatically run** `/codex:rescue` with the diff as context for independent code review
 - Evaluate findings:
   - No findings / clean → continue pipeline
   - Auto-fixable (typos, missing imports, style) → fix inline, continue
@@ -66,17 +65,17 @@ systematically. Tests verify behavior; Codex reviews design and logic.
 **Value:** Low-cost hint. The actual automatic invocation happens when `/devops-flow`
 runs and reaches Step 6 with an unclear root cause (see Integration Point 2).
 
-### 4. QA Agent — Adversarial Review
+### 4. QA Agent — Codex Review
 
 **When:** QA agent runs verification on changes.
-**Skill:** `/codex:adversarial-review`
+**Skill:** `/codex:rescue`
 **Behavior:**
-- **Automatically run** `/codex:adversarial-review` when QA detects high-risk
+- **Automatically run** `/codex:rescue` when QA detects high-risk
   or complex changes (multi-file, architectural, security-sensitive)
 - For simple changes (single file, trivial fix) → skip Codex, standard QA only
 - Findings included in QA_RESULT output under `codex_review`
 
-**Value:** Harder review that challenges assumptions, not just verifies correctness.
+**Value:** Independent review from a second AI that challenges assumptions.
 
 ### 5. Research Agent — Parallel Delegation
 
@@ -95,10 +94,9 @@ runs and reaches Step 6 with an unclear root cause (see Integration Point 2).
 | Integration Point | Estimated Cost | Frequency |
 |---|---|---|
 | /devops-ship review | ~20-40K tokens | Per ship (~2-5/week) |
-| /devops-ship adversarial | ~30-60K tokens | Major bumps only |
 | /devops-flow rescue | ~30-50K tokens | When stuck (~1-3/week) |
 | post.flow.debug | 0 (suggestion only) | N/A |
-| QA adversarial | ~20-40K tokens | Per QA run |
+| QA review | ~20-40K tokens | Per QA run |
 | Research delegation | ~20-40K tokens | Per research task |
 
 Note: These tokens are consumed on the **Codex/OpenAI side**, not the Claude
@@ -108,7 +106,7 @@ session budget. The only Claude-side cost is the skill invocation overhead.
 
 | Symptom | Cause | Fix |
 |---|---|---|
-| `/codex:review` not found | Plugin not installed | Install via Settings → Plugins |
+| `/codex:rescue` not found | Plugin not installed | Install via Settings → Plugins |
 | Codex auth error | Token expired | Run `codex auth` in terminal |
 | Review returns empty | No diff to review | Ensure changes exist vs. main |
-| Rescue hangs | Codex job stuck | `/codex:cancel` then retry |
+| Rescue hangs | Codex job stuck | Cancel and retry |

--- a/plugins/devops/docs/architecture.html
+++ b/plugins/devops/docs/architecture.html
@@ -1057,7 +1057,7 @@
   <span class="from">/devops-flow</span> <span class="to">&rarr; suggests /devops-ship &mdash; after fix is applied and changes are ready</span>
   <span class="from">/devops-project-setup</span> <span class="to">&rarr; informs user to run /devops-readme &mdash; for README generation</span>
   <span class="from">/devops-extend-skill</span> <span class="to">&rarr; reads all skills &mdash; to list available extension targets</span>
-  <span class="from">/devops-ship</span> <span class="to">&rarr; optional /codex:review &mdash; for major version bumps (if codex-plugin-cc installed)</span>
+  <span class="from">/devops-ship</span> <span class="to">&rarr; optional /codex:rescue &mdash; pre-ship code review (if codex-plugin-cc installed)</span>
 </div>
 
 <h3>Hook &rarr; Hook Chains</h3>

--- a/plugins/devops/skills/devops-ship/SKILL.md
+++ b/plugins/devops/skills/devops-ship/SKILL.md
@@ -91,7 +91,7 @@ If `success: false` → call `render_completion_card` with variant `ship-blocked
 
 **MUST run** if codex-plugin-cc is installed — not optional, not suggested.
 
-1. patch/minor → `/codex:review`; major → `/codex:adversarial-review`
+1. Invoke `/codex:rescue` with the diff as context for independent code review
 2. Evaluate findings:
    - **No findings / clean** → continue to Step 3
    - **Auto-fixable** (typos, missing imports, style) → fix inline, continue


### PR DESCRIPTION
## Summary
- Replace non-existent codex skill references (`/codex:review`, `/codex:adversarial-review`, `/codex:cancel`) with actual available skills (`/codex:rescue`, `/codex:setup`)
- Fix across 7 files: ship SKILL, QA agent, codex-integration deep-knowledge, INSTALL, README, architecture diagram
- Align marketplace.json version with current release

## Test plan
- [x] `npm run lint` — clean
- [x] `npm test` — 61/61 passed
- [x] Grep confirms no phantom refs remain (outside CHANGELOG history)