### PR TITLE
feat(hooks): MCP server health check (#78)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.41.1] — 2026-04-14
+
+### Added
+
+- **hooks** — MCP server health check: detects dead servers after hard PC shutdowns via PID heartbeat files, blocks with clear message instead of cryptic MCP errors
+- **mcp-server** — heartbeat module: each server registers its PID on startup, cleans up on graceful exit
+
 ## [0.40.9] — 2026-04-14
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.40.9**
+**Version: 0.41.1**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.40.9",
+  "version": "0.41.1",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/hooks/hooks.json
+++ b/plugins/devops/hooks/hooks.json
@@ -27,6 +27,12 @@
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/pre-tool-use/pre.ship.guard.js" }
         ],
         "matcher": "Bash"
+      },
+      {
+        "hooks": [
+          { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/pre-tool-use/pre.mcp.health.js" }
+        ],
+        "matcher": "mcp__plugin_devops_"
       }
     ],
     "PostToolUse": [

--- a/plugins/devops/hooks/pre-tool-use/pre.mcp.health.js
+++ b/plugins/devops/hooks/pre-tool-use/pre.mcp.health.js
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+/**
+ * @hook pre.mcp.health
+ * @version 0.1.0
+ * @event PreToolUse
+ * @plugin devops
+ * @description Detects dead MCP servers before tool calls fail cryptically.
+ *   Each MCP server writes a PID file on startup (via mcp-server/lib/heartbeat.js).
+ *   This hook checks if the PID is still alive. If not, it blocks with a clear
+ *   message telling the user to start a new session.
+ *
+ *   Typical cause: hard PC shutdown (Stop-Computer -Force) kills MCP processes,
+ *   but the resumed conversation still references them.
+ */
+
+require('../lib/plugin-guard');
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const PREFIX = 'dotclaude-mcp-';
+
+// Map tool-name prefixes to MCP server names
+const SERVER_MAP = {
+  'dotclaude-completion': 'dotclaude-completion',
+  'dotclaude-ship':       'dotclaude-ship',
+  'dotclaude-issues':     'dotclaude-issues',
+};
+
+function pidFileFor(serverName) {
+  return path.join(os.tmpdir(), `${PREFIX}${serverName}.pid`);
+}
+
+function isProcessAlive(pid) {
+  try {
+    process.kill(pid, 0); // signal 0 = existence check, no kill
+    return true;
+  } catch (err) {
+    // EPERM = process exists but we lack permission → alive
+    if (err.code === 'EPERM') return true;
+    return false;
+  }
+}
+
+function resolveServer(toolName) {
+  // tool names look like: mcp__plugin_devops_dotclaude-ship__ship_build
+  // extract the server key between "plugin_devops_" and the next "__"
+  const match = toolName.match(/plugin_devops_([a-z0-9-]+)__/);
+  if (!match) return null;
+  const key = match[1];
+  return SERVER_MAP[key] || null;
+}
+
+let inputData = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', d => { inputData += d; });
+process.stdin.on('end', () => {
+  let hook;
+  try { hook = JSON.parse(inputData); }
+  catch { process.exit(0); }
+
+  const toolName = hook.tool_name || '';
+  const serverName = resolveServer(toolName);
+  if (!serverName) process.exit(0);
+
+  const pidFile = pidFileFor(serverName);
+
+  // No PID file → server never registered (old version or first run) — pass through
+  if (!fs.existsSync(pidFile)) process.exit(0);
+
+  let pid;
+  try {
+    pid = parseInt(fs.readFileSync(pidFile, 'utf8').trim(), 10);
+  } catch {
+    process.exit(0);
+  }
+
+  if (!pid || isNaN(pid)) process.exit(0);
+
+  // PID alive → server is running, all good
+  if (isProcessAlive(pid)) process.exit(0);
+
+  // Dead server detected — block and warn
+  const W = 54;
+  const line = '─'.repeat(W);
+  console.error('');
+  console.error(`⚠️  MCP SERVER DOWN — ${serverName}`);
+  console.error(line);
+  console.error(`PID ${pid} is no longer running.`);
+  console.error(`The server died (likely due to a hard PC shutdown).`);
+  console.error('');
+  console.error('Fix: Start a new Claude Code session.');
+  console.error('MCP servers are started on session init and cannot');
+  console.error('be restarted mid-conversation.');
+  console.error(line);
+
+  // Clean up stale PID file so the message doesn't repeat after user
+  // starts a new session (the new server will write a fresh one)
+  try { fs.unlinkSync(pidFile); } catch { /* ignore */ }
+
+  process.exit(2);
+});

--- a/plugins/devops/mcp-server/index.js
+++ b/plugins/devops/mcp-server/index.js
@@ -19,6 +19,7 @@ import { readFileSync, writeFileSync, readdirSync, statSync } from "node:fs";
 import { join, resolve, dirname } from "node:path";
 import { homedir, tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
+import { register as registerHeartbeat } from "./lib/heartbeat.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PLUGIN_ROOT = resolve(__dirname, '..');
@@ -814,4 +815,5 @@ server.registerTool(
 // Connect and start
 const transport = new StdioServerTransport();
 await server.connect(transport);
+registerHeartbeat("dotclaude-completion");
 console.error("[dotclaude-completion-mcp] Server started on stdio");

--- a/plugins/devops/mcp-server/issues/index.js
+++ b/plugins/devops/mcp-server/issues/index.js
@@ -16,6 +16,7 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { z } from "zod";
 import { execSync } from "node:child_process";
 import { tokenize, scoreIssue } from "./matching.js";
+import { register as registerHeartbeat } from "../lib/heartbeat.js";
 
 // ---------------------------------------------------------------------------
 // Issue cache
@@ -123,3 +124,5 @@ setInterval(fetchIssues, REFRESH_INTERVAL_MS);
 // Start
 const transport = new StdioServerTransport();
 await server.connect(transport);
+registerHeartbeat("dotclaude-issues");
+console.error("[dotclaude-issues-mcp] Server started on stdio");

--- a/plugins/devops/mcp-server/lib/heartbeat.js
+++ b/plugins/devops/mcp-server/lib/heartbeat.js
@@ -1,0 +1,41 @@
+/**
+ * @module mcp-heartbeat
+ * @version 0.1.0
+ * @description Lightweight heartbeat for MCP servers.
+ *   Each server calls register() at startup to write a PID file.
+ *   The PreToolUse hook (pre.mcp.health.js) checks these PIDs
+ *   to detect dead servers after hard shutdowns / session resume.
+ *
+ *   PID files live in os.tmpdir() — they survive soft reboots but
+ *   the PIDs they reference won't, so the health check catches it.
+ */
+
+import { writeFileSync, unlinkSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+const PREFIX = "dotclaude-mcp-";
+
+/**
+ * Register this MCP server's PID.
+ * Call once after server.connect() succeeds.
+ *
+ * @param {string} name  Server name matching .mcp.json key
+ *                        (e.g. "dotclaude-completion", "dotclaude-ship", "dotclaude-issues")
+ */
+export function register(name) {
+  const pidFile = join(tmpdir(), `${PREFIX}${name}.pid`);
+  try {
+    writeFileSync(pidFile, String(process.pid), "utf8");
+
+    // Clean up on graceful exit
+    const cleanup = () => {
+      try { unlinkSync(pidFile); } catch { /* already gone */ }
+    };
+    process.on("exit", cleanup);
+    process.on("SIGINT", () => { cleanup(); process.exit(0); });
+    process.on("SIGTERM", () => { cleanup(); process.exit(0); });
+  } catch {
+    // Non-fatal — health check will just skip this server
+  }
+}

--- a/plugins/devops/mcp-server/ship/index.js
+++ b/plugins/devops/mcp-server/ship/index.js
@@ -16,6 +16,7 @@
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { register as registerHeartbeat } from "../lib/heartbeat.js";
 
 import { schema as preflightSchema, handler as preflightHandler } from "./tools/preflight.js";
 import { schema as buildSchema, handler as buildHandler } from "./tools/build.js";
@@ -97,4 +98,5 @@ registerTool(
 // Connect and start
 const transport = new StdioServerTransport();
 await server.connect(transport);
+registerHeartbeat("dotclaude-ship");
 console.error("[dotclaude-ship-mcp] Server started on stdio");


### PR DESCRIPTION
## Summary\n- Detects dead MCP servers after hard PC shutdowns via PID heartbeat files\n- PreToolUse hook blocks with clear message instead of cryptic MCP errors\n- Each MCP server registers its PID on startup, cleans up on graceful exit\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)