### PR TITLE
fix(usage): tune thresholds, spacing, and stale indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.43.3] — 2026-04-15
+
+### Fixed
+
+- **usage card** — context-health thresholds raised from 40/80 to 120/200 calls, appropriate for Opus 1M sessions
+- **usage card** — added blank line spacing around meter bars for better readability
+- **usage card** — replaced cryptic `▲ stale` indicator with clear `cached · ~2h old` label, hidden when data is <30min old
+
 ## [0.43.2] — 2026-04-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.43.2**
+**Version: 0.43.3**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.43.2",
+  "version": "0.43.3",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/mcp-server/index.js
+++ b/plugins/devops/mcp-server/index.js
@@ -27,8 +27,8 @@ const PLUGIN_ROOT = resolve(__dirname, '..');
 const BAR_WIDTH              = 14;
 const WINDOW_5H_MIN          = 300;
 const WINDOW_WK_MIN          = 10080;
-const HEALTH_WARN_THRESHOLD  = 40;
-const HEALTH_CRIT_THRESHOLD  = 80;
+const HEALTH_WARN_THRESHOLD  = 120;
+const HEALTH_CRIT_THRESHOLD  = 200;
 
 /** Safely parse a JSON string; returns the original value on failure. */
 function tryParse(v) {
@@ -140,20 +140,22 @@ function renderUsageMeterForCard(usageData, delta5h, deltaWk, healthLine) {
     lines.push(renderUsageLine('Wk', w.pct, elapsedWkPct, deltaWk, w.resetInMinutes));
   }
 
-  // Stale/cached data indicator
-  if (usageData._cached && usageData._ageMinutes > 0) {
+  // Stale/cached data indicator — only show when data is notably old (>30min)
+  if (usageData._cached && usageData._ageMinutes > 30) {
     const ageLabel = usageData._ageMinutes >= 60
-      ? `${Math.round(usageData._ageMinutes / 60)}h ago`
-      : `${usageData._ageMinutes}m ago`;
-    lines.push(`\u26a0 stale (~${ageLabel})`);
+      ? `~${Math.round(usageData._ageMinutes / 60)}h old`
+      : `~${usageData._ageMinutes}m old`;
+    lines.push('');
+    lines.push(`cached \u00b7 ${ageLabel}`);
   }
 
   lines.push('```');
 
   // Health line is the first line inside the code fence, above bars
+  // Add blank line after health line to visually separate it from the bars
   if (healthLine) {
     const idx = 1; // after opening ```
-    lines.splice(idx, 0, healthLine);
+    lines.splice(idx, 0, healthLine, '');
   }
 
   return lines.join('\n');

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.43.2",
+  "version": "0.43.3",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to Gemma 4 E4B via llama.cpp to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary\n- Raise context-health thresholds from 40/80 to 120/200 for Opus 1M sessions\n- Add blank line spacing around meter bars for readability\n- Replace cryptic stale indicator with clear cached label\n- Fix marketplace.json version drift (was stuck at 0.42.1)\n\nCloses #94