### PR TITLE
feat(concept): iteration tabs in single file + /reload signal

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.44.0"
+    "version": "0.45.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.44.0",
+      "version": "0.45.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to Gemma 4 E4B via llama.cpp to save tokens.",
-      "version": "0.44.0",
+      "version": "0.45.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [0.46.0] — 2026-04-17
+
+### Changed
+
+- **concept** — iterations of a concept page now live as tab sections inside a single HTML file instead of separate `-v{N}` files. The tab bar is anchored in the content header above the variants; past iterations are frozen (disabled inputs + readonly comments preserving the user's submitted values) and remain clickable so users can review their own feedback history. Step 5c of the skill now appends a new `<section data-iteration="N">` and signals the browser — no more `meta refresh` redirect files
+- **concept** — filenames drop the `-v{version}` segment: one concept session = one file (`{date}-{slug}.html`)
+
+### Added
+
+- **concept** — `/reload` counter endpoint on the concept bridge server. Claude POSTs after rewriting the HTML; the browser's `pollReload` loop issues `location.reload()` when the counter advances. Closes the gap where iteration 2+ was written to disk but the existing tab kept showing iteration 1's submitted state
+- **concept** — origin guard on `/reload`: rejects POSTs with a foreign `Origin` header so random localhost pages cannot hijack reloads
+
+### Fixed
+
+- **concept** — `showIteration()` now also hides `panel-submitted` when switching to a frozen iteration, preventing a mid-processing spinner from bleeding through the historical snapshot
+- **release** — aligned `.claude-plugin/marketplace.json` from stale 0.44.0 to 0.45.0 (pre-0.46.0 ship blocker)
+
 ## [0.45.0] — 2026-04-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.45.0**
+**Version: 0.46.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.45.0",
+  "version": "0.46.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/scripts/concept-server.py
+++ b/plugins/devops/scripts/concept-server.py
@@ -7,6 +7,8 @@ Replaces `python -m http.server` with a custom server that adds:
 - POST /reset — Claude clears decisions after processing; conditional on
   version to avoid dropping submissions that land between GET and POST
   (see /reset docs below).
+- GET/POST /reload — Claude bumps a counter after rewriting the HTML file;
+  the browser polls and reloads when the counter advances.
 
 This bypasses Chrome MCP JS injection limitations entirely. The page
 communicates with Claude through HTTP endpoints instead of requiring
@@ -34,6 +36,12 @@ _decisions = '{"submitted": false, "decisions": [], "comments": []}'
 # the server version has advanced and the reset is rejected with 409 so the
 # second submission is not silently dropped.
 _version = 0
+# Reload counter — bumped by Claude via POST /reload after the HTML file is
+# rewritten (new iteration appended, content refreshed, etc). The browser
+# polls GET /reload and issues location.reload() when the counter advances.
+# This closes the gap where Claude mutates the file on disk but the existing
+# tab keeps showing stale content.
+_reload_counter = 0
 _lock = threading.Lock()
 
 
@@ -68,11 +76,15 @@ class ConceptBridgeHandler(http.server.SimpleHTTPRequestHandler):
                 obj = {"submitted": False, "decisions": [], "comments": []}
             obj["_version"] = version
             self._json_response(obj)
+        elif self.path == '/reload':
+            with _lock:
+                counter = _reload_counter
+            self._json_response({"counter": counter})
         else:
             super().do_GET()
 
     def do_POST(self):
-        global _heartbeat_ts, _decisions, _version
+        global _heartbeat_ts, _decisions, _version, _reload_counter
         if self.path == '/heartbeat':
             with _lock:
                 _heartbeat_ts = int(time.time() * 1000)
@@ -86,6 +98,14 @@ class ConceptBridgeHandler(http.server.SimpleHTTPRequestHandler):
                 _version += 1
                 version = _version
             self._json_response({"ok": True, "version": version})
+        elif self.path == '/reload':
+            # Claude POSTs here after rewriting the HTML file (e.g. appending
+            # a new iteration section). The browser poller sees the bumped
+            # counter and reloads the tab — guaranteeing the DOM matches disk.
+            with _lock:
+                _reload_counter += 1
+                counter = _reload_counter
+            self._json_response({"ok": True, "counter": counter})
         elif self.path == '/reset':
             # Optional body: {"version": N}. When present, only reset if N
             # matches the current server version — otherwise a newer submission

--- a/plugins/devops/scripts/concept-server.py
+++ b/plugins/devops/scripts/concept-server.py
@@ -102,6 +102,19 @@ class ConceptBridgeHandler(http.server.SimpleHTTPRequestHandler):
             # Claude POSTs here after rewriting the HTML file (e.g. appending
             # a new iteration section). The browser poller sees the bumped
             # counter and reloads the tab — guaranteeing the DOM matches disk.
+            #
+            # Origin guard: only Claude (no Origin header — curl) or the
+            # concept page itself (same-origin fetch) may bump the counter.
+            # A cross-origin browser page would send a foreign Origin and is
+            # rejected. Localhost binding already limits blast radius, but
+            # this stops random tabs from hijacking reloads.
+            origin = self.headers.get('Origin')
+            host = self.headers.get('Host', '')
+            if origin is not None:
+                allowed = {f'http://{host}', f'http://localhost:{host.split(":")[-1]}', f'http://127.0.0.1:{host.split(":")[-1]}'}
+                if origin not in allowed:
+                    self.send_error(403, "forbidden origin")
+                    return
             with _lock:
                 _reload_counter += 1
                 counter = _reload_counter

--- a/plugins/devops/skills/devops-concept/SKILL.md
+++ b/plugins/devops/skills/devops-concept/SKILL.md
@@ -240,6 +240,7 @@ are present. **Grep the generated file** for each required pattern:
 | 12 | `data-iteration` | Iteration section marker |
 | 13 | `iteration-tabs` | Tab bar container in the decision panel |
 | 14 | `pollReload` | Reload-signal poller (picks up file rewrites) |
+| 15 | `sec.hidden` | Tab-switch JS toggles the `hidden` attribute — prevents all iterations rendering at once |
 
 **If ANY pattern is missing → DO NOT open the page.** Fix the HTML first,
 then re-validate. This is a **blocking gate** — no exceptions, no "this
@@ -406,12 +407,12 @@ separate "in-place edit" vs. "new file" distinction anymore.
 Procedure on every iteration (including the very first response to feedback):
 
 1. Read the existing HTML file (same path, always).
-2. Freeze the currently-active iteration section:
-   - Remove its `data-active` attribute.
-   - Set `disabled` on every tri-state button, checkbox, slider, radio inside it.
-   - Set `readonly` on every textarea/input inside it.
-   - Preserve the submitted values so the frozen snapshot shows exactly what
-     the user sent (read the values from the just-processed decisions JSON).
+2. Freeze the currently-active iteration section per the rules in
+   `deep-knowledge/templates.md` § Freezing Past Iterations (authoritative
+   source). In short: remove `data-active`, add `hidden`, disable every
+   `input`/`textarea`/`select`/`button` inside the section, set `readonly`
+   on text inputs and textareas, preserve the submitted values exactly
+   (read them from the just-processed decisions JSON).
 3. Append a new `<section data-iteration="{N+1}" data-active>` with the
    updated / next-round content (new variants, refined options, whatever
    the feedback produced). Set `submitted: false` in `#concept-decisions`,

--- a/plugins/devops/skills/devops-concept/SKILL.md
+++ b/plugins/devops/skills/devops-concept/SKILL.md
@@ -122,10 +122,11 @@ generation), old localStorage state is automatically discarded so the user
 sees a clean new version instead of stale selections from a previous page.
 
 **Rules:**
-- In-place feedback-loop updates (Step 5c): keep the SAME `data-page-version`
-  → user selections survive the update cycle
-- New version file (version bump or "nochmal neu"): set a NEW timestamp
-  → old state auto-clears, fresh page
+- Every iteration append (Step 5c): keep the SAME `data-page-version`
+  → user selections on earlier frozen tabs survive the reload
+- A fresh `data-page-version` is only ever set if the user explicitly
+  starts a brand-new concept session for the same slug (rare — usually
+  a new date means a new file anyway)
 
 Additionally, the offline submit queue (`localStorage` key `{slug}-pending`)
 caches decisions submitted while Claude is disconnected and auto-delivers
@@ -164,35 +165,59 @@ signal Claude monitors.
 
 ### File Location
 
-Write to: `docs/concepts/{timestamp}-{slug}-v{version}.html`
+Write to: `docs/concepts/{timestamp}-{slug}.html`
 
-**Fixed naming pattern** (all three segments mandatory, in this order):
+**Fixed naming pattern** (both segments mandatory, in this order):
 
 | Segment | Format | Example |
 |---------|--------|---------|
 | `{timestamp}` | ISO date `YYYY-MM-DD` | `2026-04-12` |
 | `{slug}` | kebab-case topic summary, max 40 chars | `auth-middleware-redesign` |
-| `{version}` | Integer starting at `1`, incremented per revision of the same slug | `1` |
 
-Full example: `docs/concepts/2026-04-12-auth-middleware-redesign-v1.html`
+Full example: `docs/concepts/2026-04-12-auth-middleware-redesign.html`
 
 - Create the `docs/concepts/` directory if it doesn't exist
 - This directory is **git-tracked** — concepts are project artifacts meant
   to be shared with other repo users
-- To determine the next version: glob for `docs/concepts/*-{slug}-v*.html`,
-  parse the highest existing version number, and increment by 1.
-  If no match exists, start at `v1`
+- **One file per concept session** — all iterations live inside the same
+  HTML file as separate `<section data-iteration="N">` blocks, switched via
+  tabs in the decision panel (see "Iteration Tabs" below). There are no
+  `-v2`, `-v3` files.
+- If a file for the same slug already exists on the same day and the user
+  starts a genuinely new topic, append a short disambiguator (e.g.
+  `…-auth-middleware-redesign-2.html`) — do NOT treat this as a version bump.
 
-### Versioning vs. In-Place Update
+### Iteration Tabs (single file, many iterations)
 
-| Situation | Action | Version |
-|-----------|--------|---------|
-| Feedback loop iteration (Step 5c) | Update the **same file** in-place, refresh the existing tab | No bump — stays `v1` |
-| New concept session for the same topic (user revisits later) | Create a **new file** with incremented version | Bump → `v2`, `v3`, … |
-| Fundamental rework after feedback (user says "nochmal neu") | Create a **new file** with incremented version | Bump → next `vN` |
+Every concept page is a stack of iteration tabs. The **tab bar lives in the
+decision panel at the top** of the content area (a slim strip above the
+variants, not in the right sidebar — the sidebar stays reserved for submit
+controls). Each tab shows exactly one iteration; the active one is interactive,
+all earlier ones are frozen (disabled inputs showing the user's submitted
+selections, read-only comments).
 
-**Rule of thumb:** within an active feedback loop, never bump the version.
-A version bump only happens when a new file is created.
+| Situation | Action | Result |
+|-----------|--------|--------|
+| First generation | Write the file with `<section data-iteration="1" data-active>` and one tab "Iteration 1" | Tab 1 active |
+| Feedback loop iteration (Step 5c) | Append `<section data-iteration="N+1" data-active>` to the same file, remove `data-active` from the previous section, freeze it, add a new tab and make it active | New tab "Iteration N+1" auto-active, old tab selectable and read-only |
+| Fundamental rework ("nochmal neu") | Same as a feedback iteration — just another tab. The full history stays visible. | Another tab appended |
+
+**Rules:**
+- **Never create a second file** for iterations of the same concept — always
+  append a section to the existing file and POST `/reload` (see Step 5c).
+- The active iteration is the only one that accepts input. Submit sends
+  decisions for the active iteration only.
+- Freeze previous iterations visually: disabled tri-state buttons showing
+  which state the user submitted, read-only comment fields with the text
+  the user entered. Users can click back to earlier tabs to review their
+  own past feedback at any time.
+- Only the active tab runs the heartbeat / submit UI ("music"). Clicking
+  an older tab shows its frozen snapshot but does not re-arm submit.
+- Tab bar must stay compact (one line, horizontally scrollable if many
+  iterations) so it does not push variant content out of view.
+
+See `deep-knowledge/templates.md` § Iteration Tabs for the reference
+HTML/CSS/JS.
 
 ### Post-Generation Validation (mandatory gate)
 
@@ -212,6 +237,9 @@ are present. **Grep the generated file** for each required pattern:
 | 9 | `panel-submitted` | Submitted-state panel element |
 | 10 | `localStorage` | Reload resilience (state persistence with TTL) |
 | 11 | `data-page-version` | Page version tag for localStorage invalidation |
+| 12 | `data-iteration` | Iteration section marker |
+| 13 | `iteration-tabs` | Tab bar container in the decision panel |
+| 14 | `pollReload` | Reload-signal poller (picks up file rewrites) |
 
 **If ANY pattern is missing → DO NOT open the page.** Fix the HTML first,
 then re-validate. This is a **blocking gate** — no exceptions, no "this
@@ -371,37 +399,39 @@ User submits → Claude reads → Claude processes → Claude updates page → U
    - For concepts: develop chosen variant, archive alternatives
    - For comparisons: proceed with selected winner
 ### 5c. Update the Page
-After processing, **update the HTML page in the browser** to reflect results.
+After processing, **append a new iteration tab** to the same HTML file and
+signal the browser to reload. This is the ONLY update path — there is no
+separate "in-place edit" vs. "new file" distinction anymore.
 
-**In-place update (same version, normal case):**
-1. Reset `submitted` to `false` in `#concept-decisions`
-2. Remove `concept-submitted` class from `<body>`
-3. Re-enable the submit button
-4. Update the page content to show processed results, next decisions, or
-   confirmation of completed actions
-5. Add a visual "Verarbeitet" indicator on processed items
+Procedure on every iteration (including the very first response to feedback):
 
-This allows the user to **review the updated state and submit again** for
-further refinement or additional decisions.
+1. Read the existing HTML file (same path, always).
+2. Freeze the currently-active iteration section:
+   - Remove its `data-active` attribute.
+   - Set `disabled` on every tri-state button, checkbox, slider, radio inside it.
+   - Set `readonly` on every textarea/input inside it.
+   - Preserve the submitted values so the frozen snapshot shows exactly what
+     the user sent (read the values from the just-processed decisions JSON).
+3. Append a new `<section data-iteration="{N+1}" data-active>` with the
+   updated / next-round content (new variants, refined options, whatever
+   the feedback produced). Set `submitted: false` in `#concept-decisions`,
+   remove `concept-submitted` from `<body>`, re-enable the submit button.
+4. Append a new entry in the `.iteration-tabs` bar for iteration N+1 and
+   mark it active (set `aria-selected="true"`, remove that attribute from
+   the previous tab — but keep the previous tab clickable so the user can
+   re-read their frozen history).
+5. POST to the bridge: `curl -s -X POST http://localhost:{port}/reload`.
+   The browser's `pollReload` loop sees the counter bump and calls
+   `location.reload()`. The reload lands on the new active iteration
+   because the HTML declares it via `data-active`.
 
-**New version (version bump, e.g. after "nochmal neu"):**
-When a new version file is created while the old tab is still open:
-1. Write the new HTML file (`docs/concepts/…-v{N+1}.html`)
-2. The bridge server already serves all files in `docs/concepts/` — the new
-   file is immediately accessible at `http://localhost:{port}/{new-filename}`
-3. **Redirect the existing tab** by overwriting the old HTML file with a
-   minimal redirect page:
-   ```html
-   <!DOCTYPE html>
-   <html><head>
-     <meta http-equiv="refresh" content="0;url=http://localhost:{port}/{new-filename}">
-   </head><body>
-     <p>Neue Version: <a href="http://localhost:{port}/{new-filename}">{new-filename}</a></p>
-   </body></html>
-   ```
-   The user's tab auto-navigates to the new version within 1 second.
-4. Do NOT leave the old tab in "Entscheidungen übermittelt" state — the user
-   must never be stuck waiting on a tab that Claude is no longer monitoring
+The tab bar is anchored at the top of the content area inside the decision
+panel header — it must never shift into the right-side submit sidebar, and
+it must stay on a single row (horizontal scroll if it overflows).
+
+Do NOT write a redirect file. Do NOT create a new `-v{N}` file. The entire
+concept session — first render, every iteration, "nochmal neu" reworks —
+lives in the single `{date}-{slug}.html`.
 
 ### 5d. Resume Monitoring
 Return to Step 4 (monitor for next submission). The loop continues until:
@@ -410,8 +440,9 @@ Return to Step 4 (monitor for next submission). The loop continues until:
 - There are no more decisions to make (all items processed)
 
 ### 5e. Persist
-Write a cumulative summary to `docs/concepts/{same-timestamp}-{same-slug}-v{same-version}-decisions.json`
-after each iteration (append, don't overwrite previous rounds).
+Write a cumulative summary to `docs/concepts/{same-timestamp}-{same-slug}-decisions.json`
+after each iteration (append a new entry per iteration — don't overwrite
+previous rounds; each entry records its `iteration` number).
 
 ## Step 6 — Completion Card
 

--- a/plugins/devops/skills/devops-concept/deep-knowledge/templates.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/templates.md
@@ -1221,8 +1221,20 @@ function showIteration(n) {
   const activeSec = document.querySelector('section[data-iteration][data-active]');
   const isLive = activeSec && String(activeSec.dataset.iteration) === String(n);
   document.body.classList.toggle('viewing-frozen', !isLive);
+  // Hide ALL live panel states when viewing a frozen iteration — otherwise
+  // a mid-processing spinner (panel-submitted) or the ready panel can bleed
+  // through and misrepresent the frozen snapshot as interactive.
   const panelReady = document.getElementById('panel-ready');
+  const panelSubmitted = document.getElementById('panel-submitted');
+  const panelFrozen = document.getElementById('panel-frozen');
   if (panelReady) panelReady.style.display = isLive ? 'block' : 'none';
+  if (panelSubmitted) {
+    // Only show panel-submitted when live AND concept-submitted is set
+    const submitted = document.body.classList.contains('concept-submitted');
+    panelSubmitted.style.display = (isLive && submitted) ? 'block' : 'none';
+  }
+  // Optional passive hint while viewing history
+  if (panelFrozen) panelFrozen.style.display = isLive ? 'none' : 'block';
 }
 
 document.querySelectorAll('.iteration-tab').forEach(tab => {

--- a/plugins/devops/skills/devops-concept/deep-knowledge/templates.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/templates.md
@@ -25,8 +25,25 @@ starting points and inspiration — deviate freely when the content calls for it
         <button id="theme-toggle" aria-label="Toggle theme">🌙/☀️</button>
       </header>
 
+      <!-- Iteration tabs — one entry per iteration, active = current round.
+           Older tabs are clickable but show a frozen snapshot. Anchored here
+           above <main> so the tab bar lives in the decision panel header
+           without crowding the variant content. -->
+      <nav class="iteration-tabs" role="tablist" aria-label="Iterationen">
+        <!-- Auto-populated, one tab per <section data-iteration="N">:
+        <button class="iteration-tab" role="tab" data-iteration="1" aria-selected="false">Iteration 1</button>
+        <button class="iteration-tab" role="tab" data-iteration="2" aria-selected="true">Iteration 2</button>
+        -->
+      </nav>
+
       <main>
-        <!-- Variant-specific content -->
+        <!-- One <section data-iteration="N"> per iteration. Exactly one has
+             data-active. All others render their controls disabled/readonly
+             and preserve the values the user submitted that round. -->
+        <!--
+        <section data-iteration="1" hidden>...frozen first round...</section>
+        <section data-iteration="2" data-active>...current round (active)...</section>
+        -->
       </main>
     </div>
 
@@ -810,7 +827,8 @@ function restoreState() {
     }
     // Version check — discard state from a different page version
     // (Claude sets data-page-version on <html> when generating the page;
-    // in-place feedback-loop updates keep the same value, new versions change it)
+    // iteration appends keep the same value so frozen-tab state survives;
+    // only a fresh concept session for the same slug bumps the value)
     const currentVersion = document.documentElement.dataset.pageVersion || '';
     if (state._pageVersion && state._pageVersion !== currentVersion) {
       localStorage.removeItem(STORAGE_KEY);
@@ -1081,3 +1099,174 @@ a concept HTML file directly), the heartbeat check gracefully degrades — the
 `fetch('/heartbeat')` call fails silently, the heartbeat stays stale, and the
 submit button remains disabled. The user can still use the page for read-only
 review.
+
+## Iteration Tabs
+
+Iterations of a concept page are appended as `<section data-iteration="N">`
+blocks inside the same HTML file. The tab bar lives **inside the content
+area's header, above `<main>`** — NOT in the right-side decision sidebar
+(which stays reserved for submit controls).
+
+### Tab Bar HTML
+
+```html
+<nav class="iteration-tabs" role="tablist" aria-label="Iterationen">
+  <button class="iteration-tab" role="tab"
+          data-iteration="1"
+          aria-selected="false"
+          aria-controls="iter-1">
+    Iteration 1
+  </button>
+  <button class="iteration-tab" role="tab"
+          data-iteration="2"
+          aria-selected="true"
+          aria-controls="iter-2">
+    Iteration 2
+  </button>
+</nav>
+
+<main>
+  <section id="iter-1" data-iteration="1" hidden>…frozen round 1…</section>
+  <section id="iter-2" data-iteration="2" data-active>…active round 2…</section>
+</main>
+```
+
+Rules:
+- Exactly one section carries `data-active`. The matching tab has
+  `aria-selected="true"`.
+- Non-active sections get the `hidden` attribute AND are frozen
+  (see "Freezing Past Iterations" below).
+- Tabs stay clickable — switching tab reveals the chosen section and
+  hides all others. Tabs never disappear.
+
+### Tab Bar CSS
+
+```css
+.iteration-tabs {
+  display: flex;
+  gap: 4px;
+  overflow-x: auto;
+  padding: 8px 0 0;
+  border-bottom: 1px solid var(--border);
+  scrollbar-width: thin;
+}
+.iteration-tab {
+  flex: 0 0 auto;
+  padding: 8px 16px;
+  border: 1px solid var(--border);
+  border-bottom: none;
+  border-radius: 6px 6px 0 0;
+  background: var(--bg-subtle);
+  color: var(--fg-muted);
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+.iteration-tab:hover { background: var(--bg-hover); color: var(--fg); }
+.iteration-tab[aria-selected="true"] {
+  background: var(--bg);
+  color: var(--fg);
+  border-color: var(--accent);
+  font-weight: 600;
+  position: relative;
+}
+.iteration-tab[aria-selected="true"]::after {
+  content: "";
+  position: absolute;
+  left: 0; right: 0; bottom: -1px;
+  height: 2px;
+  background: var(--bg);
+}
+/* Frozen (non-active) iteration: slightly dimmed, no pointer events on inputs */
+section[data-iteration]:not([data-active]) {
+  opacity: 0.85;
+}
+section[data-iteration]:not([data-active]) .tri-state-btn,
+section[data-iteration]:not([data-active]) input,
+section[data-iteration]:not([data-active]) textarea,
+section[data-iteration]:not([data-active]) select {
+  pointer-events: none;
+  filter: grayscale(0.4);
+}
+```
+
+### Freezing Past Iterations
+
+When appending iteration N+1, Claude must freeze the previous section so
+the user sees exactly what they submitted:
+
+1. Remove `data-active`, add `hidden` to the previous `<section>`.
+2. On every `input`, `textarea`, `select`, `button` inside it: set `disabled`.
+3. On every `textarea`, `input[type="text"]`: set `readonly`.
+4. For tri-state buttons: keep the `aria-pressed`/selected class exactly as
+   the user submitted it — do NOT clear selections.
+5. Add a small "Eingefroren — Iteration N" banner at the top of the section
+   (optional but strongly recommended) so the user knows why it is read-only.
+
+### Tab Switch JS
+
+```javascript
+// --- Iteration Tabs ---
+function showIteration(n) {
+  document.querySelectorAll('section[data-iteration]').forEach(sec => {
+    const match = String(sec.dataset.iteration) === String(n);
+    sec.hidden = !match;
+  });
+  document.querySelectorAll('.iteration-tab').forEach(tab => {
+    const match = String(tab.dataset.iteration) === String(n);
+    tab.setAttribute('aria-selected', match ? 'true' : 'false');
+  });
+  // Heartbeat/submit "music" only runs for the active iteration. Older
+  // iterations are frozen snapshots — no re-submit, no new decisions.
+  const activeSec = document.querySelector('section[data-iteration][data-active]');
+  const isLive = activeSec && String(activeSec.dataset.iteration) === String(n);
+  document.body.classList.toggle('viewing-frozen', !isLive);
+  const panelReady = document.getElementById('panel-ready');
+  if (panelReady) panelReady.style.display = isLive ? 'block' : 'none';
+}
+
+document.querySelectorAll('.iteration-tab').forEach(tab => {
+  tab.addEventListener('click', () => showIteration(tab.dataset.iteration));
+});
+
+// On load, show whichever iteration is marked data-active.
+document.addEventListener('DOMContentLoaded', () => {
+  const active = document.querySelector('section[data-iteration][data-active]');
+  if (active) showIteration(active.dataset.iteration);
+});
+```
+
+### Reload Polling (pick up file rewrites)
+
+Every iteration append rewrites the HTML file on disk, then Claude POSTs
+`/reload` on the bridge server. The browser polls `/reload` and reloads
+when the counter advances — guaranteeing the tab matches disk without any
+browser MCP injection.
+
+```javascript
+// --- Reload Poller ---
+// The bridge server exposes /reload with a monotonic counter. Claude POSTs
+// to bump it after rewriting the HTML file. The page polls and reloads
+// when it sees a newer counter than the one it booted with.
+let _bootReloadCounter = null;
+async function pollReload() {
+  try {
+    const res = await fetch('/reload', { cache: 'no-store' });
+    if (!res.ok) return;
+    const { counter } = await res.json();
+    if (_bootReloadCounter === null) { _bootReloadCounter = counter; return; }
+    if (counter > _bootReloadCounter) {
+      // New iteration landed on disk — reload so the tab bar and new
+      // section appear. localStorage preserves frozen-tab state.
+      location.reload();
+    }
+  } catch (e) { /* bridge offline — ignore, retry next tick */ }
+}
+setInterval(pollReload, 3000);
+document.addEventListener('DOMContentLoaded', pollReload);
+```
+
+**Why 3 s?** Fast enough that the new iteration appears within a blink
+after Claude finishes writing, slow enough that idle pages do not hammer
+the server. The cron tick for heartbeat runs every 60 s — those two loops
+are independent.

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.45.0",
+  "version": "0.46.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to Gemma 4 E4B via llama.cpp to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

Fixes the long-standing bug where iteration 2+ of a concept page was written to disk but the browser tab kept showing iteration 1's submitted state. Also reshapes the iteration model: instead of `-v{N}` files + meta-refresh redirects, every iteration lives as a `<section data-iteration="N">` block inside a single `{date}-{slug}.html`. A tab bar in the content header (above the variants, not in the right sidebar) switches between rounds. Past iterations are frozen — disabled inputs and readonly comments preserve exactly what the user submitted, so they can click back and review their own feedback history without losing the active round.

## Changes

- **concept-server.py** — new `/reload` counter endpoint. Claude POSTs after rewriting the HTML; the browser polls and issues `location.reload()` when the counter advances. Origin-guarded so cross-origin localhost pages cannot trigger reloads.
- **SKILL.md** — one file per concept session (filename drops `-v{version}`); Step 5c rewritten to append a section and POST `/reload` instead of redirecting; validation gate adds `data-iteration`, `iteration-tabs`, `pollReload`, and `sec.hidden` as required patterns.
- **templates.md** — tab bar HTML in the common structure; new Iteration Tabs section with CSS, tab-switch JS, freeze rules, and the reload poller; `showIteration()` hides `panel-submitted` too so a live spinner cannot bleed through a frozen snapshot.

## Codex review

1 must-fix (panel-submitted leak) + 3 should-fix (conflicting freeze rules, missing `hidden` grep pattern, `/reload` origin guard) — all addressed in commit `e0cf7ba`.