### PR TITLE
fix(card): drop redundant branch after merge + warn on missing cwd

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.48.0"
+    "version": "0.48.1"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.48.0",
+      "version": "0.48.1",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to Gemma 4 E4B via llama.cpp to save tokens.",
-      "version": "0.48.0",
+      "version": "0.48.1",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.48.1] — 2026-04-18
+
+### Fixed
+
+- **completion-card** — trailing branch segment is no longer duplicated when the card already says `merged → origin/<base>`. The `` `main` `` at the end of the state line after a merge to main was redundant. Branch segment is now suppressed when `state.merged && state.branch === state.merged`. Uses the raw `state.branch` (no `'main'` fallback) so a card without a known branch doesn't get silently stripped
+- **completion-card** — warn-log when the card would render without clickable links because `cwd` is missing (empty `repoUrl` + any of `pr`/`merged`/`commit`/`branch` set). Callers of `render_completion_card` should pass `cwd` pointing at the target repo; without it, `getRepoUrl` falls back to the MCP server's plugin dir and all links turn into plain text
+
+### Changed
+
+- **schema/render_completion_card** — `cwd` description tightened: "STRONGLY RECOMMENDED for ship-* variants — without it the card cannot render clickable PR/commit/branch links"
+- **skills/devops-ship** — Step 6 (Completion Card) now explicitly documents the `cwd` requirement and shows it in the example call
+
 ## [0.48.0] — 2026-04-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.48.0**
+**Version: 0.48.1**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.48.0",
+  "version": "0.48.1",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/mcp-server/index.js
+++ b/plugins/devops/mcp-server/index.js
@@ -317,9 +317,14 @@ function renderState(state, variant, repoUrl) {
 
   // Order: most important first — merge · PR · push · commit · branch
   // When merged, "pushed" is redundant (you can't merge without pushing)
+  // When branch equals the merge target, the trailing branch is also redundant
+  // (use raw state.branch — do NOT use the 'main' fallback, or a card with
+  // unknown branch would silently drop the segment when merged === 'main')
+  const rawBranch = state.branch;
   const segments = [mergeStr, prStr];
   if (!state.merged) segments.push(pushStr);
-  segments.push(commitStr, branchStr);
+  segments.push(commitStr);
+  if (!(state.merged && rawBranch && state.merged === rawBranch)) segments.push(branchStr);
   let line = icon + ' ' + segments.join(' \u00b7 ');
 
   if (state.appStatus === 'running')     line += ' \u00b7 app running';
@@ -413,6 +418,12 @@ function renderCard(input, meterText, buildId) {
   // Block B — End state (with extra blank line above for visual separation)
   if (config.state) {
     const repoUrl = getRepoUrl(input.cwd);
+    if (!repoUrl && input.state && (input.state.pr || input.state.merged || input.state.commit || input.state.branch)) {
+      console.warn(
+        '[dotclaude-completion-mcp] repoUrl empty — card will render without clickable links. ' +
+        'Pass cwd set to the target repo to fix.'
+      );
+    }
     const stateLine = renderState(input.state, variant, repoUrl);
     if (stateLine) {
       parts.push(stateLine);
@@ -715,7 +726,7 @@ server.registerTool(
       ]).describe("Card variant based on task outcome"),
       summary: z.string().max(80).describe("Max ~10 words, user's language"),
       lang: z.enum(["en", "de"]).default("de").describe("UI language for CTA"),
-      cwd: z.string().optional().describe("Working directory for build-ID computation (e.g. worktree path). Falls back to git toplevel if omitted."),
+      cwd: z.string().optional().describe("Working directory of the target repo. STRONGLY RECOMMENDED for ship-* variants — without it, getRepoUrl falls back to the MCP server's own cwd (plugin dir) and the card cannot render clickable PR/commit/branch links."),
       buildId: z.string().optional().describe("Pre-computed build-ID (from ship_build). If provided, skips internal computation. Use this when the worktree/branch state may have changed after building (e.g. post-merge)."),
       session_id: z.string().optional().describe("Session ID for flag writing"),
       changes: z.preprocess(

--- a/plugins/devops/skills/devops-ship/SKILL.md
+++ b/plugins/devops/skills/devops-ship/SKILL.md
@@ -274,13 +274,16 @@ If `success: false` → log warning but continue to Step 6. Cleanup failures are
 
 ## Step 6 — Completion Card
 
-Call `render_completion_card` MCP tool (dotclaude-completion server) with data from previous steps:
+Call `render_completion_card` MCP tool (dotclaude-completion server) with data from previous steps.
+
+**CRITICAL — `cwd` is required for clickable links.** Without `cwd`, `getRepoUrl` falls back to the MCP server's own working directory (plugin dir, not your target repo) and the card renders PR/commit/branch as plain text. Always pass the same `cwd` you used for the ship tools.
 
 ```
 render_completion_card({
   variant: "ship-successful",
   summary: "<~10 words, user's language>",
   lang: "de",
+  cwd: "<current working directory — same as ship_release>",
   buildId: <from ship_build.buildId>,
   changes: [<from ship_build/devops-ship_version_bump results>],
   tests: [<from ship_build results>],

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.48.0",
+  "version": "0.48.1",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to Gemma 4 E4B via llama.cpp to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

Two small refinements to the completion-card renderer surfaced after v0.48.0 ship:

1. **Trailing branch is redundant after merge.** The state line already says `merged → origin/main`, so appending `` · `main` `` at the end is noise. Suppressed when `state.merged && state.branch === state.merged`. Uses the raw `state.branch` (not the `'main'` fallback) to avoid stripping cards with unknown branch.
2. **Warn-log when `cwd` is missing.** Callers of `render_completion_card` must pass `cwd` pointing at the target repo — otherwise `getRepoUrl` falls back to the MCP server's own cwd (plugin dir) and the card renders PR/commit/branch as plain text. Now a `console.warn` makes this visible.

## Why

Last ship's card rendered `merged → origin/main · PR #103 … · 6f9d4c8 · ``main``` with zero clickable links — both because `cwd` wasn't passed and because the trailing `main` was redundant anyway. User noticed, asked to fix.

## Other

- Schema description of `cwd` in `render_completion_card` tightened.
- `skills/devops-ship` Step 6 now documents `cwd` as required for clickable links.

## Review

Codex gate: 2 findings, both fixed before commit — raw-branch skip guard, warn-level + branch guard on the log.

## Test plan

- [x] `npm run lint && npm run test` — 89/89 pass
- [x] This ship's completion card should render with clickable PR/commit links AND no trailing `main` segment (both fixes validated in-flight)