### PR TITLE
fix(usage): correct delta across cycle resets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.41.6] — 2026-04-14
+
+### Fixed
+
+- **usage** — delta computation now detects cycle resets: when a usage window resets (e.g. weekly 100% → 2%), baseline is treated as 0 instead of the stale previous-cycle value (was: `+-98%` instead of `+2%`)
+- **usage** — `formatDelta` no longer prepends `+` on negative values (was: `+-98%`)
+
 ## [0.41.5] — 2026-04-14
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.41.5**
+**Version: 0.41.6**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.41.5",
+  "version": "0.41.6",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/mcp-server/index.js
+++ b/plugins/devops/mcp-server/index.js
@@ -64,7 +64,16 @@ function renderBar(pct, elapsedPct) {
 function formatDelta(delta) {
   if (delta == null) return '';
   if (isNaN(delta)) delta = 0;
-  return '+' + delta + '%';
+  const sign = delta >= 0 ? '+' : '';
+  return sign + delta + '%';
+}
+
+// Compute delta between two usage snapshots, handling cycle resets.
+// If fresh pct < previous pct, a new cycle started — baseline is 0.
+function computeDelta(freshPct, prevPct) {
+  const f = freshPct || 0;
+  const p = prevPct || 0;
+  return f < p ? f : f - p;
 }
 
 function formatResetShort(minutes) {
@@ -543,8 +552,8 @@ function refreshUsage() {
             let delta5h = null;
             let deltaWk = null;
             if (previous?.session) {
-              delta5h = (escalatedData.session?.pct || 0) - (previous.session?.pct || 0);
-              deltaWk = (escalatedData.weekly?.pct || 0) - (previous.weekly?.pct || 0);
+              delta5h = computeDelta(escalatedData.session?.pct, previous.session?.pct);
+              deltaWk = computeDelta(escalatedData.weekly?.pct, previous.weekly?.pct);
             }
             return { success: true, data: escalatedData, delta5h, deltaWk };
           }
@@ -563,8 +572,8 @@ function refreshUsage() {
       let delta5h = null;
       let deltaWk = null;
       if (previous?.session) {
-        delta5h = (freshData.session?.pct || 0) - (previous.session?.pct || 0);
-        deltaWk = (freshData.weekly?.pct || 0) - (previous.weekly?.pct || 0);
+        delta5h = computeDelta(freshData.session?.pct, previous.session?.pct);
+        deltaWk = computeDelta(freshData.weekly?.pct, previous.weekly?.pct);
       }
       return { success: true, data: freshData, delta5h, deltaWk };
     }
@@ -586,8 +595,8 @@ function refreshUsage() {
         let delta5h = null;
         let deltaWk = null;
         if (previous?.session) {
-          delta5h = (retryData.session?.pct || 0) - (previous.session?.pct || 0);
-          deltaWk = (retryData.weekly?.pct || 0) - (previous.weekly?.pct || 0);
+          delta5h = computeDelta(retryData.session?.pct, previous.session?.pct);
+          deltaWk = computeDelta(retryData.weekly?.pct, previous.weekly?.pct);
         }
         return { success: true, data: retryData, delta5h, deltaWk };
       }


### PR DESCRIPTION
## Summary\n- Delta computation now detects cycle resets — when a usage window resets (weekly 100% → 2%), baseline is 0 instead of the stale previous-cycle value\n- `formatDelta` no longer prepends `+` on negative values (`+-98%` → `-98%`)\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)