### PR TITLE
fix(devops-concept): auto-reset browser panel + deterministic pending

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.45.0"
+    "version": "0.46.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.45.0",
+      "version": "0.46.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to Gemma 4 E4B via llama.cpp to save tokens.",
-      "version": "0.45.0",
+      "version": "0.46.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [0.46.1] — 2026-04-17
+
+### Fixed
+
+- **concept** — Claude's cron was missing user submissions silently. The prompt substring-matched `"submitted":true` (no space), but the `/decisions` JSON is emitted via `json.dumps` as `"submitted": true` (with space). The check never fired and Claude kept ticking on `false` until the user intervened manually
+- **concept** — browser panel no longer gets stuck on "Entscheidungen übermittelt". Server stamps `_processed_at` on every successful `/reset`; the existing 5 s heartbeat tick polls `/decisions`, compares against the local `_submittedAt`, and calls `restorePanelToReady()` when the server stamp is newer. No JS-eval injection from Claude needed
+
+### Added
+
+- **concept** — `GET /pending` endpoint returns strict `{"pending": bool, "version": int}` so the cron can pipe through `python -c` and get exactly `true` / `false` with no fuzzy-match risk
+- **concept** — `_processed_at` field on `/decisions` responses (ISO-8601 UTC, empty string until first reset). Browser-side `pollProcessedState()` compares against local `_submittedAt` to auto-restore the ready panel
+- **concept** — Pattern #16 in Post-Generation Validation (`pollProcessedState`) guarantees generated pages carry the auto-reset poll handler
+
+### Changed
+
+- **concept** — cron prompt in SKILL.md Step 3 rewritten to use `/pending` + `python -c`. Explicit note about why fuzzy matching was dropped
+- **concept** — SKILL.md Step 5c: `/reset` is now documented as a prerequisite of the iteration rewrite, coupling cleanly with `pollProcessedState` + `pollReload`
+
 ## [0.46.0] — 2026-04-17
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.46.0**
+**Version: 0.46.1**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.46.0",
+  "version": "0.46.1",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/scripts/concept-server.py
+++ b/plugins/devops/scripts/concept-server.py
@@ -3,10 +3,15 @@ Concept Bridge Server — HTTP-based heartbeat and decision bridge.
 
 Replaces `python -m http.server` with a custom server that adds:
 - GET/POST /heartbeat — Claude signals presence via curl, page polls via fetch
-- GET/POST /decisions — Page submits decisions via POST, Claude reads via GET
+- GET/POST /decisions — Page submits decisions via POST, Claude reads via GET.
+  GET response includes `_version` (for optimistic /reset concurrency) and
+  `_processed_at` (ISO timestamp of the last successful /reset — the browser
+  uses this to auto-restore the panel to the ready state after Claude processes).
+- GET /pending — Deterministic signal for Claude's cron: returns
+  `{"pending": bool, "version": int}` with no free-form content to fuzzy-match.
 - POST /reset — Claude clears decisions after processing; conditional on
   version to avoid dropping submissions that land between GET and POST
-  (see /reset docs below).
+  (see /reset docs below). Updates `_processed_at` on success.
 - GET/POST /reload — Claude bumps a counter after rewriting the HTML file;
   the browser polls and reloads when the counter advances.
 
@@ -27,6 +32,7 @@ import os
 import sys
 import time
 import threading
+from datetime import datetime, timezone
 
 _heartbeat_ts = 0
 _decisions = '{"submitted": false, "decisions": [], "comments": []}'
@@ -36,6 +42,12 @@ _decisions = '{"submitted": false, "decisions": [], "comments": []}'
 # the server version has advanced and the reset is rejected with 409 so the
 # second submission is not silently dropped.
 _version = 0
+# ISO-8601 UTC timestamp of the last successful /reset (i.e. when Claude
+# finished processing a submission). The browser polls /decisions, compares
+# `processed_at` against its own `submittedAt`, and auto-restores the panel
+# to the ready state when it sees a newer processed_at than its submission.
+# Empty string until the first reset; clients treat that as "never processed".
+_processed_at = ''
 # Reload counter — bumped by Claude via POST /reload after the HTML file is
 # rewritten (new iteration appended, content refreshed, etc). The browser
 # polls GET /reload and issues location.reload() when the counter advances.
@@ -43,6 +55,10 @@ _version = 0
 # tab keeps showing stale content.
 _reload_counter = 0
 _lock = threading.Lock()
+
+
+def _iso_now():
+    return datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z'
 
 
 class ConceptBridgeHandler(http.server.SimpleHTTPRequestHandler):
@@ -65,9 +81,13 @@ class ConceptBridgeHandler(http.server.SimpleHTTPRequestHandler):
             # Return the stored decisions payload with the current server
             # version appended as `_version`. Claude must pass this value back
             # to POST /reset for the optimistic-concurrency check to work.
+            # `processed_at` is the ISO timestamp of the last /reset and lets
+            # the browser detect "Claude finished processing" without a JS
+            # eval round-trip — see templates.md § Panel State Reset.
             with _lock:
                 data = _decisions
                 version = _version
+                processed_at = _processed_at
             try:
                 obj = json.loads(data)
                 if not isinstance(obj, dict):
@@ -75,7 +95,22 @@ class ConceptBridgeHandler(http.server.SimpleHTTPRequestHandler):
             except Exception:
                 obj = {"submitted": False, "decisions": [], "comments": []}
             obj["_version"] = version
+            obj["_processed_at"] = processed_at
             self._json_response(obj)
+        elif self.path == '/pending':
+            # Deterministic one-shot signal for Claude's cron: unambiguous
+            # {"pending": bool, "version": int} so the cron instruction does
+            # not have to substring-match against free-form JSON. Avoids
+            # the "submitted:true vs submitted: true" fuzzy-match trap.
+            with _lock:
+                data = _decisions
+                version = _version
+            try:
+                obj = json.loads(data)
+                pending = bool(isinstance(obj, dict) and obj.get('submitted') is True)
+            except Exception:
+                pending = False
+            self._json_response({"pending": pending, "version": version})
         elif self.path == '/reload':
             with _lock:
                 counter = _reload_counter
@@ -84,7 +119,7 @@ class ConceptBridgeHandler(http.server.SimpleHTTPRequestHandler):
             super().do_GET()
 
     def do_POST(self):
-        global _heartbeat_ts, _decisions, _version, _reload_counter
+        global _heartbeat_ts, _decisions, _version, _processed_at, _reload_counter
         if self.path == '/heartbeat':
             with _lock:
                 _heartbeat_ts = int(time.time() * 1000)
@@ -137,7 +172,8 @@ class ConceptBridgeHandler(http.server.SimpleHTTPRequestHandler):
             with _lock:
                 if expected is None or expected == _version:
                     _decisions = '{"submitted": false, "decisions": [], "comments": []}'
-                    self._json_response({"ok": True, "version": _version})
+                    _processed_at = _iso_now()
+                    self._json_response({"ok": True, "version": _version, "processed_at": _processed_at})
                 else:
                     # Mismatch — newer submission landed after Claude read
                     self._conflict_response({

--- a/plugins/devops/skills/devops-concept/SKILL.md
+++ b/plugins/devops/skills/devops-concept/SKILL.md
@@ -241,6 +241,7 @@ are present. **Grep the generated file** for each required pattern:
 | 13 | `iteration-tabs` | Tab bar container in the decision panel |
 | 14 | `pollReload` | Reload-signal poller (picks up file rewrites) |
 | 15 | `sec.hidden` | Tab-switch JS toggles the `hidden` attribute — prevents all iterations rendering at once |
+| 16 | `pollProcessedState` | Auto-reset poll handler — restores the ready panel when the server's `_processed_at` advances past the local `_submittedAt` |
 
 **If ANY pattern is missing → DO NOT open the page.** Fix the HTML first,
 then re-validate. This is a **blocking gate** — no exceptions, no "this
@@ -288,26 +289,40 @@ AND provides HTTP endpoints for heartbeat and decision exchange.
    (1) Heartbeat POST:
        Bash: curl -s -X POST http://localhost:{port}/heartbeat > /dev/null
 
-   (2) Decision poll with optimistic-concurrency reset:
-       Bash: curl -s http://localhost:{port}/decisions
+   (2) Pending check — use the deterministic /pending endpoint, NOT a
+       substring match on /decisions. The response is a strict JSON object
+       `{"pending": true|false, "version": N}` with no free-form content.
+       Bash (produces ONLY the literal string "true" or "false"):
+         curl -s http://localhost:{port}/pending | python -c "import sys,json; d=json.load(sys.stdin); print('true' if d.get('pending') else 'false')"
 
-       If the response contains `"submitted":true` →
-         • Note the `_version` field from the response.
-         • Parse the JSON (decisions + comments) — strip `_version` before processing.
-         • Process them per Step 5 (Live Feedback Loop) — act on the user's
-           choices (approve/tweak/reject, included options, comment-driven tweaks).
+       If the output is exactly "false" → produce NO user-visible output. Silent tick.
+
+       If the output is exactly "true" → fetch the full payload and process:
+         Bash: curl -s http://localhost:{port}/decisions
+         • Parse the JSON. Note `_version`. Strip `_version` and `_processed_at`
+           before treating the rest as decision data.
+         • Process per Step 5 (Live Feedback Loop) — act on the user's choices
+           (approve/tweak/reject, included options, comment-driven tweaks).
          • After processing, reset conditionally — pass the noted version:
-           Bash: curl -s -X POST -H "Content-Type: application/json" \
+           Bash: curl -s -o /dev/null -w "%{http_code}" -X POST \
+                       -H "Content-Type: application/json" \
                        -d '{"version": <noted>}' http://localhost:{port}/reset
-         • If the response is `409` (version mismatch) → the user submitted
-           again while you were processing. Re-fetch `/decisions`, process the
+         • If the HTTP code is 409 (version mismatch) → the user submitted
+           again while you were processing. Re-fetch /decisions, process the
            new payload (which supersedes what you just finished), then retry
            the conditional reset with the new `_version`.
-         • Report the outcome to the user.
-
-       If `"submitted":false` → produce NO user-visible output. Silent tick.
+         • Report the outcome to the user. The browser's panel auto-resets
+           within 5s via the `_processed_at` heartbeat poll — no browser-eval
+           injection required.
    EOF)
    ```
+
+   **Why `/pending` + `python -c` instead of a substring check?** The
+   `/decisions` JSON response is formatted via Python's default
+   `json.dumps`, which emits `"submitted": true` **with** a space after the
+   colon — a literal `contains "submitted":true` test silently misses every
+   submission. `/pending` collapses the signal to a strict boolean so the
+   cron body cannot drift into false negatives between ticks.
 
    **Why combined, not two crons?** One cron minimizes race conditions and makes
    the contract explicit: every tick does both. Minimum cron resolution is 1 min,
@@ -404,7 +419,14 @@ After processing, **append a new iteration tab** to the same HTML file and
 signal the browser to reload. This is the ONLY update path — there is no
 separate "in-place edit" vs. "new file" distinction anymore.
 
-Procedure on every iteration (including the very first response to feedback):
+Procedure on every iteration (including the very first response to feedback).
+Before the steps below, POST `/reset` with the captured `_version` (see cron
+prompt in Step 3). This stamps `_processed_at` on the server so the
+browser's `pollProcessedState` can restore the panel to the ready state
+automatically — Claude does NOT send a browser-eval reset. The subsequent
+`pollReload` tick picks up the file rewrite and the tab reloads onto the
+new active iteration. See `deep-knowledge/templates.md` § Panel State Reset
+for the polling contract.
 
 1. Read the existing HTML file (same path, always).
 2. Freeze the currently-active iteration section per the rules in

--- a/plugins/devops/skills/devops-concept/deep-knowledge/monitoring.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/monitoring.md
@@ -30,15 +30,32 @@ The loop continues until the user is done (closes page or says "fertig").
 
 ### Primary: HTTP Bridge (preferred)
 
-Claude polls the bridge server for submitted decisions:
+Claude's cron polls the bridge server for the deterministic pending flag:
+
+```bash
+curl -s http://localhost:$PORT/pending
+# → {"pending": true|false, "version": N}
+```
+
+`/pending` is a strict, machine-readable one-shot signal — use it instead
+of substring-matching `/decisions`. The `/decisions` JSON response is
+formatted via `json.dumps` which emits `"submitted": true` **with** a space
+after the colon, so a literal `contains "submitted":true` check silently
+misses every real submission. The cron in SKILL.md Step 3 pipes `/pending`
+through `python -c` and only falls back to `/decisions` when pending is
+true, eliminating that class of bug.
+
+Once pending is true, Claude fetches the full payload:
 
 ```bash
 curl -s http://localhost:$PORT/decisions
 ```
 
-Returns JSON with `"submitted": true` when the user has clicked Submit.
-The page POSTs decisions to `/decisions` on submit (see `templates.md`
-§ Submit Handler).
+The response contains the user's decisions plus two metadata fields:
+- `_version` — monotonic counter. Pass back to POST /reset for
+  optimistic-concurrency checking.
+- `_processed_at` — ISO-8601 UTC timestamp of the last successful /reset.
+  The **browser** uses this to self-restore the panel; Claude can ignore it.
 
 ### Fallback: JS eval (when bridge server unavailable)
 
@@ -122,10 +139,21 @@ Returns JSON. Check the `submitted` field:
 
 No browser eval needed. The bridge server handles everything.
 
-**Reset after processing** — tell the bridge server to clear decisions:
+**Reset after processing** — tell the bridge server to clear decisions.
+Always pass the captured `_version` so a submission that races with your
+reset is not silently dropped (409 = retry):
 ```bash
-curl -s -X POST http://localhost:$PORT/reset
+curl -s -o /dev/null -w "%{http_code}" -X POST \
+     -H "Content-Type: application/json" \
+     -d '{"version": <noted>}' http://localhost:$PORT/reset
 ```
+
+On success the server stamps `_processed_at` with the current UTC time.
+The browser polls `/decisions` every 5 s, compares `_processed_at` against
+its local `_submittedAt`, and — when the server stamp is newer — flips the
+panel back to the ready state by itself. **No JS eval injection from
+Claude required.** See `templates.md` § Panel State Reset for the client
+contract.
 
 ### Legacy Fallback: JS Eval (for page updates)
 
@@ -286,22 +314,20 @@ Map decisions back to the original context:
 After processing a submission, Claude MUST reset the bridge server and
 update the browser page:
 
-1. **Reset bridge server state:**
+1. **Reset bridge server state (conditional on `_version`):**
    ```bash
-   curl -s -X POST http://localhost:$PORT/reset
+   curl -s -o /dev/null -w "%{http_code}" -X POST \
+        -H "Content-Type: application/json" \
+        -d '{"version": <noted>}' http://localhost:$PORT/reset
    ```
+   A 200 stamps `_processed_at`; a 409 means a newer submission arrived —
+   re-fetch `/decisions` and process that instead.
 
-2. **Reset page UI** (via browser eval if available):
-   ```javascript
-   document.body.classList.remove('concept-submitted');
-   document.getElementById('concept-decisions').textContent =
-     JSON.stringify({submitted: false, round: N+1, decisions: [], comments: []});
-   document.getElementById('panel-submitted').style.display = 'none';
-   document.getElementById('panel-ready').style.display = 'block';
-   document.getElementById('submit-btn').disabled = false;
-   document.getElementById('submit-btn').textContent = 'Entscheidungen abschicken';
-   ```
-   If no browser eval tool is available, inform the user to refresh the page.
+2. **Page UI auto-resets** — the browser's 5 s heartbeat tick sees the
+   new `_processed_at` and calls `restorePanelToReady()` locally. No
+   browser eval needed from Claude. If the page is disconnected (closed
+   tab / crashed tool), the reset still applies server-side and will take
+   effect the next time the page loads.
 
 3. **Update content to reflect processed state** (via browser eval if available):
    - Mark processed items visually (checkmark, "Verarbeitet" badge)

--- a/plugins/devops/skills/devops-concept/deep-knowledge/templates.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/templates.md
@@ -946,11 +946,17 @@ the matching `id` attribute for the anchor link to work.
 
 ### Submit Handler
 ```javascript
+// Timestamp of the most recent submit click. Compared against the server's
+// `_processed_at` in the heartbeat poll to detect "Claude finished processing"
+// and auto-restore the ready panel without a JS eval round-trip.
+let _submittedAt = 0;
+
 document.getElementById('submit-btn').addEventListener('click', async () => {
   const data = collectDecisions();
   const container = document.getElementById('concept-decisions');
   container.textContent = JSON.stringify(data);
   document.body.classList.add('concept-submitted');
+  _submittedAt = Date.now();
 
   // Switch panel to "submitted" state immediately (optimistic UI)
   document.getElementById('panel-ready').style.display = 'none';
@@ -991,25 +997,34 @@ async function retryPendingSubmission() {
 
 ### Panel State Reset
 
-When Claude processes decisions and updates the page (Step 5c), it resets
-the panel back to the "ready" state via browser eval:
+When Claude finishes processing, it calls `POST /reset` on the bridge server.
+The server stamps `_processed_at` with the current time. The page's heartbeat
+poll (see § Claude Connection Heartbeat) reads that timestamp on the next
+tick and — if it's newer than `_submittedAt` — runs `restorePanelToReady()`
+locally. No browser eval injection from Claude needed; the page self-heals.
 
 ```javascript
-// Called by Claude after processing — resets the panel for the next round
-document.getElementById('panel-submitted').style.display = 'none';
-document.getElementById('panel-ready').style.display = 'block';
-document.getElementById('submit-btn').disabled = false;
-document.getElementById('submit-btn').textContent = 'Entscheidungen abschicken';
-document.body.classList.remove('concept-submitted');
-// Clear cached decisions so reload doesn't resurrect stale selections
-const slug = location.pathname.split('/').pop().replace('.html', '');
-localStorage.removeItem('concept-state-' + slug);
+// Called by the heartbeat poll when the server's processed_at has advanced
+// past our last submit. Also safe to call manually for legacy eval paths.
+function restorePanelToReady() {
+  document.getElementById('panel-submitted').style.display = 'none';
+  document.getElementById('panel-ready').style.display = 'block';
+  const btn = document.getElementById('submit-btn');
+  btn.disabled = false;
+  btn.textContent = 'Entscheidungen abschicken';
+  document.body.classList.remove('concept-submitted');
+  _submittedAt = 0;
+  // Clear cached decisions so reload doesn't resurrect stale selections
+  const slug = location.pathname.split('/').pop().replace('.html', '');
+  localStorage.removeItem('concept-state-' + slug);
+}
 ```
 
 This is the visual cycle:
 ```
 [Ready: button active] → User clicks Submit → [Submitted: waiting indicator]
-    → Claude processes → [Ready: button active again, new round]
+    → Claude processes → POST /reset → heartbeat poll sees processed_at >
+    submittedAt → restorePanelToReady() → [Ready: button active, new round]
 ```
 
 ### Theme Toggle
@@ -1053,6 +1068,26 @@ async function pollHeartbeat() {
   }
 }
 
+// Poll /decisions for the server's `_processed_at` timestamp. When the
+// server stamp is newer than our last submit we know Claude ran POST /reset
+// and we should flip the panel back to ready — fully client-driven, no
+// browser-eval injection from Claude needed.
+async function pollProcessedState() {
+  if (!_submittedAt) return; // nothing pending locally
+  try {
+    const res = await fetch('/decisions', { cache: 'no-store' });
+    const data = await res.json();
+    const processedIso = data && data._processed_at;
+    if (!processedIso) return;
+    const processedMs = Date.parse(processedIso);
+    if (Number.isFinite(processedMs) && processedMs > _submittedAt) {
+      restorePanelToReady();
+    }
+  } catch (e) {
+    // Server unreachable — will retry next tick
+  }
+}
+
 function checkClaudeConnection() {
   // Suppress warning during grace period — Claude needs time to start the
   // bridge server, set up the heartbeat cron, and send the first POST.
@@ -1083,7 +1118,11 @@ function checkClaudeConnection() {
 // Poll heartbeat every 5 seconds — starts immediately so data arrives ASAP.
 // checkClaudeConnection() is a no-op during grace period, so the warning
 // won't flash before Claude has had time to set up.
-setInterval(async () => { await pollHeartbeat(); checkClaudeConnection(); }, 5000);
+setInterval(async () => {
+  await pollHeartbeat();
+  checkClaudeConnection();
+  await pollProcessedState();
+}, 5000);
 ```
 
 **Claude-side heartbeat** (executed by Claude via Bash or CronCreate):

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.46.0",
+  "version": "0.46.1",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to Gemma 4 E4B via llama.cpp to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

Two tightly coupled bugs in the HTTP-bridge concept loop:

1. **Submission pickup silently missed** — Claude's cron substring-matched `"submitted":true` against the raw `/decisions` JSON. The server emits `"submitted": true` (with a space, `json.dumps` default), so the check never fired. User had to intervene manually.
2. **Browser panel stuck on "Entscheidungen übermittelt"** — old reset flow relied on Claude sending a JS-eval reset; with the pure HTTP bridge that path no longer existed.

## Fix

- **Server**: new `GET /pending` → strict `{"pending": bool, "version": int}`; `/reset` stamps `_processed_at`; `/decisions` response exposes `_processed_at` alongside `_version`.
- **Browser**: submit records `_submittedAt = Date.now()`. New `pollProcessedState()` inside the 5 s heartbeat tick compares server `_processed_at` against local `_submittedAt` and calls `restorePanelToReady()` when the server stamp is newer — no Claude-driven eval injection.
- **Cron prompt** (SKILL.md Step 3): rewritten to use `/pending` piped through `python -c` producing exactly `true`/`false`; explicit note about why fuzzy matching was dropped.
- **Docs**: Pattern #16 added to Post-Generation Validation (`pollProcessedState`); monitoring.md documents the `_processed_at` contract and version-guarded `/reset`.
- **Release hygiene**: synced stale `.claude-plugin/marketplace.json` (was 0.45.0 while everything else was already 0.46.0 from the previous ship).

## Test plan

- [x] `npm test` — 89/89 pass
- [x] `npm run lint` — clean
- [x] Curl roundtrip: submit → `/pending` true → `/reset` stamps `processed_at` → `/pending` false → stale `/reset` returns 409
- [x] `/reload` + origin guard still work after merge with 0.46.0's reload feature