### PR TITLE
feat(autonomous): 3-min auto-start, safety doc extraction, evals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [0.45.0] — 2026-04-17
+
+### Added
+
+- **autonomous** — 3-minute auto-start timer via one-shot `CronCreate`. Step 4 arms a cron at `now+3min` with an `AUTONOMOUS_AUTOSTART:` prompt that encodes the full execution context (task, mode, desktop, shutdown, branch). "Ja, los!" cancels the timer; "Noch nicht" re-arms fresh +3 min so the user can ask clarifying questions. No answer → cron fires and Step 0.1 picks up execution. Re-arm guard: if autostart fires while another `AskUserQuestion` is pending, the timer is re-armed instead of interrupting the open question
+- **autonomous** — new `deep-knowledge/autonomous-execution.md` containing the execution mode gate, safety guardrails (forbidden ops in both modes), and late-permission protocol (previously inline in SKILL.md)
+- **autonomous** — `evals/evals.json` with 15 should/should-not-trigger cases to lock down the skill description
+
+### Changed
+
+- **autonomous** — SKILL.md description tightened to ~60 words with explicit SHUTDOWN-risk disclaimer; `version:` frontmatter key removed; `argument-hint` gained a concrete example; emojis in Step 3e checklist replaced with `[OK]`/`[--]` ASCII markers; Browser-Credo duplicate collapsed to a short reference to `browser-tool-strategy.md`
+- **autonomous** — triggers pruned to a tighter canonical list (dropped `devops-autonomous`, `autonom weiter`, `ich bin gleich weg`, `ich geh kurz weg`, `unattended mode`, `mach weiter ohne mich`)
+
+### Fixed
+
+- **release** — aligned `.claude-plugin/marketplace.json` from stale 0.44.0 to 0.44.1 (pre-0.45.0 ship blocker)
+
 ## [0.44.1] — 2026-04-16
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.44.1**
+**Version: 0.45.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.44.1",
+  "version": "0.45.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/deep-knowledge/INDEX.md
+++ b/plugins/devops/deep-knowledge/INDEX.md
@@ -9,6 +9,7 @@ Quick-reference for all deep-knowledge topics. Read this FIRST to find the right
 | [agent-conventions.md](agent-conventions.md) | Agent Naming & Collaboration Conventions | [role:X · Type] Task description |
 | [agent-orchestration.md](agent-orchestration.md) | Agent Orchestration | Shared orchestration logic for agent selection, prompting, and wave execution. |
 | [agent-proactivity.md](agent-proactivity.md) | Proactive Agent Orchestration | Cross-cutting rule for when to involve specialized agents without explicit us... |
+| [autonomous-execution.md](autonomous-execution.md) | Autonomous Execution — Gate, Guardrails, Late-Permission Protocol | Detailed execution rules for `devops-autonomous` Step 5. Read this at the sta... |
 | [browser-tool-strategy.md](browser-tool-strategy.md) | Browser Tool Strategy | Cross-cutting rules for browser interaction across all skills. Every skill that |
 | [claude-directory-structure.md](claude-directory-structure.md) | Claude Directory Structure Convention | All Claude Code configuration belongs inside `.claude/`. Nothing Claude-specific |
 | [code-defaults.md](code-defaults.md) | Code Defaults | Standard coding conventions enforced across all projects using the devops plu... |

--- a/plugins/devops/deep-knowledge/autonomous-execution.md
+++ b/plugins/devops/deep-knowledge/autonomous-execution.md
@@ -1,0 +1,67 @@
+# Autonomous Execution — Gate, Guardrails, Late-Permission Protocol
+
+Detailed execution rules for `devops-autonomous` Step 5. Read this at the start of
+autonomous execution.
+
+## Execution Mode Gate
+
+Behavior depends on `$EXEC_MODE` from Step 2.
+
+### `analyze` mode
+- **Allowed:** Read, Glob, Grep, WebFetch, WebSearch, Agent (research only),
+  screenshots (visual inspection), git log/blame/diff.
+- **Forbidden:** Write, Edit, Bash (except read-only commands like `ls`, `git log`,
+  `npm list`, `cat`), git commit, any file modification.
+- **Output:** Analysis report with findings, architecture insights, recommendations,
+  code-quality observations, potential improvements — but NO changes applied.
+- Desktop (if chosen): take screenshots for visual verification, never interact.
+
+### `implement` mode
+- **Phase 1 — Analyse:** full analysis like `analyze` mode (read code, understand
+  architecture, check dependencies, decide strategy).
+- **Phase 2 — Implement:** implement, test, build, verify.
+- No ship — all changes stay local until the user returns.
+
+## Safety Guardrails (both modes)
+
+**Forbidden (always):**
+- git push (any branch), force-push
+- /ship or /devops-ship
+- creating PRs
+- external communications (Discord, email, Slack, GitHub comments/issues)
+- purchases, account creation
+- destructive git ops (`reset --hard`, `clean -f`, `branch -D`)
+- deleting files outside project
+- modifying system config
+
+All changes stay local — the user reviews and decides to ship when they return.
+Log as "blocked action" in the report if the task required one.
+
+**Additional allowed in `implement` mode:** git commit (current sub-branch),
+git pull/fetch, file ops within project, browser/desktop automation, builds,
+tests, linters, installing dev deps.
+
+## Late Permission Handling
+
+If during autonomous execution a permission is needed that wasn't primed in Step 3:
+
+1. **Do NOT ask the user.** They are AFK. The Post-Confirmation Lockout is absolute.
+2. Log the missing permission and what it was needed for.
+3. Complete as much remaining work as possible WITHOUT the missing permission.
+4. Commit all progress locally (implement mode) or save analysis state.
+5. Write `AUTONOMOUS-RESUME.json` to project root:
+   ```json
+   {
+     "task": "<original goal>",
+     "mode": "<implement|analyze>",
+     "missingPermission": "<what was needed and why>",
+     "progress": "<summary of what was completed>",
+     "remaining": "<what couldn't be done>",
+     "shutdownRequested": true,
+     "branch": "<current-branch-name>",
+     "timestamp": "<ISO-8601>"
+   }
+   ```
+6. Proceed to Step 7 (Report) with status **INTERRUPTED**.
+7. Proceed to Step 8 (Shutdown) — **shutdown IS executed** if the user chose it.
+   The resume file ensures continuity on next boot.

--- a/plugins/devops/skills/devops-autonomous/SKILL.md
+++ b/plugins/devops/skills/devops-autonomous/SKILL.md
@@ -1,18 +1,13 @@
 ---
 name: devops-autonomous
-version: 0.1.0
 description: >-
-  Activate fully autonomous agent orchestration for when the user is leaving
-  their PC. Collects the task, primes permissions, then runs agents autonomously
-  (implementation, computer-use desktop interaction, live browser/app testing).
-  Delivers a structured report and completion card when done.
-  Optionally shuts down the PC after completion.
-  Triggers on: "devops-autonomous", "autonomous", "autonomer modus",
-  "ich geh kurz weg", "mach das alleine", "run this while I'm away",
-  "autonom weiter", "ich bin gleich weg", "afk mode", "unattended mode",
-  "mach weiter ohne mich", "autopilot". Do NOT trigger for normal orchestration
-  where the user stays present — use /devops-agents instead.
-argument-hint: "[optional: task description]"
+  Fully autonomous agent orchestration for when the user is away from the PC.
+  Runs agents without supervision (implementation, desktop interaction, live
+  browser/app tests) and can OPTIONALLY SHUT DOWN THE PC after completion.
+  Triggers: "autonomous", "autonomer modus", "mach das alleine",
+  "run this while I'm away", "afk mode", "autopilot". Do NOT trigger when the user
+  stays present — use /devops-agents instead.
+argument-hint: "[task, e.g. 'refactor auth module and run tests']"
 allowed-tools: >-
   Bash(*), Read, Write, Edit, Glob, Grep, Agent,
   AskUserQuestion, CronCreate, CronDelete, CronList,
@@ -36,6 +31,23 @@ Silently check (do not surface "not found"):
 1. `~/.claude/skills/autonomous/SKILL.md` + `reference.md`
 2. `{project}/.claude/skills/autonomous/SKILL.md` + `reference.md`
 3. Merge: project > global > plugin defaults
+
+## Step 0.1 — Auto-Start Prompt Detection
+
+If the incoming user message starts with `AUTONOMOUS_AUTOSTART:`, this is the
+3-minute timeout from Step 4 firing. The user is likely AFK.
+
+1. **Pending-question guard:** If an `AskUserQuestion` is currently active (the
+   Step 4b confirmation, a clarifying question, or anything else), do NOT
+   auto-start. Re-arm a fresh one-shot cron at `now + 3min` with the same
+   `AUTONOMOUS_AUTOSTART:` prompt and context, log "Autostart verschoben —
+   offene Frage aktiv", continue waiting.
+2. If no question is pending: parse `task`, `mode`, `desktop`, `shutdown`,
+   `branch` from the prompt.
+3. Output once: **"3-Minuten-Timeout — starte jetzt autonom."**
+4. Skip Steps 1-4 entirely. Permissions were already primed in the parent session.
+5. Jump directly to Step 5 with the parsed context. The Post-Confirmation Lockout
+   is active from this moment.
 
 ## Step 0.5 — Resume Detection
 
@@ -99,18 +111,11 @@ Save the choice as `$EXEC_MODE` (`implement` if option 1, `analyze` if option 2)
 > 1. label: "Hintergrund (empfohlen)" — description: "Kein Desktop-Takeover, du kannst den PC weiter nutzen. Browser-Tests (Playwright/Preview) laufen trotzdem."
 > 2. label: "Desktop übernehmen" — description: "Computer-Use für volle Desktop-/Native-App-Interaktion (Maus/Tastatur)."
 
-Browser-based testing (Playwright, Preview) runs regardless of this choice — it
-operates in its own window and doesn't occupy the desktop. This question only
-controls whether computer-use (mouse/keyboard takeover) is used for **native apps**.
-
-**Browser interaction in background mode:** Even in "Hintergrund" mode, Claude has
-full read+write browser access via `$BROWSER_TOOL` (set in Step 3b). The waterfall
-(Chrome MCP → Playwright → Preview) ensures a working tool is always selected.
-All three are DOM/protocol-based — no mouse/keyboard takeover, no desktop occupation.
-**Never fall back to computer-use for browser tasks** — it only has read-tier access
-to browsers (screenshots only, no clicks or typing). The **Edge Credo** applies
-identically in background mode — same Edge instance, same user context, same tab
-reuse rules (see `deep-knowledge/browser-tool-strategy.md` § Edge Credo).
+This question only controls whether computer-use (mouse/keyboard takeover) is used
+for **native apps**. Browser tools (`$BROWSER_TOOL` from Step 3b) work in both modes
+and never occupy the desktop. Never fall back to computer-use for browser tasks —
+see `deep-knowledge/browser-tool-strategy.md` (§ Edge Credo applies identically
+in autonomous mode).
 
 In `analyze` mode, desktop is only used for visual inspection (screenshots), never for interaction.
 
@@ -160,29 +165,77 @@ trigger a lightweight read-only call to each to prime the permission.
 ### 3e — Confirmation Checklist
 Display a checklist of all primed permissions:
 ```
-✅ Browser: {$BROWSER_TOOL} aktiv (Chrome MCP / Playwright / Preview)
-✅ Computer-Use: {app1, app2} genehmigt  (nur wenn Desktop-Modus)
-✅ Dateisystem: Lesen/Schreiben genehmigt
-✅ Shell: Bash genehmigt
-✅ MCP Tools: {list} genehmigt
+[OK] Browser: {$BROWSER_TOOL} aktiv (Chrome MCP / Playwright / Preview)
+[OK] Computer-Use: {app1, app2} genehmigt  (nur wenn Desktop-Modus)
+[OK] Dateisystem: Lesen/Schreiben genehmigt
+[OK] Shell: Bash genehmigt
+[OK] MCP Tools: {list} genehmigt
 ```
-Mark tools that weren't needed as "—  nicht benötigt".
+Mark tools that weren't needed as `[--] nicht benötigt`.
 
-## Step 4 — Final Confirmation
+## Step 4 — Final Confirmation with 3-Minute Auto-Start
 
-Ask: **"Alle Berechtigungen erteilt. Soll ich jetzt autonom starten?"** → "Ja, los!" / "Noch nicht"
+**The user may already be walking away.** The confirmation must NOT block autonomous
+execution if the user doesn't answer. Implement the 3-minute auto-start via a
+one-shot cron BEFORE asking the question.
 
-**Auto-start:** If no user response and no new messages for 3 minutes, start
-automatically. Output: "3 Minuten ohne Antwort — starte jetzt autonom."
+### 4a — Arm the Auto-Start Timer
+
+Compute `now + 3 minutes` in local time. Derive the 5-field cron expression
+(minute, hour, day-of-month, month, `*`). Example for "today 14:26":
+`26 14 <today_dom> <today_month> *`.
+
+Call `CronCreate` with `recurring: false` and a prompt that encodes the full
+execution context (the user will not be there to re-enter it):
+
+```
+CronCreate({
+  cron: "<M> <H> <D> <Mo> *",
+  recurring: false,
+  prompt: "AUTONOMOUS_AUTOSTART: 3-minute confirmation timeout reached. Resume devops-autonomous Step 5 with: task=<goal>, mode=<EXEC_MODE>, desktop=<yes|no>, shutdown=<yes|no>, branch=<current-branch>."
+})
+```
+
+Save the returned `jobId` as `$TIMEOUT_JOB_ID`.
+
+### 4b — Ask Confirmation
+
+Ask via `AskUserQuestion`:
+> header: "Start"
+> question: "Alle Berechtigungen erteilt. Soll ich jetzt autonom starten? (Ohne Antwort starte ich nach 3 Minuten automatisch.)"
+> Options (fixed order):
+> 1. label: "Ja, los!" — description: "Sofort starten, PC kann verlassen werden."
+> 2. label: "Noch nicht" — description: "Timer um 3 Minuten zurücksetzen — ich kann noch Rückfragen stellen."
+
+### 4c — Resolve
+
+- **"Ja, los!"** → `CronDelete($TIMEOUT_JOB_ID)`, proceed to Step 5.
+- **"Noch nicht"** → `CronDelete($TIMEOUT_JOB_ID)`, then re-arm fresh: `CronCreate`
+  one-shot at `now + 3min` with the same `AUTONOMOUS_AUTOSTART:` prompt, save
+  new `$TIMEOUT_JOB_ID`. The user may now ask clarifying questions or reconsider.
+  Every additional "Noch nicht" resets the timer again. The only way out is
+  "Ja, los!" (start) or full session close (user abandoned).
+- **No answer / timeout fires** → see Step 0.1 for the auto-start handler.
+
+**Re-arm guard (cron fires while another question is pending):** If the
+`AUTONOMOUS_AUTOSTART:` prompt arrives WHILE an `AskUserQuestion` is still
+active (e.g. a clarifying question from Claude), do NOT auto-start. Instead
+re-arm a fresh one-shot cron at `now + 3min` and continue waiting for the
+pending answer. This prevents the auto-start from interrupting a legitimate
+in-flight question. Log once: "Autostart verschoben — offene Frage aktiv."
+
+**Critical:** The cron is session-only (in-memory). If the user fully closes the
+Claude session before the timeout elapses, auto-start will NOT fire. Tell the
+user verbally: the session must stay running.
 
 ### Post-Confirmation Lockout
 
-**After the user confirms (or auto-start triggers), ZERO user interaction is allowed.**
+**After the user confirms, ZERO user interaction is allowed.**
 No `AskUserQuestion`, no inline questions, no confirmation prompts, no permission
 requests. The user is AFK — they will not see anything.
 
 If something unexpected happens during autonomous execution:
-- **Missing permission** → trigger Late Permission Protocol (Step 5, "Late Permission Handling")
+- **Missing permission** → trigger Late Permission Protocol (see `deep-knowledge/autonomous-execution.md`)
 - **Ambiguous decision** → choose the safer/simpler option, log the choice in the report
 - **Blocked action** → log it, continue with remaining work
 - **Shutdown was requested** → always execute shutdown, even if work is incomplete (after saving progress)
@@ -192,62 +245,14 @@ after confirmation is the next session (via Resume Detection in Step 0.5).
 
 ## Step 5 — Autonomous Execution
 
-### Execution Mode Gate
+Behavior depends on `$EXEC_MODE` from Step 2. The full execution gate, safety
+guardrails, and late-permission protocol live in
+`deep-knowledge/autonomous-execution.md` — read that file at the start of Step 5.
 
-Behavior depends on `$EXEC_MODE` from Step 2:
-
-**`analyze` mode:**
-- **Allowed:** Read, Glob, Grep, WebFetch, WebSearch, Agent (research only),
-  screenshots (visual inspection), git log/blame/diff
-- **Forbidden:** Write, Edit, Bash (except read-only commands like `ls`, `git log`,
-  `npm list`, `cat`), git commit, any file modification
-- **Output:** Analysis report with findings, architecture insights, recommendations,
-  code quality observations, potential improvements — but NO changes applied
-- Desktop (if chosen): take screenshots for visual verification, never interact
-
-**`implement` mode:**
-- **Phase 1 — Analyse:** Erst vollständige Analyse wie im `analyze`-Modus (Code lesen,
-  Architektur verstehen, Abhängigkeiten prüfen, Strategie festlegen).
-- **Phase 2 — Implementierung:** Dann implementieren, testen, builden, verifizieren.
-- Kein Ship — alles bleibt lokal bis der User zurück ist.
-
-### Safety Guardrails (both modes)
-
-**Forbidden (always):** git push (any branch), force-push, /ship or /devops-ship,
-creating PRs, external communications (Discord, email, Slack, GitHub
-comments/issues), purchases, account creation, destructive git ops (reset --hard,
-clean -f, branch -D), deleting files outside project, modifying system config.
-All changes stay local — the user reviews and decides to ship when they return.
-Log as "blocked action" if needed for the task.
-
-**Additional allowed in `implement` mode:** git commit (current sub-branch),
-git pull/fetch, file ops within project, browser/desktop automation, builds,
-tests, linters, installing dev deps.
-
-### Late Permission Handling
-
-If during autonomous execution a permission is needed that wasn't primed in Step 3:
-
-1. **Do NOT ask the user.** They are AFK. The Post-Confirmation Lockout is absolute.
-2. Log the missing permission and what it was needed for.
-3. Complete as much remaining work as possible WITHOUT the missing permission.
-4. Commit all progress locally (implement mode) or save analysis state.
-5. Write `AUTONOMOUS-RESUME.json` to project root:
-   ```json
-   {
-     "task": "<original goal>",
-     "mode": "<implement|analyze>",
-     "missingPermission": "<what was needed and why>",
-     "progress": "<summary of what was completed>",
-     "remaining": "<what couldn't be done>",
-     "shutdownRequested": true|false,
-     "branch": "<current-branch-name>",
-     "timestamp": "<ISO-8601>"
-   }
-   ```
-6. Proceed to Step 7 (Report) with status **INTERRUPTED**.
-7. Proceed to Step 8 (Shutdown) — **shutdown IS executed** if the user chose it.
-   The resume file ensures continuity on next boot.
+Quick summary:
+- `analyze` → read-only (Read, Glob, Grep, WebFetch, git log/blame/diff, screenshots). No Write/Edit/commit.
+- `implement` → Phase 1 analyse, Phase 2 implement+test+build+verify. No push/ship/PR.
+- **Forbidden in both modes:** push, force-push, /ship, create PRs, external comms, purchases, destructive git ops, system config changes.
 
 ### Strategy
 

--- a/plugins/devops/skills/devops-autonomous/evals/evals.json
+++ b/plugins/devops/skills/devops-autonomous/evals/evals.json
@@ -1,0 +1,81 @@
+{
+  "skill": "devops-autonomous",
+  "description": "Trigger evaluation for devops-autonomous. High-stakes skill (can shut down PC) — triggers must be precise.",
+  "evals": [
+    {
+      "query": "Ich geh kurz weg, kannst du das alleine fertig machen?",
+      "should_trigger": true,
+      "reason": "Contains 'mach das alleine' semantic — canonical trigger via 'alleine fertig machen'."
+    },
+    {
+      "query": "afk mode — refactor the auth module and run tests while I'm gone",
+      "should_trigger": true,
+      "reason": "Explicit 'afk mode' keyword plus autonomous task."
+    },
+    {
+      "query": "Autopilot: fix the failing CI tests and ship when green",
+      "should_trigger": true,
+      "reason": "'Autopilot' trigger keyword."
+    },
+    {
+      "query": "Mach das alleine, ich bin gleich weg",
+      "should_trigger": true,
+      "reason": "Two canonical German triggers combined."
+    },
+    {
+      "query": "Run this while I'm away at lunch",
+      "should_trigger": true,
+      "reason": "Explicit 'while I'm away' phrasing."
+    },
+    {
+      "query": "Autonomer Modus bitte — analysiere die Codebase und erstelle einen Report",
+      "should_trigger": true,
+      "reason": "Explicit 'autonomer modus' keyword plus analyze task."
+    },
+    {
+      "query": "Kannst du bitte die Auth-Module refactoren?",
+      "should_trigger": false,
+      "reason": "Normal task request — user is present. Should use /devops-agents or inline work."
+    },
+    {
+      "query": "Use agents to refactor the auth module in parallel",
+      "should_trigger": false,
+      "reason": "Explicit agent orchestration but user is present — /devops-agents."
+    },
+    {
+      "query": "Fix this bug",
+      "should_trigger": false,
+      "reason": "Simple inline task, no AFK signal."
+    },
+    {
+      "query": "Erklär mir bitte wie der Auth-Flow funktioniert",
+      "should_trigger": false,
+      "reason": "Explanation request, not autonomous work."
+    },
+    {
+      "query": "Debug this error",
+      "should_trigger": false,
+      "reason": "Debugging task — use /devops-flow."
+    },
+    {
+      "query": "Research the state of edge computing in 2026",
+      "should_trigger": false,
+      "reason": "Research-only task — use /devops-deep-research."
+    },
+    {
+      "query": "Lass die Agents das parallel machen",
+      "should_trigger": false,
+      "reason": "Agent orchestration without AFK signal — /devops-agents."
+    },
+    {
+      "query": "Unattended mode: build the release, run full test suite, shutdown when done",
+      "should_trigger": true,
+      "reason": "Canonical 'unattended mode' + shutdown intent."
+    },
+    {
+      "query": "Mach weiter ohne mich — ich bin in einem Meeting",
+      "should_trigger": true,
+      "reason": "'Mach weiter ohne mich' canonical trigger."
+    }
+  ]
+}

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.44.1",
+  "version": "0.45.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to Gemma 4 E4B via llama.cpp to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

Harden `devops-autonomous` against skill-creator best practices and add a real 3-minute auto-start so AFK-users can leave the PC with confidence.

### Added
- 3-minute auto-start timer via one-shot `CronCreate`. Step 4 arms a cron at `now+3min` with an `AUTONOMOUS_AUTOSTART:` prompt that encodes the full execution context. "Ja, los!" cancels; "Noch nicht" re-arms +3 min for clarifying Q&A. Re-arm guard prevents autostart from interrupting an open `AskUserQuestion`.
- `deep-knowledge/autonomous-execution.md` — execution mode gate, safety guardrails, late-permission protocol (extracted from SKILL.md).
- `evals/evals.json` with 15 should/should-not-trigger cases.

### Changed
- SKILL.md description tightened (~60 words) with explicit SHUTDOWN-risk disclaimer.
- `version:` frontmatter key removed; `argument-hint` gained a concrete example.
- Emojis in Step 3e checklist replaced with `[OK]`/`[--]` ASCII markers.
- Browser-Credo duplicate collapsed to a reference.
- Trigger list pruned to a tighter canonical set.

### Fixed
- Pre-ship blocker: aligned `marketplace.json` 0.44.0 → 0.44.1.
