### PR TITLE
feat(deep-knowledge): pre-mortem / red-team integration

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.46.1"
+    "version": "0.46.2"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.46.1",
+      "version": "0.46.2",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to Gemma 4 E4B via llama.cpp to save tokens.",
-      "version": "0.46.1",
+      "version": "0.46.2",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [0.47.0] — 2026-04-18
+
+### Added
+
+- **deep-knowledge** — new cross-cutting doc `pre-mortem.md` defining inline adversarial self-critique before non-trivial changes: 7 triggers (security, migrations, breaking contracts, refactors >3 files, concurrency, destructive ops, external integrations), explicit skip list, 7-question set, inline-only output rule, stop criterion. Indexed in `INDEX.md`
+- **agents** — new `redteam` agent for escalated adversarial review. Read-only tools, structured `REDTEAM_REVIEW` output (risks with file/line, severity, mitigation shape), never writes code. Runs parallel to `po` in Wave 0
+- **deep-knowledge/agent-proactivity.md + plugin-behavior.md** — cross-references to the new pre-mortem doc so substantial changes trigger the self-critique without explicit user intent
+- **agents/core.md, feature.md, frontend.md, ai.md** — each gains a pre-mortem read-line in its Rules block
+- **skills/devops-autonomous** — Step 5 now mandates the pre-mortem before any mutating op, with `high`-severity risks blocking execution (written into `AUTONOMOUS-RESUME.json` as BLOCKER)
+- **skills/devops-flow** — Step 7 adds the "how could this fix break something else?" pre-mortem before writing the fix
+
+### Changed
+
+- **marketplace.json** — version aligned from stale 0.46.1 to 0.46.2 baseline (drive-by fix to unblock preflight)
+
 ## [0.46.2] — 2026-04-18
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.46.2**
+**Version: 0.47.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.46.2",
+  "version": "0.47.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/agents/ai.md
+++ b/plugins/devops/agents/ai.md
@@ -41,6 +41,7 @@ Your worktree starts on HEAD (main). You MUST rebase immediately:
 
 ## Rules
 
+- Read `{PLUGIN_ROOT}/deep-knowledge/pre-mortem.md` before non-trivial implementation.
 - Always handle API rate limits and timeouts
 - Implement fallbacks for model unavailability
 - Never hardcode API keys — use environment variables

--- a/plugins/devops/agents/core.md
+++ b/plugins/devops/agents/core.md
@@ -41,6 +41,7 @@ Your worktree starts on HEAD (main). You MUST rebase immediately:
 
 ## Rules
 
+- Read `{PLUGIN_ROOT}/deep-knowledge/pre-mortem.md` before non-trivial implementation.
 - Define interfaces/contracts before implementation
 - Commit contracts separately from implementation (clear git bisect point)
 - Never depend on frontend — frontend depends on core

--- a/plugins/devops/agents/feature.md
+++ b/plugins/devops/agents/feature.md
@@ -123,6 +123,7 @@ Agent({ subagent_type: "research", model: "sonnet", prompt: "..." })
 
 ## Rules
 
+- Read `{PLUGIN_ROOT}/deep-knowledge/pre-mortem.md` before non-trivial implementation.
 - Always work in a worktree (isolation: worktree)
 - Commit logical units, not mega-commits
 - Push before reporting completion

--- a/plugins/devops/agents/frontend.md
+++ b/plugins/devops/agents/frontend.md
@@ -40,6 +40,7 @@ Your worktree starts on HEAD (main). You MUST rebase immediately:
 
 ## Rules
 
+- Read `{PLUGIN_ROOT}/deep-knowledge/pre-mortem.md` before non-trivial implementation.
 - Always verify visual output with screenshots
 - Follow existing component patterns in the project
 - CSS changes need responsive verification

--- a/plugins/devops/agents/redteam.md
+++ b/plugins/devops/agents/redteam.md
@@ -1,0 +1,101 @@
+---
+name: redteam
+description: >-
+  Red-team / adversarial review agent — scans a plan or code change for
+  failure modes, blind spots, and hidden risks before implementation.
+  Produces a list of concrete risks with file/line references; does NOT
+  fix code.
+  <example>Red-team this migration plan for race conditions and partial-failure modes</example>
+  <example>Find the ways this auth change can silently fail</example>
+model: opus
+effort: high
+color: red
+tools: ["Read", "Grep", "Glob", "WebFetch"]
+---
+
+# Red-Team Agent
+
+Adversarial review. Your job is to find what will break — not to fix it.
+
+## Context
+
+Before starting, read `{PLUGIN_ROOT}/deep-knowledge/pre-mortem.md` for the
+question set and triggers. You are the escalated, agent-level version of
+the inline pre-mortem: same questions, deeper scan, structured output.
+
+## Mindset
+
+- **Assume the author was sloppy**, even if they weren't. Look for the
+  shortcut, the missed edge case, the implicit assumption.
+- **Hunt invariants**. Every codebase has rules nobody wrote down. The
+  change probably breaks one.
+- **Think like an attacker or an unlucky user**, not like the author.
+  What input, timing, or sequence makes the happy path lie?
+- **Concrete beats clever**. "Races on two concurrent requests to
+  `services/auth.ts:42`" beats "may have concurrency issues".
+
+## Responsibilities
+
+- Review the plan or diff against the pre-mortem question set
+- Identify concrete failure modes with file/line references
+- Classify each risk by severity (high / medium / low)
+- Suggest the shape of mitigation (guard, test, scope cut) — not the fix
+- Flag missing tests for the risks found
+- Call out violated codebase assumptions explicitly
+
+## What You Do NOT Do
+
+- Write or edit production code. The implementing agent folds in mitigations.
+- Rewrite the plan. Challenge it; let the orchestrator decide the response.
+- Duplicate PO-level scope debate. PO owns "should we build this";
+  you own "how does what we're building fail".
+
+## Collaboration
+
+- **Receives from**: Feature agent, /devops-agents orchestrator, or user
+- **Runs parallel to**: `po` in Wave 0 (strategy) — PO asks *should we*,
+  Red-Team asks *how does it fail*
+- **Hands off to**: Core / Feature / Frontend / AI agents (they implement
+  the mitigations)
+- **Judgment call**: not every wave needs a red-team pass. Trigger per
+  `deep-knowledge/pre-mortem.md` When to Apply.
+
+## Naming Convention
+
+Per `deep-knowledge/agent-conventions.md`:
+
+```
+[role:redteam · Analysis] <3-6 word task>
+```
+
+## Output Format
+
+```
+REDTEAM_REVIEW:
+  scope: <one-line summary of what was reviewed>
+  risks:
+    - id: R1
+      severity: high|medium|low
+      category: race|partial-failure|edge-case|assumption|destructive|security|external
+      location: <file:line or "plan">
+      description: <one sentence — what fails and under which condition>
+      mitigation_shape: <guard | test | scope cut | rollback plan — one line>
+    - id: R2
+      ...
+  missing_tests: [list of scenarios that should have tests]
+  violated_assumptions: [list — each with file:line where the assumption lives]
+  verdict: proceed | proceed-with-mitigations | rework
+  notes: <free text, optional, max 3 lines>
+```
+
+## Rules
+
+- Every risk must have a file/line or explicit "plan-level" tag. No vague
+  "could be buggy" entries.
+- Cap at 10 risks. If you find more, raise `verdict: rework` and list the
+  top 10 by severity.
+- No fixes in code. Shape-of-mitigation only.
+- Do not block on low-severity risks alone — they are logged, not gates.
+- If the change falls under the skip list in `pre-mortem.md`, respond with
+  `verdict: proceed`, zero risks, and a one-line note explaining why the
+  review was unnecessary.

--- a/plugins/devops/deep-knowledge/INDEX.md
+++ b/plugins/devops/deep-knowledge/INDEX.md
@@ -21,6 +21,7 @@ Quick-reference for all deep-knowledge topics. Read this FIRST to find the right
 | [git-hygiene.md](git-hygiene.md) | Git Hygiene | Cross-cutting git rules referenced by `/devops-commit`, `/devops-ship`, and h... |
 | [merge-safety.md](merge-safety.md) | Merge Safety — Parallel Development | Cross-cutting reference for preventing silent overwrites when multiple develo... |
 | [plugin-behavior.md](plugin-behavior.md) | Plugin Behavior Rules | Core behavioral rules enforced by the devops plugin. |
+| [pre-mortem.md](pre-mortem.md) | Pre-Mortem / Red-Team Self-Critique | Cross-cutting rule for reducing blind spots before non-trivial changes. |
 | [skill-extension-guide.md](skill-extension-guide.md) | Skill Extension Guide — For Plugin Integrators | How to customize devops skills and agents for your project. |
 | [test-strategy.md](test-strategy.md) | Test Execution Strategy | Cross-cutting rules for when and how to test. Referenced by the completion flow |
 | [tool-selection.md](tool-selection.md) | Tool Selection (Windows) | Preferred tool usage when operating on Windows environments. |

--- a/plugins/devops/deep-knowledge/agent-proactivity.md
+++ b/plugins/devops/deep-knowledge/agent-proactivity.md
@@ -47,6 +47,14 @@ When the task requires investigation before implementation:
 - Competitive analysis → research agent
 - User perspective validation → gamer agent
 
+### Before Substantial Changes — Pre-Mortem
+
+Before any non-trivial implementation, apply the inline pre-mortem defined
+in [`pre-mortem.md`](pre-mortem.md). Trigger list (security paths, migrations,
+breaking contracts, refactors >3 files, concurrency, destructive ops, external
+integrations) is canonical there. For higher-stakes work, escalate to the
+`redteam` agent in Wave 0, parallel to `po`.
+
 ## When NOT to Orchestrate
 
 - Single-file, single-domain edits (typo fix, add a log line, rename a variable)

--- a/plugins/devops/deep-knowledge/plugin-behavior.md
+++ b/plugins/devops/deep-knowledge/plugin-behavior.md
@@ -49,6 +49,15 @@ about emoji avoidance do NOT apply when relaying MCP tool output.
 "too small", no file is "outside scope". Only valid skip: clearly mid-task turns
 where Claude is still executing a multi-step plan.
 
+## Pre-Mortem Before Substantial Changes
+
+Before implementing security-sensitive, migration, breaking-change, or
+destructive work, apply the inline pre-mortem from
+[`pre-mortem.md`](pre-mortem.md). Trigger/skip lists and the question set
+live there. Results fold into the implementation (guards, tests, narrower
+scope) — never as a separate artifact. For high-stakes work, escalate to
+the `redteam` agent in Wave 0.
+
 ## Token Awareness
 
 - `ss.tokens.scan` scans for expensive files at session start

--- a/plugins/devops/deep-knowledge/pre-mortem.md
+++ b/plugins/devops/deep-knowledge/pre-mortem.md
@@ -1,0 +1,80 @@
+# Pre-Mortem / Red-Team Self-Critique
+
+Cross-cutting rule for reducing blind spots before non-trivial changes.
+
+## Purpose
+
+A short adversarial self-critique — "how would I sabotage this without
+anyone noticing?" — surfaces failure modes before they reach production.
+Runs **inline in reasoning**, never as a separate artifact. Cap: ~30 seconds
+of thought, stop as soon as 1-2 concrete risks are identified and folded
+into the implementation.
+
+## When to Apply (Triggers)
+
+Apply the pre-mortem before starting implementation when the task involves:
+
+- **Security-relevant code paths** — authentication, session handling,
+  permissions, cryptography, input validation, secret handling
+- **State or schema migrations** — DB migrations, data backfills, schema
+  changes that touch existing rows
+- **Breaking changes to public contracts** — API shapes, IPC messages,
+  exported function signatures, config keys
+- **Refactors spanning more than 3 files** — any change broad enough that
+  a silent regression could hide in an untouched caller
+- **Concurrency / race-sensitive code** — async chains, shared mutable
+  state, locks, request ordering, retry logic
+- **Destructive operations** — `delete`, `drop`, `rm -rf`, force-push,
+  irreversible file moves, cache invalidation
+- **External integrations** — new 3rd-party API calls, webhook handlers,
+  auth against external providers
+
+## When NOT to Apply (Skip)
+
+- Typos, copy changes, pure CSS tweaks
+- Adding a log line, renaming a local variable
+- Pure Q&A or explanation with no code change
+- Single-file trivial edits (one function, clear scope)
+
+Strictly respect the skip list. Pre-mortem on trivia is noise.
+
+## What to Ask (Question Set)
+
+Pick the 2-3 most relevant questions for the change at hand:
+
+1. How would I implement this so it looks correct but silently fails in
+   production?
+2. Which race condition or ordering change breaks this?
+3. What happens on partial failure mid-operation — half-written state,
+   interrupted transaction, retry after crash?
+4. Which edge case (empty, null, very large, negative, concurrent,
+   duplicate) flips the behaviour?
+5. Which existing assumption in the codebase am I violating — invariants,
+   contracts, data shape, ordering?
+6. What looks fine in the happy path but is already broken elsewhere?
+7. What is the rollback story if this is wrong?
+
+## Output Rule
+
+Results flow **inline into the implementation** — as guard clauses, targeted
+tests, explicit error handling, or a narrower scope. **Do not** emit:
+
+- A separate markdown summary of the pre-mortem
+- A concept page or artifact file
+- A long prose block explaining what was considered
+
+Mention a concrete risk in a sentence only if it changes what you implement
+or what you ask the user.
+
+## Stop Criterion
+
+As soon as 1-2 concrete risks are identified and addressed, proceed with
+implementation. The pre-mortem is a scan, not an audit — do not spiral into
+hypothetical failure modes with no actionable response.
+
+## Relationship to the Red-Team Agent
+
+For larger or higher-stakes work, escalate to the `redteam` agent in a wave
+(parallel to `po`). The agent produces a list of concrete risks with
+file/line references; the implementing agent folds them in. The inline
+pre-mortem above is the always-on lightweight version.

--- a/plugins/devops/skills/devops-autonomous/SKILL.md
+++ b/plugins/devops/skills/devops-autonomous/SKILL.md
@@ -249,6 +249,15 @@ Behavior depends on `$EXEC_MODE` from Step 2. The full execution gate, safety
 guardrails, and late-permission protocol live in
 `deep-knowledge/autonomous-execution.md` — read that file at the start of Step 5.
 
+**Mandatory pre-mortem before any executing step (implement mode):**
+Unsupervised execution means no user is there to catch a bad call mid-flight.
+Before the first Write/Edit/Bash that mutates state, apply the inline pre-mortem
+from `deep-knowledge/pre-mortem.md` — full question set, all triggers treated
+as active by default (security, migration, breaking-change, refactor, concurrency,
+destructive, external). Fold the output into guards, tests, and scope cuts.
+If a `high`-severity risk has no concrete mitigation, pause execution and write
+it to `AUTONOMOUS-RESUME.json` as a BLOCKER rather than proceeding.
+
 Quick summary:
 - `analyze` → read-only (Read, Glob, Grep, WebFetch, git log/blame/diff, screenshots). No Write/Edit/commit.
 - `implement` → Phase 1 analyse, Phase 2 implement+test+build+verify. No push/ship/PR.

--- a/plugins/devops/skills/devops-flow/SKILL.md
+++ b/plugins/devops/skills/devops-flow/SKILL.md
@@ -79,6 +79,15 @@ Find the actual broken invariant — not just the symptom. Ask:
 
 ## Step 7 — Implement fix (if appropriate)
 
+Before writing the fix, run the inline pre-mortem from
+`{PLUGIN_ROOT}/deep-knowledge/pre-mortem.md` — with special focus on the
+question: **"How could this fix break something else?"** A fix that resolves
+the reported symptom while regressing a sibling path is a net loss. Cover:
+
+- Which other callers rely on the behaviour I'm about to change?
+- Does this fix paper over a deeper invariant violation?
+- Could the root cause reappear in a different branch of the same code path?
+
 Apply the fix. Then verify:
 1. The specific error no longer occurs
 2. Related functionality still works

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.46.2",
+  "version": "0.47.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to Gemma 4 E4B via llama.cpp to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

Integrates an inline adversarial self-critique ("pre-mortem") before non-trivial changes, plus a new `redteam` agent for escalated adversarial review. No new slash-skill, no PreToolUse hook — contextual activation only, driven by deep-knowledge references.

## Changes

- **deep-knowledge/pre-mortem.md** — 7 triggers (security, migrations, breaking contracts, refactors >3 files, concurrency, destructive ops, external integrations), explicit skip list (typos, log lines, single-file trivia), 7-question set, inline-only output rule, stop criterion (1–2 concrete risks → proceed)
- **agents/redteam.md** — adversarial review agent, read-only tools (Read, Grep, Glob, WebFetch), structured `REDTEAM_REVIEW` output with file/line references, severity, and mitigation shape. Does NOT write code — implementing agent folds in mitigations. Runs parallel to `po` in Wave 0
- **deep-knowledge/agent-proactivity.md** + **plugin-behavior.md** — cross-references to pre-mortem so substantial changes trigger the self-critique without explicit user prompt
- **agents/core.md, feature.md, frontend.md, ai.md** — each gains a pre-mortem read-line in its Rules block
- **skills/devops-autonomous** — Step 5 mandates pre-mortem before mutating ops (unsupervised execution); `high`-severity risks without concrete mitigation block execution and write to `AUTONOMOUS-RESUME.json` as BLOCKER
- **skills/devops-flow** — Step 7 adds "how could this fix break something else?" pre-mortem before writing the fix
- **marketplace.json** — drive-by fix: stale 0.46.1 baseline realigned to 0.46.2 before the minor bump

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` — 89/89 tests pass
- [x] INDEX.md regenerated via `scripts/gen-dk-index.js` (21 entries, alphabetical)
- [x] All YAML frontmatter validates (5 agent files, 2 skill files)
- [x] Links verified: `pre-mortem.md` + `redteam.md` referenced from 6 call sites
- [ ] Observational: trigger the pre-mortem in a real security/migration task and confirm inline risks surface without a separate artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)