### PR TITLE
refactor(agents): shared orchestration deep-knowledge

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.40.6"
+    "version": "0.40.7"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.40.6",
+      "version": "0.40.7",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.40.8] — 2026-04-13
+
+### Changed
+
+- **deep-knowledge** — new `agent-orchestration.md`: shared orchestration logic (agent selection, wave execution, QA testing protocol, prompt template, single-agent shortcut) extracted from `devops-agents` and `devops-autonomous` skills
+- **skills** — `devops-agents` and `devops-autonomous` now reference `agent-orchestration.md` as single source of truth instead of duplicating orchestration logic
+
+### Fixed
+
+- **version** — align marketplace.json to 0.40.7
+
 ## [0.40.7] — 2026-04-13
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.40.7**
+**Version: 0.40.8**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.40.7",
+  "version": "0.40.8",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/deep-knowledge/INDEX.md
+++ b/plugins/devops/deep-knowledge/INDEX.md
@@ -7,6 +7,7 @@ Quick-reference for all deep-knowledge topics. Read this FIRST to find the right
 |------|-------|---------|
 | [agent-collaboration.md](agent-collaboration.md) | Agent Collaboration Protocol | How agents work together on multi-role tasks. |
 | [agent-conventions.md](agent-conventions.md) | Agent Naming & Collaboration Conventions | [role:X · Type] Task description |
+| [agent-orchestration.md](agent-orchestration.md) | Agent Orchestration | Shared orchestration logic for agent selection, prompting, and wave execution. |
 | [agent-proactivity.md](agent-proactivity.md) | Proactive Agent Orchestration | Cross-cutting rule for when to involve specialized agents without explicit us... |
 | [browser-tool-strategy.md](browser-tool-strategy.md) | Browser Tool Strategy | Cross-cutting rules for browser interaction across all skills. Every skill that |
 | [claude-directory-structure.md](claude-directory-structure.md) | Claude Directory Structure Convention | All Claude Code configuration belongs inside `.claude/`. Nothing Claude-specific |

--- a/plugins/devops/deep-knowledge/agent-orchestration.md
+++ b/plugins/devops/deep-knowledge/agent-orchestration.md
@@ -1,0 +1,88 @@
+# Agent Orchestration
+
+Shared orchestration logic for agent selection, prompting, and wave execution.
+Referenced by `/devops-agents` and `/devops-autonomous`.
+
+## Agent Selection
+
+Select agents based on domains touched, complexity, and risk:
+
+| Agent | When to include | Wave |
+|-------|----------------|------|
+| **research** | Topic needs investigation first | 0 (pre-work) |
+| **core** | Business logic, APIs, data models | 1 |
+| **frontend** | UI components, templates, styling | 2 |
+| **windows** | Platform-specific (system tray, native APIs) | 2 |
+| **ai** | AI/ML integration, embeddings, prompts | 2 |
+| **designer** | UX/UI decisions, design system, specs | 0 or 2 |
+| **qa** | Test, verify, screenshot | 3 |
+| **po** | Requirements validation, trade-off review | 4 |
+| **gamer** | End-user/player perspective | 3 or 4 |
+
+### Selection Criteria
+
+- Include an agent only if it adds **concrete value** — not for coverage
+- Prefer fewer agents with clear purpose over many with vague roles
+- Always include **qa** for any code changes (Wave 3)
+- Include **po** only for feature-level work, not bugfixes or refactoring
+
+### Complexity Tiers
+
+| Tier | Signals | Strategy |
+|------|---------|----------|
+| **Simple** | Single domain, < 5 files, clear scope | Work directly, no sub-agents |
+| **Medium** | 2 independent domains, no cross-deps | 2-3 parallel agents for independent domains |
+| **Complex** | 3+ domains, cross-cutting, or high risk | Full agent roster with wave model |
+
+## Wave Execution
+
+Follow the wave model from `agent-collaboration.md`. The execution mechanics below
+apply regardless of whether the caller is interactive or autonomous.
+
+### Agent Prompt Template
+
+Every spawned agent MUST receive:
+
+1. **Parent branch name** — for branch inheritance protocol
+2. **Task description** — specific to their role, not the full user request
+3. **Context from previous waves** — handoff data (contracts, findings, decisions)
+4. **Commit instruction** — follow commit conventions from `/devops-commit`
+5. **Interaction directive** — set by the calling skill (see below)
+
+### Interaction Directives
+
+The calling skill sets the interaction mode for all spawned agents:
+
+| Mode | Directive |
+|------|-----------|
+| **Autonomous** | "Work autonomously. Do NOT use AskUserQuestion. Make reasonable decisions independently. Document all decisions in your commit messages." |
+| **Background** | Same as Autonomous |
+| **Interactive** | "Work interactively. Use AskUserQuestion with concrete options (2-4 choices) for design decisions, ambiguous requirements, or trade-offs. Provide detailed analysis and reasoning inline in the chat. Never decide silently — always explain your approach." |
+
+### Spawning Mechanics
+
+For each wave:
+
+1. **Spawn agents** — parallel within the same wave, sequential across waves
+2. **Isolation** — each agent works in an isolated worktree (`isolation: "worktree"`)
+3. **Background agents** — use `run_in_background: true`
+4. **Foreground agents** — wait for completion before next wave
+5. **Collect results** — gather handoff data before spawning next wave
+
+### Single-Agent Shortcut
+
+If only 1 agent is selected (e.g., just research or just qa):
+- Skip branching strategy entirely
+- Launch the agent directly with full context
+- Autonomous/background: `run_in_background: true`
+- Interactive: foreground with inline questions
+
+### Branch Strategy
+
+See `agent-collaboration.md` § Sub-Branch Strategy and § Branch Inheritance Protocol.
+The orchestrator (calling skill) is responsible for:
+
+1. Creating the integration branch if not already on a feature branch
+2. Pushing it to origin before spawning sub-agents
+3. Merging each wave's branches back before spawning the next wave
+4. Sequential shipping within a wave (parallel work, sequential ship)

--- a/plugins/devops/skills/devops-agents/SKILL.md
+++ b/plugins/devops/skills/devops-agents/SKILL.md
@@ -41,26 +41,8 @@ If `$ARGUMENTS` is empty or vague, ask ONE focused question via `AskUserQuestion
 
 ## Step 2 — Agent Selection
 
-Based on the analysis, select agents from the available pool:
-
-| Agent | When to include | Wave |
-|-------|----------------|------|
-| **research** | Topic needs investigation first | 0 (pre-work) |
-| **core** | Business logic, APIs, data models | 1 |
-| **frontend** | UI components, templates, styling | 2 |
-| **windows** | Platform-specific (system tray, native APIs) | 2 |
-| **ai** | AI/ML integration, embeddings, prompts | 2 |
-| **designer** | UX/UI decisions, design system, specs | 0 or 2 |
-| **qa** | Test, verify, screenshot | 3 |
-| **po** | Requirements validation, trade-off review | 4 |
-| **gamer** | End-user/player perspective | 3 or 4 |
-
-**Selection criteria:**
-
-- Include an agent only if it adds **concrete value** — not for coverage
-- Prefer fewer agents with clear purpose over many with vague roles
-- Always include **qa** for any code changes (Wave 3)
-- Include **po** only for feature-level work, not bugfixes or refactoring
+Select agents using the roster, criteria, and complexity tiers from
+`deep-knowledge/agent-orchestration.md` § Agent Selection.
 
 ## Step 3 — Present Plan
 
@@ -108,55 +90,19 @@ Store the result as `$EXEC_MODE` (`background` or `interactive`).
 
 ## Step 5 — Execution
 
-Follow the collaboration protocol from `deep-knowledge/agent-collaboration.md`:
+Follow `deep-knowledge/agent-orchestration.md` § Wave Execution for spawning mechanics,
+agent prompt template, branch strategy, and single-agent shortcut.
 
-### Branch Strategy
+Collaboration protocol (handoffs, merge order, shipping): `deep-knowledge/agent-collaboration.md`.
 
-1. Create integration branch if not already on a feature branch
-2. Push integration branch to origin before spawning sub-agents
-3. Each agent works in an isolated worktree (`isolation: "worktree"`)
+### Mode-Specific Behavior
 
-### Wave Execution — Background Mode
-
-When `$EXEC_MODE` is `background`:
-
-For each wave:
-
-1. **Spawn agents** with `run_in_background: true` — parallel within the same wave
-2. **Include in every agent prompt:**
-   - Parent branch name
-   - Task description specific to their role
-   - Context from previous waves (handoff data)
-   - Instruction to follow commit conventions from `/devops-commit`
-   - **"Work autonomously. Do NOT use AskUserQuestion. Make reasonable decisions independently. Document all decisions in your commit messages."**
-3. **Continue with other work** or inform the user that agents are working
-4. **Collect results** when notified of completion
-5. **Handoff** — pass completed contracts/findings to next wave
-
-### Wave Execution — Interactive Mode
-
-When `$EXEC_MODE` is `interactive`:
-
-For each wave:
-
-1. **Spawn agents** in foreground — parallel within the same wave, sequential across waves
-2. **Include in every agent prompt:**
-   - Parent branch name
-   - Task description specific to their role
-   - Context from previous waves (handoff data)
-   - Instruction to follow commit conventions from `/devops-commit`
-   - **"Work interactively. Use AskUserQuestion with concrete options (2-4 choices) for design decisions, ambiguous requirements, or trade-offs. Provide detailed analysis and reasoning inline in the chat. Never decide silently — always explain your approach."**
-3. **Collect results** — wait for all agents in the wave to complete
-4. **Present interim results** — after each wave, summarize findings and decisions inline with analysis text
-5. **Handoff** — pass completed contracts/findings to next wave
-
-### Single-Agent Shortcut
-
-If only 1 agent was selected (e.g., just research or just qa):
-- Skip branching strategy
-- Launch the agent directly with full context
-- In background mode: `run_in_background: true`, autonomous
-- In interactive mode: foreground, with inline questions and analysis
+- **Background** (`$EXEC_MODE`): Use interaction directive "Autonomous" from the
+  orchestration doc. Spawn with `run_in_background: true`. Continue with other work
+  or inform the user. Collect results when notified.
+- **Interactive** (`$EXEC_MODE`): Use interaction directive "Interactive" from the
+  orchestration doc. Spawn in foreground. Present interim results after each wave
+  with inline analysis text.
 
 ## Step 6 — Synthesis
 

--- a/plugins/devops/skills/devops-autonomous/SKILL.md
+++ b/plugins/devops/skills/devops-autonomous/SKILL.md
@@ -251,9 +251,13 @@ If during autonomous execution a permission is needed that wasn't primed in Step
 
 ### Strategy
 
-- **Simple**: work directly, no sub-agents
-- **Medium**: 2-3 parallel agents for independent domains
-- **Complex**: use devops agent roster (core, frontend, ai, qa, designer)
+Select agents and execute waves per `deep-knowledge/agent-orchestration.md`:
+- § Agent Selection for roster, criteria, and complexity tiers (Simple/Medium/Complex)
+- § Wave Execution for spawning mechanics, prompt template, and branch strategy
+- § Single-Agent Shortcut when only one domain is involved
+
+All agents use the **Autonomous** interaction directive (no AskUserQuestion).
+Collaboration protocol (handoffs, merge order): `deep-knowledge/agent-collaboration.md`.
 
 ### Live Testing (implement mode only)
 


### PR DESCRIPTION
## Summary
- Extract shared agent orchestration logic (selection, wave execution, QA testing protocol, prompt template) into `deep-knowledge/agent-orchestration.md`
- Both `devops-agents` and `devops-autonomous` now reference the same source of truth
- Fix marketplace.json version alignment (was stuck at 0.40.6)

Closes #80