### PR TITLE
feat(skills): QA testing protocol for agents + autonomous

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.40.4"
+    "version": "0.40.5"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.40.4",
+      "version": "0.40.5",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.40.6] — 2026-04-13
+
+### Added
+
+- **skills** — QA Testing Protocol in `devops-agents`: unit tests, build check, browser-based visual verification via waterfall (Chrome MCP → Playwright → Preview); computer-use requires explicit user opt-in
+- **skills** — `devops-autonomous` Live Testing now references agents' QA protocol as single source of truth instead of duplicating testing logic
+
+### Fixed
+
+- **version** — sync marketplace.json to 0.40.5 (was left at 0.40.4 in prior release)
+
 ## [0.40.5] — 2026-04-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.40.5**
+**Version: 0.40.6**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/skills/devops-agents/SKILL.md
+++ b/plugins/devops/skills/devops-agents/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: devops-agents
-version: 0.3.0
+version: 0.4.0
 description: >-
   Evaluate which agents are useful for a task and orchestrate their parallel or
   sequential execution. Use when the user explicitly wants orchestrated agent
@@ -11,7 +11,7 @@ description: >-
   Do NOT trigger for: simple single-file edits, quick fixes, explanations,
   or research-only tasks (use /devops-deep-research).
 argument-hint: "[task description or goal]"
-allowed-tools: Agent, Read, Glob, Grep, Bash, Write, Edit, AskUserQuestion, mcp__plugin_devops_dotclaude-completion__*
+allowed-tools: Agent, Read, Glob, Grep, Bash, Write, Edit, AskUserQuestion, mcp__plugin_devops_dotclaude-completion__*, mcp__Claude_Preview__preview_start, mcp__Claude_Preview__preview_list
 ---
 
 # Orchestrate
@@ -51,7 +51,7 @@ Based on the analysis, select agents from the available pool:
 | **windows** | Platform-specific (system tray, native APIs) | 2 |
 | **ai** | AI/ML integration, embeddings, prompts | 2 |
 | **designer** | UX/UI decisions, design system, specs | 0 or 2 |
-| **qa** | Test, verify, screenshot | 3 |
+| **qa** | Unit tests, build check, browser-based visual verification | 3 |
 | **po** | Requirements validation, trade-off review | 4 |
 | **gamer** | End-user/player perspective | 3 or 4 |
 
@@ -149,6 +149,51 @@ For each wave:
 3. **Collect results** — wait for all agents in the wave to complete
 4. **Present interim results** — after each wave, summarize findings and decisions inline with analysis text
 5. **Handoff** — pass completed contracts/findings to next wave
+
+### QA Wave — Testing Protocol
+
+The QA agent (Wave 3) MUST follow these testing rules. Include ALL applicable
+instructions in the QA agent prompt.
+
+**1. Unit/Integration Tests**
+Run relevant test suites via Bash (`npm test`, `npm run test:unit`, etc.).
+Target specific test files for changed modules — see `deep-knowledge/test-strategy.md`.
+
+**2. Build Verification**
+Run the build command (`npm run build` or equivalent) to verify compilation succeeds.
+
+**3. Browser-Based Visual Verification (UI projects)**
+For projects with a UI (web apps, Electron, etc.):
+- **Orchestrator** (before spawning QA): probe the browser tool waterfall from
+  `deep-knowledge/browser-tool-strategy.md` (Chrome MCP → Playwright → Preview).
+  Set `$BROWSER_TOOL` to the first responder. If Preview is selected, start a
+  server via `preview_start` and capture `$SERVER_ID`.
+- **QA agent** uses whichever tool the orchestrator selected:
+  - Chrome MCP: `computer` (screenshot), `read_page`
+  - Playwright: `browser_take_screenshot`, `browser_snapshot`
+  - Preview: `preview_screenshot`, `preview_snapshot` (pass `serverId`)
+- All three are DOM/protocol-based — no desktop takeover, no user interruption.
+- Skip visual verification for non-UI changes (config, scripts, docs).
+
+**4. Computer-Use Restriction — HARD RULE**
+**NEVER** use computer-use (`mcp__computer-use__*`) for testing unless the user
+**explicitly** requested desktop takeover (e.g., "Desktop übernehmen", "use
+computer-use", "nimm den Desktop", "desktop testing").
+
+Browser-based testing via the waterfall tools is always allowed and runs in the
+background. Computer-use is the **only** testing method that requires explicit
+user opt-in.
+
+**QA Agent Prompt — Append These Instructions:**
+```
+Test the changes:
+1. Run unit/integration tests for changed modules
+2. Run the build to verify it succeeds
+3. [If UI project] Use {$BROWSER_TOOL} to visually verify changed views —
+   take screenshots of key flows. Tool: {tool-specific instructions from waterfall}.
+4. Do NOT use computer-use or desktop takeover for testing
+5. Report results as: { method: "...", result: "pass" | "fail — reason" }
+```
 
 ### Single-Agent Shortcut
 

--- a/plugins/devops/skills/devops-autonomous/SKILL.md
+++ b/plugins/devops/skills/devops-autonomous/SKILL.md
@@ -253,13 +253,23 @@ If during autonomous execution a permission is needed that wasn't primed in Step
 
 - **Simple**: work directly, no sub-agents
 - **Medium**: 2-3 parallel agents for independent domains
-- **Complex**: use devops agent roster (core, frontend, ai, qa, designer)
+- **Complex**: follow devops-agents orchestration logic (Step 1-2 analysis, wave-based
+  execution with core, frontend, ai, qa, designer agents). Key differences in autonomous:
+  - **All agents run in background** (`run_in_background: true`, no interactive mode)
+  - **No AskUserQuestion** — agents decide autonomously, log decisions in commits
+  - **QA Testing Protocol applies** — see devops-agents SKILL.md § QA Wave for
+    unit tests, build checks, and browser-based visual verification rules
+  - **Computer-use restriction** — only if user chose "Desktop übernehmen" in Step 2
 
 ### Live Testing (implement mode only)
 
-After implementation: run build, run tests, then use `$BROWSER_TOOL` (from Step 3b)
-to open the app, screenshot key flows, verify visually. For native desktop apps
-(not browser), use computer-use if desktop mode was chosen. Track progress via TodoWrite.
+Follow the **QA Testing Protocol** from devops-agents SKILL.md § QA Wave.
+Use `$BROWSER_TOOL` (from Step 3b) for all browser-based visual verification.
+
+**Autonomous-specific additions:**
+- **Native desktop apps**: use computer-use **only** if user chose "Desktop
+  übernehmen" in Step 2. Otherwise skip native-app visual testing.
+- Track progress via TodoWrite.
 
 ## Step 6 — Error Handling
 


### PR DESCRIPTION
## Summary\n\n- Add QA Wave Testing Protocol to `devops-agents`: unit tests, build check, browser-based visual verification via waterfall (Chrome MCP → Playwright → Preview)\n- Computer-use for testing requires explicit user opt-in (hard rule)\n- `devops-autonomous` Live Testing now references agents' QA protocol as single source of truth\n- Fix marketplace.json version sync (0.40.4 → 0.40.5)\n\nCloses #78