### PR TITLE
fix(completion): drop redundant branch from state line (#78)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.40.8"
+    "version": "0.41.3"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.40.8",
+      "version": "0.41.3",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.41.4] — 2026-04-14
+
+### Fixed
+
+- **completion** — state line no longer shows redundant branch when it matches the merge target (e.g. `merged → main … main` → `merged → main`)
+- **version** — aligned marketplace.json to 0.41.3 (was stuck at 0.40.8 from previous releases)
+
 ## [0.41.3] — 2026-04-14
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.41.3**
+**Version: 0.41.4**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.41.3",
+  "version": "0.41.4",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/mcp-server/index.js
+++ b/plugins/devops/mcp-server/index.js
@@ -306,7 +306,10 @@ function renderState(state, variant, repoUrl) {
   }
 
   // Order: most important first — merge · PR · push · commit · branch
-  let line = icon + ' ' + mergeStr + ' \u00b7 ' + prStr + ' \u00b7 ' + pushStr + ' \u00b7 ' + commitStr + ' \u00b7 ' + branchStr;
+  // Skip trailing branch when it duplicates the merge target (e.g. "merged → main … `main`")
+  const showBranch = !state.merged || state.merged !== branch;
+  let line = icon + ' ' + mergeStr + ' \u00b7 ' + prStr + ' \u00b7 ' + pushStr + ' \u00b7 ' + commitStr;
+  if (showBranch) line += ' \u00b7 ' + branchStr;
 
   if (state.appStatus === 'running')     line += ' \u00b7 app running';
   if (state.appStatus === 'not-started') line += ' \u00b7 app not started';


### PR DESCRIPTION
## Summary
- State line no longer shows redundant branch when it matches the merge target (e.g. `merged → main · … · main` → `merged → main · …`)
- Aligned marketplace.json version from 0.40.8 to 0.41.3 (pre-existing drift from previous releases)

