### PR TITLE
fix(windows): cygpath for browser file:// URLs + DK

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.46.0"
+    "version": "0.46.1"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.46.0",
+      "version": "0.46.1",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to Gemma 4 E4B via llama.cpp to save tokens.",
-      "version": "0.46.0",
+      "version": "0.46.1",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [0.46.2] — 2026-04-18
+
+### Fixed
+
+- **devops-autonomous** — `AUTONOMOUS-REPORT.html` failed to open in Edge on Windows. `start msedge "file://$(pwd)/..."` produced `file:///c/Users/...` (MSYS path without drive colon), which Chromium cannot resolve (`ERR_FILE_NOT_FOUND`). Now runs the path through `cygpath -m` → valid `file:///C:/Users/...` URL
+- **devops-repo-health** — same `file://` trap fixed in the "Open & Monitor" step. The `{filepath}` placeholder is now wrapped in `cygpath -m` before prefixing `file:///`
+
+### Added
+
+- **deep-knowledge** — new cross-cutting doc `browser-file-urls.md` documenting the Git-Bash / Chromium file:// URL trap on Windows, with the canonical `cygpath -m` recipe and a smoke-test. Indexed in `INDEX.md`
+
+### Changed
+
+- **marketplace.json** — version re-synced from `0.46.0` (stale) to the actual release line. Prevents future `ship_preflight` version-consistency errors
+
 ## [0.46.1] — 2026-04-17
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.46.1**
+**Version: 0.46.2**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.46.1",
+  "version": "0.46.2",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/deep-knowledge/INDEX.md
+++ b/plugins/devops/deep-knowledge/INDEX.md
@@ -10,6 +10,7 @@ Quick-reference for all deep-knowledge topics. Read this FIRST to find the right
 | [agent-orchestration.md](agent-orchestration.md) | Agent Orchestration | Shared orchestration logic for agent selection, prompting, and wave execution. |
 | [agent-proactivity.md](agent-proactivity.md) | Proactive Agent Orchestration | Cross-cutting rule for when to involve specialized agents without explicit us... |
 | [autonomous-execution.md](autonomous-execution.md) | Autonomous Execution — Gate, Guardrails, Late-Permission Protocol | Detailed execution rules for `devops-autonomous` Step 5. Read this at the sta... |
+| [browser-file-urls.md](browser-file-urls.md) | Browser File URLs (Windows + Git-Bash) | Cross-cutting rule: whenever a skill opens a local HTML file in a browser |
 | [browser-tool-strategy.md](browser-tool-strategy.md) | Browser Tool Strategy | Cross-cutting rules for browser interaction across all skills. Every skill that |
 | [claude-directory-structure.md](claude-directory-structure.md) | Claude Directory Structure Convention | All Claude Code configuration belongs inside `.claude/`. Nothing Claude-specific |
 | [code-defaults.md](code-defaults.md) | Code Defaults | Standard coding conventions enforced across all projects using the devops plu... |

--- a/plugins/devops/deep-knowledge/browser-file-urls.md
+++ b/plugins/devops/deep-knowledge/browser-file-urls.md
@@ -1,0 +1,73 @@
+# Browser File URLs (Windows + Git-Bash)
+
+Cross-cutting rule: whenever a skill opens a local HTML file in a browser
+(Edge, Chrome, Firefox) via `start`, ensure the `file://` URL uses a **native
+Windows path with drive colon**, not the MSYS-style path that Git-Bash returns
+by default.
+
+## The trap
+
+In Git-Bash on Windows:
+
+```bash
+$(pwd)       # → /c/Users/Jerem/...    (MSYS path, no colon, lowercase drive)
+pwd -W       # → C:/Users/Jerem/...    (native Windows path)
+cygpath -m . # → C:/Users/Jerem/...    (same, portable)
+```
+
+Naive concatenation breaks:
+
+```bash
+# WRONG — produces file:///c/Users/... → ERR_FILE_NOT_FOUND
+start msedge "file://$(pwd)/report.html"
+```
+
+Chromium/Edge parses `file:///c/Users/...` and treats `c` as the first path
+segment, not a drive letter, because the colon is missing. The browser shows
+"Die Datei wurde nicht gefunden" / `ERR_FILE_NOT_FOUND`.
+
+## The rule
+
+**Always** convert to a native Windows path before building the URL, and use
+**three** slashes after `file:`:
+
+```bash
+# Preferred — cygpath is portable across Git-Bash and MSYS2
+start msedge "file:///$(cygpath -m "$(pwd)")/report.html"
+
+# Alternative — pwd -W (Git-Bash specific)
+start msedge "file:///$(pwd -W)/report.html"
+```
+
+For arbitrary paths (not just `$(pwd)`):
+
+```bash
+start msedge "file:///$(cygpath -m "$abs_path")"
+```
+
+## Verification
+
+Before shipping any skill that opens a local file, smoke-test the URL
+construction:
+
+```bash
+echo "file:///$(cygpath -m "$(pwd)")/TEST.html"
+# → file:///C:/Users/.../TEST.html   ✓ drive letter + colon
+```
+
+If the output shows `file:///c/Users/...` (no colon), the URL is broken.
+
+## Skills that must follow this rule
+
+- `devops-autonomous` (AUTONOMOUS-REPORT.html)
+- `devops-concept` (concept pages)
+- `devops-repo-health` (interactive branch report)
+- any future skill that writes an HTML file and opens it in a browser
+
+## Cross-platform note
+
+On macOS/Linux `$(pwd)` already returns an absolute POSIX path, so
+`file://$(pwd)/foo.html` works. The trap is Windows-specific. Skills that run
+on both platforms should branch on `$OSTYPE` or unconditionally use
+`cygpath -m` (no-op on systems where `cygpath` is absent — guard with
+`command -v cygpath`).

--- a/plugins/devops/skills/devops-autonomous/SKILL.md
+++ b/plugins/devops/skills/devops-autonomous/SKILL.md
@@ -342,10 +342,16 @@ Use a clean, modern dark-theme design. Structure:
 
 ### 7c — Open in Browser
 
-After writing the HTML file, open it in Edge:
+After writing the HTML file, open it in Edge. **Always convert the Git-Bash
+path to a native Windows path first** — `$(pwd)` returns `/c/Users/...` which
+produces a broken `file:///c/Users/...` URL (Chromium/Edge can't resolve the
+missing drive colon → `ERR_FILE_NOT_FOUND`):
+
 ```bash
-start msedge "file://$(pwd)/AUTONOMOUS-REPORT.html"
+start msedge "file:///$(cygpath -m "$(pwd)")/AUTONOMOUS-REPORT.html"
 ```
+
+See `deep-knowledge/browser-file-urls.md` for the full rule.
 
 The completion card is still rendered in the CLI as the last visible output
 (VERBATIM relay as always). The HTML report is the **primary deliverable** —

--- a/plugins/devops/skills/devops-repo-health/SKILL.md
+++ b/plugins/devops/skills/devops-repo-health/SKILL.md
@@ -313,8 +313,13 @@ Follow `/devops-concept` Step 3 (Open) and Step 4 (Monitor), respecting the
 new tab in running Edge, user's profile context, Claude extension for interaction.
 
 ```bash
-start "" msedge "{filepath}"
+start "" msedge "file:///$(cygpath -m "{filepath}")"
 ```
+
+**Windows note:** always run `{filepath}` through `cygpath -m` before
+prefixing `file:///` — raw `$(pwd)`-style paths produce a broken
+`file:///c/Users/...` URL (missing drive colon → `ERR_FILE_NOT_FOUND`).
+See `deep-knowledge/browser-file-urls.md`.
 
 Inform the user:
 

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.46.1",
+  "version": "0.46.2",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to Gemma 4 E4B via llama.cpp to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

Fix `AUTONOMOUS-REPORT.html` (and the repo-health page) failing to open in Edge on Windows. `$(pwd)` in Git-Bash returns an MSYS path `/c/Users/...` without the drive colon; prefixed with `file://` it becomes `file:///c/Users/...` which Chromium cannot resolve (`ERR_FILE_NOT_FOUND`). Switched both skills to `file:///$(cygpath -m "$(pwd)")/...` and added a cross-cutting deep-knowledge doc so future skills don't hit the same trap.

## Changes

- **devops-autonomous** — `cygpath -m` in the Edge-open command
- **devops-repo-health** — same fix on the `{filepath}` open step
- **deep-knowledge/browser-file-urls.md** — new cross-cutting rule (trap, recipe, smoke-test, affected skills)
- **marketplace.json** — version re-synced from stale `0.46.0`
- Version bump `0.46.1 → 0.46.2`

## Tests

- `npm run lint` ✅
- `npm run test` — 89/89 ✅
- Manual: `start msedge "file:///$(cygpath -m "$(pwd)")/TEST-URL.html"` opens correctly in Edge
- Codex review gate: findings addressed (repo-health follow-up)