### PR TITLE
fix(concept): heartbeat grace period + localStorage reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.42.1] — 2026-04-14
+
+### Fixed
+
+- **concept** — heartbeat connection check no longer fires before the 30s grace period, fixing false "nicht verbunden" warning on page load
+- **concept** — panel reset now clears localStorage so stale decisions don't resurface on reload
+- **concept** — added `HEARTBEAT_GRACE_MS` to post-generation validation gate (pattern #6)
+- **version** — aligned marketplace.json to 0.42.0 (was stuck at 0.41.5)
+
 ## [0.42.0] — 2026-04-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.42.0**
+**Version: 0.42.1**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.42.0",
+  "version": "0.42.1",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/skills/devops-concept/SKILL.md
+++ b/plugins/devops/skills/devops-concept/SKILL.md
@@ -192,10 +192,11 @@ are present. **Grep the generated file** for each required pattern:
 | 3 | `connection-warning` | Disconnection warning element |
 | 4 | `checkClaudeConnection` | Heartbeat checker function |
 | 5 | `HEARTBEAT_STALE_MS` | Heartbeat staleness threshold |
-| 6 | `pollHeartbeat` | HTTP heartbeat polling function |
-| 7 | `panel-ready` | Ready-state panel element |
-| 8 | `panel-submitted` | Submitted-state panel element |
-| 9 | `localStorage` | Reload resilience (state persistence with TTL) |
+| 6 | `HEARTBEAT_GRACE_MS` | Grace period — suppresses warning during startup |
+| 7 | `pollHeartbeat` | HTTP heartbeat polling function |
+| 8 | `panel-ready` | Ready-state panel element |
+| 9 | `panel-submitted` | Submitted-state panel element |
+| 10 | `localStorage` | Reload resilience (state persistence with TTL) |
 
 **If ANY pattern is missing → DO NOT open the page.** Fix the HTML first,
 then re-validate. This is a **blocking gate** — no exceptions, no "this

--- a/plugins/devops/skills/devops-concept/deep-knowledge/templates.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/templates.md
@@ -907,6 +907,9 @@ document.getElementById('panel-ready').style.display = 'block';
 document.getElementById('submit-btn').disabled = false;
 document.getElementById('submit-btn').textContent = 'Entscheidungen abschicken';
 document.body.classList.remove('concept-submitted');
+// Clear cached decisions so reload doesn't resurrect stale selections
+const slug = location.pathname.split('/').pop().replace('.html', '');
+localStorage.removeItem('concept-state-' + slug);
 ```
 
 This is the visual cycle:
@@ -942,6 +945,8 @@ and the page communicate through.
 ```javascript
 // --- Claude Connection Heartbeat (HTTP Bridge) ---
 const HEARTBEAT_STALE_MS = 90000; // 90s — safely covers 60s cron interval + buffer
+const HEARTBEAT_GRACE_MS = 30000; // 30s — Claude needs time to start bridge + cron
+const _pageLoadedAt = Date.now();
 let _lastHeartbeatTs = 0;
 
 async function pollHeartbeat() {
@@ -955,6 +960,10 @@ async function pollHeartbeat() {
 }
 
 function checkClaudeConnection() {
+  // Suppress warning during grace period — Claude needs time to start the
+  // bridge server, set up the heartbeat cron, and send the first POST.
+  if (Date.now() - _pageLoadedAt < HEARTBEAT_GRACE_MS) return;
+
   const isConnected = _lastHeartbeatTs && (Date.now() - _lastHeartbeatTs) < HEARTBEAT_STALE_MS;
   const warning = document.getElementById('connection-warning');
   const btn = document.getElementById('submit-btn');
@@ -977,11 +986,10 @@ function checkClaudeConnection() {
   }
 }
 
-// Poll heartbeat every 5 seconds, check connection after each poll
+// Poll heartbeat every 5 seconds — starts immediately so data arrives ASAP.
+// checkClaudeConnection() is a no-op during grace period, so the warning
+// won't flash before Claude has had time to set up.
 setInterval(async () => { await pollHeartbeat(); checkClaudeConnection(); }, 5000);
-// Initial grace period: 30 seconds — Claude needs time to start the bridge
-// server, set up the heartbeat cron, and send the first POST.
-setTimeout(async () => { await pollHeartbeat(); checkClaudeConnection(); }, 30000);
 ```
 
 **Claude-side heartbeat** (executed by Claude via Bash or CronCreate):

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.42.0",
+  "version": "0.42.1",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to Gemma 4 E4B via llama.cpp to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary
- Fix false "nicht verbunden" warning on concept page load — heartbeat check now respects 30s grace period
- Panel reset clears localStorage to prevent stale decisions resurfacing on reload
- Added `HEARTBEAT_GRACE_MS` to post-generation validation gate
- Aligned marketplace.json version (was stuck at 0.41.5)

Closes #87