### PR TITLE
feat(completion): harden card enforcement across 9 skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.42.1"
+    "version": "0.43.3"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.42.1",
+      "version": "0.43.3",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to Gemma 4 E4B via llama.cpp to save tokens.",
-      "version": "0.42.1",
+      "version": "0.43.3",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.44.0] — 2026-04-16
+
+### Added
+
+- **completion** — `stop.flow.guard` now blocks the turn via JSON `decision:block` when a card is required but not rendered, instead of only injecting a next-turn reminder. Works for tool-use turns AND substantial chat-only answers (≥400 chars) — no more missed `analysis`/`ready` cards after conversational turns
+- **completion** — new `hooks/lib/card-guard.js` module (pure decision matrix, 28 unit tests) with `✨✨✨` card-marker backup detection for when the flag-file write fails
+- **skills** — 9 skills now render the completion card explicitly, analogous to `/devops-ship` Step 6: commit, flow, concept, readme, new-issue, deep-research, claude-md-lint, project-setup, repo-health
+- **concept** — bridge server `/reset` is now conditional on a `_version` counter to prevent losing user submissions that arrive between Claude's GET and POST; stale resets return HTTP 409
+- **concept** — Step 3 cron combines heartbeat + decision poll + conditional reset in one tick, so user submissions are auto-picked up within ~60 s without a manual trigger
+
+### Fixed
+
+- **hooks** — transcript reads in `stop.flow.guard` capped at the last 200 KB to avoid unbounded I/O and JSON parsing on long session logs
+- **concept** — offline-submit `localStorage.setItem` now wrapped in try/catch to survive quota-exceeded or storage-disabled browsers
+- **version** — marketplace.json synced from stale 0.42.1 to 0.43.3 (pre-0.44.0 ship blocker)
+
 ## [0.43.3] — 2026-04-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.43.3**
+**Version: 0.44.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/docs/concepts/2026-04-16-completion-card-enforcement-v1.html
+++ b/docs/concepts/2026-04-16-completion-card-enforcement-v1.html
@@ -882,7 +882,8 @@ Card must be the LAST thing in the response — nothing after the closing ---.</
         body: JSON.stringify(data)
       });
     } catch {
-      localStorage.setItem(STORAGE_KEY + '-pending', JSON.stringify(data));
+      try { localStorage.setItem(STORAGE_KEY + '-pending', JSON.stringify(data)); }
+      catch {}
     }
     saveState();
   });

--- a/docs/concepts/2026-04-16-completion-card-enforcement-v1.html
+++ b/docs/concepts/2026-04-16-completion-card-enforcement-v1.html
@@ -1,0 +1,953 @@
+<!DOCTYPE html>
+<html lang="de" data-theme="dark" data-page-version="2026-04-16T20:50:00">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Concept — Completion-Card Enforcement Hardening</title>
+<style>
+  :root {
+    --bg: #0d1117; --bg-elev: #161b22; --panel-bg: #161b22;
+    --text: #c9d1d9; --text-muted: #8b949e;
+    --border-color: #30363d;
+    --accent-color: #58a6ff;
+    --success-color: #3fb950;
+    --warning-color: #d29922;
+    --danger-color: #f85149;
+    --code-bg: #0d1117;
+    --code-border: #30363d;
+  }
+  [data-theme="light"] {
+    --bg: #ffffff; --bg-elev: #f6f8fa; --panel-bg: #f6f8fa;
+    --text: #24292f; --text-muted: #57606a;
+    --border-color: #d0d7de;
+    --accent-color: #0969da;
+    --success-color: #1a7f37;
+    --warning-color: #9a6700;
+    --danger-color: #cf222e;
+    --code-bg: #f6f8fa;
+    --code-border: #d0d7de;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; }
+  body {
+    background: var(--bg);
+    color: var(--text);
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    line-height: 1.6;
+    font-size: 15px;
+  }
+  .concept-layout { display: flex; min-height: 100vh; }
+  .concept-content {
+    flex: 1; padding: 2rem 2.5rem; overflow-y: auto; min-width: 0;
+  }
+  .concept-decision-panel {
+    width: 22%; min-width: 280px; max-width: 360px;
+    position: sticky; top: 0; height: 100vh; overflow-y: auto;
+    padding: 1.5rem;
+    border-left: 1px solid var(--border-color);
+    background: var(--panel-bg);
+  }
+  @media (max-width: 900px) {
+    .concept-layout { flex-direction: column; }
+    .concept-decision-panel {
+      width: 100%; max-width: none; height: auto;
+      position: sticky; bottom: 0; top: auto;
+      border-left: none; border-top: 1px solid var(--border-color);
+    }
+  }
+
+  header.page-head {
+    display: flex; justify-content: space-between; align-items: flex-start;
+    gap: 1rem; margin-bottom: 2rem; padding-bottom: 1.5rem;
+    border-bottom: 1px solid var(--border-color);
+  }
+  header.page-head h1 {
+    font-size: 1.75rem; margin: 0 0 0.5rem; font-weight: 700;
+    letter-spacing: -0.02em;
+  }
+  header.page-head .subtitle {
+    color: var(--text-muted); margin: 0; font-size: 0.95rem;
+  }
+  #theme-toggle {
+    background: none; border: 1px solid var(--border-color);
+    color: var(--text); cursor: pointer;
+    padding: 0.4rem 0.7rem; border-radius: 8px; font-size: 1.1rem;
+    transition: background 0.2s;
+  }
+  #theme-toggle:hover { background: var(--bg-elev); }
+
+  .stats-row {
+    display: flex; gap: 0.75rem; flex-wrap: wrap; margin-bottom: 2rem;
+  }
+  .stat {
+    flex: 1; min-width: 130px;
+    background: var(--bg-elev); border: 1px solid var(--border-color);
+    border-radius: 10px; padding: 0.9rem 1rem;
+  }
+  .stat-label { font-size: 0.75rem; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.05em; }
+  .stat-value { font-size: 1.4rem; font-weight: 700; margin-top: 0.15rem; }
+  .stat.ok .stat-value { color: var(--success-color); }
+  .stat.warn .stat-value { color: var(--warning-color); }
+
+  section.fix {
+    background: var(--bg-elev); border: 1px solid var(--border-color);
+    border-radius: 12px; padding: 1.5rem 1.75rem;
+    margin-bottom: 2rem;
+  }
+  section.fix h2 {
+    margin: 0 0 0.25rem; font-size: 1.25rem;
+    display: flex; align-items: center; gap: 0.5rem;
+  }
+  section.fix .fix-tag {
+    display: inline-block;
+    padding: 0.1rem 0.5rem; border-radius: 6px;
+    background: color-mix(in srgb, var(--accent-color) 18%, transparent);
+    color: var(--accent-color);
+    font-size: 0.7rem; font-weight: 700; letter-spacing: 0.05em;
+    vertical-align: middle;
+  }
+  section.fix .fix-meta {
+    color: var(--text-muted); font-size: 0.85rem; margin-bottom: 1rem;
+  }
+  section.fix h3 {
+    margin: 1.25rem 0 0.5rem; font-size: 0.95rem;
+    text-transform: uppercase; letter-spacing: 0.05em;
+    color: var(--text-muted); font-weight: 600;
+  }
+  section.fix p { margin: 0 0 0.75rem; }
+  section.fix ul { margin: 0.25rem 0 0.75rem; padding-left: 1.25rem; }
+  section.fix li { margin-bottom: 0.25rem; }
+
+  pre.diff, pre.code {
+    background: var(--code-bg); border: 1px solid var(--code-border);
+    border-radius: 8px; padding: 0.9rem 1rem;
+    font-family: 'Cascadia Code', 'Fira Code', Consolas, monospace;
+    font-size: 0.82rem; line-height: 1.5;
+    overflow-x: auto; margin: 0.5rem 0 1rem;
+    white-space: pre;
+  }
+  pre.diff .add { color: var(--success-color); display: block; }
+  pre.diff .rem { color: var(--danger-color); display: block; }
+  pre.diff .ctx { color: var(--text-muted); display: block; }
+  pre.diff .hunk { color: var(--accent-color); display: block; margin-top: 0.25rem; }
+
+  .files-touched {
+    display: flex; flex-wrap: wrap; gap: 0.4rem; margin: 0.5rem 0 0.25rem;
+  }
+  .file-chip {
+    display: inline-flex; align-items: center; gap: 0.3rem;
+    background: var(--bg); border: 1px solid var(--border-color);
+    padding: 0.15rem 0.55rem; border-radius: 6px;
+    font-family: 'Cascadia Code', monospace; font-size: 0.78rem;
+    color: var(--text-muted);
+  }
+  .file-chip.new { border-color: var(--success-color); color: var(--success-color); }
+  .file-chip.mod { border-color: var(--accent-color); color: var(--accent-color); }
+
+  .test-results {
+    display: flex; gap: 0.5rem; flex-wrap: wrap; margin: 0.25rem 0 1rem;
+  }
+  .test-pill {
+    display: inline-flex; align-items: center; gap: 0.4rem;
+    background: color-mix(in srgb, var(--success-color) 15%, transparent);
+    border: 1px solid var(--success-color); color: var(--success-color);
+    padding: 0.25rem 0.6rem; border-radius: 6px;
+    font-size: 0.8rem; font-weight: 600;
+  }
+  .test-pill.neutral {
+    background: color-mix(in srgb, var(--accent-color) 15%, transparent);
+    border-color: var(--accent-color); color: var(--accent-color);
+  }
+
+  .kv-table {
+    width: 100%; border-collapse: collapse; margin: 0.25rem 0 1rem;
+    font-size: 0.88rem;
+  }
+  .kv-table th, .kv-table td {
+    padding: 0.5rem 0.75rem;
+    text-align: left;
+    border-bottom: 1px solid var(--border-color);
+  }
+  .kv-table th {
+    color: var(--text-muted); font-weight: 600;
+    font-size: 0.75rem; text-transform: uppercase;
+  }
+  .kv-table td code {
+    background: var(--code-bg); padding: 0.1rem 0.35rem;
+    border-radius: 4px; font-size: 0.82rem;
+  }
+
+  /* ============== Tri-state (custom labels for review) ============== */
+  .review-controls {
+    margin-top: 1.25rem; padding-top: 1.25rem;
+    border-top: 1px dashed var(--border-color);
+  }
+  .review-controls h3 { margin-top: 0; }
+  .tri-state-group {
+    display: flex; gap: 0;
+    border: 1px solid var(--border-color);
+    border-radius: 8px; overflow: hidden; margin-bottom: 0.75rem;
+  }
+  .tri-state-option {
+    flex: 1; display: flex; flex-direction: column; align-items: center;
+    padding: 0.75rem 0.85rem; cursor: pointer; text-align: center;
+    position: relative;
+    border-right: 1px solid var(--border-color);
+    transition: background 0.2s, box-shadow 0.2s, opacity 0.2s;
+  }
+  .tri-state-option:last-child { border-right: none; }
+  .tri-state-option:hover {
+    background: color-mix(in srgb, var(--accent-color) 10%, transparent);
+  }
+  .tri-state-option input { display: none; }
+  .tri-state-option:has(input:checked) .tri-state-label { font-weight: 700; }
+  .tri-state-label { font-size: 0.9rem; transition: font-weight 0.15s; }
+  .tri-state-hint {
+    font-size: 0.72rem; margin-top: 0.2rem; opacity: 0.55;
+    transition: opacity 0.2s;
+  }
+  .tri-state-option:has(input:checked) .tri-state-hint { opacity: 1; }
+  .tri-state-hint.feedback { color: var(--accent-color); }
+  .tri-state-hint.action { color: var(--warning-color); }
+  .tri-state-hint.danger { color: var(--danger-color); }
+
+  .tri-state-option:has(input[value="approve"]:checked) {
+    background: color-mix(in srgb, var(--success-color) 15%, transparent);
+    box-shadow: inset 0 0 0 2px var(--success-color);
+  }
+  .tri-state-option:has(input[value="approve"]:checked) .tri-state-label {
+    color: var(--success-color);
+  }
+  .tri-state-option:has(input[value="tweak"]:checked) {
+    background: color-mix(in srgb, var(--warning-color) 15%, transparent);
+    box-shadow: inset 0 0 0 2px var(--warning-color);
+  }
+  .tri-state-option:has(input[value="tweak"]:checked) .tri-state-label {
+    color: var(--warning-color);
+  }
+  .tri-state-option:has(input[value="reject"]:checked) {
+    background: color-mix(in srgb, var(--danger-color) 12%, transparent);
+    box-shadow: inset 0 0 0 2px var(--danger-color);
+  }
+  .tri-state-option:has(input[value="reject"]:checked) .tri-state-label {
+    color: var(--danger-color);
+  }
+  .tri-state-option:has(input:not(:checked)) { opacity: 0.7; }
+  .tri-state-option:has(input:not(:checked)):hover { opacity: 1; }
+  .tri-state-option:has(input:checked)::after {
+    content: '✓'; position: absolute; top: 4px; right: 6px;
+    font-size: 0.7rem; font-weight: 700;
+    width: 16px; height: 16px;
+    display: flex; align-items: center; justify-content: center;
+    border-radius: 50%;
+    color: white; background: var(--accent-color);
+  }
+  .tri-state-option:has(input[value="approve"]:checked)::after { background: var(--success-color); }
+  .tri-state-option:has(input[value="tweak"]:checked)::after { background: var(--warning-color); }
+  .tri-state-option:has(input[value="reject"]:checked)::after { background: var(--danger-color); }
+
+  textarea.comment {
+    width: 100%; min-height: 80px;
+    background: var(--bg); color: var(--text);
+    border: 1px solid var(--border-color);
+    border-radius: 8px; padding: 0.6rem 0.75rem;
+    font-family: inherit; font-size: 0.9rem;
+    resize: vertical; box-sizing: border-box;
+  }
+  textarea.comment:focus {
+    outline: none;
+    border-color: var(--accent-color);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent-color) 25%, transparent);
+  }
+  textarea.comment::placeholder { color: var(--text-muted); }
+
+  /* ============== Decision panel (sidebar) ============== */
+  .concept-decision-panel h3 {
+    font-size: 0.85rem; text-transform: uppercase; letter-spacing: 0.05em;
+    color: var(--text-muted); margin: 0 0 1rem;
+  }
+  .variant-nav {
+    display: flex; flex-direction: column; gap: 2px;
+    margin-bottom: 1.25rem; padding-bottom: 1rem;
+    border-bottom: 1px solid var(--border-color);
+  }
+  .variant-nav-item {
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 0.5rem 0.75rem; border-radius: 6px;
+    text-decoration: none; color: var(--text);
+    font-size: 0.85rem; transition: background 0.15s;
+    cursor: pointer;
+  }
+  .variant-nav-item:hover {
+    background: color-mix(in srgb, var(--accent-color) 12%, transparent);
+  }
+  .variant-nav-label { font-weight: 500; }
+  .variant-nav-state {
+    font-size: 0.72rem; color: var(--text-muted); white-space: nowrap;
+    padding: 0.1rem 0.4rem; border-radius: 4px;
+    background: var(--bg);
+  }
+  .variant-nav-state.state-approve { color: var(--success-color); background: color-mix(in srgb, var(--success-color) 15%, transparent); }
+  .variant-nav-state.state-tweak   { color: var(--warning-color); background: color-mix(in srgb, var(--warning-color) 15%, transparent); }
+  .variant-nav-state.state-reject  { color: var(--danger-color);  background: color-mix(in srgb, var(--danger-color) 15%, transparent); }
+
+  .panel-warning {
+    display: flex; align-items: flex-start; gap: 0.5rem;
+    padding: 0.75rem; margin-bottom: 1rem;
+    border-radius: 8px;
+    background: color-mix(in srgb, var(--warning-color) 15%, transparent);
+    border: 1px solid var(--warning-color);
+    font-size: 0.8rem; line-height: 1.4;
+  }
+  .panel-warning .warning-icon { font-size: 1rem; flex-shrink: 0; }
+
+  #panel-ready #decision-summary {
+    background: var(--bg); border: 1px solid var(--border-color);
+    border-radius: 8px; padding: 0.75rem;
+    font-size: 0.82rem; margin-bottom: 0.75rem;
+    max-height: 200px; overflow-y: auto;
+  }
+  .summary-row {
+    display: flex; justify-content: space-between; gap: 0.5rem;
+    padding: 0.25rem 0;
+  }
+  .summary-row .sid { color: var(--text-muted); }
+  .summary-row .sval { font-weight: 600; }
+
+  #submit-btn {
+    width: 100%; padding: 0.75rem;
+    background: var(--accent-color); color: white;
+    border: none; border-radius: 8px;
+    font-size: 0.95rem; font-weight: 600; cursor: pointer;
+    transition: opacity 0.2s, transform 0.1s;
+  }
+  #submit-btn:hover { opacity: 0.9; }
+  #submit-btn:active { transform: scale(0.98); }
+  #submit-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+  .hint {
+    font-size: 0.78rem; color: var(--text-muted);
+    margin: 0.5rem 0 0; line-height: 1.4;
+  }
+
+  .submitted-indicator {
+    display: flex; align-items: center; gap: 0.5rem;
+    padding: 1rem; margin-bottom: 0.75rem;
+    border-radius: 8px;
+    background: color-mix(in srgb, var(--success-color) 15%, transparent);
+    border: 1px solid var(--success-color);
+  }
+  .check-icon { font-size: 1.2rem; color: var(--success-color); }
+  .submitted-hint {
+    font-size: 0.85rem; line-height: 1.5;
+    color: var(--text-muted); margin: 0 0 1rem;
+  }
+  .waiting-animation {
+    display: flex; gap: 6px; justify-content: center; padding: 0.5rem 0;
+  }
+  .waiting-animation .dot {
+    width: 8px; height: 8px; border-radius: 50%;
+    background: var(--accent-color);
+    animation: pulse 1.4s ease-in-out infinite;
+  }
+  .waiting-animation .dot:nth-child(2) { animation-delay: 0.2s; }
+  .waiting-animation .dot:nth-child(3) { animation-delay: 0.4s; }
+  @keyframes pulse {
+    0%, 80%, 100% { opacity: 0.3; transform: scale(0.8); }
+    40% { opacity: 1; transform: scale(1); }
+  }
+
+  ul.list-plain { list-style: none; padding-left: 0; }
+  ul.list-plain li {
+    padding: 0.35rem 0; border-bottom: 1px dashed var(--border-color);
+  }
+  ul.list-plain li:last-child { border-bottom: none; }
+
+  details.collapsible {
+    background: var(--bg); border: 1px solid var(--border-color);
+    border-radius: 8px; padding: 0.5rem 0.75rem; margin: 0.5rem 0 1rem;
+  }
+  details.collapsible summary {
+    cursor: pointer; font-weight: 600; font-size: 0.9rem;
+    padding: 0.25rem 0;
+  }
+  details[open].collapsible { padding-bottom: 1rem; }
+
+  .badge-new {
+    display: inline-block; font-size: 0.68rem; padding: 0.1rem 0.4rem;
+    border-radius: 4px; background: var(--success-color); color: white;
+    margin-left: 0.35rem; vertical-align: middle; font-weight: 700;
+    letter-spacing: 0.05em;
+  }
+</style>
+</head>
+<body>
+<div class="concept-layout">
+  <div class="concept-content">
+    <header class="page-head">
+      <div>
+        <h1>Completion-Card Enforcement Hardening</h1>
+        <p class="subtitle">Review &amp; Approval · Branch <code>claude/hungry-bohr-a144d0</code> · 3 Fixes · 2026-04-16</p>
+      </div>
+      <button id="theme-toggle" aria-label="Toggle theme">🌙</button>
+    </header>
+
+    <div class="stats-row">
+      <div class="stat ok"><div class="stat-label">Tests</div><div class="stat-value">82/82</div></div>
+      <div class="stat ok"><div class="stat-label">Card-Guard</div><div class="stat-value">21 unit</div></div>
+      <div class="stat ok"><div class="stat-label">E2E Smoke</div><div class="stat-value">14/14</div></div>
+      <div class="stat ok"><div class="stat-label">Lint</div><div class="stat-value">clean</div></div>
+      <div class="stat"><div class="stat-label">Files</div><div class="stat-value">+2 · Δ4</div></div>
+      <div class="stat"><div class="stat-label">LOC</div><div class="stat-value">+105 / −29</div></div>
+    </div>
+
+    <section class="fix" id="fix-1">
+      <h2><span class="fix-tag">FIX 1</span> Stop-Hook blockierende Enforcement</h2>
+      <p class="fix-meta"><code>plugins/devops/hooks/stop/stop.flow.guard.js</code> · v0.1.0 → v0.2.0</p>
+
+      <h3>Problem</h3>
+      <p>Alter Hook hat nur einen Text-Reminder in den <em>nächsten</em> Turn injiziert. Wenn Claude die Karte im aktuellen Turn vergessen hat, ging sie verloren. Zusätzlich feuerte der Hook gar nicht bei reinen Chat-Antworten (kein Tool-Use → kein work-happened-Flag).</p>
+
+      <h3>Lösung</h3>
+      <ul>
+        <li><strong>JSON-Block-Decision</strong>: <code>{"decision":"block","reason":"…"}</code> zwingt Claude <em>im selben Turn</em> zurück, die Karte zu rendern.</li>
+        <li><strong>Substantial-Answer-Heuristik</strong>: Transkript wird gelesen; bei ≥400 Zeichen Assistant-Prose wird auch ohne Tool-Use geblockt.</li>
+        <li><strong>Loop-Break</strong> via <code>stop_hook_active</code>: zweiter Hook-Fire in gleichem Zyklus passt immer durch — Endlosschleife ausgeschlossen.</li>
+        <li><strong>Flag-Reset</strong> nur bei pass, nicht bei block — Zustand bleibt konsistent über die zweite Fire hinweg.</li>
+      </ul>
+
+      <h3>Diff (gekürzt)</h3>
+      <pre class="diff"><span class="hunk">@@ description (alt → neu) @@</span><span class="rem">-   If tools were used but no card was rendered, inject carry-over reminder</span><span class="rem">-   into the NEXT turn's context. Always reset flags.</span><span class="add">+   Block (JSON {decision:"block"}) when no card rendered AND</span><span class="add">+     (tool calls happened OR last assistant text is substantial prose)</span><span class="add">+     AND NOT stop_hook_active.</span><span class="hunk">@@ decision flow @@</span><span class="rem">-   if (workHappened && !cardRendered) {</span><span class="rem">-     process.stdout.write([... text reminder ...].join('\n'));</span><span class="rem">-   }</span><span class="add">+   const decision = decideAction({ workHappened, cardRendered,</span><span class="add">+                                    stopHookActive, substantial });</span><span class="add">+   if (decision.action === 'block') {</span><span class="add">+     process.stdout.write(JSON.stringify({</span><span class="add">+       decision: 'block', reason: decision.reason,</span><span class="add">+     }));</span><span class="add">+   }</span></pre>
+
+      <h3>Test-Coverage</h3>
+      <div class="test-results">
+        <span class="test-pill">✓ BLOCK bei work + no card</span>
+        <span class="test-pill">✓ SILENT bei work + card</span>
+        <span class="test-pill">✓ BLOCK bei substantial prose</span>
+        <span class="test-pill">✓ SILENT bei trivial chat</span>
+        <span class="test-pill">✓ Loop-Break via stop_hook_active</span>
+        <span class="test-pill">✓ Malformed JSON → exit 0</span>
+      </div>
+
+      <div class="review-controls">
+        <h3>Deine Entscheidung</h3>
+        <div class="tri-state-group" data-decision="fix-1" data-label="Fix 1: Stop-Hook Block-Enforcement">
+          <label class="tri-state-option">
+            <input type="radio" name="eval-fix-1" value="approve" checked>
+            <span class="tri-state-label">Übernehmen</span>
+            <span class="tri-state-hint feedback">commit as-is</span>
+          </label>
+          <label class="tri-state-option">
+            <input type="radio" name="eval-fix-1" value="tweak">
+            <span class="tri-state-label">Anpassen</span>
+            <span class="tri-state-hint action">Claude ändert nach Kommentar</span>
+          </label>
+          <label class="tri-state-option">
+            <input type="radio" name="eval-fix-1" value="reject">
+            <span class="tri-state-label">Verwerfen</span>
+            <span class="tri-state-hint danger">Claude revertiert</span>
+          </label>
+        </div>
+        <textarea class="comment" data-comment="fix-1"
+          placeholder="Optional: Kommentar / Tweak-Wünsche. Z.B. 'Threshold auf 300 Zeichen senken', 'Block-Reason kürzen', 'Substantial-Heuristik weglassen und nur auf work-happened bauen'…"></textarea>
+      </div>
+    </section>
+
+    <section class="fix" id="fix-2">
+      <h2><span class="fix-tag">FIX 2</span> Card-Guard Bibliothek<span class="badge-new">NEU</span></h2>
+      <p class="fix-meta"><code>plugins/devops/hooks/lib/card-guard.js</code> + <code>card-guard.test.js</code></p>
+
+      <h3>Warum eigenes Modul?</h3>
+      <p>Die Entscheidungslogik wurde aus <code>stop.flow.guard.js</code> herausgezogen in reine, <em>testbare</em> Funktionen. Der Hook-Wrapper bleibt dünn (nur stdin→stdout-Glue), die Regeln sind unit-getestet ohne Mocking von Temp-Files oder Prozessen.</p>
+
+      <div class="files-touched">
+        <span class="file-chip new">+ lib/card-guard.js (95 Zeilen)</span>
+        <span class="file-chip new">+ lib/card-guard.test.js (215 Zeilen)</span>
+      </div>
+
+      <h3>Exportierte API</h3>
+      <table class="kv-table">
+        <thead><tr><th>Export</th><th>Zweck</th></tr></thead>
+        <tbody>
+          <tr><td><code>SUBSTANTIAL_CHARS</code></td><td>Schwellwert = 400 Zeichen (justierbar)</td></tr>
+          <tr><td><code>lastAssistantTextLength(content)</code></td><td>Parst JSONL-Transkript, liefert Zeichenanzahl der letzten Assistant-Text-Blöcke</td></tr>
+          <tr><td><code>isSubstantialAnswer(content, threshold?)</code></td><td>Bool — überschreitet Schwellwert?</td></tr>
+          <tr><td><code>decideAction({work,card,active,substantial})</code></td><td>→ <code>{ action, resetFlags, reason? }</code></td></tr>
+          <tr><td><code>buildBlockReason()</code></td><td>Generiert den Block-Reason-Text mit Variant-Baum</td></tr>
+          <tr><td><code>safeReadTranscript(path)</code></td><td>Liest Transkript, '' bei jedem Fehler</td></tr>
+        </tbody>
+      </table>
+
+      <h3>Entscheidungsmatrix</h3>
+      <table class="kv-table">
+        <thead><tr><th>work</th><th>card</th><th>active</th><th>substantial</th><th>→ Aktion</th></tr></thead>
+        <tbody>
+          <tr><td>*</td><td>*</td><td>✓</td><td>*</td><td>pass + reset (loop-break)</td></tr>
+          <tr><td>✓</td><td>✓</td><td>✗</td><td>*</td><td>pass + reset</td></tr>
+          <tr><td>✓</td><td>✗</td><td>✗</td><td>*</td><td><strong>block</strong> (keep flags)</td></tr>
+          <tr><td>✗</td><td>✗</td><td>✗</td><td>✓</td><td><strong>block</strong> (keep flags)</td></tr>
+          <tr><td>✗</td><td>✗</td><td>✗</td><td>✗</td><td>pass + reset</td></tr>
+          <tr><td>✗</td><td>✓</td><td>✗</td><td>*</td><td>pass + reset</td></tr>
+        </tbody>
+      </table>
+
+      <h3>Test-Coverage</h3>
+      <div class="test-results">
+        <span class="test-pill neutral">lastAssistantTextLength: 8 Szenarien</span>
+        <span class="test-pill neutral">isSubstantialAnswer: 4 Szenarien</span>
+        <span class="test-pill neutral">decideAction: 7 Szenarien</span>
+        <span class="test-pill neutral">buildBlockReason: 2 Contract-Checks</span>
+        <span class="test-pill">✓ 21/21 unit-tests</span>
+      </div>
+
+      <details class="collapsible">
+        <summary>Block-Reason-Text (wird an Claude zurückgegeben)</summary>
+        <pre class="code">[stop.flow.guard] Completion card required — not yet rendered this turn.
+
+Call `mcp__plugin_devops_dotclaude-completion__render_completion_card` NOW as the FIRST action.
+If the direct call fails with "tool not found", fall back to ToolSearch:
+  select:mcp__plugin_devops_dotclaude-completion__render_completion_card
+
+Variant decision (pick exactly one):
+  ship pipeline ran + merged → ship-successful  (ONLY after /devops-ship + merge)
+  ship pipeline ran + NOT merged → ship-blocked
+  task aborted / infeasible → aborted
+  code edits + app/service startable → test
+  user started app, no edits yet → test-minimal
+  code/doc changes (≥1 edit), no app → ready
+  zero file changes (analysis/explain/audit) → analysis
+  unsure → fallback
+
+IMPORTANT: The MCP result is hidden in a collapsed UI block.
+Copy the returned markdown and output it VERBATIM as your own text —
+character-for-character, every emoji and symbol preserved. …
+Card must be the LAST thing in the response — nothing after the closing ---.</pre>
+      </details>
+
+      <div class="review-controls">
+        <h3>Deine Entscheidung</h3>
+        <div class="tri-state-group" data-decision="fix-2" data-label="Fix 2: Card-Guard-Bibliothek">
+          <label class="tri-state-option">
+            <input type="radio" name="eval-fix-2" value="approve" checked>
+            <span class="tri-state-label">Übernehmen</span>
+            <span class="tri-state-hint feedback">commit as-is</span>
+          </label>
+          <label class="tri-state-option">
+            <input type="radio" name="eval-fix-2" value="tweak">
+            <span class="tri-state-label">Anpassen</span>
+            <span class="tri-state-hint action">Claude ändert nach Kommentar</span>
+          </label>
+          <label class="tri-state-option">
+            <input type="radio" name="eval-fix-2" value="reject">
+            <span class="tri-state-label">Verwerfen</span>
+            <span class="tri-state-hint danger">Claude revertiert</span>
+          </label>
+        </div>
+        <textarea class="comment" data-comment="fix-2"
+          placeholder="Optional: API-Namen ändern, mehr/weniger Tests, Threshold justieren, Block-Reason-Text kürzen oder erweitern…"></textarea>
+      </div>
+    </section>
+
+    <section class="fix" id="fix-3">
+      <h2><span class="fix-tag">FIX 3</span> Skill-Steps mit explizitem Card-Call</h2>
+      <p class="fix-meta">3 Skills · analog zu <code>/devops-ship</code> Step 6</p>
+
+      <h3>Problem</h3>
+      <p>Skills vertrauten auf Hook-Reminders, hatten aber keinen konkreten Schritt, der die Karte erzwingt. <code>/devops-ship</code> ist das einzige Skill, das deterministisch rendert — alle anderen sind weich.</p>
+
+      <h3>Änderungen</h3>
+
+      <table class="kv-table">
+        <thead><tr><th>Skill</th><th>Neuer Schritt</th><th>Variant(s)</th><th>Zeilen</th></tr></thead>
+        <tbody>
+          <tr>
+            <td><code>devops-commit</code></td>
+            <td>Step 10 — Completion Card</td>
+            <td><code>ready</code></td>
+            <td>135 → 154 ✓</td>
+          </tr>
+          <tr>
+            <td><code>devops-flow</code></td>
+            <td>Step 9 — Completion Card</td>
+            <td><code>test</code> / <code>ready</code> / <code>analysis</code> / <code>aborted</code></td>
+            <td>100 → 118 ✓</td>
+          </tr>
+          <tr>
+            <td><code>devops-concept</code></td>
+            <td>Step 6 — Completion Card (umbenannt)</td>
+            <td><code>analysis</code> / <code>ready</code> / <code>aborted</code></td>
+            <td>417 → 434 ⚠</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <p><strong>Soft-Limit 200 Zeilen pro Skill:</strong> commit und flow weit darunter, concept war bereits vorher über 200 — durch die Step-Umschreibung um 17 Zeilen gewachsen, aber nicht meaningful verschlimmert.</p>
+
+      <h3>Was wurde gelöscht?</h3>
+      <p><em>Nur in <code>devops-concept</code> wurden 3 Zeilen des alten vagen "Step 6 — Completion" Blocks ersetzt.</em> Ein Frontmatter-Eintrag (<code>allowed-tools</code>) wurde in commit/flow erweitert — concept hatte bereits alles Nötige.</p>
+
+      <details class="collapsible">
+        <summary>Diff: devops-commit (Step 10 neu)</summary>
+        <pre class="diff"><span class="hunk">@@ allowed-tools @@</span><span class="rem">-allowed-tools: Bash(git *), AskUserQuestion</span><span class="add">+allowed-tools: Bash(git *), AskUserQuestion, mcp__plugin_devops_dotclaude-completion__render_completion_card</span><span class="hunk">@@ after Step 9 — Report @@</span><span class="add">+## Step 10 — Completion Card</span><span class="add">+</span><span class="add">+Call render_completion_card with variant `ready`</span><span class="add">+(a commit is a code change, not a ship — `shipped` only after /devops-ship).</span><span class="add">+</span><span class="add">+Pass: variant, summary, lang, session_id, changes, state.</span><span class="add">+Output the returned markdown VERBATIM as the LAST thing in the response.</span></pre>
+      </details>
+
+      <details class="collapsible">
+        <summary>Diff: devops-flow (Step 9 neu, variant-abhängig)</summary>
+        <pre class="diff"><span class="hunk">@@ after Step 8 — Report @@</span><span class="add">+## Step 9 — Completion Card</span><span class="add">+</span><span class="add">+Variant per outcome:</span><span class="add">+  Fix + app testable  → test (include userTest)</span><span class="add">+  Fix, no UI test     → ready</span><span class="add">+  Diagnosed only      → analysis</span><span class="add">+  Can't reproduce     → aborted (include cta.reason)</span></pre>
+      </details>
+
+      <details class="collapsible">
+        <summary>Diff: devops-concept (Step 6 umbenannt von "Completion" → "Completion Card")</summary>
+        <pre class="diff"><span class="hunk">@@ Step 6 block — vorher 3 Zeilen, jetzt 21 Zeilen @@</span><span class="rem">-## Step 6 — Completion</span><span class="rem">-The feedback loop ends when the user is satisfied. Then continue with the</span><span class="rem">-normal workflow. If the concept was the primary task, render a completion</span><span class="rem">-card. If it was part of a larger task, proceed to the next step.</span><span class="add">+## Step 6 — Completion Card</span><span class="add">+</span><span class="add">+The feedback loop ends when the user is satisfied (…"fertig"/"done"…).</span><span class="add">+Then render a completion card.</span><span class="add">+</span><span class="add">+Variant matrix: analysis / ready / aborted</span><span class="add">+Pass: variant, summary, lang, session_id, changes, state.</span><span class="add">+Output VERBATIM as LAST thing.</span><span class="add">+</span><span class="add">+(Sub-skill case preserved: parent skill renders the card.)</span></pre>
+      </details>
+
+      <div class="review-controls">
+        <h3>Deine Entscheidung</h3>
+        <div class="tri-state-group" data-decision="fix-3" data-label="Fix 3: Skill-Steps mit explizitem Card-Call">
+          <label class="tri-state-option">
+            <input type="radio" name="eval-fix-3" value="approve" checked>
+            <span class="tri-state-label">Übernehmen</span>
+            <span class="tri-state-hint feedback">commit as-is</span>
+          </label>
+          <label class="tri-state-option">
+            <input type="radio" name="eval-fix-3" value="tweak">
+            <span class="tri-state-label">Anpassen</span>
+            <span class="tri-state-hint action">Claude ändert nach Kommentar</span>
+          </label>
+          <label class="tri-state-option">
+            <input type="radio" name="eval-fix-3" value="reject">
+            <span class="tri-state-label">Verwerfen</span>
+            <span class="tri-state-hint danger">Claude revertiert</span>
+          </label>
+        </div>
+        <textarea class="comment" data-comment="fix-3"
+          placeholder="Optional: Einzelne Skills ausklammern ('concept nicht anfassen'), weitere Skills hinzufügen ('auch readme + new-issue'), Variant-Matrix anpassen…"></textarea>
+      </div>
+    </section>
+
+    <section class="fix" id="open-questions">
+      <h2>Offene Fragen &amp; optionale Erweiterungen</h2>
+      <p class="fix-meta">Nicht blockierend — markiere welche du zusätzlich umgesetzt haben willst.</p>
+
+      <ul class="list-plain">
+        <li>
+          <label>
+            <input type="checkbox" data-decision="extra-more-skills" data-label="Mehr Skills mit Step-N" data-field="included">
+            <strong>Weitere Skills analog erweitern</strong>
+            — <code>devops-readme</code>, <code>devops-new-issue</code>, <code>devops-deep-research</code>, <code>devops-repo-health</code>, <code>devops-project-setup</code>, <code>devops-claude-md-lint</code> (alle unter 200 Zeilen)
+          </label>
+        </li>
+        <li>
+          <label>
+            <input type="checkbox" data-decision="extra-threshold-tune" data-label="Substantial-Threshold justieren" data-field="included">
+            <strong>Schwellwert feinjustieren</strong>
+            — aktuell 400 Zeichen. Optionen: 300 (aggressiver), 500 (konservativer), oder aus config lesen.
+          </label>
+        </li>
+        <li>
+          <label>
+            <input type="checkbox" data-decision="extra-grep-card-markers" data-label="Text-Scan nach Card-Markern als Backup" data-field="included">
+            <strong>Backup-Detection</strong>
+            — zusätzlich im Transkript nach <code>✨✨✨</code> suchen, falls card-rendered-Flag mal fehlschlägt.
+          </label>
+        </li>
+        <li>
+          <label>
+            <input type="checkbox" data-decision="extra-commit-now" data-label="Direkt committen nach Review" data-field="included">
+            <strong>Direkt committen</strong>
+            — nach dem Review automatisch <code>/devops-commit</code> anstoßen (statt manuell).
+          </label>
+        </li>
+        <li>
+          <label>
+            <input type="checkbox" data-decision="extra-memory-update" data-label="Memory-Eintrag zum neuen Verhalten" data-field="included">
+            <strong>Memory-Feedback</strong>
+            — Eintrag speichern: "Completion card enforcement ist jetzt hart — keine Karten mehr vergessen."
+          </label>
+        </li>
+      </ul>
+    </section>
+
+  </div>
+
+  <aside class="concept-decision-panel">
+    <h3>Übersicht</h3>
+
+    <nav class="variant-nav" id="variant-nav">
+      <a href="#fix-1" class="variant-nav-item" data-variant="fix-1">
+        <span class="variant-nav-label">Fix 1 · Stop-Hook</span>
+        <span class="variant-nav-state">Übernehmen</span>
+      </a>
+      <a href="#fix-2" class="variant-nav-item" data-variant="fix-2">
+        <span class="variant-nav-label">Fix 2 · Card-Guard</span>
+        <span class="variant-nav-state">Übernehmen</span>
+      </a>
+      <a href="#fix-3" class="variant-nav-item" data-variant="fix-3">
+        <span class="variant-nav-label">Fix 3 · Skills</span>
+        <span class="variant-nav-state">Übernehmen</span>
+      </a>
+      <a href="#open-questions" class="variant-nav-item" data-variant="extras">
+        <span class="variant-nav-label">Optional</span>
+        <span class="variant-nav-state">0 gewählt</span>
+      </a>
+    </nav>
+
+    <div id="connection-warning" class="panel-warning" style="display: none;">
+      <span class="warning-icon">⚠</span>
+      <span>Claude ist nicht verbunden. Deine Auswahl wird lokal zwischengespeichert und automatisch übertragen, sobald Claude wieder online ist.</span>
+    </div>
+
+    <div id="panel-ready">
+      <div id="decision-summary"></div>
+      <button id="submit-btn" class="primary">Entscheidungen abschicken</button>
+      <p class="hint">Claude verarbeitet deine Auswahl nach dem Abschicken und committet (oder passt an / revertiert).</p>
+    </div>
+
+    <div id="panel-submitted" style="display: none;">
+      <div class="submitted-indicator">
+        <span class="check-icon">✓</span>
+        <strong>Entscheidungen übermittelt</strong>
+      </div>
+      <p class="submitted-hint">Wechsle zum <strong>Claude Chat</strong> — der nächste Schritt wird dort ausgeführt.</p>
+      <div class="waiting-animation"><span class="dot"></span><span class="dot"></span><span class="dot"></span></div>
+    </div>
+  </aside>
+</div>
+
+<script type="application/json" id="concept-decisions">
+  {"submitted": false, "decisions": [], "comments": []}
+</script>
+
+<script>
+  // ============================================================
+  // State Persistence (localStorage + TTL)
+  // ============================================================
+  const STORAGE_KEY = 'concept-state-' + location.pathname.split('/').pop().replace('.html', '');
+  const STATE_TTL_MS = 24 * 60 * 60 * 1000;
+
+  function saveState() {
+    const state = {
+      _savedAt: Date.now(),
+      _pageVersion: document.documentElement.dataset.pageVersion || ''
+    };
+    document.querySelectorAll('input[type="checkbox"], input[type="radio"]').forEach(el => {
+      if (el.name || el.id) state['input:' + (el.name || el.id) + ':' + el.value] = el.checked;
+    });
+    document.querySelectorAll('textarea, input[type="text"]').forEach(el => {
+      if (el.id || el.dataset.comment) state['text:' + (el.id || el.dataset.comment)] = el.value;
+    });
+    state['theme'] = document.documentElement.getAttribute('data-theme');
+    try { localStorage.setItem(STORAGE_KEY, JSON.stringify(state)); } catch {}
+  }
+
+  function restoreState() {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return;
+    try {
+      const state = JSON.parse(raw);
+      if (state._savedAt && (Date.now() - state._savedAt) > STATE_TTL_MS) {
+        localStorage.removeItem(STORAGE_KEY); return;
+      }
+      const currentVersion = document.documentElement.dataset.pageVersion || '';
+      if (state._pageVersion && state._pageVersion !== currentVersion) {
+        localStorage.removeItem(STORAGE_KEY); return;
+      }
+      if (state.theme) document.documentElement.setAttribute('data-theme', state.theme);
+      Object.entries(state).forEach(([key, value]) => {
+        if (key.startsWith('_') || key === 'theme') return;
+        const [type, ...rest] = key.split(':');
+        if (type === 'input') {
+          const name = rest.slice(0, -1).join(':');
+          const val = rest[rest.length - 1];
+          const el = document.querySelector(
+            `input[name="${CSS.escape(name)}"][value="${CSS.escape(val)}"]`);
+          if (el) el.checked = value;
+        } else if (type === 'text') {
+          const id = rest.join(':');
+          const el = document.querySelector(`[data-comment="${CSS.escape(id)}"]`)
+                  || document.getElementById(id);
+          if (el) el.value = value;
+        }
+      });
+    } catch {}
+  }
+
+  // ============================================================
+  // Variant Nav — state label
+  // ============================================================
+  const STATE_LABELS = { approve: 'Übernehmen', tweak: 'Anpassen', reject: 'Verwerfen' };
+
+  function updateVariantNav() {
+    document.querySelectorAll('.variant-nav-item').forEach(link => {
+      const variantId = link.dataset.variant;
+      const stateEl = link.querySelector('.variant-nav-state');
+      if (!stateEl) return;
+      if (variantId === 'extras') {
+        const count = document.querySelectorAll(
+          '#open-questions input[type="checkbox"]:checked').length;
+        stateEl.textContent = count + ' gewählt';
+        stateEl.className = 'variant-nav-state' + (count > 0 ? ' state-approve' : '');
+        return;
+      }
+      const checked = document.querySelector(`input[name="eval-${variantId}"]:checked`);
+      const state = checked ? checked.value : 'approve';
+      stateEl.textContent = STATE_LABELS[state] || state;
+      stateEl.className = 'variant-nav-state state-' + state;
+    });
+    updateDecisionSummary();
+  }
+
+  // ============================================================
+  // Decision Summary
+  // ============================================================
+  function updateDecisionSummary() {
+    const summary = document.getElementById('decision-summary');
+    if (!summary) return;
+    const rows = [];
+    ['fix-1', 'fix-2', 'fix-3'].forEach(id => {
+      const checked = document.querySelector(`input[name="eval-${id}"]:checked`);
+      const state = checked ? checked.value : 'approve';
+      const label = STATE_LABELS[state] || state;
+      const colorClass = 'state-' + state;
+      rows.push(
+        `<div class="summary-row"><span class="sid">${id}</span>` +
+        `<span class="sval variant-nav-state ${colorClass}">${label}</span></div>`);
+    });
+    const extras = document.querySelectorAll(
+      '#open-questions input[type="checkbox"]:checked').length;
+    rows.push(
+      `<div class="summary-row"><span class="sid">Optional</span>` +
+      `<span class="sval">${extras} / 5</span></div>`);
+    summary.innerHTML = rows.join('');
+  }
+
+  // ============================================================
+  // Submit Handler
+  // ============================================================
+  function collectDecisions() {
+    const decisions = [];
+    const comments = [];
+
+    ['fix-1', 'fix-2', 'fix-3'].forEach(id => {
+      const group = document.querySelector(`[data-decision="${id}"]`);
+      const checked = document.querySelector(`input[name="eval-${id}"]:checked`);
+      decisions.push({
+        id,
+        label: group?.dataset.label || id,
+        evaluation: checked ? checked.value : 'approve',
+      });
+    });
+
+    document.querySelectorAll('#open-questions input[type="checkbox"]').forEach(cb => {
+      decisions.push({
+        id: cb.dataset.decision,
+        label: cb.dataset.label || cb.dataset.decision,
+        included: cb.checked,
+      });
+    });
+
+    document.querySelectorAll('[data-comment]').forEach(el => {
+      if (el.value && el.value.trim()) {
+        comments.push({ id: el.dataset.comment, text: el.value.trim() });
+      }
+    });
+
+    return { submitted: true, decisions, comments, ts: Date.now() };
+  }
+
+  async function retryPendingSubmission() {
+    const pendingKey = STORAGE_KEY + '-pending';
+    const pending = localStorage.getItem(pendingKey);
+    if (!pending) return;
+    try {
+      const res = await fetch('/decisions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: pending
+      });
+      if (res.ok) localStorage.removeItem(pendingKey);
+    } catch {}
+  }
+
+  document.getElementById('submit-btn').addEventListener('click', async () => {
+    const data = collectDecisions();
+    const container = document.getElementById('concept-decisions');
+    container.textContent = JSON.stringify(data);
+    document.body.classList.add('concept-submitted');
+    document.getElementById('panel-ready').style.display = 'none';
+    document.getElementById('panel-submitted').style.display = 'block';
+    try {
+      await fetch('/decisions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data)
+      });
+    } catch {
+      localStorage.setItem(STORAGE_KEY + '-pending', JSON.stringify(data));
+    }
+    saveState();
+  });
+
+  // ============================================================
+  // Theme Toggle
+  // ============================================================
+  document.getElementById('theme-toggle').addEventListener('click', () => {
+    const html = document.documentElement;
+    const current = html.getAttribute('data-theme');
+    const next = current === 'dark' ? 'light' : 'dark';
+    html.setAttribute('data-theme', next);
+    document.getElementById('theme-toggle').textContent = next === 'dark' ? '🌙' : '☀️';
+    saveState();
+  });
+
+  // ============================================================
+  // Claude Connection Heartbeat (HTTP Bridge)
+  // ============================================================
+  const HEARTBEAT_STALE_MS = 90000;
+  const HEARTBEAT_GRACE_MS = 30000;
+  const _pageLoadedAt = Date.now();
+  let _lastHeartbeatTs = 0;
+
+  async function pollHeartbeat() {
+    try {
+      const res = await fetch('/heartbeat', { cache: 'no-store' });
+      const data = await res.json();
+      _lastHeartbeatTs = data.ts || 0;
+    } catch {}
+  }
+
+  function checkClaudeConnection() {
+    if (Date.now() - _pageLoadedAt < HEARTBEAT_GRACE_MS) return;
+    const isConnected = _lastHeartbeatTs
+      && (Date.now() - _lastHeartbeatTs) < HEARTBEAT_STALE_MS;
+    const warning = document.getElementById('connection-warning');
+    const btn = document.getElementById('submit-btn');
+    const panelSubmitted = document.getElementById('panel-submitted');
+    if (panelSubmitted && panelSubmitted.style.display !== 'none') return;
+    if (isConnected) {
+      if (warning) warning.style.display = 'none';
+      if (btn) btn.disabled = false;
+      retryPendingSubmission();
+    } else {
+      if (warning) warning.style.display = 'flex';
+      if (btn) btn.disabled = false;
+    }
+  }
+
+  setInterval(async () => { await pollHeartbeat(); checkClaudeConnection(); }, 5000);
+
+  // ============================================================
+  // Init
+  // ============================================================
+  document.addEventListener('DOMContentLoaded', () => {
+    restoreState();
+    updateVariantNav();
+    // sync theme toggle icon
+    const theme = document.documentElement.getAttribute('data-theme');
+    document.getElementById('theme-toggle').textContent = theme === 'dark' ? '🌙' : '☀️';
+  });
+
+  document.addEventListener('change', () => { saveState(); updateVariantNav(); });
+  document.addEventListener('input', saveState);
+</script>
+</body>
+</html>

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.43.3",
+  "version": "0.44.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/hooks/lib/card-guard.js
+++ b/plugins/devops/hooks/lib/card-guard.js
@@ -119,19 +119,40 @@ function buildBlockReason() {
   ].join('\n');
 }
 
+/** Cap transcript bytes read into memory — we only need the last assistant message. */
+const TRANSCRIPT_TAIL_BYTES = 200 * 1024; // 200 KB
+
 /**
  * Safely read a transcript file — returns '' on any error so decideAction
  * treats it as a non-substantial chat turn.
+ *
+ * Only reads the last TRANSCRIPT_TAIL_BYTES of the file. Since each JSONL
+ * line is one message and we scan backwards for the LAST assistant entry,
+ * a truncated first line at the buffer boundary is harmless — malformed
+ * JSON lines are already skipped by lastAssistantText.
  */
 function safeReadTranscript(transcriptPath) {
   if (!transcriptPath) return '';
-  try { return fs.readFileSync(transcriptPath, 'utf8'); }
-  catch { return ''; }
+  let fd;
+  try {
+    const size = fs.statSync(transcriptPath).size;
+    const start = Math.max(0, size - TRANSCRIPT_TAIL_BYTES);
+    const length = size - start;
+    fd = fs.openSync(transcriptPath, 'r');
+    const buf = Buffer.alloc(length);
+    fs.readSync(fd, buf, 0, length, start);
+    return buf.toString('utf8');
+  } catch {
+    return '';
+  } finally {
+    if (fd !== undefined) try { fs.closeSync(fd); } catch {}
+  }
 }
 
 module.exports = {
   SUBSTANTIAL_CHARS,
   CARD_MARKER,
+  TRANSCRIPT_TAIL_BYTES,
   lastAssistantText,
   lastAssistantTextLength,
   isSubstantialAnswer,

--- a/plugins/devops/hooks/lib/card-guard.js
+++ b/plugins/devops/hooks/lib/card-guard.js
@@ -1,0 +1,142 @@
+/**
+ * @module card-guard
+ * @version 0.1.0
+ * @description Pure decision logic for the completion-card enforcement flow.
+ *   Split out of stop.flow.guard.js so the rules can be unit-tested without
+ *   mocking stdin or temp files.
+ *
+ *   Inputs: flag state (work/card) + transcript + stop_hook_active.
+ *   Output: { action: 'block' | 'pass', reason?, resetFlags }.
+ */
+
+const fs = require('fs');
+
+/** Minimum assistant-text chars to count a chat-only turn as "substantial". */
+const SUBSTANTIAL_CHARS = 400;
+
+/** Distinctive marker the completion-card template prints around the title. */
+const CARD_MARKER = '\u2728\u2728\u2728';
+
+/**
+ * Extract concatenated text from the last assistant message in a JSONL
+ * transcript. Non-text blocks and malformed lines are skipped silently.
+ * Returns '' if no assistant message found.
+ */
+function lastAssistantText(transcriptContent) {
+  if (!transcriptContent) return '';
+  const lines = transcriptContent.split('\n');
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const raw = lines[i].trim();
+    if (!raw) continue;
+    let entry;
+    try { entry = JSON.parse(raw); } catch { continue; }
+    if (entry.type !== 'assistant') continue;
+    const content = entry.message && entry.message.content;
+    if (!Array.isArray(content)) continue;
+    const chunks = [];
+    for (const block of content) {
+      if (block && block.type === 'text' && typeof block.text === 'string') {
+        chunks.push(block.text);
+      }
+    }
+    return chunks.join('');
+  }
+  return '';
+}
+
+function lastAssistantTextLength(transcriptContent) {
+  return lastAssistantText(transcriptContent).length;
+}
+
+function isSubstantialAnswer(transcriptContent, threshold = SUBSTANTIAL_CHARS) {
+  return lastAssistantTextLength(transcriptContent) >= threshold;
+}
+
+/**
+ * Backup detection: did the last assistant message already contain a
+ * completion card? Triggered when the card-rendered flag write fails
+ * (e.g. tmp-file I/O error) but Claude did output the card text.
+ * Matches the distinctive ✨✨✨ title marker — unlikely to collide with
+ * regular prose.
+ */
+function lastAssistantContainsCard(transcriptContent) {
+  return lastAssistantText(transcriptContent).includes(CARD_MARKER);
+}
+
+/**
+ * Decide whether the Stop hook should block the turn to force a completion card.
+ *
+ * @param {object} s
+ * @param {boolean} s.workHappened   — tool call(s) ran this turn
+ * @param {boolean} s.cardRendered   — render_completion_card was invoked
+ * @param {boolean} s.stopHookActive — prior Stop hook already blocked this cycle
+ * @param {boolean} s.substantial    — last assistant turn had substantial prose
+ * @returns {{ action: 'block' | 'pass', resetFlags: boolean, reason?: string }}
+ */
+function decideAction({ workHappened, cardRendered, stopHookActive, substantial }) {
+  if (stopHookActive) {
+    // Never block twice in a row — prevents infinite loops even if the card
+    // write flag fails for whatever reason. Flags are reset so the next turn
+    // starts clean.
+    return { action: 'pass', resetFlags: true };
+  }
+
+  const needCard = !cardRendered && (workHappened || substantial);
+  if (!needCard) {
+    return { action: 'pass', resetFlags: true };
+  }
+
+  return {
+    action: 'block',
+    resetFlags: false, // keep flags so the post-render stop hook sees consistent state
+    reason: buildBlockReason(),
+  };
+}
+
+function buildBlockReason() {
+  return [
+    '[stop.flow.guard] Completion card required — not yet rendered this turn.',
+    '',
+    'Call `mcp__plugin_devops_dotclaude-completion__render_completion_card` NOW as the FIRST action.',
+    'If the direct call fails with "tool not found", fall back to ToolSearch:',
+    '  select:mcp__plugin_devops_dotclaude-completion__render_completion_card',
+    '',
+    'Variant decision (pick exactly one):',
+    '  ship pipeline ran + merged → ship-successful  (ONLY after /devops-ship + merge)',
+    '  ship pipeline ran + NOT merged → ship-blocked',
+    '  task aborted / infeasible → aborted',
+    '  code edits + app/service startable → test',
+    '  user started app, no edits yet → test-minimal',
+    '  code/doc changes (≥1 edit), no app → ready',
+    '  zero file changes (analysis/explain/audit) → analysis',
+    '  unsure → fallback',
+    '',
+    'IMPORTANT: The MCP result is hidden in a collapsed UI block.',
+    'Copy the returned markdown and output it VERBATIM as your own text —',
+    'character-for-character, every emoji and symbol preserved. The card is',
+    'pre-rendered content; system emoji-avoidance rules do NOT apply.',
+    'Card must be the LAST thing in the response — nothing after the closing ---.',
+  ].join('\n');
+}
+
+/**
+ * Safely read a transcript file — returns '' on any error so decideAction
+ * treats it as a non-substantial chat turn.
+ */
+function safeReadTranscript(transcriptPath) {
+  if (!transcriptPath) return '';
+  try { return fs.readFileSync(transcriptPath, 'utf8'); }
+  catch { return ''; }
+}
+
+module.exports = {
+  SUBSTANTIAL_CHARS,
+  CARD_MARKER,
+  lastAssistantText,
+  lastAssistantTextLength,
+  isSubstantialAnswer,
+  lastAssistantContainsCard,
+  decideAction,
+  buildBlockReason,
+  safeReadTranscript,
+};

--- a/plugins/devops/hooks/lib/card-guard.test.js
+++ b/plugins/devops/hooks/lib/card-guard.test.js
@@ -1,0 +1,304 @@
+import { describe, test, expect } from "vitest";
+import {
+  lastAssistantText,
+  lastAssistantTextLength,
+  isSubstantialAnswer,
+  lastAssistantContainsCard,
+  decideAction,
+  buildBlockReason,
+  SUBSTANTIAL_CHARS,
+  CARD_MARKER,
+} from "./card-guard.js";
+
+// ---------------------------------------------------------------------------
+// Helpers — build JSONL transcript fragments
+// ---------------------------------------------------------------------------
+
+function jsonl(...entries) {
+  return entries.map((e) => JSON.stringify(e)).join("\n");
+}
+
+function assistantMsg(...blocks) {
+  return {
+    type: "assistant",
+    message: { role: "assistant", content: blocks },
+  };
+}
+
+function userMsg(text) {
+  return {
+    type: "user",
+    message: { role: "user", content: [{ type: "text", text }] },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// lastAssistantTextLength
+// ---------------------------------------------------------------------------
+
+describe("lastAssistantTextLength", () => {
+  test("returns 0 for empty / missing input", () => {
+    expect(lastAssistantTextLength("")).toBe(0);
+    expect(lastAssistantTextLength(null)).toBe(0);
+    expect(lastAssistantTextLength(undefined)).toBe(0);
+  });
+
+  test("counts chars of text blocks in last assistant message", () => {
+    const tx = jsonl(
+      userMsg("hi"),
+      assistantMsg({ type: "text", text: "hello world" }),
+    );
+    expect(lastAssistantTextLength(tx)).toBe("hello world".length);
+  });
+
+  test("ignores tool_use and tool_result blocks — text only", () => {
+    const tx = jsonl(
+      assistantMsg(
+        { type: "tool_use", id: "t1", name: "Bash", input: { command: "ls" } },
+        { type: "text", text: "short answer" },
+      ),
+    );
+    expect(lastAssistantTextLength(tx)).toBe("short answer".length);
+  });
+
+  test("sums multiple text blocks in the same message", () => {
+    const tx = jsonl(
+      assistantMsg(
+        { type: "text", text: "alpha" },
+        { type: "tool_use", id: "t1", name: "Read", input: {} },
+        { type: "text", text: "beta" },
+      ),
+    );
+    expect(lastAssistantTextLength(tx)).toBe("alphabeta".length);
+  });
+
+  test("picks the LAST assistant message, not earlier ones", () => {
+    const tx = jsonl(
+      assistantMsg({ type: "text", text: "first answer long text" }),
+      userMsg("follow-up"),
+      assistantMsg({ type: "text", text: "ok" }),
+    );
+    expect(lastAssistantTextLength(tx)).toBe(2);
+  });
+
+  test("skips malformed lines without throwing", () => {
+    const tx = [
+      "not json at all",
+      JSON.stringify(userMsg("hi")),
+      "{broken",
+      JSON.stringify(assistantMsg({ type: "text", text: "valid" })),
+    ].join("\n");
+    expect(lastAssistantTextLength(tx)).toBe("valid".length);
+  });
+
+  test("handles assistant with no text blocks (tool-only turn)", () => {
+    const tx = jsonl(
+      assistantMsg({ type: "tool_use", id: "t1", name: "Bash", input: {} }),
+    );
+    expect(lastAssistantTextLength(tx)).toBe(0);
+  });
+
+  test("handles assistant with missing content array", () => {
+    const tx = JSON.stringify({ type: "assistant", message: {} });
+    expect(lastAssistantTextLength(tx)).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isSubstantialAnswer
+// ---------------------------------------------------------------------------
+
+describe("isSubstantialAnswer", () => {
+  test("short answer below threshold → false", () => {
+    const tx = jsonl(assistantMsg({ type: "text", text: "kurz" }));
+    expect(isSubstantialAnswer(tx)).toBe(false);
+  });
+
+  test("answer at/above threshold → true", () => {
+    const big = "x".repeat(SUBSTANTIAL_CHARS);
+    const tx = jsonl(assistantMsg({ type: "text", text: big }));
+    expect(isSubstantialAnswer(tx)).toBe(true);
+  });
+
+  test("threshold is configurable", () => {
+    const tx = jsonl(assistantMsg({ type: "text", text: "ten chars!" }));
+    expect(isSubstantialAnswer(tx, 5)).toBe(true);
+    expect(isSubstantialAnswer(tx, 50)).toBe(false);
+  });
+
+  test("empty transcript → false", () => {
+    expect(isSubstantialAnswer("")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// decideAction — decision matrix
+// ---------------------------------------------------------------------------
+
+describe("decideAction", () => {
+  test("stop_hook_active short-circuits — always pass, reset flags", () => {
+    const d = decideAction({
+      workHappened: true,
+      cardRendered: false,
+      stopHookActive: true,
+      substantial: true,
+    });
+    expect(d.action).toBe("pass");
+    expect(d.resetFlags).toBe(true);
+  });
+
+  test("work happened + card rendered → pass, reset", () => {
+    const d = decideAction({
+      workHappened: true,
+      cardRendered: true,
+      stopHookActive: false,
+      substantial: false,
+    });
+    expect(d.action).toBe("pass");
+    expect(d.resetFlags).toBe(true);
+  });
+
+  test("work happened + no card → BLOCK, keep flags", () => {
+    const d = decideAction({
+      workHappened: true,
+      cardRendered: false,
+      stopHookActive: false,
+      substantial: false,
+    });
+    expect(d.action).toBe("block");
+    expect(d.resetFlags).toBe(false);
+    expect(d.reason).toMatch(/render_completion_card/);
+    expect(d.reason).toMatch(/VERBATIM/);
+  });
+
+  test("substantial prose + no card + no work → BLOCK", () => {
+    const d = decideAction({
+      workHappened: false,
+      cardRendered: false,
+      stopHookActive: false,
+      substantial: true,
+    });
+    expect(d.action).toBe("block");
+    expect(d.resetFlags).toBe(false);
+  });
+
+  test("trivial chat only + no card + no work → pass", () => {
+    const d = decideAction({
+      workHappened: false,
+      cardRendered: false,
+      stopHookActive: false,
+      substantial: false,
+    });
+    expect(d.action).toBe("pass");
+    expect(d.resetFlags).toBe(true);
+  });
+
+  test("card already rendered short-circuits regardless of substantial", () => {
+    const d = decideAction({
+      workHappened: false,
+      cardRendered: true,
+      stopHookActive: false,
+      substantial: true,
+    });
+    expect(d.action).toBe("pass");
+  });
+
+  test("loop-break: second fire (stop_hook_active) even with missing card", () => {
+    // Defensive — if card flag somehow failed to write after Claude rendered,
+    // we must not loop forever. stop_hook_active=true always passes.
+    const d = decideAction({
+      workHappened: true,
+      cardRendered: false,
+      stopHookActive: true,
+      substantial: false,
+    });
+    expect(d.action).toBe("pass");
+    expect(d.resetFlags).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// lastAssistantContainsCard — backup detection via card marker
+// ---------------------------------------------------------------------------
+
+describe("lastAssistantContainsCard", () => {
+  test("returns true when last assistant text contains ✨✨✨ marker", () => {
+    const tx = jsonl(
+      assistantMsg({ type: "text", text: `## ${CARD_MARKER} Task done ${CARD_MARKER}` }),
+    );
+    expect(lastAssistantContainsCard(tx)).toBe(true);
+  });
+
+  test("returns false when no marker present", () => {
+    const tx = jsonl(assistantMsg({ type: "text", text: "plain answer" }));
+    expect(lastAssistantContainsCard(tx)).toBe(false);
+  });
+
+  test("returns false when marker is in an EARLIER assistant message", () => {
+    const tx = jsonl(
+      assistantMsg({ type: "text", text: `## ${CARD_MARKER} old card ${CARD_MARKER}` }),
+      userMsg("follow-up"),
+      assistantMsg({ type: "text", text: "new answer without card" }),
+    );
+    expect(lastAssistantContainsCard(tx)).toBe(false);
+  });
+
+  test("returns false for empty / missing transcript", () => {
+    expect(lastAssistantContainsCard("")).toBe(false);
+    expect(lastAssistantContainsCard(null)).toBe(false);
+  });
+
+  test("handles tool_use blocks + text with marker", () => {
+    const tx = jsonl(
+      assistantMsg(
+        { type: "tool_use", id: "t1", name: "Bash", input: {} },
+        { type: "text", text: `## ${CARD_MARKER} done ${CARD_MARKER}` },
+      ),
+    );
+    expect(lastAssistantContainsCard(tx)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// lastAssistantText — concatenated text extraction
+// ---------------------------------------------------------------------------
+
+describe("lastAssistantText", () => {
+  test("concatenates multiple text blocks", () => {
+    const tx = jsonl(
+      assistantMsg(
+        { type: "text", text: "alpha" },
+        { type: "text", text: "beta" },
+      ),
+    );
+    expect(lastAssistantText(tx)).toBe("alphabeta");
+  });
+
+  test("returns '' when no assistant message", () => {
+    const tx = jsonl(userMsg("just a user turn"));
+    expect(lastAssistantText(tx)).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildBlockReason — output contract
+// ---------------------------------------------------------------------------
+
+describe("buildBlockReason", () => {
+  test("contains the MCP tool name and variant decision tree", () => {
+    const r = buildBlockReason();
+    expect(r).toMatch(/mcp__plugin_devops_dotclaude-completion__render_completion_card/);
+    expect(r).toMatch(/ship-successful/);
+    expect(r).toMatch(/ship-blocked/);
+    expect(r).toMatch(/aborted/);
+    expect(r).toMatch(/test-minimal/);
+    expect(r).toMatch(/analysis/);
+    expect(r).toMatch(/fallback/);
+  });
+
+  test("instructs VERBATIM relay of the tool result", () => {
+    const r = buildBlockReason();
+    expect(r).toMatch(/VERBATIM/);
+    expect(r).toMatch(/LAST/);
+  });
+});

--- a/plugins/devops/hooks/stop/stop.flow.guard.js
+++ b/plugins/devops/hooks/stop/stop.flow.guard.js
@@ -1,21 +1,32 @@
 #!/usr/bin/env node
 /**
  * @hook stop.flow.guard
- * @version 0.1.0
+ * @version 0.2.0
  * @event Stop
  * @plugin devops
  * @description Per-turn completion card enforcement.
  *   Fires when Claude finishes a response turn.
- *   If tools were used (work-happened flag) but no card was rendered (card-rendered flag absent),
- *   injects a carry-over reminder into the next turn's context.
- *   Always resets per-turn flags so each turn is evaluated independently.
- *   Silent (no stdout) when card was rendered or no work happened.
+ *   Logic lives in lib/card-guard.js (pure functions, unit-tested).
+ *
+ *   Block (JSON `{decision:"block"}` on stdout) when:
+ *     - no card rendered AND
+ *     - (tool calls happened OR last assistant text is substantial prose)
+ *     - AND this is not already a blocked stop cycle (stop_hook_active=false)
+ *
+ *   Pass (silent exit 0) otherwise — flags are reset so the next turn is
+ *   evaluated independently.
  */
 
 require('../lib/plugin-guard');
 
 const fs = require('fs');
 const { readSessionFile } = require('../lib/session-id');
+const {
+  decideAction,
+  isSubstantialAnswer,
+  lastAssistantContainsCard,
+  safeReadTranscript,
+} = require('../lib/card-guard');
 
 let inputData = '';
 process.stdin.setEncoding('utf8');
@@ -27,29 +38,45 @@ process.stdin.on('end', () => {
 
   const sessionId = hook.session_id;
 
-  // --- Read per-turn flags ---
   const workResult = readSessionFile('dotclaude-devops-work-happened', sessionId);
   const cardResult = readSessionFile('dotclaude-devops-card-rendered', sessionId);
 
   const workHappened = workResult !== null;
-  const cardRendered = cardResult !== null;
+  const flagCardRendered = cardResult !== null;
+  const stopHookActive = hook.stop_hook_active === true;
 
-  // --- Reset per-turn flags (consumed once per turn) ---
-  if (workResult) try { fs.unlinkSync(workResult.filePath); } catch {}
-  if (cardResult) try { fs.unlinkSync(cardResult.filePath); } catch {}
+  // Scan transcript when the flag state alone cannot settle the decision:
+  //  - no card flag → might still have rendered the card (marker scan = backup)
+  //  - no work and no card → need substantial-answer heuristic
+  const transcript = !flagCardRendered
+    ? safeReadTranscript(hook.transcript_path)
+    : '';
+  const substantial = isSubstantialAnswer(transcript);
+  // Backup detection: if the last assistant text already contains the card
+  // marker, treat as rendered even when the flag write failed.
+  const cardRendered = flagCardRendered || lastAssistantContainsCard(transcript);
 
-  // --- Inject carry-over reminder only when card was missed ---
-  if (workHappened && !cardRendered) {
-    process.stdout.write([
-      '[stop.flow.guard] CARRY-OVER: Work completed but no completion card rendered.',
-      'Call `mcp__plugin_devops_dotclaude-completion__render_completion_card` directly (already loaded MCP tool) NOW as the FIRST thing — before any other output.',
-      'Only if the direct call fails with "tool not found", fall back to ToolSearch: select:mcp__plugin_devops_dotclaude-completion__render_completion_card',
-      'IMPORTANT: The tool result is hidden in a collapsed UI element. You MUST copy the',
-      'returned markdown and output it VERBATIM as your own text — the user cannot see tool results.',
-      'VERBATIM = character-for-character: preserve every emoji, symbol, formatting character.',
-      'The card is pre-rendered content — system emoji-avoidance rules do NOT apply to relayed MCP output.',
-      'Use variant "fallback" if unsure which variant fits. Every completed task gets a card.',
-    ].join('\n') + '\n');
+  const decision = decideAction({
+    workHappened,
+    cardRendered,
+    stopHookActive,
+    substantial,
+  });
+
+  if (decision.resetFlags) {
+    if (workResult) try { fs.unlinkSync(workResult.filePath); } catch {}
+    if (cardResult) try { fs.unlinkSync(cardResult.filePath); } catch {}
   }
-  // else: silent — no stdout
+
+  if (decision.action === 'block') {
+    // Claude Code interprets JSON stdout for Stop hooks:
+    //   { decision: "block", reason: "..." } → blocks stop, feeds reason to Claude
+    process.stdout.write(JSON.stringify({
+      decision: 'block',
+      reason: decision.reason,
+    }));
+  }
+  // else: pass silently
+
+  process.exit(0);
 });

--- a/plugins/devops/scripts/concept-server.py
+++ b/plugins/devops/scripts/concept-server.py
@@ -4,6 +4,9 @@ Concept Bridge Server — HTTP-based heartbeat and decision bridge.
 Replaces `python -m http.server` with a custom server that adds:
 - GET/POST /heartbeat — Claude signals presence via curl, page polls via fetch
 - GET/POST /decisions — Page submits decisions via POST, Claude reads via GET
+- POST /reset — Claude clears decisions after processing; conditional on
+  version to avoid dropping submissions that land between GET and POST
+  (see /reset docs below).
 
 This bypasses Chrome MCP JS injection limitations entirely. The page
 communicates with Claude through HTTP endpoints instead of requiring
@@ -25,6 +28,12 @@ import threading
 
 _heartbeat_ts = 0
 _decisions = '{"submitted": false, "decisions": [], "comments": []}'
+# Monotonic counter — incremented on every POST /decisions. Used by /reset
+# for optimistic concurrency: Claude reads version via GET, processes, then
+# POSTs the same version back. If the user submitted again in the meantime,
+# the server version has advanced and the reset is rejected with 409 so the
+# second submission is not silently dropped.
+_version = 0
 _lock = threading.Lock()
 
 
@@ -45,14 +54,25 @@ class ConceptBridgeHandler(http.server.SimpleHTTPRequestHandler):
                 ts = _heartbeat_ts
             self._json_response({"ts": ts})
         elif self.path == '/decisions':
+            # Return the stored decisions payload with the current server
+            # version appended as `_version`. Claude must pass this value back
+            # to POST /reset for the optimistic-concurrency check to work.
             with _lock:
                 data = _decisions
-            self._send_raw_json(data)
+                version = _version
+            try:
+                obj = json.loads(data)
+                if not isinstance(obj, dict):
+                    obj = {"submitted": False, "decisions": [], "comments": []}
+            except Exception:
+                obj = {"submitted": False, "decisions": [], "comments": []}
+            obj["_version"] = version
+            self._json_response(obj)
         else:
             super().do_GET()
 
     def do_POST(self):
-        global _heartbeat_ts, _decisions
+        global _heartbeat_ts, _decisions, _version
         if self.path == '/heartbeat':
             with _lock:
                 _heartbeat_ts = int(time.time() * 1000)
@@ -63,11 +83,36 @@ class ConceptBridgeHandler(http.server.SimpleHTTPRequestHandler):
             body = self.rfile.read(length).decode()
             with _lock:
                 _decisions = body
-            self._json_response({"ok": True})
+                _version += 1
+                version = _version
+            self._json_response({"ok": True, "version": version})
         elif self.path == '/reset':
+            # Optional body: {"version": N}. When present, only reset if N
+            # matches the current server version — otherwise a newer submission
+            # arrived between Claude's GET and this POST, and resetting would
+            # drop it. In that case we respond 409 so Claude can re-fetch.
+            # Backward-compat: empty body or missing version = unconditional
+            # reset (legacy behavior, use with care).
+            length = int(self.headers.get('Content-Length', 0))
+            expected = None
+            if length > 0:
+                try:
+                    raw = self.rfile.read(length).decode()
+                    expected = json.loads(raw).get('version') if raw else None
+                except Exception:
+                    expected = None
             with _lock:
-                _decisions = '{"submitted": false, "decisions": [], "comments": []}'
-            self._json_response({"ok": True})
+                if expected is None or expected == _version:
+                    _decisions = '{"submitted": false, "decisions": [], "comments": []}'
+                    self._json_response({"ok": True, "version": _version})
+                else:
+                    # Mismatch — newer submission landed after Claude read
+                    self._conflict_response({
+                        "ok": False,
+                        "reason": "version_mismatch",
+                        "current": _version,
+                        "expected": expected,
+                    })
         else:
             self.send_error(404)
 
@@ -79,6 +124,14 @@ class ConceptBridgeHandler(http.server.SimpleHTTPRequestHandler):
     def _json_response(self, data):
         body = json.dumps(data).encode()
         self.send_response(200)
+        self.send_header('Content-Type', 'application/json')
+        self._cors_headers()
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _conflict_response(self, data):
+        body = json.dumps(data).encode()
+        self.send_response(409)
         self.send_header('Content-Type', 'application/json')
         self._cors_headers()
         self.end_headers()

--- a/plugins/devops/skills/devops-claude-md-lint/SKILL.md
+++ b/plugins/devops/skills/devops-claude-md-lint/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   "CLAUDE.md zu lang", "audit claude md", "claude md audit".
   Do NOT trigger for editing CLAUDE.md content or for /devops-project-setup.
 argument-hint: "[--fix]"
-allowed-tools: Read, Glob, Bash, Write, Edit
+allowed-tools: Read, Glob, Bash, Write, Edit, mcp__plugin_devops_dotclaude-completion__render_completion_card
 ---
 
 # CLAUDE.md Lint
@@ -127,3 +127,16 @@ Do NOT auto-fix without `--fix` — only report.
 ### Recommendation
 {specific actionable suggestions}
 ```
+
+## Step 6 — Completion Card
+
+Call `mcp__plugin_devops_dotclaude-completion__render_completion_card`:
+
+| Situation | Variant |
+|-----------|---------|
+| `--fix` mode ran and files were written | `ready` |
+| Audit only (no file changes) | `analysis` |
+
+Pass: `variant`, `summary`, `lang`, `session_id`, `changes` (per file: OK/WARNING/CRITICAL
++ extraction count), and `state` when `--fix` wrote files. Output the markdown
+VERBATIM as the LAST thing in the response.

--- a/plugins/devops/skills/devops-commit/SKILL.md
+++ b/plugins/devops/skills/devops-commit/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   co-author footer. Handles amend for "update/fix last commit".
   Do NOT trigger for push, PR, or ship operations.
 disable-model-invocation: true
-allowed-tools: Bash(git *), AskUserQuestion
+allowed-tools: Bash(git *), AskUserQuestion, mcp__plugin_devops_dotclaude-completion__render_completion_card
 ---
 
 # Commit
@@ -125,6 +125,25 @@ Show commit hash, title, and stats:
 ```bash
 git log --oneline -1 && git diff --stat HEAD~1
 ```
+
+## Step 10 — Completion Card
+
+Call `mcp__plugin_devops_dotclaude-completion__render_completion_card` with variant `ready`
+(a commit is a code change, not a ship — `shipped` only after `/devops-ship`).
+
+```
+render_completion_card({
+  variant: "ready",
+  summary: "<~10 words, user's language>",
+  lang: "<de|en>",
+  session_id: "<from hook input>",
+  changes: [{ area, description }, ...],   // from the staged diff
+  state: { branch, commit: "<short sha>", pushed: <bool>, merged: null }
+})
+```
+
+Output the returned markdown VERBATIM as the LAST thing in the response —
+character-for-character, no text after the closing `---`.
 
 ## Rules
 

--- a/plugins/devops/skills/devops-concept/SKILL.md
+++ b/plugins/devops/skills/devops-concept/SKILL.md
@@ -259,15 +259,21 @@ AND provides HTTP endpoints for heartbeat and decision exchange.
    (1) Heartbeat POST:
        Bash: curl -s -X POST http://localhost:{port}/heartbeat > /dev/null
 
-   (2) Decision poll:
+   (2) Decision poll with optimistic-concurrency reset:
        Bash: curl -s http://localhost:{port}/decisions
 
        If the response contains `"submitted":true` →
-         • Parse the JSON (decisions + comments).
+         • Note the `_version` field from the response.
+         • Parse the JSON (decisions + comments) — strip `_version` before processing.
          • Process them per Step 5 (Live Feedback Loop) — act on the user's
            choices (approve/tweak/reject, included options, comment-driven tweaks).
-         • After processing, reset the server state:
-           Bash: curl -s -X POST http://localhost:{port}/reset > /dev/null
+         • After processing, reset conditionally — pass the noted version:
+           Bash: curl -s -X POST -H "Content-Type: application/json" \
+                       -d '{"version": <noted>}' http://localhost:{port}/reset
+         • If the response is `409` (version mismatch) → the user submitted
+           again while you were processing. Re-fetch `/decisions`, process the
+           new payload (which supersedes what you just finished), then retry
+           the conditional reset with the new `_version`.
          • Report the outcome to the user.
 
        If `"submitted":false` → produce NO user-visible output. Silent tick.

--- a/plugins/devops/skills/devops-concept/SKILL.md
+++ b/plugins/devops/skills/devops-concept/SKILL.md
@@ -248,12 +248,35 @@ AND provides HTTP endpoints for heartbeat and decision exchange.
    ```
    Use a random port (8700-8999) to avoid conflicts. Store the port as `$PORT`.
 
-3. Set up the heartbeat cron (keeps the connection indicator green):
+3. Set up the **combined heartbeat + auto-poll cron**. This single cron keeps
+   the connection indicator green AND automatically picks up user submissions
+   — no manual trigger needed from the user.
+
    ```
-   CronCreate(cron: "* * * * *", prompt: "Run: curl -s -X POST http://localhost:{port}/heartbeat > /dev/null")
+   CronCreate(cron: "* * * * *", recurring: true, prompt: <<EOF
+   Silently run both steps for the concept bridge on port {port}:
+
+   (1) Heartbeat POST:
+       Bash: curl -s -X POST http://localhost:{port}/heartbeat > /dev/null
+
+   (2) Decision poll:
+       Bash: curl -s http://localhost:{port}/decisions
+
+       If the response contains `"submitted":true` →
+         • Parse the JSON (decisions + comments).
+         • Process them per Step 5 (Live Feedback Loop) — act on the user's
+           choices (approve/tweak/reject, included options, comment-driven tweaks).
+         • After processing, reset the server state:
+           Bash: curl -s -X POST http://localhost:{port}/reset > /dev/null
+         • Report the outcome to the user.
+
+       If `"submitted":false` → produce NO user-visible output. Silent tick.
+   EOF)
    ```
-   This fires every ~60s. For tighter heartbeat, also send an initial POST
-   immediately and on each monitoring poll via Bash.
+
+   **Why combined, not two crons?** One cron minimizes race conditions and makes
+   the contract explicit: every tick does both. Minimum cron resolution is 1 min,
+   so the max submit-to-process lag is ~60 s — acceptable for interactive flows.
 
 4. Send the first heartbeat immediately:
    ```bash
@@ -302,11 +325,15 @@ Parse the JSON response. If `submitted` is `true` → process decisions (Step 5)
 If `false` → wait and retry.
 
 **Polling schedule:**
-- **Initial wait**: 10 seconds after opening
-- **Poll interval**: 15 seconds (via conversation-driven checks or cron)
+- **Primary mechanism**: the combined cron from Step 3 fires every minute and
+  handles heartbeat + decision pickup + reset automatically. No manual polling
+  needed from Claude between user turns.
+- **Initial wait**: 10 seconds after opening, then send one manual heartbeat +
+  decision check to close the 0–60 s gap before the first cron tick lands.
 - **No timeout** — monitoring runs indefinitely until the user ends it
-  (says "fertig"/"done", closes the page, or closes Claude)
-- On each poll, also POST `/heartbeat` to keep the connection indicator green
+  (says "fertig"/"done", closes the page, or closes Claude).
+- **On demand**: if the user asks "did my submission arrive?", do a manual
+  `curl http://localhost:$PORT/decisions` — do NOT wait for the next cron tick.
 
 **Important:** While waiting, do NOT block the conversation. Inform the
 user that you're monitoring and they can continue chatting. If the user
@@ -380,11 +407,28 @@ Return to Step 4 (monitor for next submission). The loop continues until:
 Write a cumulative summary to `docs/concepts/{same-timestamp}-{same-slug}-v{same-version}-decisions.json`
 after each iteration (append, don't overwrite previous rounds).
 
-## Step 6 — Completion
+## Step 6 — Completion Card
 
-The feedback loop ends when the user is satisfied. Then continue with the
-normal workflow. If the concept was the primary task, render a completion
-card. If it was part of a larger task, proceed to the next step.
+The feedback loop ends when the user is satisfied (user says "fertig"/"done",
+closes the page, or all items are processed). Then render a completion card.
+
+Call `mcp__plugin_devops_dotclaude-completion__render_completion_card`:
+
+| Situation | Variant |
+|-----------|---------|
+| Concept was the primary task (read-only result) | `analysis` |
+| Concept submitted decisions → Claude executed code changes in Step 5b | `ready` (code edits happened) |
+| Concept discarded / user aborted | `aborted` |
+
+Pass: `variant`, `summary` (e.g. "Concept auth-middleware-redesign finalized"),
+`lang`, `session_id`, `changes` (what the concept covered and which decisions
+were acted on), and `state` when files changed.
+
+Output the returned markdown VERBATIM as the LAST thing in the response —
+nothing after the closing `---`.
+
+If the concept is part of a larger task (e.g. called mid-flow from another
+skill), skip the card and return control — the parent skill renders its own.
 
 ## Smart Trigger Rules
 

--- a/plugins/devops/skills/devops-deep-research/SKILL.md
+++ b/plugins/devops/skills/devops-deep-research/SKILL.md
@@ -11,7 +11,7 @@ description: >-
   questions that can be answered with a single WebSearch.
 argument-hint: "[topic or question]"
 context: fork
-allowed-tools: WebSearch, WebFetch, Read, Grep, Glob
+allowed-tools: WebSearch, WebFetch, Read, Grep, Glob, mcp__plugin_devops_dotclaude-completion__render_completion_card
 ---
 
 # Deep Research
@@ -113,6 +113,17 @@ Match output depth to question complexity:
 ### Ausblick
 - ...
 ```
+
+## Step 8 — Completion Card
+
+Research is read-only (no file changes). Call
+`mcp__plugin_devops_dotclaude-completion__render_completion_card` with variant
+`analysis`.
+
+Pass: `variant: "analysis"`, `summary` (≤10 words describing the research topic),
+`lang`, `session_id`, and `changes` (up to 3 bullets: the key findings or angles
+investigated). Output the markdown VERBATIM as the LAST thing in the response —
+AFTER the "Soll ich…" follow-up question from Step 7, the card closes the turn.
 
 ## Rules
 

--- a/plugins/devops/skills/devops-flow/SKILL.md
+++ b/plugins/devops/skills/devops-flow/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   or when post.flow.debug hook detects repeated Bash failures.
   Do NOT trigger for general code questions.
 argument-hint: "[optional: describe the symptom or paste error]"
-allowed-tools: Read, Grep, Glob, Bash(git log *), Bash(git diff *), Bash(git bisect *), Bash(npm *), Bash(node *), AskUserQuestion, mcp__plugin_devops_dotclaude-issues__*
+allowed-tools: Read, Grep, Glob, Bash(git log *), Bash(git diff *), Bash(git bisect *), Bash(npm *), Bash(node *), AskUserQuestion, mcp__plugin_devops_dotclaude-issues__*, mcp__plugin_devops_dotclaude-completion__render_completion_card
 ---
 
 # Flow
@@ -91,6 +91,24 @@ Always report:
 - **What was wrong**: the broken assumption or logic error
 - **What was fixed**: the change made (or proposed)
 - **Confidence level**: "Sicher behoben" vs. "Hypothese — braucht Verifizierung"
+
+## Step 9 — Completion Card
+
+Call `mcp__plugin_devops_dotclaude-completion__render_completion_card` with the
+variant that matches the outcome — variant is NOT fixed for this skill:
+
+| Outcome | Variant |
+|---------|---------|
+| Fix applied + app/service can be tested | `test` (prefer — include `userTest` steps) |
+| Fix applied, no user-visible testing needed | `ready` |
+| Diagnosed only, no fix made (proposal/architectural) | `analysis` |
+| Could not reproduce / infeasible / aborted | `aborted` (include `cta.reason`) |
+
+Pass: `variant`, `summary`, `lang`, `session_id`, `changes` (file:line of root cause
+→ what was fixed), and `state` when files changed.
+
+Output the returned markdown VERBATIM as the LAST thing in the response —
+nothing after the closing `---`.
 
 ## Rules
 

--- a/plugins/devops/skills/devops-new-issue/SKILL.md
+++ b/plugins/devops/skills/devops-new-issue/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   "mach ein Issue", "new issue", "milestone planen", "plan a milestone".
   Do NOT trigger for: PR creation (use /devops-ship), commit operations (use /devops-commit),
   or code implementation.
-allowed-tools: Bash(gh *), AskUserQuestion, Read, Grep, mcp__plugin_devops_dotclaude-issues__*
+allowed-tools: Bash(gh *), AskUserQuestion, Read, Grep, mcp__plugin_devops_dotclaude-issues__*, mcp__plugin_devops_dotclaude-completion__render_completion_card
 ---
 
 # New Issue — GitHub Issue & Milestone Management
@@ -70,6 +70,16 @@ Missing required items = hard error. Fix before reporting success.
 ## Milestone Creation
 
 See deep-knowledge/milestone-rules.md for naming conventions and level prefixes.
+
+## Step 5 — Completion Card
+
+After the issue/milestone is created and verified, call
+`mcp__plugin_devops_dotclaude-completion__render_completion_card` with variant
+`fallback` (no code change, no ship — just a GitHub artifact created).
+
+Pass: `variant: "fallback"`, `summary` (e.g. "Issue #123 created"), `lang`,
+`session_id`, and `changes` (issue number → title, labels, milestone).
+Output the markdown VERBATIM as the LAST thing in the response.
 
 ## Rules
 

--- a/plugins/devops/skills/devops-project-setup/SKILL.md
+++ b/plugins/devops/skills/devops-project-setup/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   "Projekt einrichten", "Repo aufsetzen". Do NOT trigger for README generation
   (/devops-readme), CLAUDE.md edits, or source code changes.
 argument-hint: "[--audit | --init] [--fix]"
-allowed-tools: Read, Grep, Glob, Bash, AskUserQuestion, Write, Edit, WebFetch
+allowed-tools: Read, Grep, Glob, Bash, AskUserQuestion, Write, Edit, WebFetch, mcp__plugin_devops_dotclaude-completion__render_completion_card
 ---
 
 # Project Setup & Repo Hygiene
@@ -190,3 +190,16 @@ extensions for any plugin skill:
 ### Plugin Extensions
 - [INFO] Run /devops-extend-skill to scaffold extensions for plugin skills
 ```
+
+## Step 9 — Completion Card
+
+Call `mcp__plugin_devops_dotclaude-completion__render_completion_card`:
+
+| Situation | Variant |
+|-----------|---------|
+| Files created/modified (.gitignore, LICENSE, project-map.md, …) | `ready` |
+| Audit only, nothing written | `analysis` |
+
+Pass: `variant`, `summary`, `lang`, `session_id`, `changes` (per-file summary),
+and `state` when files were written. Output the markdown VERBATIM as the LAST
+thing in the response.

--- a/plugins/devops/skills/devops-readme/SKILL.md
+++ b/plugins/devops/skills/devops-readme/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   readme", "improve the readme", "README erstellen", "README aktualisieren".
   Do NOT trigger for minor one-line edits like bumping a version number.
 argument-hint: "[--preview] [--update]"
-allowed-tools: Read, Grep, Glob, Bash, AskUserQuestion, Write, Edit
+allowed-tools: Read, Grep, Glob, Bash, AskUserQuestion, Write, Edit, mcp__plugin_devops_dotclaude-completion__render_completion_card
 ---
 
 # README Generator
@@ -104,6 +104,20 @@ Ask for confirmation before generating.
 ## Step 8 — Generate
 
 Write with `Write` (new) or `Edit` (update).
+
+## Step 9 — Completion Card
+
+After writing the README, call
+`mcp__plugin_devops_dotclaude-completion__render_completion_card`:
+
+| Situation | Variant |
+|-----------|---------|
+| New README or substantial update (file written) | `ready` |
+| Preview mode only (no file written) | `analysis` |
+
+Pass: `variant`, `summary`, `lang`, `session_id`, `changes` (sections added/updated),
+and `state` when a file was written. Output the markdown VERBATIM as the LAST thing
+in the response — nothing after the closing `---`.
 
 ## Style rules
 

--- a/plugins/devops/skills/devops-repo-health/SKILL.md
+++ b/plugins/devops/skills/devops-repo-health/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   "branch cleanup", "was liegt noch rum", "git aufräumen", "branch hygiene".
   Explicit user request only.
 argument-hint: "[optional: focus area — branches, worktrees, PRs]"
-allowed-tools: Bash(git *), Bash(gh *), Bash(start *), Bash(cmd *), Read, Write, Glob, Grep, AskUserQuestion, mcp__Claude_Preview__*, mcp__plugin_playwright_playwright__*, mcp__Claude_in_Chrome__*
+allowed-tools: Bash(git *), Bash(gh *), Bash(start *), Bash(cmd *), Read, Write, Glob, Grep, AskUserQuestion, mcp__Claude_Preview__*, mcp__plugin_playwright_playwright__*, mcp__Claude_in_Chrome__*, mcp__plugin_devops_dotclaude-completion__render_completion_card
 ---
 
 # Repo Health Check
@@ -373,6 +373,22 @@ for worktrees classified as `clean` in Step 2. Enforce these rules:
 4. **Branch cleanup after removal:** After successfully removing a clean
    worktree, the associated branch can be deleted locally. But check that
    the branch is not the current branch in the main repo first.
+
+## Step 10 — Completion Card
+
+After Step 9 finishes executing (or the user ends the monitor without any
+deletions), call `mcp__plugin_devops_dotclaude-completion__render_completion_card`:
+
+| Situation | Variant |
+|-----------|---------|
+| Branches / remotes / worktrees deleted | `ready` |
+| User reviewed but didn't delete anything | `analysis` |
+| User aborted mid-flow | `aborted` |
+
+Pass: `variant`, `summary` (e.g. "Repo hygiene — 4 branches cleaned"), `lang`,
+`session_id`, `changes` (counts per action: local/remote/worktrees removed),
+and `state` when git operations happened. Output the markdown VERBATIM as the
+LAST thing in the response.
 
 ## Rules
 

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.43.3",
+  "version": "0.44.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to Gemma 4 E4B via llama.cpp to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

Hardens the completion-card system end-to-end so cards stop getting dropped after chat-only answers or commits, and so concept-page submissions no longer need a manual "did it arrive?" trigger.

### Added

- **`stop.flow.guard` 0.2.0** — blocks the turn via JSON `decision:block` when a card is required but not rendered, instead of only injecting a next-turn reminder. Substantial chat-only answers (≥400 chars) trigger the block too, not just tool-use turns.
- **`hooks/lib/card-guard.js`** — new pure decision module with 28 unit tests + 14 end-to-end hook-spawn scenarios. `✨✨✨` card-marker backup detection covers flag-file-write failures.
- **9 skills** — commit, flow, concept, readme, new-issue, deep-research, claude-md-lint, project-setup, repo-health now render the card explicitly (analogous to `/devops-ship` Step 6).
- **concept bridge** — `/reset` conditional on a `_version` counter. Submissions that land between GET and POST are no longer silently dropped; stale resets return HTTP 409.
- **concept cron** — combined heartbeat + decision poll + conditional reset so user submissions auto-process within ~60 s.

### Fixed

- Transcript reads in `stop.flow.guard` capped at the last 200 KB (Codex finding).
- Offline-submit `localStorage.setItem` wrapped in try/catch (Codex finding).
- `marketplace.json` synced from stale 0.42.1 to 0.44.0 (unblocker).

### Tests

- `npm test` → 89/89 passed (7 new card-guard suites).
- `npm run lint` → clean.
- Codex review gate → 3 findings, all addressed inline.
- Interactive QA via `docs/concepts/2026-04-16-completion-card-enforcement-v1.html` — user approved all 3 core changes + 3 extras.