### PR TITLE
feat(ship): prevent silent merge overwrites in parallel dev

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.40.7"
+    "version": "0.40.8"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.40.7",
+      "version": "0.40.8",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.41.0] — 2026-04-14
+
+### Added
+
+- **ship** — merge safety system to prevent silent overwrites in parallel development:
+  - `git-sync.js` v0.2.0: conflicts abort + warn instead of auto-resolving with `--ours`
+  - `preflight.js`: file overlap detection (branch vs base), `merge.conflictstyle` config check
+  - `release.js`: mandatory rebase-gate before merge, configurable merge strategy (squash/merge/rebase)
+  - `github.js`: PR mergeability re-check on reuse, strategy parameter for `mergePR()`
+  - `SKILL.md` Step 1.5: AI-driven rebase, conflict resolution, and post-rebase test run
+- **deep-knowledge** — `merge-safety.md`: reference doc covering diff3, Mergiraf, branch protection, squash ancestry problem
+
+### Fixed
+
+- **version** — align marketplace.json to 0.40.8
+
 ## [0.40.8] — 2026-04-13
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.40.8**
+**Version: 0.41.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.40.8",
+  "version": "0.41.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/deep-knowledge/INDEX.md
+++ b/plugins/devops/deep-knowledge/INDEX.md
@@ -17,6 +17,7 @@ Quick-reference for all deep-knowledge topics. Read this FIRST to find the right
 | [desktop-testing.md](desktop-testing.md) | Automated Desktop Testing (Computer Use) | Rules for when and how Claude takes over the desktop to run visual UI tests |
 | [fact-verification.md](fact-verification.md) | Fact Verification | Cross-cutting rule for all web research, claims, and statistics. |
 | [git-hygiene.md](git-hygiene.md) | Git Hygiene | Cross-cutting git rules referenced by `/devops-commit`, `/devops-ship`, and h... |
+| [merge-safety.md](merge-safety.md) | Merge Safety — Parallel Development | Preventing silent overwrites: rebase gates, diff3, Mergiraf, branch protection |
 | [plugin-behavior.md](plugin-behavior.md) | Plugin Behavior Rules | Core behavioral rules enforced by the devops plugin. |
 | [skill-extension-guide.md](skill-extension-guide.md) | Skill Extension Guide — For Plugin Integrators | How to customize devops skills and agents for your project. |
 | [test-strategy.md](test-strategy.md) | Test Execution Strategy | Cross-cutting rules for when and how to test. Referenced by the completion flow |

--- a/plugins/devops/deep-knowledge/git-hygiene.md
+++ b/plugins/devops/deep-knowledge/git-hygiene.md
@@ -19,3 +19,11 @@ Cross-cutting git rules referenced by `/devops-commit`, `/devops-ship`, and hook
 - Never force-push to `main`/`master` without explicit user confirmation.
 - After merge: local branch is deleted, remote branch is deleted by `--delete-branch`.
 - Stale branches (upstream gone, no worktree) are cleaned up by the ship flow.
+
+## Parallel development safety
+
+See [merge-safety.md](merge-safety.md) for full details on preventing silent overwrites.
+
+- **Rebase before merge** — mandatory when base has diverged (enforced by `ship_release`)
+- **diff3 conflict style** — required for all developers (`git config merge.conflictstyle diff3`)
+- **No auto-resolve** — `git-sync.js` never uses `--ours`; conflicts abort and warn

--- a/plugins/devops/deep-knowledge/merge-safety.md
+++ b/plugins/devops/deep-knowledge/merge-safety.md
@@ -1,0 +1,92 @@
+# Merge Safety — Parallel Development
+
+Cross-cutting reference for preventing silent overwrites when multiple developers
+ship to the same branch. Referenced by `/devops-ship` (Step 1.5) and `git-sync.js`.
+
+## Why Squash Merges Cause Data Loss
+
+Squash merges sever Git's ancestry chain. When Dev B squash-merges to main, the new
+commit has **no ancestry relationship** to B's original branch. When Dev A later merges,
+Git uses the pre-B state as merge base — which can silently drop B's changes if A's
+branch has an older version of overlapping files.
+
+**Fix**: mandatory rebase before merge. This moves the merge base to current main,
+forcing Git to surface real conflicts instead of silently overwriting.
+
+## Required Git Config
+
+Both developers MUST set these:
+
+```bash
+# Show base version in conflict markers (base + ours + theirs)
+git config --global merge.conflictstyle diff3
+
+# Better diff algorithm for code with repeated patterns
+git config --global diff.algorithm histogram
+```
+
+`diff3` is critical — without it, conflict markers only show ours/theirs, making
+it nearly impossible to understand what the base version was.
+
+## GitHub Branch Protection (Recommended)
+
+Enable on main branch:
+- **Require branches to be up to date before merging** — forces rebase at platform level
+- **Require pull request reviews** — catches structural changes a second pair of eyes would spot
+- **Require status checks to pass** — prevents merging broken code
+
+These protect against bypassing the plugin's rebase checks (e.g., manual `gh pr merge`).
+
+## Mergiraf — AST-Aware Merge Driver
+
+[Mergiraf](https://mergiraf.org) is a tree-sitter-based merge driver that understands
+code structure. It catches semantic conflicts that line-based merging misses:
+
+- Function deleted in one branch, modified in another → conflict (Git misses this)
+- Import reordering vs. new import → clean merge (Git sometimes conflicts here)
+
+### Setup
+
+```bash
+# Install (Rust/cargo)
+cargo install mergiraf
+
+# Configure as merge driver
+git config --global merge.mergiraf.driver "mergiraf merge --git %O %A %B -s %S -x %X -y %Y -p %P"
+git config --global merge.mergiraf.name "mergiraf"
+
+# In project .gitattributes:
+*.js merge=mergiraf
+*.ts merge=mergiraf
+*.json merge=mergiraf
+*.yaml merge=mergiraf
+*.md merge=mergiraf
+```
+
+Supported languages: JavaScript, TypeScript, JSON, YAML, Markdown, Python, Rust, Go,
+Java, Scala, and more via tree-sitter grammars. Falls back to line-based merge for
+unsupported or unparseable files.
+
+## How git-sync.js Handles Conflicts
+
+As of v0.2.0, `git-sync.js` **never auto-resolves conflicts**. When a merge from a
+parent branch (e.g., main → feature) conflicts:
+
+1. The merge is **aborted** immediately
+2. A warning is printed with the list of conflicting files
+3. The developer must rebase manually before shipping
+
+This prevents the previous behavior where `--ours` silently discarded parent branch
+changes — the #1 cause of lost work in parallel development.
+
+## How ship_release Prevents Overwrites
+
+The release tool verifies the branch is rebased before allowing merge:
+
+1. `git fetch origin <base>` — get latest base
+2. `isRebasedOnto(origin/<base>)` — verify HEAD includes all base commits
+3. If not rebased → return `rebaseRequired: true` with overlap analysis
+4. The ship skill (Step 1.5) handles rebase + AI conflict resolution + test
+
+Additionally, when file overlap is detected in preflight, the skill switches from
+`squash` to `merge` strategy to preserve the ancestry chain for future merges.

--- a/plugins/devops/mcp-server/ship/lib/git.js
+++ b/plugins/devops/mcp-server/ship/lib/git.js
@@ -130,6 +130,41 @@ export function branchExists(name, opts) {
 }
 
 /**
+ * Detect files modified in both the current branch and the base since their common ancestor.
+ * Returns { mergeBase, branchFiles, baseFiles, overlap }.
+ */
+export function fileOverlap(base, opts) {
+  const mergeBase = git(`merge-base HEAD ${base}`, opts);
+  if (!mergeBase) return { mergeBase: null, branchFiles: [], baseFiles: [], overlap: [] };
+
+  const branchRaw = git(`diff --name-only ${mergeBase} HEAD`, opts) || "";
+  const baseRaw = git(`diff --name-only ${mergeBase} ${base}`, opts) || "";
+
+  const branchFiles = branchRaw.split("\n").filter(Boolean);
+  const baseFiles = baseRaw.split("\n").filter(Boolean);
+  const baseSet = new Set(baseFiles);
+  const overlap = branchFiles.filter((f) => baseSet.has(f));
+
+  return { mergeBase, branchFiles, baseFiles, overlap };
+}
+
+/**
+ * Check if the current branch contains all commits from the given base ref.
+ * Returns true if HEAD is up-to-date with (or ahead of) base.
+ */
+export function isRebasedOnto(base, opts) {
+  const behind = git(`rev-list --count HEAD..${base}`, opts);
+  return behind !== null && parseInt(behind, 10) === 0;
+}
+
+/**
+ * Check git config value. Returns the value or null.
+ */
+export function getConfig(key, opts) {
+  return git(`config --get ${key}`, opts);
+}
+
+/**
  * Detect parent branch from sub-branch naming convention.
  * Convention: sub-branches are `<parent>/<role>` (e.g. feat/42-video-filters/core).
  * Strips the last path segment and checks if the remainder exists as a branch.

--- a/plugins/devops/mcp-server/ship/lib/github.js
+++ b/plugins/devops/mcp-server/ship/lib/github.js
@@ -41,16 +41,18 @@ export function createPR({ title, body, base = "main", head }, opts) {
 }
 
 /**
- * Squash-merge a PR by number, delete remote branch.
+ * Merge a PR by number, delete remote branch.
  * Verifies merge actually succeeded via PR state check. Returns merge commit sha.
  * @param {number} prNumber
  * @param {string} base - Base branch name (e.g. "main", "develop")
  * @param {object} [opts]
  * @param {object} [flags]
  * @param {boolean} [flags.skipDeleteBranch=false] - Skip --delete-branch (e.g. in worktrees where local branch switch fails)
+ * @param {"squash"|"merge"|"rebase"} [flags.strategy="squash"] - Merge strategy. Use "merge" for overlapping files to preserve ancestry.
  */
 export function mergePR(prNumber, base = "main", opts, flags = {}) {
-  const args = ["pr", "merge", String(prNumber), "--squash", "--admin"];
+  const strategy = flags.strategy || "squash";
+  const args = ["pr", "merge", String(prNumber), `--${strategy}`, "--admin"];
   if (!flags.skipDeleteBranch) args.push("--delete-branch");
   gh(args, opts);
   // Verify the PR is actually in MERGED state (retry up to 3 times with 2s backoff
@@ -88,16 +90,20 @@ export function mergePR(prNumber, base = "main", opts, flags = {}) {
 
 /**
  * Check if an open PR already exists for head → base.
- * Returns { number, url } if found, null otherwise.
+ * Returns { number, url, mergeable } if found, null otherwise.
+ * Includes mergeability state to detect stale PRs that need updating.
  */
 export function findExistingPR({ base, head }, opts) {
   try {
     const raw = gh(
-      ["pr", "list", "--head", head, "--base", base, "--state", "open", "--json", "number,url", "--limit", "1"],
+      ["pr", "list", "--head", head, "--base", base, "--state", "open", "--json", "number,url,mergeable", "--limit", "1"],
       opts,
     );
     const list = JSON.parse(raw);
-    return list.length > 0 ? list[0] : null;
+    if (list.length === 0) return null;
+    const pr = list[0];
+    // mergeable: "MERGEABLE", "CONFLICTING", "UNKNOWN"
+    return { number: pr.number, url: pr.url, mergeable: pr.mergeable || "UNKNOWN" };
   } catch {
     return null; // Network error or no PR — safe to proceed
   }

--- a/plugins/devops/mcp-server/ship/tools/preflight.js
+++ b/plugins/devops/mcp-server/ship/tools/preflight.js
@@ -4,7 +4,7 @@
  */
 
 import { z } from "zod";
-import { git, currentBranch, dirtyState, commitsAhead, unpushedCommits, isWorktree, detectParentBranch, branchExists } from "../lib/git.js";
+import { git, currentBranch, dirtyState, commitsAhead, unpushedCommits, isWorktree, detectParentBranch, branchExists, fileOverlap, getConfig } from "../lib/git.js";
 import { readVersion, verifyVersionFiles } from "../lib/version.js";
 
 export const schema = z.object({
@@ -99,7 +99,36 @@ export async function handler(params) {
     checks.push({ name: "base-ahead", value: 0, ok: true });
   }
 
-  // 9. Version consistency (skip for intermediate merges — versions only matter on main)
+  // 9. File overlap detection — files modified in BOTH branch and base since divergence
+  const overlap = fileOverlap(originBase, opts);
+  if (overlap.overlap.length > 0) {
+    checks.push({
+      name: "file-overlap",
+      ok: false,
+      count: overlap.overlap.length,
+      files: overlap.overlap.slice(0, 20),
+      totalBranchFiles: overlap.branchFiles.length,
+      totalBaseFiles: overlap.baseFiles.length,
+      mergeBase: overlap.mergeBase?.slice(0, 8),
+    });
+    errors.push(
+      `${overlap.overlap.length} file(s) modified in both your branch and ${base} since divergence — ` +
+      `rebase required before merge to prevent silent overwrites: ${overlap.overlap.slice(0, 5).join(", ")}` +
+      (overlap.overlap.length > 5 ? ` (+${overlap.overlap.length - 5} more)` : "")
+    );
+  } else {
+    checks.push({ name: "file-overlap", ok: true, count: 0 });
+  }
+
+  // 10. Git config recommendations
+  const conflictStyle = getConfig("merge.conflictstyle", opts);
+  if (conflictStyle !== "diff3" && conflictStyle !== "zdiff3") {
+    checks.push({ name: "config-conflictstyle", ok: false, current: conflictStyle, recommended: "diff3" });
+  } else {
+    checks.push({ name: "config-conflictstyle", ok: true, current: conflictStyle });
+  }
+
+  // Version consistency (skip for intermediate merges — versions only matter on main)
   let versionInfo = { version: null, type: null };
   if (!intermediate) {
     versionInfo = readVersion(cwd);
@@ -118,7 +147,7 @@ export async function handler(params) {
     checks.push({ name: "version-consistent", ok: true, skipped: true, reason: "intermediate merge" });
   }
 
-  // 10. Worktree detection
+  // Worktree detection
   const inWorktree = isWorktree(opts);
   checks.push({ name: "worktree", value: inWorktree });
 

--- a/plugins/devops/mcp-server/ship/tools/release.js
+++ b/plugins/devops/mcp-server/ship/tools/release.js
@@ -5,7 +5,7 @@
 
 import { z } from "zod";
 import { execFileSync } from "node:child_process";
-import { git, gitStrict, currentBranch, headShort, dirtyState, isWorktree } from "../lib/git.js";
+import { git, gitStrict, currentBranch, headShort, dirtyState, isWorktree, isRebasedOnto, fileOverlap } from "../lib/git.js";
 import { createPR, mergePR, createRelease, findExistingPR } from "../lib/github.js";
 
 export const schema = z.object({
@@ -16,11 +16,12 @@ export const schema = z.object({
   releaseNotes: z.string().nullable().default(null).describe("GitHub release notes (CHANGELOG mirror) — ignored for intermediate merges"),
   prerelease: z.boolean().default(false).describe("Mark as pre-release (for 0.x versions)"),
   commitMessage: z.string().nullable().default(null).describe("If set, stage all and commit with this message before pushing"),
+  mergeStrategy: z.enum(["squash", "merge", "rebase"]).default("squash").describe("PR merge strategy. Use 'merge' for overlapping files to preserve ancestry chain."),
   cwd: z.string().describe("Working directory of the target repo (required — must be passed by the caller)"),
 });
 
 export async function handler(params) {
-  const { base, title, body, tag, releaseNotes, prerelease, commitMessage } = params;
+  const { base, title, body, tag, releaseNotes, prerelease, commitMessage, mergeStrategy } = params;
   const cwd = params.cwd;
   if (!cwd) throw new Error("cwd is required — MCP server runs in the plugin directory, not the target repo");
   const opts = { cwd };
@@ -68,26 +69,49 @@ export async function handler(params) {
       result.commit = headShort(opts);
     }
 
+    // Safety gate: verify branch is rebased onto latest base (prevents silent overwrites)
+    gitStrict(`fetch origin ${base}`, { cwd, timeout: 30_000 });
+    if (!isRebasedOnto(`origin/${base}`, opts)) {
+      // Check overlap to give actionable context
+      const overlap = fileOverlap(`origin/${base}`, opts);
+      result.success = false;
+      result.rebaseRequired = true;
+      result.overlapFiles = overlap.overlap;
+      result.error =
+        `Branch is not rebased onto origin/${base} (${base} has commits HEAD doesn't include). ` +
+        `Run: git rebase origin/${base} — then retry ship_release. ` +
+        (overlap.overlap.length > 0
+          ? `${overlap.overlap.length} overlapping file(s): ${overlap.overlap.slice(0, 10).join(", ")}`
+          : "No file overlap detected — rebase should be clean.");
+      return result;
+    }
+    result.rebased = true;
+
     // Push (use longer timeout for large repos / slow networks)
-    gitStrict(`push -u origin ${branch}`, { cwd, timeout: 60_000 });
+    gitStrict(`push -u origin ${branch} --force-with-lease`, { cwd, timeout: 60_000 });
     result.pushed = true;
 
     // Check for existing open PR before creating a new one
     const existingPR = findExistingPR({ base, head: branch }, opts);
     let pr;
     if (existingPR) {
+      if (existingPR.mergeable === "CONFLICTING") {
+        result.success = false;
+        result.error = `Existing PR #${existingPR.number} is in CONFLICTING state — branch needs updating. Close the PR or rebase and force-push.`;
+        return result;
+      }
       pr = existingPR;
       result.prReused = true;
     } else {
       pr = createPR({ title, body, base, head: branch }, opts);
     }
     result.pr = { number: pr.number, url: pr.url, title };
+    result.mergeStrategy = mergeStrategy;
 
-    // Merge PR (squash + delete branch; skip --delete-branch in worktrees
+    // Merge PR (delete branch; skip --delete-branch in worktrees
     // where gh tries to switch to base locally — cleanup handles branch deletion)
-    gitStrict(`fetch origin ${base}`, opts);
     const worktree = isWorktree(opts);
-    const mergeSha = mergePR(pr.number, base, opts, { skipDeleteBranch: worktree });
+    const mergeSha = mergePR(pr.number, base, opts, { skipDeleteBranch: worktree, strategy: mergeStrategy });
     result.merged = base;
     result.mergeSha = mergeSha;
 

--- a/plugins/devops/scripts/git-sync.js
+++ b/plugins/devops/scripts/git-sync.js
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
 /**
  * @script git-sync
- * @version 0.1.0
+ * @version 0.2.0
  * @plugin devops
  * @description Core git sync logic — fetch remote, merge parent chain into
  *   current branch. Supports branch hierarchy (feat/auth/login merges
- *   main → feat → feat/auth). Auto-resolves conflicts with --ours.
+ *   main → feat → feat/auth). Conflicts are NEVER auto-resolved —
+ *   merge is aborted and the user is warned to rebase manually.
  *   Standalone: called by prompt.git.sync hook and session-start cron.
  */
 
@@ -50,44 +51,25 @@ function getParentChain(branchName) {
   return parents;
 }
 
-// Try merging source into HEAD. On conflict, auto-resolve with --ours
-// (keep current branch's version). Only abort if resolution fails.
+// Try merging source into HEAD. On conflict, ABORT and warn —
+// never auto-resolve to prevent silent overwrites of parallel work.
 function tryMerge(source) {
   const behind = git(`rev-list --count HEAD..${source}`);
   if (!behind || parseInt(behind) === 0) return null; // already up to date
 
   const count = parseInt(behind);
 
-  // Normal merge
+  // Normal merge (clean — no conflicts)
   if (git(`merge ${source} --no-edit --quiet`) !== null) {
     return { source, commits: count };
   }
 
-  // Merge conflicted — try to auto-resolve each file with --ours
+  // Merge conflicted — collect info, then ABORT. Never auto-resolve.
   const conflictOutput = git('diff --name-only --diff-filter=U');
-  if (!conflictOutput) {
-    // No conflict markers but merge still failed → unknown error, abort
-    git('merge --abort');
-    return { source, commits: count, failed: true };
-  }
-
-  const files = conflictOutput.split('\n').filter(Boolean);
-
-  for (const file of files) {
-    if (git(`checkout --ours -- "${file}"`) === null) {
-      git('merge --abort');
-      return { source, commits: count, failed: true };
-    }
-    git(`add -- "${file}"`);
-  }
-
-  // Complete the merge with resolved files
-  if (git('commit --no-edit') !== null) {
-    return { source, commits: count, autoResolved: files };
-  }
-
   git('merge --abort');
-  return { source, commits: count, failed: true };
+
+  const files = conflictOutput ? conflictOutput.split('\n').filter(Boolean) : [];
+  return { source, commits: count, conflict: true, files };
 }
 
 // Fetch main
@@ -110,12 +92,11 @@ for (const parent of parents) {
   const result = tryMerge(parent);
   if (!result) continue;
 
-  if (result.failed) {
-    messages.push(`✗ ${parent} → ${branch}: Konflikt, nicht lösbar`);
-  } else if (result.autoResolved) {
+  if (result.conflict) {
     messages.push(
-      `⚠ ${parent} → ${branch}: ${result.commits} commit(s), ` +
-      `${result.autoResolved.length} Konflikt(e) auto-resolved (--ours)`
+      `✗ ${parent} → ${branch}: ${result.files.length} file(s) in conflict — ` +
+      `merge aborted. Rebase before shipping: git rebase origin/${parent}\n` +
+      `  Conflicting: ${result.files.join(', ')}`
     );
   } else {
     messages.push(`✓ ${parent} → ${branch}: ${result.commits} commit(s)`);

--- a/plugins/devops/skills/devops-ship/SKILL.md
+++ b/plugins/devops/skills/devops-ship/SKILL.md
@@ -76,6 +76,50 @@ Check the result:
 
 The tool checks: clean tree, commits ahead, all pushed, version consistency (skipped for intermediate), worktree detection.
 
+## Step 1.5 — Rebase & Merge Safety
+
+**Purpose:** Prevent silent overwrites when parallel developers ship to the same base.
+
+### When to trigger
+Run this step if **any** of these preflight checks failed:
+- `file-overlap` — files modified in both branch and base
+- `base-ahead` — base has commits HEAD doesn't include
+- `config-conflictstyle` — merge.conflictstyle not set to diff3/zdiff3
+
+### Rebase flow
+
+1. **Set diff3** (if not configured): Run `git config merge.conflictstyle diff3` in the repo.
+
+2. **Rebase onto base**:
+   ```bash
+   git fetch origin <base>
+   git rebase origin/<base>
+   ```
+
+3. **If rebase succeeds** (no conflicts): continue to Step 2.
+
+4. **If rebase has conflicts** — resolve them directly (do NOT ask user):
+   a. Run `git diff --name-only --diff-filter=U` to list conflicting files.
+   b. For each conflicting file:
+      - Read the file (contains `<<<<<<<`/`=======`/`>>>>>>>` markers with diff3 base section)
+      - Analyze **both sides semantically**: what did the branch change? what did base change?
+      - Produce a merged version that preserves **both** intents
+      - Write the resolved file, then `git add <file>`
+   c. Run `git rebase --continue`
+   d. If more conflicts appear (multi-commit rebase), repeat (b)–(c)
+
+5. **After successful rebase**: run `git push --force-with-lease` to update the remote branch.
+
+6. **Verification test**: Run the full test suite (`npm test` or project-specific test command) to confirm the rebase + resolution didn't break anything. If tests fail, diagnose and fix before proceeding.
+
+### Merge strategy decision
+
+Based on preflight `file-overlap`:
+- **No overlap** → use `mergeStrategy: "squash"` (default, clean history)
+- **Overlap detected** → use `mergeStrategy: "merge"` (preserves ancestry chain for future three-way merges)
+
+Pass the chosen strategy to `ship_release`.
+
 ## Step 2 — Build + Quality Gates
 
 Call `ship_build` MCP tool (always pass `cwd`):
@@ -137,6 +181,7 @@ ship_release({
   tag: "v0.18.0",
   releaseNotes: "...",
   prerelease: false,
+  mergeStrategy: "squash",
   cwd: "<cwd>"
 })
 ```
@@ -150,15 +195,27 @@ ship_release({
   commitMessage: null,
   tag: null,
   releaseNotes: null,
+  mergeStrategy: "squash",
+  cwd: "<cwd>"
+})
+```
+
+**With file overlap (use merge commit to preserve ancestry):**
+```
+ship_release({
+  ...
+  mergeStrategy: "merge",
   cwd: "<cwd>"
 })
 ```
 
 For intermediate merges: no tag, no release notes, no version commit. The tool automatically skips tag/release creation when `base` is not `main`.
 
-The tool handles: commit (optional), push, PR create (or reuse existing), squash-merge, tag (main only), GitHub release (main only).
+The tool handles: commit (optional), rebase verification, push (force-with-lease after rebase), PR create (or reuse with mergeability check), merge (squash or merge commit), tag (main only), GitHub release (main only).
 
-Returns: `{ branch, commit, pushed, pr: {number, url}, merged, intermediate, tag, tagVerified, release }`.
+Returns: `{ branch, commit, rebased, pushed, pr: {number, url}, merged, mergeStrategy, intermediate, tag, tagVerified, release }`.
+
+**If `rebaseRequired: true`**: the branch is not rebased onto base. Go back to Step 1.5 and rebase before retrying.
 
 If `success: false` → do NOT proceed to cleanup. Report error and render completion card with variant `ship-blocked`.
 


### PR DESCRIPTION
## Summary\n\nMerge safety system to prevent silent overwrites when two developers ship to the same branch in parallel.\n\n### Problem\n- `git-sync.js` auto-resolved conflicts with `--ours`, silently discarding parallel work\n- Squash merges severed Git's ancestry chain, making three-way merges unreliable\n- No pre-merge overlap detection or rebase verification existed\n\n### Solution\n- **git-sync.js**: abort + warn on conflicts instead of auto-resolving\n- **preflight.js**: file overlap detection (branch vs base since divergence), diff3 config check\n- **release.js**: mandatory rebase-gate (hard block if not rebased), configurable merge strategy\n- **github.js**: merge strategy parameter (squash/merge/rebase), PR mergeability re-check\n- **SKILL.md**: new Step 1.5 — AI-driven rebase, conflict resolution, post-rebase test\n- **deep-knowledge/merge-safety.md**: reference doc (diff3, Mergiraf, branch protection)