### PR TITLE
feat(completion): GitHub links + origin/main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.40.9] — 2026-04-14
+
+### Changed
+
+- **completion** — state line elements (commit, branch, PR, merge target) now render as clickable GitHub links
+- **completion** — merge target changed from `main` to `origin/main` for clarity (state line + CTA)
+
 ## [0.41.0] — 2026-04-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.41.0**
+**Version: 0.40.9**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.41.0",
+  "version": "0.40.9",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/mcp-server/index.js
+++ b/plugins/devops/mcp-server/index.js
@@ -167,7 +167,7 @@ const VARIANTS = {
 
 const CTA = {
   en: {
-    'ship-successful-merged': '## \ud83d\ude80 SHIPPED. merged \u2192 {merged} \u2014 All DONE',
+    'ship-successful-merged': '## \ud83d\ude80 SHIPPED. merged \u2192 origin/{merged} \u2014 All DONE',
     'ship-successful-plain':  '## \ud83d\ude80 SHIPPED \u2014 All DONE',
     ready:                    '## \ud83d\udce6 READY \u2014 SHIP or CHANGE?',
     'ship-blocked':           '## \u26d4 BLOCKED. {reason} \u2014 FIX or SKIP?',
@@ -178,7 +178,7 @@ const CTA = {
     fallback:                 '## \ud83d\udd27 DONE \u2014 Anything ELSE?',
   },
   de: {
-    'ship-successful-merged': '## \ud83d\ude80 SHIPPED. merged \u2192 {merged} \u2014 Alles ERLEDIGT',
+    'ship-successful-merged': '## \ud83d\ude80 SHIPPED. merged \u2192 origin/{merged} \u2014 Alles ERLEDIGT',
     'ship-successful-plain':  '## \ud83d\ude80 SHIPPED \u2014 Alles ERLEDIGT',
     ready:                    '## \ud83d\udce6 READY \u2014 SHIP oder ÄNDERN?',
     'ship-blocked':           '## \u26d4 BLOCKED. {reason} \u2014 FIX oder SKIP?',
@@ -189,6 +189,28 @@ const CTA = {
     fallback:                 '## \ud83d\udd27 DONE \u2014 Noch was ANDERES?',
   },
 };
+
+/**
+ * Resolve the GitHub HTTPS base URL from the git remote origin.
+ * Returns e.g. "https://github.com/owner/repo" or '' on failure.
+ */
+function getRepoUrl(cwd) {
+  try {
+    const raw = execSync('git remote get-url origin', {
+      encoding: 'utf8', timeout: 5000,
+      cwd: cwd || undefined,
+    }).trim();
+    // SSH: git@github.com:owner/repo.git
+    const sshMatch = raw.match(/git@github\.com:(.+?)(?:\.git)?$/);
+    if (sshMatch) return 'https://github.com/' + sshMatch[1];
+    // HTTPS: https://github.com/owner/repo.git
+    const httpsMatch = raw.match(/https:\/\/github\.com\/(.+?)(?:\.git)?$/);
+    if (httpsMatch) return 'https://github.com/' + httpsMatch[1];
+    return '';
+  } catch {
+    return '';
+  }
+}
 
 function getBuildId(overrideCwd) {
   try {
@@ -238,7 +260,7 @@ function renderTests(tests) {
   return '**Tests**\n' + items.join('\n');
 }
 
-function renderState(state, variant) {
+function renderState(state, variant, repoUrl) {
   if (!state) {
     if (variant === 'analysis') return '\u2796 No changes to repo';
     return '';
@@ -253,18 +275,37 @@ function renderState(state, variant) {
   else                                         icon = '\u2796';
 
   const branch = state.branch || 'main';
-  const branchStr = branch + (state.worktree ? ' (worktree)' : '');
-  const commitStr = state.commit ? state.commit : 'uncommitted';
+  const branchLabel = branch + (state.worktree ? ' (worktree)' : '');
+  const branchStr = repoUrl
+    ? '[`' + branchLabel + '`](' + repoUrl + '/tree/' + branch + ')'
+    : '`' + branchLabel + '`';
+
+  const commitStr = state.commit
+    ? (repoUrl
+      ? '[' + state.commit + '](' + repoUrl + '/commit/' + state.commit + ')'
+      : state.commit)
+    : 'uncommitted';
+
   const pushStr = state.pushed ? 'pushed' : 'not pushed';
 
   let prStr = 'no PR';
-  if (state.pr) prStr = 'PR #' + state.pr.number + ' "' + state.pr.title + '"';
+  if (state.pr) {
+    const prLabel = 'PR #' + state.pr.number + ' "' + state.pr.title + '"';
+    prStr = repoUrl
+      ? '[' + prLabel + '](' + repoUrl + '/pull/' + state.pr.number + ')'
+      : prLabel;
+  }
 
   let mergeStr = 'not merged';
-  if (state.merged) mergeStr = 'merged \u2192 ' + state.merged;
+  if (state.merged) {
+    const target = 'origin/' + state.merged;
+    mergeStr = repoUrl
+      ? 'merged \u2192 [' + target + '](' + repoUrl + '/tree/' + state.merged + ')'
+      : 'merged \u2192 ' + target;
+  }
 
   // Order: most important first — merge · PR · push · commit · branch
-  let line = icon + ' ' + mergeStr + ' \u00b7 ' + prStr + ' \u00b7 ' + pushStr + ' \u00b7 ' + commitStr + ' \u00b7 `' + branchStr + '`';
+  let line = icon + ' ' + mergeStr + ' \u00b7 ' + prStr + ' \u00b7 ' + pushStr + ' \u00b7 ' + commitStr + ' \u00b7 ' + branchStr;
 
   if (state.appStatus === 'running')     line += ' \u00b7 app running';
   if (state.appStatus === 'not-started') line += ' \u00b7 app not started';
@@ -356,7 +397,8 @@ function renderCard(input, meterText, buildId) {
 
   // Block B — End state (with extra blank line above for visual separation)
   if (config.state) {
-    const stateLine = renderState(input.state, variant);
+    const repoUrl = getRepoUrl(input.cwd);
+    const stateLine = renderState(input.state, variant, repoUrl);
     if (stateLine) {
       parts.push(stateLine);
       parts.push('');

--- a/plugins/devops/templates/completion-card.md
+++ b/plugins/devops/templates/completion-card.md
@@ -230,35 +230,43 @@ Fields that don't apply are shown with explicit negative values.
 {{state-icon}} {{merge}} · {{pr}} · {{push}} · {{commit}} · {{branch}}
 ```
 
+Elements are linked to their GitHub page when the repo URL can be resolved:
+- commit hash → `[abc1234](https://github.com/owner/repo/commit/abc1234)`
+- branch → [`feat/xyz`](https://github.com/owner/repo/tree/feat/xyz)
+- PR → [PR #N "Title"](https://github.com/owner/repo/pull/N)
+- merge target → [origin/main](https://github.com/owner/repo/tree/main)
+
+Falls back to plain text when no GitHub remote is detected.
+
 | Field | Positive | Negative |
 |-------|----------|----------|
-| merge | `merged → remote/main` | `not merged` |
-| pr | `PR #N "Title"` | `no PR` |
+| merge | `merged → [origin/main](…/tree/main)` | `not merged` |
+| pr | `[PR #N "Title"](…/pull/N)` | `no PR` |
 | push | `pushed` | `not pushed` |
-| commit | `abc1234` (committed hash) | `uncommitted` |
-| branch | `feat/xyz` or `feat/xyz (worktree)` | `main` (no feature branch) |
+| commit | `[abc1234](…/commit/abc1234)` | `uncommitted` |
+| branch | [`feat/xyz`](…/tree/feat/xyz) or [`feat/xyz (worktree)`](…/tree/feat/xyz) | [`main`](…/tree/main) |
 
 **Examples — all states:**
 
 | State | One-liner |
 |-------|-----------|
-| Fresh, nothing committed | 🔀 not merged · no PR · not pushed · uncommitted · `feat/xyz` |
-| Committed, not pushed | 🔀 not merged · no PR · not pushed · abc1234 · `feat/xyz` |
-| Pushed, no PR | 🔀 not merged · no PR · pushed · abc1234 · `feat/xyz` |
-| PR open | 🔀 not merged · PR #42 "Filter refactor" · pushed · abc1234 · `feat/xyz` |
-| Merged via PR | ✅ merged → remote/main · PR #42 "Filter refactor" · pushed · abc1234 · `feat/xyz` |
-| Direct push | ✅ merged → remote/main · no PR · pushed · abc1234 · `main` |
-| Worktree, not pushed | 🔀 not merged · no PR · not pushed · abc1234 · `feat/xyz (worktree)` |
-| Worktree, PR open | 🔀 not merged · PR #42 "Filter refactor" · pushed · abc1234 · `feat/xyz (worktree)` |
-| App running (after edits) | 🟢 not merged · no PR · not pushed · abc1234 · `feat/xyz` · app running |
-| App needs start | 🟡 not merged · no PR · not pushed · abc1234 · `feat/xyz` · app not started |
+| Fresh, nothing committed | 🔀 not merged · no PR · not pushed · uncommitted · [`feat/xyz`](…/tree/feat/xyz) |
+| Committed, not pushed | 🔀 not merged · no PR · not pushed · [abc1234](…/commit/abc1234) · [`feat/xyz`](…/tree/feat/xyz) |
+| Pushed, no PR | 🔀 not merged · no PR · pushed · [abc1234](…/commit/abc1234) · [`feat/xyz`](…/tree/feat/xyz) |
+| PR open | 🔀 not merged · [PR #42 "Filter refactor"](…/pull/42) · pushed · [abc1234](…/commit/abc1234) · [`feat/xyz`](…/tree/feat/xyz) |
+| Merged via PR | ✅ merged → [origin/main](…/tree/main) · [PR #42 "Filter refactor"](…/pull/42) · pushed · [abc1234](…/commit/abc1234) · [`feat/xyz`](…/tree/feat/xyz) |
+| Direct push | ✅ merged → [origin/main](…/tree/main) · no PR · pushed · [abc1234](…/commit/abc1234) · [`main`](…/tree/main) |
+| Worktree, not pushed | 🔀 not merged · no PR · not pushed · [abc1234](…/commit/abc1234) · [`feat/xyz (worktree)`](…/tree/feat/xyz) |
+| Worktree, PR open | 🔀 not merged · [PR #42 "Filter refactor"](…/pull/42) · pushed · [abc1234](…/commit/abc1234) · [`feat/xyz (worktree)`](…/tree/feat/xyz) |
+| App running (after edits) | 🟢 not merged · no PR · not pushed · [abc1234](…/commit/abc1234) · [`feat/xyz`](…/tree/feat/xyz) · app running |
+| App needs start | 🟡 not merged · no PR · not pushed · [abc1234](…/commit/abc1234) · [`feat/xyz`](…/tree/feat/xyz) · app not started |
 | No changes | ➖ No changes to repo |
 
 **State icons:**
 
 | Icon | Meaning |
 |------|---------|
-| ✅ | Final — on remote/main, all done |
+| ✅ | Final — on origin/main, all done |
 | 🔀 | In progress — branch/worktree, not on main yet |
 | 🟢 | App running — user must test |
 | 🟡 | App not started — user must start |
@@ -353,7 +361,7 @@ The footer line sits between the separator and the CTA. It contains:
 | 7 | aborted | 🚫 | opt. | — | — | dep. | yes |
 | 8 | **fallback** | 🔧 | yes | — | — | dep. | yes |
 
-- **ship-successful (1)**: ONLY after /devops-ship + successfully merged to remote/main. PR vs. direct push → state line shows the difference.
+- **ship-successful (1)**: ONLY after /devops-ship + successfully merged to origin/main. PR vs. direct push → state line shows the difference.
 - **ship-blocked (3)**: ONLY after /devops-ship + NOT merged (PR open, build fail, etc.).
 - **test (4)**: Code edits + app/service started or startable. Applies to ANY project type (web, CLI, desktop, API, game — not just UI). If user needs to test, always use this variant and try to start the app.
 - **test-minimal (5)**: User starts app via prompt, no edits done yet. Minimal greeting card.
@@ -375,7 +383,7 @@ The footer line sits between the separator and the CTA. It contains:
 ### Variant Selection Rules
 
 ```
-if   ship pipeline ran + merged to remote/main  → ship-successful (1)
+if   ship pipeline ran + merged to origin/main  → ship-successful (1)
 elif ship pipeline ran + NOT merged              → ship-blocked (3)
 elif task aborted / infeasible / rate-limited    → aborted (7)
 elif code edits + app/service started or startable → test (4)
@@ -387,7 +395,7 @@ else                                             → fallback (8)
 
 **STRICT variant rules (never violate):**
 
-- **ship-successful**: ONLY after `/devops-ship` ran `ship_release` and it was merged to remote/main. A commit, push, or PR alone is NEVER "ship-successful". Use `ready` instead.
+- **ship-successful**: ONLY after `/devops-ship` ran `ship_release` and it was merged to origin/main. A commit, push, or PR alone is NEVER "ship-successful". Use `ready` instead.
 - **ship-blocked**: ONLY after `/devops-ship` ran but did NOT merge (build failed, PR open, gate failed). Never use for plain uncommitted/unpushed state.
 - **test-minimal**: ONLY when the user freshly starts the app via a prompt and no code edits have been made yet. Never after a commit, task completion, or any other action. This is a session-start greeting, nothing else.
 - **ready**: Default for any completed code/doc change (>=1 edit) that hasn't gone through the ship pipeline. Threshold is >=1 edit — not >5.


### PR DESCRIPTION
## Summary\n- State line elements (commit hash, branch, PR, merge target) now link to their GitHub pages\n- Merge target changed from `main` to `origin/main` for clarity\n- Graceful fallback to plain text when no GitHub remote is detected\n\n## Test plan\n- [x] vitest: 61/61 passed\n- [x] eslint: 0 errors