### PR TITLE
fix(mcp): block stale MCP tools after mid-session plugin upgrade

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.43.3"
+    "version": "0.44.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.43.3",
+      "version": "0.44.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to Gemma 4 E4B via llama.cpp to save tokens.",
-      "version": "0.43.3",
+      "version": "0.44.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.44.1] — 2026-04-16
+
+### Fixed
+
+- **mcp** — block stale MCP tool calls after a mid-session plugin upgrade. `ss.plugin.update` writes `~/.claude/plugins/.mcp-stale.json` when a plugin's installPath moves; `pre.mcp.health` compares that sentinel against the MCP server's PID-file mtime and refuses `mcp__plugin_devops_*` calls with a clear restart message until the servers are respawned. Cache repairs at the same version overwrite in place and do NOT trigger the guard.
+- **mcp** — hardened sentinel logic: `>=` mtime comparison tolerates same-millisecond writes, corrupt sentinel JSON is deleted and passes through instead of wedging all MCP calls, and the cleanup path runs before the early exit when the marketplaces directory is absent
+- **release** — aligned `.claude-plugin/marketplace.json` from stale 0.43.3 to 0.44.0 (pre-0.44.1 ship blocker)
+
 ## [0.44.0] — 2026-04-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.44.0**
+**Version: 0.44.1**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.44.0",
+  "version": "0.44.1",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/hooks/pre-tool-use/pre.mcp.health.js
+++ b/plugins/devops/hooks/pre-tool-use/pre.mcp.health.js
@@ -78,39 +78,49 @@ process.stdin.on('end', () => {
 
   // Stale-after-update check: if the sentinel is newer than the PID file, the
   // running MCP process was spawned before the plugin upgrade wiped its
-  // installPath. If the PID file is newer (or there is no sentinel matching
-  // this server), the server was respawned after the upgrade — clear the
-  // sentinel so future calls pass through.
+  // installPath. If the PID file is newer-or-equal (>= handles same-millisecond
+  // writes on fast disks), the server was respawned after the upgrade — clear
+  // the sentinel so future calls pass through.
+  //
+  // Corrupt/unparseable sentinels are deleted rather than treated as hard
+  // blocks; otherwise a truncated file would wedge every MCP call until the
+  // user removed it manually.
   if (fs.existsSync(sentinelFile)) {
-    let sentinel;
+    let sentinel = null;
+    let sentinelCorrupt = false;
     try { sentinel = JSON.parse(fs.readFileSync(sentinelFile, 'utf8')); }
-    catch { sentinel = null; }
-    const sentinelMtime = fs.statSync(sentinelFile).mtimeMs;
-    const affectsThisServer = sentinel?.plugins?.some(p => p.name === 'devops') ?? true;
+    catch { sentinelCorrupt = true; }
 
-    if (affectsThisServer) {
-      if (pidMtime > sentinelMtime) {
-        // Server was respawned after the upgrade — safe. Drop the sentinel.
-        try { fs.unlinkSync(sentinelFile); } catch { /* ignore */ }
-      } else {
-        const upgrades = (sentinel?.plugins || [])
-          .map(p => `${p.name} ${p.from} → ${p.to}`)
-          .join(', ') || 'plugin';
-        const W = 60;
-        const line = '─'.repeat(W);
-        console.error('');
-        console.error(`⚠️  MCP SERVER STALE — ${serverName}`);
-        console.error(line);
-        console.error(`Plugin upgraded this session: ${upgrades}.`);
-        console.error('The running MCP process was spawned from the old');
-        console.error('installPath, which has been replaced. File reads will');
-        console.error('fail or return stale data.');
-        console.error('');
-        console.error('Fix: Start a new Claude Code session. MCP servers are');
-        console.error('only spawned on session init — they cannot be');
-        console.error('reconnected mid-conversation.');
-        console.error(line);
-        process.exit(2);
+    if (sentinelCorrupt) {
+      try { fs.unlinkSync(sentinelFile); } catch { /* ignore */ }
+    } else {
+      const sentinelMtime = fs.statSync(sentinelFile).mtimeMs;
+      const affectsThisServer = sentinel?.plugins?.some(p => p.name === 'devops') ?? true;
+
+      if (affectsThisServer) {
+        if (pidMtime >= sentinelMtime && pidMtime > 0) {
+          // Server was respawned after the upgrade — safe. Drop the sentinel.
+          try { fs.unlinkSync(sentinelFile); } catch { /* ignore */ }
+        } else {
+          const upgrades = (sentinel?.plugins || [])
+            .map(p => `${p.name} ${p.from} → ${p.to}`)
+            .join(', ') || 'plugin';
+          const W = 60;
+          const line = '─'.repeat(W);
+          console.error('');
+          console.error(`⚠️  MCP SERVER STALE — ${serverName}`);
+          console.error(line);
+          console.error(`Plugin upgraded this session: ${upgrades}.`);
+          console.error('The running MCP process was spawned from the old');
+          console.error('installPath, which has been replaced. File reads will');
+          console.error('fail or return stale data.');
+          console.error('');
+          console.error('Fix: Start a new Claude Code session. MCP servers are');
+          console.error('only spawned on session init — they cannot be');
+          console.error('reconnected mid-conversation.');
+          console.error(line);
+          process.exit(2);
+        }
       }
     }
   }

--- a/plugins/devops/hooks/pre-tool-use/pre.mcp.health.js
+++ b/plugins/devops/hooks/pre-tool-use/pre.mcp.health.js
@@ -1,16 +1,23 @@
 #!/usr/bin/env node
 /**
  * @hook pre.mcp.health
- * @version 0.1.0
+ * @version 0.2.0
  * @event PreToolUse
  * @plugin devops
- * @description Detects dead MCP servers before tool calls fail cryptically.
+ * @description Detects dead or stale MCP servers before tool calls fail cryptically.
  *   Each MCP server writes a PID file on startup (via mcp-server/lib/heartbeat.js).
- *   This hook checks if the PID is still alive. If not, it blocks with a clear
- *   message telling the user to start a new session.
+ *   This hook checks two conditions in order:
  *
- *   Typical cause: hard PC shutdown (Stop-Computer -Force) kills MCP processes,
- *   but the resumed conversation still references them.
+ *   1. Stale-after-update: ss.plugin.update writes ~/.claude/plugins/.mcp-stale.json
+ *      when a plugin's installPath moves (real version upgrade). If that sentinel
+ *      is newer than the server's PID file, the running MCP process is pointing at
+ *      deleted files → block with a restart message.
+ *
+ *   2. Dead process: PID file exists but the process no longer runs (typical cause:
+ *      hard PC shutdown). Block with a restart message and clean up the stale PID.
+ *
+ *   If the PID file is newer than the sentinel, the server was respawned after
+ *   the update — the sentinel is cleared so subsequent calls pass through.
  */
 
 require('../lib/plugin-guard');
@@ -20,6 +27,8 @@ const path = require('path');
 const os = require('os');
 
 const PREFIX = 'dotclaude-mcp-';
+const home = process.env.HOME || process.env.USERPROFILE || '';
+const sentinelFile = path.join(home, '.claude', 'plugins', '.mcp-stale.json');
 
 // Map tool-name prefixes to MCP server names
 const SERVER_MAP = {
@@ -65,6 +74,46 @@ process.stdin.on('end', () => {
   if (!serverName) process.exit(0);
 
   const pidFile = pidFileFor(serverName);
+  const pidMtime = fs.existsSync(pidFile) ? fs.statSync(pidFile).mtimeMs : 0;
+
+  // Stale-after-update check: if the sentinel is newer than the PID file, the
+  // running MCP process was spawned before the plugin upgrade wiped its
+  // installPath. If the PID file is newer (or there is no sentinel matching
+  // this server), the server was respawned after the upgrade — clear the
+  // sentinel so future calls pass through.
+  if (fs.existsSync(sentinelFile)) {
+    let sentinel;
+    try { sentinel = JSON.parse(fs.readFileSync(sentinelFile, 'utf8')); }
+    catch { sentinel = null; }
+    const sentinelMtime = fs.statSync(sentinelFile).mtimeMs;
+    const affectsThisServer = sentinel?.plugins?.some(p => p.name === 'devops') ?? true;
+
+    if (affectsThisServer) {
+      if (pidMtime > sentinelMtime) {
+        // Server was respawned after the upgrade — safe. Drop the sentinel.
+        try { fs.unlinkSync(sentinelFile); } catch { /* ignore */ }
+      } else {
+        const upgrades = (sentinel?.plugins || [])
+          .map(p => `${p.name} ${p.from} → ${p.to}`)
+          .join(', ') || 'plugin';
+        const W = 60;
+        const line = '─'.repeat(W);
+        console.error('');
+        console.error(`⚠️  MCP SERVER STALE — ${serverName}`);
+        console.error(line);
+        console.error(`Plugin upgraded this session: ${upgrades}.`);
+        console.error('The running MCP process was spawned from the old');
+        console.error('installPath, which has been replaced. File reads will');
+        console.error('fail or return stale data.');
+        console.error('');
+        console.error('Fix: Start a new Claude Code session. MCP servers are');
+        console.error('only spawned on session init — they cannot be');
+        console.error('reconnected mid-conversation.');
+        console.error(line);
+        process.exit(2);
+      }
+    }
+  }
 
   // No PID file → server never registered (old version or first run) — pass through
   if (!fs.existsSync(pidFile)) process.exit(0);

--- a/plugins/devops/hooks/session-start/ss.plugin.update.js
+++ b/plugins/devops/hooks/session-start/ss.plugin.update.js
@@ -170,7 +170,15 @@ function rebuildCache(marketplace, pluginName, pluginDir, version, sha) {
   return { ok: true };
 }
 
-if (!fs.existsSync(marketplacesDir)) process.exit(0);
+// If the marketplaces directory is missing, there are no updates to run.
+// Still clean up any lingering sentinel from a prior session — otherwise it
+// would block every MCP tool call indefinitely.
+if (!fs.existsSync(marketplacesDir)) {
+  if (fs.existsSync(sentinelFile)) {
+    try { fs.unlinkSync(sentinelFile); } catch { /* ignore */ }
+  }
+  process.exit(0);
+}
 
 const updated = [];
 // Tracks plugins whose installPath moved and that expose MCP servers.

--- a/plugins/devops/hooks/session-start/ss.plugin.update.js
+++ b/plugins/devops/hooks/session-start/ss.plugin.update.js
@@ -1,13 +1,18 @@
 #!/usr/bin/env node
 /**
  * @hook ss.plugin.update
- * @version 0.5.0
+ * @version 0.6.0
  * @event SessionStart
  * @plugin devops
  * @description Auto-update plugin marketplace clones, rebuild cache, and update registry.
  *   Workaround for anthropics/claude-code#14061 — Desktop never runs git pull
  *   on marketplace clones and never rebuilds the plugin cache.
  *   Shares the same update logic as /devops-self-update (see SKILL.md).
+ *
+ *   When a plugin with an MCP server is upgraded mid-session, the running
+ *   MCP processes point at the now-deleted old installPath. A sentinel file
+ *   (~/.claude/plugins/.mcp-stale.json) is written so pre.mcp.health can
+ *   block MCP tool calls until the user restarts Claude Code.
  */
 
 require('../lib/plugin-guard');
@@ -20,6 +25,7 @@ const home = process.env.HOME || process.env.USERPROFILE || '';
 const marketplacesDir = path.join(home, '.claude', 'plugins', 'marketplaces');
 const cacheDir = path.join(home, '.claude', 'plugins', 'cache');
 const registryFile = path.join(home, '.claude', 'plugins', 'installed_plugins.json');
+const sentinelFile = path.join(home, '.claude', 'plugins', '.mcp-stale.json');
 
 function run(cmd, cwd) {
   try {
@@ -167,6 +173,9 @@ function rebuildCache(marketplace, pluginName, pluginDir, version, sha) {
 if (!fs.existsSync(marketplacesDir)) process.exit(0);
 
 const updated = [];
+// Tracks plugins whose installPath moved and that expose MCP servers.
+// Used at the end to either write or clear the stale sentinel.
+const mcpAffected = [];
 
 for (const marketplace of fs.readdirSync(marketplacesDir)) {
   const mDir = path.join(marketplacesDir, marketplace);
@@ -253,8 +262,40 @@ for (const marketplace of fs.readdirSync(marketplacesDir)) {
         cacheRepair: (cacheMissing || cacheStale) && !versionChanged,
         error: result.ok ? null : (result.missing || result.mismatch),
       });
+
+      // Real version upgrades of MCP-bearing plugins invalidate running MCP
+      // processes — they were spawned from the now-deleted installPath.
+      // Cache repairs at the same version overwrite files in place, so the
+      // running Node process (code already in RAM) keeps working.
+      if (versionChanged && result.ok && fs.existsSync(path.join(dir, '.mcp.json'))) {
+        mcpAffected.push({
+          name,
+          marketplace,
+          from: beforeVersions[name] || '?',
+          to: after,
+        });
+      }
     }
   }
+}
+
+// Manage the MCP-stale sentinel. Writing it here is safe even if Claude Code
+// spawns MCP servers AFTER this hook runs — pre.mcp.health compares the PID
+// file's mtime against the sentinel's mtime, so a fresh spawn clears it on
+// the first tool call. Stale sentinels from a previous session are cleaned
+// up when this hook runs without MCP-affecting changes.
+if (mcpAffected.length > 0) {
+  try {
+    fs.writeFileSync(
+      sentinelFile,
+      JSON.stringify({ stampedAt: new Date().toISOString(), plugins: mcpAffected }, null, 2),
+    );
+  } catch {
+    // Sentinel write failed — MCP tools will still work, just without the guard
+  }
+} else if (fs.existsSync(sentinelFile)) {
+  // Nothing moved this run — any lingering sentinel is from a prior session
+  try { fs.unlinkSync(sentinelFile); } catch { /* ignore */ }
 }
 
 if (updated.length === 0) process.exit(0);

--- a/plugins/devops/skills/devops-self-update/SKILL.md
+++ b/plugins/devops/skills/devops-self-update/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: devops-self-update
-version: 0.3.0
+version: 0.4.0
 description: >-
   Manually update the devops plugin to latest from GitHub. Delegates to
   ss.plugin.update hook (pull + cache + registry), then adds changelog and
@@ -108,6 +108,10 @@ Commits: {count} new commits
 Verified: ✓ version aligned, ✓ cache complete, ✓ {skill_count} skills
 Restart the session for hooks and MCP tools to take effect.
 Skills are available immediately.
+
+⚠ MCP tools (/devops-ship, /devops-new-issue, completion card) will be
+blocked by pre.mcp.health until restart — the running MCP processes
+point at the now-deleted old installPath.
 ```
 
 ## Known Issues
@@ -122,3 +126,11 @@ Skills are available immediately.
 - **Plugin key naming**: Marketplace and plugin name must differ
   (`devops@dotclaude`, not `devops@devops`). Identical names hide the
   plugin from the Customize UI.
+
+- **MCP stale after upgrade**: When the plugin version changes, the
+  marketplace clone's old cache dir is wiped and a new installPath is
+  registered. MCP servers spawned earlier in the session still point at
+  the deleted path. `ss.plugin.update` writes `.mcp-stale.json` so
+  `pre.mcp.health` blocks further MCP calls until the user restarts.
+  Cache repairs at the same version overwrite files in place and do NOT
+  trigger the sentinel.

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.44.0",
+  "version": "0.44.1",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to Gemma 4 E4B via llama.cpp to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

Fixes a bug where MCP servers (`dotclaude-ship`, `dotclaude-completion`, `dotclaude-issues`) silently break after a mid-session plugin upgrade. `ss.plugin.update` wipes the old `installPath` when a plugin version changes — but MCP servers spawned earlier in the session still point at the deleted files, causing `/devops-ship` and friends to fail cryptically.

**Fix:**
- `ss.plugin.update` writes `~/.claude/plugins/.mcp-stale.json` on real version upgrades of MCP-bearing plugins (cache repairs at the same version overwrite in place and do NOT trigger the sentinel).
- `pre.mcp.health` compares the sentinel's mtime against the MCP server's PID-file mtime. Fresh spawn (PID newer) auto-clears the sentinel; stale server (PID older) blocks with a clear "restart Claude" message.
- Sentinel is cleaned up at the next session start when no MCP-affecting updates happen, or when the marketplaces directory is missing.

**Hardened per Codex review:**
- `>=` mtime comparison tolerates same-millisecond writes on fast disks.
- Corrupt sentinel JSON is deleted and passes through instead of wedging every MCP call.
- Cleanup path runs before the early exit when marketplaces/ is absent.

Also aligns `.claude-plugin/marketplace.json` from 0.43.3 to 0.44.1 (pre-existing drift).

## Test plan
- [x] `npm test` — 89/89 pass
- [x] `npm run lint` — clean
- [x] Smoke: sentinel + no PID → block exit 2
- [x] Smoke: sentinel + newer PID → auto-clear, pass through
- [x] Smoke: corrupt sentinel → delete and pass through