### PR TITLE
fix(hooks): team changelog since-tracking + identity

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.41.4"
+    "version": "0.41.5"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.41.4",
+      "version": "0.41.5",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Fixed
 
+- **hooks** — `ss.team.changelog`: only show team changes since last display (was: all commits since user's last own commit, repeating already-seen changes across sessions)
+- **hooks** — `ss.team.changelog`: persist "last shown" timestamp to `%TEMP%` keyed by repo remote URL hash (worktree-independent)
+- **hooks** — `ss.team.changelog`: resolve GitHub login via `gh api user` for identity matching — fixes `isMe()` mismatches when local git config differs from GitHub noreply email (e.g. web UI commits, Claude Code Desktop)
 - **merge** — `git-sync.js`: ambiguous conflicts now use `⚠` marker (was `✗`) so the cron callback triggers Claude's semantic resolution instead of just reporting an error
 - **merge** — `git-sync.js`: post-abort guard verifies working tree is actually clean after `git merge --abort`; returns hard failure if tree is still dirty
 - **merge** — cron prompt: explicit 8-step procedure for conflict resolution — Claude MUST resolve conflicts (edit files, stage, commit), not just report them

--- a/plugins/devops/hooks/session-start/ss.team.changelog.js
+++ b/plugins/devops/hooks/session-start/ss.team.changelog.js
@@ -1,27 +1,57 @@
 #!/usr/bin/env node
 /**
  * @hook ss.team.changelog
- * @version 0.1.0
+ * @version 0.2.0
  * @event SessionStart
  * @plugin devops
  * @description Show a summary of changes made by other contributors on remote main
- *   since the user's last commit. Only triggers when the latest commit on
- *   origin/<main> is NOT by the current git user. Silent otherwise.
+ *   since the last time this hook displayed output. Persists the "last shown"
+ *   timestamp to a worktree-independent file in OS temp (keyed by repo remote URL).
+ *   Only triggers when the latest commit on origin/<main> is NOT by the current
+ *   git user. Silent otherwise.
  */
 
 require('../lib/plugin-guard');
 
 const { execSync } = require('child_process');
+const crypto = require('crypto');
+const path = require('path');
+const os = require('os');
+const fs = require('fs');
 
-function run(cmd, cwd) {
+function run(cmd, cwd, timeout = 15000) {
   try {
-    return execSync(cmd, { cwd, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'], timeout: 15000 }).trim();
+    return execSync(cmd, { cwd, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'], timeout }).trim();
   } catch {
     return '';
   }
 }
 
 const cwd = process.cwd();
+
+// --- Persistent "last shown" timestamp (worktree-independent) ---
+const remoteUrl = run('git remote get-url origin', cwd);
+const repoRoot = run('git rev-parse --show-toplevel', cwd);
+const repoKey = crypto.createHash('md5').update(remoteUrl || repoRoot || cwd).digest('hex').slice(0, 12);
+const tsFile = path.join(os.tmpdir(), `dotclaude-team-changelog-${repoKey}`);
+
+function readLastShown() {
+  try {
+    const iso = fs.readFileSync(tsFile, 'utf8').trim();
+    const d = new Date(iso);
+    return isNaN(d.getTime()) ? null : d;
+  } catch { return null; }
+}
+
+function writeLastShown() {
+  try {
+    const tmp = tsFile + '.tmp';
+    fs.writeFileSync(tmp, new Date().toISOString(), 'utf8');
+    fs.renameSync(tmp, tsFile);
+  } catch { /* best effort */ }
+}
+
+const lastShown = readLastShown();
 
 // Detect main branch from remote HEAD
 const mainBranch = (
@@ -40,13 +70,27 @@ const userEmail = run('git config user.email', cwd).toLowerCase();
 
 if (!userName && !userEmail) process.exit(0);
 
+// Resolve authenticated GitHub login (authoritative identity source).
+// gh api is network-bound — keep timeout short; falls back gracefully.
+const ghLogin = (
+  run('gh api user --jq .login', cwd, 5000) ||
+  run('git config github.user', cwd)
+).toLowerCase();
+
 // Structured git log: hash · author · email · ISO date · subject
 // Uses %x1f (unit separator) to avoid conflicts with commit message content
+// When we have a prior "last shown" timestamp, restrict to commits since then
+// and drop the -50 cap (the time window is the natural limit).
+// Without a timestamp, keep -50 as safety cap for the first run.
+const sinceArg = lastShown ? ` --since="${lastShown.toISOString()}"` : ' -50';
 const rawLog = run(
-  `git log origin/${mainBranch} --format="%H%x1f%an%x1f%ae%x1f%ai%x1f%s" -50`,
+  `git log origin/${mainBranch} --format="%H%x1f%an%x1f%ae%x1f%ai%x1f%s"${sinceArg}`,
   cwd,
 );
-if (!rawLog) process.exit(0);
+if (!rawLog) {
+  writeLastShown();
+  process.exit(0);
+}
 
 const commits = rawLog.split('\n').filter(Boolean).map(line => {
   const parts = line.split('\x1f');
@@ -69,21 +113,34 @@ function ghUsernameFromEmail(email) {
   return m ? m[1].toLowerCase() : null;
 }
 
-/** Match commit author against local git identity. */
+/** Match commit author against local git identity + authenticated GitHub login. */
 function isMe(commit) {
-  if (userEmail && commit.email === userEmail) return true;
-  if (userName && commit.name.toLowerCase() === userName) return true;
-  // Cross-match GitHub noreply username against git user.name
+  const commitName = commit.name.toLowerCase();
   const commitGhUser = ghUsernameFromEmail(commit.email);
-  if (commitGhUser && commitGhUser === userName) return true;
   const myGhUser = ghUsernameFromEmail(userEmail);
-  if (myGhUser && myGhUser === commit.name.toLowerCase()) return true;
+
+  // 1. Direct email match
+  if (userEmail && commit.email === userEmail) return true;
+  // 2. Direct name match
+  if (userName && commitName === userName) return true;
+  // 3. Authenticated GitHub login (authoritative — covers noreply emails,
+  //    web UI commits, and any name/email mismatch)
+  if (ghLogin) {
+    if (commitName === ghLogin) return true;
+    if (commitGhUser && commitGhUser === ghLogin) return true;
+  }
+  // 4. Cross-match noreply username ↔ git user.name/email
+  if (commitGhUser && commitGhUser === userName) return true;
+  if (myGhUser && myGhUser === commitName) return true;
   if (myGhUser && commitGhUser && myGhUser === commitGhUser) return true;
   return false;
 }
 
 // If the latest commit is by the user — nothing to show
-if (commits.length === 0 || isMe(commits[0])) process.exit(0);
+if (commits.length === 0 || isMe(commits[0])) {
+  writeLastShown();
+  process.exit(0);
+}
 
 // Collect commits by others until we hit one by the user
 const otherCommits = [];
@@ -91,7 +148,10 @@ for (const commit of commits) {
   if (isMe(commit)) break;
   otherCommits.push(commit);
 }
-if (otherCommits.length === 0) process.exit(0);
+if (otherCommits.length === 0) {
+  writeLastShown();
+  process.exit(0);
+}
 
 // Group by author (preserve insertion order)
 const byAuthor = new Map();
@@ -134,3 +194,6 @@ for (const [author, authorCommits] of byAuthor) {
 out.push('---');
 
 process.stdout.write(out.join('\n'));
+
+// Persist "last shown" so the next session only shows newer commits
+writeLastShown();


### PR DESCRIPTION
## Summary
- Team changelog now only shows commits since last display (persistent timestamp in `%TEMP%`, worktree-independent)
- `isMe()` identity matching fixed: resolves GitHub login via `gh api user` — covers noreply emails, web UI commits, Claude Code Desktop identity mismatches