### PR TITLE
feat(devops): main-branch protection guards + ship sentinel

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.47.0"
+    "version": "0.48.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.47.0",
+      "version": "0.48.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to Gemma 4 E4B via llama.cpp to save tokens.",
-      "version": "0.47.0",
+      "version": "0.48.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.46.2"
+    "version": "0.47.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.46.2",
+      "version": "0.47.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to Gemma 4 E4B via llama.cpp to save tokens.",
-      "version": "0.46.2",
+      "version": "0.47.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.48.0] — 2026-04-18
+
+### Added
+
+- **hooks/pre-tool-use/pre.main.guard.js** — new PreToolUse Bash guard. Blocks destructive git operations (`commit|merge|rebase|cherry-pick|revert|reset --hard|apply|am|push|restore|stash pop/drop/apply/clear|update-ref|clean` and destructive `checkout --ours/--theirs/-p/-- <path>`) when `HEAD` is on local `main`/`master`. Bypasses: not in a git repo, HEAD off main, sentinel `.claude/.ship-in-progress` present, or env `DEVOPS_ALLOW_MAIN=1`
+- **hooks/pre-tool-use/pre.edit.branch.js** — new PreToolUse guard for `Edit|Write|NotebookEdit`. Blocks file edits inside a repo when HEAD is main/master. Canonicalizes target paths (incl. symlinks pointing outside the repo) so the containment check cannot be bypassed via symlink
+- **hooks/lib/ship-sentinel.js + mcp-server/ship/lib/sentinel.js** — ship-in-progress sentinel (15 min TTL). Lets the ship pipeline run Bash fallbacks without tripping the new main guards. `ship_preflight` writes it only after all hard gates pass; `ship_cleanup` clears it on every exit path (success + all failure branches)
+- **deep-knowledge/git-hygiene.md** — new "Main-branch protection (hard rule)" section defining the policy so agents and sub-agents inherit it
+
+### Changed
+
+- **marketplace.json** — version aligned from stale 0.46.2 to 0.47.0 baseline (drive-by fix to unblock preflight)
+
 ## [0.47.0] — 2026-04-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.47.0**
+**Version: 0.48.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/deep-knowledge/git-hygiene.md
+++ b/plugins/devops/deep-knowledge/git-hygiene.md
@@ -2,6 +2,22 @@
 
 Cross-cutting git rules referenced by `/devops-commit`, `/devops-ship`, and hooks.
 
+## Main-branch protection (hard rule)
+
+- **HEAD must never be `main`/`master` while editing or committing.** New work always
+  starts from a branch derived from `origin/main`:
+  `git fetch origin && git switch -c <feat/topic> origin/main`.
+- **Never commit, merge, push, rebase, cherry-pick, reset --hard, revert, apply or
+  am on main/master directly.** The only path back to `main` is `/devops-ship`.
+- **Never create PRs manually** (`gh pr create` / `gh pr merge`). Always via
+  `/devops-ship` so build-ID, version bump, tag and completion card stay consistent.
+- Enforcement: `pre.main.guard` (Bash) and `pre.edit.branch` (Edit/Write/NotebookEdit)
+  block these actions unless a sentinel file `.claude/.ship-in-progress` is present
+  (written by `ship_preflight`, cleared by `ship_cleanup`) or `DEVOPS_ALLOW_MAIN=1`
+  is set for an explicit one-shot bypass.
+- These rules only apply inside a git working tree. Outside a repo, the guards are
+  no-ops.
+
 ## Before every commit
 
 - Run `git status --short` — verify **zero `??` (untracked)** entries.
@@ -28,6 +44,9 @@ Cross-cutting git rules referenced by `/devops-commit`, `/devops-ship`, and hook
 - Never force-push to `main`/`master` without explicit user confirmation.
 - After merge: local branch is deleted, remote branch is deleted by `--delete-branch`.
 - Stale branches (upstream gone, no worktree) are cleaned up by the ship flow.
+- After ship, `main` is checked out locally as a side-effect of cleanup. The next
+  unit of work must start with a fresh branch (`git switch -c ... origin/main`)
+  before any edits — see "Main-branch protection" above.
 
 ## Parallel development safety
 

--- a/plugins/devops/hooks/hooks.json
+++ b/plugins/devops/hooks/hooks.json
@@ -24,9 +24,16 @@
       },
       {
         "hooks": [
-          { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/pre-tool-use/pre.ship.guard.js" }
+          { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/pre-tool-use/pre.ship.guard.js" },
+          { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/pre-tool-use/pre.main.guard.js" }
         ],
         "matcher": "Bash"
+      },
+      {
+        "hooks": [
+          { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/pre-tool-use/pre.edit.branch.js" }
+        ],
+        "matcher": "Edit|Write|NotebookEdit"
       },
       {
         "hooks": [

--- a/plugins/devops/hooks/lib/ship-sentinel.js
+++ b/plugins/devops/hooks/lib/ship-sentinel.js
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+/**
+ * @module ship-sentinel
+ * @version 0.1.0
+ * @description Shared helper for the ship-in-progress sentinel file.
+ *   The sentinel lets Bash-scoped guards (pre.main.guard, pre.edit.branch)
+ *   know when the ship pipeline is running so Claude's Bash fallback retries
+ *   are not blocked while ship is legitimately touching main.
+ *
+ *   The file lives at <cwd>/.claude/.ship-in-progress and contains a JSON
+ *   payload with a timestamp + pid. It is stale after SENTINEL_MAX_AGE_MS
+ *   (15 min) to avoid deadlocks if cleanup never ran.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const SENTINEL_REL = path.join('.claude', '.ship-in-progress');
+const SENTINEL_MAX_AGE_MS = 15 * 60 * 1000;
+
+function sentinelPath(cwd) {
+  return path.join(cwd || process.cwd(), SENTINEL_REL);
+}
+
+function write(cwd) {
+  const p = sentinelPath(cwd);
+  try {
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, JSON.stringify({ ts: Date.now(), pid: process.pid }), 'utf8');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function clear(cwd) {
+  const p = sentinelPath(cwd);
+  try { fs.unlinkSync(p); return true; } catch { return false; }
+}
+
+function isActive(cwd) {
+  const p = sentinelPath(cwd);
+  try {
+    const raw = fs.readFileSync(p, 'utf8');
+    const data = JSON.parse(raw);
+    if (!data || typeof data.ts !== 'number') return false;
+    if (Date.now() - data.ts > SENTINEL_MAX_AGE_MS) {
+      try { fs.unlinkSync(p); } catch {}
+      return false;
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+module.exports = { write, clear, isActive, sentinelPath, SENTINEL_REL, SENTINEL_MAX_AGE_MS };

--- a/plugins/devops/hooks/pre-tool-use/pre.edit.branch.js
+++ b/plugins/devops/hooks/pre-tool-use/pre.edit.branch.js
@@ -20,6 +20,7 @@
 
 require('../lib/plugin-guard');
 
+const fs = require('fs');
 const path = require('path');
 const { execFileSync } = require('node:child_process');
 const { isActive: sentinelActive } = require('../lib/ship-sentinel');
@@ -51,10 +52,29 @@ function extractTargetPath(toolName, input) {
   return null;
 }
 
+function canonicalize(p) {
+  try { return fs.realpathSync.native(p); } catch { return null; }
+}
+
 function isInside(repoRoot, target) {
   if (!repoRoot || !target) return false;
   try {
-    const rel = path.relative(repoRoot, path.resolve(target));
+    const realRoot = canonicalize(repoRoot) || repoRoot;
+    const absTarget = path.resolve(target);
+    // Target may not exist yet (Write creates new files) — canonicalize the
+    // closest existing ancestor instead, so a symlinked parent is resolved.
+    let probe = absTarget;
+    let realTarget = canonicalize(probe);
+    while (!realTarget && probe !== path.dirname(probe)) {
+      probe = path.dirname(probe);
+      realTarget = canonicalize(probe);
+      if (realTarget) {
+        realTarget = path.join(realTarget, path.relative(probe, absTarget));
+        break;
+      }
+    }
+    if (!realTarget) realTarget = absTarget;
+    const rel = path.relative(realRoot, realTarget);
     return !rel.startsWith('..') && !path.isAbsolute(rel);
   } catch {
     return false;

--- a/plugins/devops/hooks/pre-tool-use/pre.edit.branch.js
+++ b/plugins/devops/hooks/pre-tool-use/pre.edit.branch.js
@@ -20,7 +20,6 @@
 
 require('../lib/plugin-guard');
 
-const fs = require('fs');
 const path = require('path');
 const { execFileSync } = require('node:child_process');
 const { isActive: sentinelActive } = require('../lib/ship-sentinel');

--- a/plugins/devops/hooks/pre-tool-use/pre.edit.branch.js
+++ b/plugins/devops/hooks/pre-tool-use/pre.edit.branch.js
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+/**
+ * @hook pre.edit.branch
+ * @version 0.1.0
+ * @event PreToolUse
+ * @plugin devops
+ * @matcher Edit|Write|NotebookEdit
+ * @description Prevent Edit/Write tool calls while HEAD is on local main/master.
+ *
+ *   Policy: new work always happens on a branch derived from origin/main.
+ *   Editing files directly on main is almost always an accident.
+ *
+ *   Bypass conditions (any one of them → exit 0):
+ *     - Not inside a git repo
+ *     - HEAD is NOT main/master
+ *     - Sentinel file .claude/.ship-in-progress exists (ship pipeline active)
+ *     - DEVOPS_ALLOW_MAIN=1 in environment
+ *     - Target path is outside the repo working tree (e.g. ~/.claude/**)
+ */
+
+require('../lib/plugin-guard');
+
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('node:child_process');
+const { isActive: sentinelActive } = require('../lib/ship-sentinel');
+
+function currentBranch(cwd) {
+  try {
+    return execFileSync('git', ['symbolic-ref', '--quiet', '--short', 'HEAD'], {
+      cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function gitTopLevel(cwd) {
+  try {
+    return execFileSync('git', ['rev-parse', '--show-toplevel'], {
+      cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function extractTargetPath(toolName, input) {
+  if (!input) return null;
+  if (toolName === 'Edit' || toolName === 'Write') return input.file_path || null;
+  if (toolName === 'NotebookEdit') return input.notebook_path || null;
+  return null;
+}
+
+function isInside(repoRoot, target) {
+  if (!repoRoot || !target) return false;
+  try {
+    const rel = path.relative(repoRoot, path.resolve(target));
+    return !rel.startsWith('..') && !path.isAbsolute(rel);
+  } catch {
+    return false;
+  }
+}
+
+let inputData = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', d => { inputData += d; });
+process.stdin.on('end', () => {
+  let hook;
+  try { hook = JSON.parse(inputData); } catch { process.exit(0); }
+
+  const toolName = hook.tool_name || '';
+  if (!['Edit', 'Write', 'NotebookEdit'].includes(toolName)) process.exit(0);
+
+  const target = extractTargetPath(toolName, hook.tool_input || {});
+  if (!target) process.exit(0);
+
+  const cwd = hook.cwd || process.cwd();
+
+  if (process.env.DEVOPS_ALLOW_MAIN === '1') process.exit(0);
+
+  const repoRoot = gitTopLevel(cwd);
+  if (!repoRoot) process.exit(0);
+
+  if (!isInside(repoRoot, target)) process.exit(0);
+
+  if (sentinelActive(repoRoot)) process.exit(0);
+
+  const branch = currentBranch(repoRoot);
+  if (!branch) process.exit(0);
+  if (branch !== 'main' && branch !== 'master') process.exit(0);
+
+  process.stderr.write(
+    `BLOCKED: Editing files on local '${branch}' is not allowed.\n` +
+    `Rule: New work always happens on a branch derived from origin/${branch}.\n` +
+    `Fix: git fetch origin && git switch -c <feat/topic> origin/${branch}  — then retry the edit.\n` +
+    `Bypass (only if the user explicitly asked to edit ${branch}): set env DEVOPS_ALLOW_MAIN=1 for this single action.\n`
+  );
+  process.exit(2);
+});

--- a/plugins/devops/hooks/pre-tool-use/pre.main.guard.js
+++ b/plugins/devops/hooks/pre-tool-use/pre.main.guard.js
@@ -37,6 +37,12 @@ const WRITE_PATTERNS = [
   /^\s*git\s+apply(\s|$)/,
   /^\s*git\s+am(\s|$)/,
   /^\s*git\s+push(\s|$)/,
+  /^\s*git\s+restore(\s|$)/,
+  /^\s*git\s+checkout\s+(--ours|--theirs|--patch|-p)(\s|$)/,
+  /^\s*git\s+checkout\s+.*\s--\s/,
+  /^\s*git\s+clean(\s|$)/,
+  /^\s*git\s+stash\s+(pop|drop|apply|clear)(\s|$)/,
+  /^\s*git\s+update-ref(\s|$)/,
 ];
 
 function currentBranch(cwd) {

--- a/plugins/devops/hooks/pre-tool-use/pre.main.guard.js
+++ b/plugins/devops/hooks/pre-tool-use/pre.main.guard.js
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+/**
+ * @hook pre.main.guard
+ * @version 0.1.0
+ * @event PreToolUse
+ * @plugin devops
+ * @matcher Bash
+ * @description Prevent accidental writes on local main/master.
+ *
+ *   Blocks Bash commands that would mutate main when HEAD is on main/master:
+ *     git commit, git merge, git rebase, git cherry-pick,
+ *     git push (any form targeting main), git reset --hard,
+ *     git revert, git apply, git am
+ *
+ *   Bypass conditions (any one of them → exit 0):
+ *     - Not inside a git repo
+ *     - HEAD is NOT main/master
+ *     - Sentinel file .claude/.ship-in-progress exists (ship pipeline active)
+ *     - DEVOPS_ALLOW_MAIN=1 in environment
+ *
+ *   Read-only git commands (status, log, diff, fetch, branch listing) pass
+ *   through untouched.
+ */
+
+require('../lib/plugin-guard');
+
+const { execFileSync } = require('node:child_process');
+const { isActive: sentinelActive } = require('../lib/ship-sentinel');
+
+const WRITE_PATTERNS = [
+  /^\s*git\s+commit(\s|$)/,
+  /^\s*git\s+merge(\s|$)/,
+  /^\s*git\s+rebase(\s|$)/,
+  /^\s*git\s+cherry-pick(\s|$)/,
+  /^\s*git\s+revert(\s|$)/,
+  /^\s*git\s+reset\s+--hard(\s|$)/,
+  /^\s*git\s+apply(\s|$)/,
+  /^\s*git\s+am(\s|$)/,
+  /^\s*git\s+push(\s|$)/,
+];
+
+function currentBranch(cwd) {
+  try {
+    return execFileSync('git', ['symbolic-ref', '--quiet', '--short', 'HEAD'], {
+      cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function isGitRepo(cwd) {
+  try {
+    execFileSync('git', ['rev-parse', '--is-inside-work-tree'], {
+      cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+let inputData = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', d => { inputData += d; });
+process.stdin.on('end', () => {
+  let hook;
+  try { hook = JSON.parse(inputData); } catch { process.exit(0); }
+
+  if ((hook.tool_name || '') !== 'Bash') process.exit(0);
+
+  const cmd = (hook.tool_input || {}).command || '';
+  if (!cmd) process.exit(0);
+
+  if (!WRITE_PATTERNS.some(re => re.test(cmd))) process.exit(0);
+
+  const cwd = hook.cwd || process.cwd();
+
+  if (process.env.DEVOPS_ALLOW_MAIN === '1') process.exit(0);
+  if (!isGitRepo(cwd)) process.exit(0);
+  if (sentinelActive(cwd)) process.exit(0);
+
+  const branch = currentBranch(cwd);
+  if (!branch) process.exit(0);
+  if (branch !== 'main' && branch !== 'master') process.exit(0);
+
+  process.stderr.write(
+    `BLOCKED: Write operation on local '${branch}' is not allowed.\n` +
+    `Rule: Never commit/merge/push directly on ${branch}. Work on a branch derived from origin/${branch} and land via /devops-ship.\n` +
+    `Fix: git fetch origin && git switch -c <feat/topic> origin/${branch}\n` +
+    `Bypass (only if the user explicitly asked to work on ${branch}): set env DEVOPS_ALLOW_MAIN=1 for this single command.\n`
+  );
+  process.exit(2);
+});

--- a/plugins/devops/mcp-server/ship/lib/sentinel.js
+++ b/plugins/devops/mcp-server/ship/lib/sentinel.js
@@ -1,0 +1,33 @@
+/**
+ * @module ship/lib/sentinel
+ * @description Writes/clears the ship-in-progress sentinel file.
+ *   Mirror of hooks/lib/ship-sentinel.js (CJS) for the MCP server (ESM).
+ *   Keep the SENTINEL_REL path in sync between both.
+ */
+
+import { mkdirSync, writeFileSync, unlinkSync } from "node:fs";
+import { join, dirname } from "node:path";
+
+export const SENTINEL_REL = ".claude/.ship-in-progress";
+
+export function sentinelPath(cwd) {
+  return join(cwd, ".claude", ".ship-in-progress");
+}
+
+export function writeSentinel(cwd) {
+  if (!cwd) return false;
+  const p = sentinelPath(cwd);
+  try {
+    mkdirSync(dirname(p), { recursive: true });
+    writeFileSync(p, JSON.stringify({ ts: Date.now(), pid: process.pid }), "utf8");
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function clearSentinel(cwd) {
+  if (!cwd) return false;
+  const p = sentinelPath(cwd);
+  try { unlinkSync(p); return true; } catch { return false; }
+}

--- a/plugins/devops/mcp-server/ship/tools/cleanup.js
+++ b/plugins/devops/mcp-server/ship/tools/cleanup.js
@@ -6,6 +6,7 @@
 
 import { z } from "zod";
 import { git, gitStrict, isWorktree, getWorktreeBranches } from "../lib/git.js";
+import { clearSentinel } from "../lib/sentinel.js";
 
 export const schema = z.object({
   branch: z.string().describe("Feature branch to delete"),
@@ -53,6 +54,7 @@ export async function handler(params) {
       gitStrict(`pull origin ${base}`, opts);
       cleaned.push(`checkout:${base}`);
     } catch (e) {
+      clearSentinel(cwd);
       return {
         success: false,
         error: `Failed to checkout ${base}: ${e.message}`,
@@ -103,6 +105,7 @@ export async function handler(params) {
     }
   }
 
+  clearSentinel(cwd);
   return {
     success: true,
     intermediate,

--- a/plugins/devops/mcp-server/ship/tools/cleanup.js
+++ b/plugins/devops/mcp-server/ship/tools/cleanup.js
@@ -24,6 +24,7 @@ export async function handler(params) {
 
   // Guard: refuse to run inside a worktree
   if (isWorktree(opts)) {
+    clearSentinel(cwd);
     return {
       success: false,
       error: "Still inside a worktree. Call ExitWorktree(action: 'remove') first, then retry ship_cleanup.",
@@ -35,6 +36,7 @@ export async function handler(params) {
   // Guard: refuse to delete a branch attached to an active worktree
   const worktreeBranches = getWorktreeBranches(opts);
   if (worktreeBranches.has(branch)) {
+    clearSentinel(cwd);
     return {
       success: false,
       error: `Branch '${branch}' is attached to an active worktree. Cannot delete — worktree session would break. Remove the worktree first (ExitWorktree action:'remove'), then retry.`,

--- a/plugins/devops/mcp-server/ship/tools/preflight.js
+++ b/plugins/devops/mcp-server/ship/tools/preflight.js
@@ -21,11 +21,6 @@ export async function handler(params) {
   const checks = [];
   const errors = [];
 
-  // Mark the ship pipeline as in-progress so pre.main.guard / pre.edit.branch
-  // hooks don't block ship internals when Claude falls back to Bash.
-  // Cleared by ship_cleanup (both success and failure paths).
-  writeSentinel(cwd);
-
   // 1. Current branch
   const branch = currentBranch(opts);
   if (!branch || branch === "HEAD") {
@@ -161,6 +156,12 @@ export async function handler(params) {
   );
 
   const ready = errors.length === 0;
+
+  // Mark the ship pipeline as in-progress only after all hard gates passed,
+  // so pre.main.guard / pre.edit.branch don't block ship internals when Claude
+  // falls back to Bash. Cleared by ship_cleanup on every exit path.
+  if (ready) writeSentinel(cwd);
+
   return {
     ready,
     branch,

--- a/plugins/devops/mcp-server/ship/tools/preflight.js
+++ b/plugins/devops/mcp-server/ship/tools/preflight.js
@@ -6,6 +6,7 @@
 import { z } from "zod";
 import { git, currentBranch, dirtyState, commitsAhead, unpushedCommits, isWorktree, detectParentBranch, branchExists, fileOverlap, getConfig } from "../lib/git.js";
 import { readVersion, verifyVersionFiles } from "../lib/version.js";
+import { writeSentinel } from "../lib/sentinel.js";
 
 export const schema = z.object({
   base: z.string().default("main").describe("Base branch to ship into (auto-detected from sub-branch naming if 'main')"),
@@ -19,6 +20,11 @@ export async function handler(params) {
   const opts = { cwd };
   const checks = [];
   const errors = [];
+
+  // Mark the ship pipeline as in-progress so pre.main.guard / pre.edit.branch
+  // hooks don't block ship internals when Claude falls back to Bash.
+  // Cleared by ship_cleanup (both success and failure paths).
+  writeSentinel(cwd);
 
   // 1. Current branch
   const branch = currentBranch(opts);

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to Gemma 4 E4B via llama.cpp to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

Three-layer protection against accidental work on local `main`/`master`:

1. **`pre.main.guard`** (Bash) — blocks destructive git ops on main: `commit|merge|rebase|cherry-pick|revert|reset --hard|apply|am|push|restore|stash pop/drop/apply/clear|update-ref|clean` and destructive `checkout` variants (`--ours`, `--theirs`, `-p`, `-- <path>`).
2. **`pre.edit.branch`** (Edit/Write/NotebookEdit) — blocks file edits inside the repo when HEAD is main. Canonicalizes symlinks so in-repo links pointing outside the repo don't bypass the containment check.
3. **Ship sentinel** (`.claude/.ship-in-progress`, 15 min TTL) — bypasses the guards during the ship pipeline itself. Written by `ship_preflight` only after all hard gates pass; cleared by `ship_cleanup` on every exit path (success + all failure branches).

Bypasses: not in a git repo, HEAD off main/master, sentinel active, or `DEVOPS_ALLOW_MAIN=1`.

Documented in `deep-knowledge/git-hygiene.md` under a new "Main-branch protection (hard rule)" section so agents and sub-agents inherit the policy.

## Why

Too many accidental commits / PRs / merges directly on local main. The guards enforce the rule "new work always starts from a branch derived from `origin/main`, only `/devops-ship` touches main."

## Review

Codex review (mandatory ship gate) surfaced 4 findings — 2 auto-fixable, 2 judgment-required — all fixed: extended WRITE_PATTERNS, symlink canonicalization, write-sentinel-after-gates, clear-sentinel-on-all-cleanup-paths. Two remaining items (per-run UUID ownership token, TTL heartbeat) deferred as known limitations; no real concurrency in current usage.

## Test plan

- [x] 12-case guard test suite (block on main, allow on feature, allow `git status/fetch`, sentinel active/stale, Write inside/outside repo, non-repo, env bypass) — all green
- [x] Regression suite for new WRITE_PATTERNS (`restore`, `checkout --ours`, `clean -fdx`, `stash pop`, `update-ref`) + Write-on-new-file-in-repo — all green
- [x] `npm run lint && npm run test` — clean, 89/89 tests pass
- [x] Ship-bootstrap runs correctly with guards already active on the feature branch