### PR TITLE
feat(local-llm): pivot to AnythingLLM + devops delegation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -19,7 +19,7 @@
     },
     {
       "name": "local-llm",
-      "description": "Local LLM integration — delegates mechanical coding tasks to Gemma 4 E4B via llama.cpp to save tokens.",
+      "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
       "version": "0.48.1",
       "author": {
         "name": "Jerry0022"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.48.1"
+    "version": "0.49.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.48.1",
+      "version": "0.49.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.48.1",
+      "version": "0.49.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ node_modules/
 .claude/token-config.json
 .claude/scheduled_tasks.lock
 .claude/usage-live.json
+.claude/.ship-in-progress
 # Plugin-managed runtime dirs
 .claude/.plugin-version
 .claude/hooks/

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ node_modules/
 .credentials.json
 *.env
 .env.*
+.claude/local-llm/config.json
 
 # OS
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [0.49.0] — 2026-04-18
+
+### Changed
+
+- **plugins/local-llm** — complete backend pivot from bundled `llama-server`/`llama.cpp` to a local **AnythingLLM Desktop** workspace. The plugin no longer manages any model itself; it speaks HTTP to the app's REST API on `http://localhost:3001`. Consumers must install AnythingLLM Desktop, generate an API key (Settings → Developer API), and run the new `local-llm-setup` skill to save it. The SessionStart hook runs a non-blocking 7-phase state machine (`ready | needs_api_key | not_installed | starting | network_blocked | auth_failed | configuring`) — a missing key or an offline backend never blocks the prompt
+
+### Added
+
+- **plugins/local-llm/hooks/lib/anythingllm-{http,lifecycle,config}.js** — shared CJS library consumed by both the SessionStart hook and the MCP server (via `createRequire` across the ESM boundary). HTTP client covers `/api/ping`, `/api/v1/auth`, workspaces, and OpenAI-compat completions. Windows lifecycle helpers detect 5 common install paths, check `tasklist`, and launch detached without `unref` surprises. Config layering: defaults → project → user; the API key is read **only** from the user layer (`~/.claude/local-llm/config.json`) to prevent accidental commits
+- **plugins/local-llm/skills/local-llm-setup** — interactive skill for first-time setup. Prompts the user for the API key in chat (without echoing), calls `scripts/save-api-key.js` to persist + verify, auto-creates the `claude-code` workspace, and reports the resulting phase
+- **plugins/local-llm/scripts/save-api-key.js** — CLI used by the setup skill. Writes the key, probes AnythingLLM, and emits a single JSON line with the current phase
+- **plugins/devops/deep-knowledge/local-llm-delegation.md** — new cross-cutting rule for all implementation agents. Defines the one-shot gate (`check-local-llm.js`), GREEN/RED tier matrix, and delegation prompt template
+- **plugins/devops/scripts/check-local-llm.js** — single-call JSON status probe with a 30s on-disk cache at `$TMP/dotclaude-local-llm-check.json`, so parallel agents do not all ping AnythingLLM simultaneously. Resolves the local-llm library from either the source repo or the installed cache
+- **plugins/devops/agents/{core,frontend,feature,ai}.md** — each gains `local_generate` + `local_status` in the tools whitelist and a one-line rule pointing to the new deep-knowledge doc
+
+### Removed
+
+- **plugins/local-llm** — old `llama-server` child-process management, GGUF auto-download chain (HF CLI / curl / PowerShell), idle-timer shutdown, Ollama sidecar launch, and the `llama-cpp.*` / `ollama.*` / `model.*` / `server.*` config fields. The model location, GPU offload, KV-cache quantization, and context size are now managed inside AnythingLLM's UI — outside this plugin's scope
+
 ## [0.48.1] — 2026-04-18
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.48.1**
+**Version: 0.49.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.48.1",
+  "version": "0.49.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/agents/ai.md
+++ b/plugins/devops/agents/ai.md
@@ -8,7 +8,7 @@ description: >-
 model: sonnet
 effort: medium
 color: magenta
-tools: ["Read", "Write", "Edit", "Bash", "Glob", "Grep", "WebSearch", "WebFetch"]
+tools: ["Read", "Write", "Edit", "Bash", "Glob", "Grep", "WebSearch", "WebFetch", "local_generate", "local_status"]
 ---
 
 # AI Agent
@@ -42,6 +42,7 @@ Your worktree starts on HEAD (main). You MUST rebase immediately:
 ## Rules
 
 - Read `{PLUGIN_ROOT}/deep-knowledge/pre-mortem.md` before non-trivial implementation.
+- For mechanical integration boilerplate (client DTOs, schema → type conversion, repeated wrappers, >20 lines): read `{PLUGIN_ROOT}/deep-knowledge/local-llm-delegation.md` and delegate to `local_generate` when the gate is green.
 - Always handle API rate limits and timeouts
 - Implement fallbacks for model unavailability
 - Never hardcode API keys — use environment variables

--- a/plugins/devops/agents/core.md
+++ b/plugins/devops/agents/core.md
@@ -8,7 +8,7 @@ description: >-
 model: sonnet
 effort: medium
 color: yellow
-tools: ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
+tools: ["Read", "Write", "Edit", "Bash", "Glob", "Grep", "local_generate", "local_status"]
 ---
 
 # Core Agent
@@ -42,6 +42,7 @@ Your worktree starts on HEAD (main). You MUST rebase immediately:
 ## Rules
 
 - Read `{PLUGIN_ROOT}/deep-knowledge/pre-mortem.md` before non-trivial implementation.
+- For mechanical code generation (DTOs, CRUD, schema, test boilerplate, >20 lines): read `{PLUGIN_ROOT}/deep-knowledge/local-llm-delegation.md` and delegate to `local_generate` when the gate is green.
 - Define interfaces/contracts before implementation
 - Commit contracts separately from implementation (clear git bisect point)
 - Never depend on frontend — frontend depends on core

--- a/plugins/devops/agents/feature.md
+++ b/plugins/devops/agents/feature.md
@@ -8,7 +8,7 @@ description: >-
   <example>Build the user settings page with backend and frontend</example>
 model: inherit
 color: cyan
-tools: ["Read", "Write", "Edit", "Bash", "Glob", "Grep", "Agent", "AskUserQuestion"]
+tools: ["Read", "Write", "Edit", "Bash", "Glob", "Grep", "Agent", "AskUserQuestion", "local_generate", "local_status"]
 ---
 
 # Feature Worker Agent
@@ -124,6 +124,7 @@ Agent({ subagent_type: "research", model: "sonnet", prompt: "..." })
 ## Rules
 
 - Read `{PLUGIN_ROOT}/deep-knowledge/pre-mortem.md` before non-trivial implementation.
+- When implementing mechanical code directly (not via sub-agent): read `{PLUGIN_ROOT}/deep-knowledge/local-llm-delegation.md` and delegate to `local_generate` when the gate is green.
 - Always work in a worktree (isolation: worktree)
 - Commit logical units, not mega-commits
 - Push before reporting completion

--- a/plugins/devops/agents/frontend.md
+++ b/plugins/devops/agents/frontend.md
@@ -8,7 +8,7 @@ description: >-
 model: sonnet
 effort: medium
 color: blue
-tools: ["Read", "Write", "Edit", "Bash", "Glob", "Grep", "preview_screenshot", "preview_snapshot"]
+tools: ["Read", "Write", "Edit", "Bash", "Glob", "Grep", "preview_screenshot", "preview_snapshot", "local_generate", "local_status"]
 ---
 
 # Frontend Agent
@@ -41,6 +41,7 @@ Your worktree starts on HEAD (main). You MUST rebase immediately:
 ## Rules
 
 - Read `{PLUGIN_ROOT}/deep-knowledge/pre-mortem.md` before non-trivial implementation.
+- For mechanical UI boilerplate (prop-typed components, form scaffolds, barrel exports, repeated variants, >20 lines): read `{PLUGIN_ROOT}/deep-knowledge/local-llm-delegation.md` and delegate to `local_generate` when the gate is green.
 - Always verify visual output with screenshots
 - Follow existing component patterns in the project
 - CSS changes need responsive verification

--- a/plugins/devops/deep-knowledge/INDEX.md
+++ b/plugins/devops/deep-knowledge/INDEX.md
@@ -19,6 +19,7 @@ Quick-reference for all deep-knowledge topics. Read this FIRST to find the right
 | [desktop-testing.md](desktop-testing.md) | Automated Desktop Testing (Computer Use) | Rules for when and how Claude takes over the desktop to run visual UI tests |
 | [fact-verification.md](fact-verification.md) | Fact Verification | Cross-cutting rule for all web research, claims, and statistics. |
 | [git-hygiene.md](git-hygiene.md) | Git Hygiene | Cross-cutting git rules referenced by `/devops-commit`, `/devops-ship`, and h... |
+| [local-llm-delegation.md](local-llm-delegation.md) | Local LLM Delegation | Cross-cutting rule for all implementation agents (core, frontend, feature, ai) |
 | [merge-safety.md](merge-safety.md) | Merge Safety — Parallel Development | Cross-cutting reference for preventing silent overwrites when multiple develo... |
 | [plugin-behavior.md](plugin-behavior.md) | Plugin Behavior Rules | Core behavioral rules enforced by the devops plugin. |
 | [pre-mortem.md](pre-mortem.md) | Pre-Mortem / Red-Team Self-Critique | Cross-cutting rule for reducing blind spots before non-trivial changes. |

--- a/plugins/devops/deep-knowledge/local-llm-delegation.md
+++ b/plugins/devops/deep-knowledge/local-llm-delegation.md
@@ -1,0 +1,65 @@
+# Local LLM Delegation
+
+Cross-cutting rule for all implementation agents (core, frontend, feature, ai)
+on when to delegate mechanical code generation to the local-llm plugin.
+
+## Gate (check once per agent session)
+
+Before the first write, probe the local backend ONCE:
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/check-local-llm.js"
+```
+
+Output is single-line JSON. Three shapes:
+
+- `{"ready": true, "tool": "local_generate"}` — delegation enabled for this session.
+- `{"ready": false, "phase": "needs_api_key" | "not_installed" | ...}` — skip delegation. Continue normally, write code directly. **Do not prompt the user or block** — the plugin signals the user separately.
+- `{"ready": false, "phase": "error"}` — probe failed. Skip delegation.
+
+Cache the answer in memory for the rest of the agent run. If `ready: false`, never call `local_generate` in this session.
+
+## When to delegate (GREEN tier — all conditions required)
+
+Delegate when ALL of these are true:
+
+1. **Mechanical.** Boilerplate, DTOs, test files from a pattern, CRUD, type defs, barrel files, enum lists, migration skeletons, serializers, fixture data.
+2. **Complete spec writable.** You can state signature + types + behavior in one paragraph without hedging.
+3. **Output > 20 lines.** Below that, writing directly is faster than prompt + review.
+4. **No cross-file reasoning.** The code is self-contained or follows a single pattern you can paste as context.
+5. **You will review the output.** Compile-check, type-check, spot-check the logic.
+
+## Never delegate (RED tier — always direct)
+
+- Debugging, root-cause analysis, log reading
+- Architectural decisions, multi-file refactors
+- Security-sensitive code (auth, crypto, input validation, SQL construction)
+- External API integration (the local model's API knowledge is stale)
+- Commit messages, PR descriptions, code review
+- Anything where the user's request is ambiguous
+
+## How to delegate
+
+Call the MCP tool directly — no wrapper:
+
+```
+local_generate({
+  task: "Precise, complete spec. Include language, signature, types, behavior.",
+  context: "Paste the one or two most relevant existing types/patterns (<2000 tokens).",
+  language: "typescript",
+  temperature: 0.2
+})
+```
+
+Then **review** the output:
+- Compiles / parses?
+- Types match the spec?
+- Edge cases not forgotten?
+- Style matches the rest of the file?
+
+If any check fails, fix it inline. Do NOT re-delegate for a fix — it is slower than editing the output yourself.
+
+## Reference
+
+Full decision matrix with GREEN/YELLOW/RED tables and prompt examples:
+`plugins/local-llm/deep-knowledge/delegation-rules.md`

--- a/plugins/devops/scripts/check-local-llm.js
+++ b/plugins/devops/scripts/check-local-llm.js
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+/**
+ * @script check-local-llm
+ * @version 0.1.0
+ * @plugin devops
+ * @description Single-call status probe for the local-llm plugin. Prints
+ *   one JSON line to stdout so implementation agents can decide whether
+ *   to delegate mechanical code generation.
+ *
+ *   Output shapes (stdout, single line):
+ *     {"ready":true,"tool":"local_generate","workspace":"<slug>"}
+ *     {"ready":false,"phase":"needs_api_key"|"not_installed"|...,"hint":"..."}
+ *     {"ready":false,"phase":"error","hint":"..."}
+ *
+ *   The result is cached on disk for 30 seconds so parallel agents hitting
+ *   this script do not all probe AnythingLLM simultaneously. Cache path:
+ *   <tmpdir>/dotclaude-local-llm-check.json
+ *
+ *   Exit code is always 0 — agents rely on the JSON, not the exit code.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const CACHE_PATH = path.join(os.tmpdir(), 'dotclaude-local-llm-check.json');
+const CACHE_TTL_MS = 30_000;
+
+function readCache() {
+  try {
+    const raw = fs.readFileSync(CACHE_PATH, 'utf8');
+    const obj = JSON.parse(raw);
+    if (obj && typeof obj.ts === 'number' && Date.now() - obj.ts < CACHE_TTL_MS && obj.result) {
+      return obj.result;
+    }
+  } catch { /* miss */ }
+  return null;
+}
+
+function writeCache(result) {
+  try {
+    fs.writeFileSync(CACHE_PATH, JSON.stringify({ ts: Date.now(), result }), 'utf8');
+  } catch { /* ignore */ }
+}
+
+function emit(obj) {
+  process.stdout.write(JSON.stringify(obj) + '\n');
+  process.exit(0);
+}
+
+(async () => {
+  const cached = readCache();
+  if (cached) emit(cached);
+
+  const libDir = resolveLocalLlmLib();
+  if (!libDir) {
+    const result = { ready: false, phase: 'not_installed', hint: 'local-llm plugin not found on disk.' };
+    writeCache(result);
+    emit(result);
+  }
+
+  let http, config;
+  try {
+    http = require(path.join(libDir, 'anythingllm-http.js'));
+    config = require(path.join(libDir, 'anythingllm-config.js'));
+  } catch (err) {
+    const result = { ready: false, phase: 'error', hint: `local-llm lib load failed: ${err.message}` };
+    writeCache(result);
+    emit(result);
+  }
+
+  const cfg = config.resolveConfig();
+  if (!config.hasApiKey(cfg)) {
+    const result = { ready: false, phase: 'needs_api_key', hint: 'Run the local-llm-setup skill.' };
+    writeCache(result);
+    emit(result);
+  }
+
+  const baseUrl = cfg.anythingllm?.baseUrl || 'http://localhost:3001';
+  const workspaceSlug = cfg.anythingllm?.workspaceSlug || 'claude-code';
+  const apiKey = cfg.anythingllm?.apiKey;
+
+  const health = await http.checkHealth(baseUrl);
+  if (!health.online) {
+    const result = { ready: false, phase: health.errorType === 'not_running' ? 'not_running' : 'network_blocked', hint: `AnythingLLM at ${baseUrl} not reachable: ${health.errorType}` };
+    writeCache(result);
+    emit(result);
+  }
+
+  const auth = await http.verifyAuth(baseUrl, apiKey);
+  if (!auth.valid) {
+    const result = { ready: false, phase: auth.errorType === 'auth_failed' ? 'auth_failed' : 'network_blocked', hint: `AnythingLLM auth failed: ${auth.error || auth.errorType}` };
+    writeCache(result);
+    emit(result);
+  }
+
+  const ws = await http.getWorkspaces(baseUrl, apiKey);
+  if (!ws.ok) {
+    const result = { ready: false, phase: 'network_blocked', hint: `Workspace list failed: ${ws.error || ws.errorType}` };
+    writeCache(result);
+    emit(result);
+  }
+
+  const exists = ws.workspaces.some((w) => w.slug === workspaceSlug);
+  if (!exists) {
+    const result = { ready: false, phase: 'configuring', hint: `Workspace "${workspaceSlug}" missing. Will auto-create on next SessionStart.` };
+    writeCache(result);
+    emit(result);
+  }
+
+  const result = { ready: true, tool: 'local_generate', workspace: workspaceSlug };
+  writeCache(result);
+  emit(result);
+})().catch((err) => {
+  emit({ ready: false, phase: 'error', hint: err.message });
+});
+
+function resolveLocalLlmLib() {
+  const sourceRepo = path.resolve(__dirname, '..', '..', 'local-llm', 'hooks', 'lib');
+  if (fs.existsSync(path.join(sourceRepo, 'anythingllm-http.js'))) return sourceRepo;
+
+  const installedRoot = path.resolve(os.homedir(), '.claude', 'plugins', 'cache', 'dotclaude', 'local-llm');
+  if (!fs.existsSync(installedRoot)) return null;
+
+  try {
+    const versions = fs.readdirSync(installedRoot).filter((v) => /^\d+\.\d+\.\d+$/.test(v));
+    versions.sort((a, b) => {
+      const [a1, a2, a3] = a.split('.').map(Number);
+      const [b1, b2, b3] = b.split('.').map(Number);
+      return (b1 - a1) || (b2 - a2) || (b3 - a3);
+    });
+    for (const v of versions) {
+      const libDir = path.join(installedRoot, v, 'hooks', 'lib');
+      if (fs.existsSync(path.join(libDir, 'anythingllm-http.js'))) return libDir;
+    }
+  } catch { /* ignore */ }
+  return null;
+}

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.48.1",
+  "version": "0.49.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "local-llm",
   "version": "0.48.1",
-  "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to Gemma 4 E4B via llama.cpp to save tokens without sacrificing quality.",
+  "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",
     "url": "https://github.com/Jerry0022"

--- a/plugins/local-llm/CONVENTIONS.md
+++ b/plugins/local-llm/CONVENTIONS.md
@@ -1,25 +1,42 @@
 # local-llm Plugin Conventions
 
 ## Purpose
-Token-saving plugin that delegates mechanical coding tasks to a local Gemma 4 E4B model.
+Token-saving plugin that delegates mechanical coding tasks to a local AnythingLLM Desktop workspace.
 Claude does the reasoning; the local LLM does the typing.
 
 ## Dependency
 Requires the **devops** plugin to be installed and enabled (shared heartbeat, MCP health check patterns).
+Requires **AnythingLLM Desktop** to be installed and configured by the user — the plugin does not
+bundle or manage any model itself.
 
 ## Config Resolution
-Project `.claude/local-llm/config.json` > Global `~/.claude/local-llm/config.json` > Plugin defaults `scripts/config.json`.
+Plugin defaults `scripts/config.json` → Project `.claude/local-llm/config.json` → User `~/.claude/local-llm/config.json`
+(later layers override earlier layers).
+
+**API key is ONLY read from the user layer** to prevent accidental commits. Project-level keys are ignored.
 
 ## Naming
 - Hook files: `{prefix}.llm.{action}.js` (e.g., `ss.llm.health.js`)
+- Shared library: `hooks/lib/anythingllm-*.js` (CJS, consumed by both hooks and the MCP server via `createRequire`)
 - MCP server name: `dotclaude-local-llm`
 - MCP tool prefix: `local_` (e.g., `local_generate`, `local_status`)
 - Deep-knowledge files: kebab-case, topic-focused
 
 ## Backend Lifecycle
-- llama-server is started lazily on first `local_generate` call
-- Auto-shutdown after configurable idle timeout (default 10 min)
-- PID tracked via heartbeat pattern (same as devops MCP servers)
+- The plugin does NOT spawn or kill any process. AnythingLLM Desktop is owned by the user.
+- SessionStart hook may launch AnythingLLM detached if installed but not running (`autoLaunch: true`).
+- The hook NEVER blocks the prompt: workspace creation, first-time launches, and model loading
+  all run async. The session continues and picks up the new state on the next SessionStart.
+
+## Phase States
+The SessionStart hook and `local_status` tool report one of:
+`ready | needs_api_key | not_installed | not_running | starting | network_blocked | auth_failed | configuring`.
+See `deep-knowledge/model-config.md` for the meaning of each.
+
+## Security
+- API key lives at `~/.claude/local-llm/config.json` (user-global, outside any repo).
+- Consumer projects that keep a project-level config MUST add `.claude/local-llm/config.json`
+  to their `.gitignore`. The plugin itself never writes a project-level config.
 
 ## Delegation Philosophy
 Claude ALWAYS reviews local LLM output before using it. The local LLM is a code generation accelerator, not an autonomous agent. See `deep-knowledge/delegation-rules.md` for the full decision matrix.

--- a/plugins/local-llm/deep-knowledge/INDEX.md
+++ b/plugins/local-llm/deep-knowledge/INDEX.md
@@ -5,5 +5,5 @@ Quick-reference for all deep-knowledge topics. Read this FIRST to find the right
 
 | File | Topic | Summary |
 |------|-------|---------|
-| [delegation-rules.md](delegation-rules.md) | LLM Delegation Rules | Decision matrix for when to delegate tasks to local Gemma 4 E4B vs. handle directly |
-| [model-config.md](model-config.md) | Model Configuration | Hardware specs, quantization guide, launch commands, troubleshooting for GTX 2080 Super |
+| [delegation-rules.md](delegation-rules.md) | LLM Delegation Rules | Decision matrix for when to delegate code generation to the local LLM vs. handle directly |
+| [model-config.md](model-config.md) | AnythingLLM Backend Configuration | Setup, config layering, phase reference, and troubleshooting for the AnythingLLM backend |

--- a/plugins/local-llm/deep-knowledge/delegation-rules.md
+++ b/plugins/local-llm/deep-knowledge/delegation-rules.md
@@ -1,7 +1,7 @@
 # Local LLM Delegation Rules
 
 Cross-cutting reference for when Claude should delegate code generation to the
-local Gemma 4 E4B model via `mcp__plugin_local-llm_dotclaude-local-llm__local_generate`.
+local model via `mcp__plugin_local-llm_dotclaude-local-llm__local_generate`.
 
 ## Philosophy
 
@@ -9,10 +9,12 @@ local Gemma 4 E4B model via `mcp__plugin_local-llm_dotclaude-local-llm__local_ge
 The local model is a fast code printer for mechanical tasks — it saves Claude's output
 tokens on work that doesn't need frontier-model intelligence.
 
-The local model (Gemma 4 E4B, ~4.5B effective parameters, Q4_K_M quantization) is:
+The backend is a local AnythingLLM Desktop workspace. The actual model is
+whatever AnythingLLM is configured to use (recommended: Ollama + `gemma4:e4b`).
+Broad capability assumptions:
 - **Good at:** Pattern completion, syntax, following exact specs, single-function code
 - **Bad at:** Multi-step reasoning, cross-file context, ambiguity resolution, API knowledge
-- **Context limit:** 8K tokens practical (model + KV cache in 8GB VRAM)
+- **Context limit:** assume ≈8K tokens practical — keep prompts tight
 
 ## Decision Matrix
 

--- a/plugins/local-llm/deep-knowledge/model-config.md
+++ b/plugins/local-llm/deep-knowledge/model-config.md
@@ -1,122 +1,105 @@
-# Model Configuration Reference — Gemma 4 E4B
+# Model Configuration Reference — AnythingLLM Backend
 
-Hardware-specific reference for running Gemma 4 E4B on consumer hardware.
+This plugin does not manage any model itself. The local LLM is owned by
+**AnythingLLM Desktop** — the user installs it once, generates an API key,
+and configures the underlying LLM inside the AnythingLLM UI. This plugin
+just speaks HTTP to the workspace.
 
-## Model Specs
+## Recommended setup
 
 | Property | Value |
 |----------|-------|
-| Architecture | Dense transformer (NOT MoE) |
-| Effective parameters | 4.5B |
-| Total parameters (incl. embeddings) | ~8B |
-| Layers | 42 |
-| Attention | Hybrid: sliding-window local (512 tokens) + global full-context |
-| Context window | 128K (theoretical), 8K-16K practical on 8GB VRAM |
-| Vocabulary | 262,144 tokens |
+| Backend app | AnythingLLM Desktop (https://anythingllm.com/download) |
+| LLM provider | Ollama |
+| Model | `gemma4:e4b` (≈4.5B effective params, dense transformer) |
+| Plugin workspace slug | `claude-code` |
+| API port | 3001 (AnythingLLM default) |
 
-## Quantization Guide (GTX 2080 Super — 8GB VRAM)
+The plugin auto-creates the `claude-code` workspace on first successful
+connect. Model choice, GPU offload, KV-cache quantization, and context size
+are all managed inside AnythingLLM's settings — outside this plugin's scope.
 
-Recommended quantizations sorted by quality:
+## One-time user steps
 
-| Quant | File Size | Fits 8GB VRAM? | Context headroom | Quality |
-|-------|-----------|-----------------|------------------|---------|
-| Q5_K_M | 5.82 GB | Yes (1.5 GB free) | 4K-8K tokens | High — best quality that fits |
-| **Q4_K_M** | **5.41 GB** | **Yes (2 GB free)** | **8K-12K tokens** | **Good — recommended default** |
-| Q4_K_S | 5.24 GB | Yes (2.5 GB free) | 8K-16K tokens | Slightly lower |
-| IQ4_XS | 5.11 GB | Yes (2.5 GB free) | 8K-20K tokens | Decent, very compact |
-| Q8_0 | 8.03 GB | NO — needs split | Requires -ngl 36 | Excellent but slow on split |
+1. Install AnythingLLM Desktop.
+2. Open it → Settings → **Developer API** → **Generate API Key**.
+3. Provider setup: pick **Ollama**, let AnythingLLM pull `gemma4:e4b` (or
+   select another model if the user prefers; the plugin does not enforce).
+4. Run the `local-llm-setup` skill in Claude Code to save the API key.
 
-**Primary recommendation: Q4_K_M** — best balance of quality, speed, and context headroom.
+## Config layering
 
-## llama-server Launch Commands
+Configuration is resolved in three layers (later overrides earlier):
 
-### Default (Q4_K_M, full GPU, 8K context):
-```bash
-llama-server -m /path/to/gemma-4-E4B-it-Q4_K_M.gguf -ngl 99 -c 8192 --host 127.0.0.1 --port 8787
-```
+1. Plugin defaults — `plugins/local-llm/scripts/config.json`
+2. Project config — `<cwd>/.claude/local-llm/config.json`
+3. User config — `~/.claude/local-llm/config.json`
 
-### Larger context with KV cache quantization (16K context):
-```bash
-llama-server -m /path/to/gemma-4-E4B-it-Q4_K_M.gguf -ngl 99 -c 16384 --ctk q4_0 --ctv q4_0 --host 127.0.0.1 --port 8787
-```
+The **API key is only read from the user layer** to prevent accidental commits.
+The setup skill always writes to the user layer.
 
-### Higher quality (Q5_K_M, less context headroom):
-```bash
-llama-server -m /path/to/gemma-4-E4B-it-Q5_K_M.gguf -ngl 99 -c 8192 --host 127.0.0.1 --port 8787
-```
+## Minimal user config (written by `local-llm-setup`)
 
-## Plugin Config Examples
-
-### Minimal config (`~/.claude/local-llm/config.json`):
 ```json
 {
-  "llama-cpp": {
-    "modelPath": "C:/models/gemma4-e4b/google_gemma-4-E4B-it-Q4_K_M.gguf"
+  "anythingllm": {
+    "apiKey": "ANYTHINGLLM-xxxxxxxxxxxxxxxxxxxxxxxx"
   }
 }
 ```
 
-### Full config with KV cache quantization:
+## Full config reference
+
 ```json
 {
-  "llama-cpp": {
-    "modelPath": "C:/models/gemma4-e4b/google_gemma-4-E4B-it-Q4_K_M.gguf",
-    "gpuLayers": 99,
-    "contextSize": 16384,
-    "kvCacheQuantK": "q4_0",
-    "kvCacheQuantV": "q4_0"
+  "anythingllm": {
+    "baseUrl": "http://localhost:3001",
+    "apiKey": "",
+    "workspaceSlug": "claude-code",
+    "workspaceName": "Claude Code",
+    "autoLaunch": true,
+    "launchTimeoutMs": 30000,
+    "pollIntervalMs": 1000
   },
-  "server": {
-    "port": 8787,
-    "idleShutdownMs": 600000
+  "generation": {
+    "temperature": 0.2,
+    "maxTokens": 4096
   }
 }
 ```
 
-### Ollama backend:
-```json
-{
-  "backend": "ollama",
-  "ollama": {
-    "model": "gemma4:e4b"
-  }
-}
-```
+| Field | Purpose |
+|-------|---------|
+| `baseUrl` | AnythingLLM API root. Keep default unless the app runs on a different port/host. |
+| `apiKey` | User-global secret. Only read from `~/.claude/local-llm/config.json`. |
+| `workspaceSlug` | Workspace the plugin talks to. Auto-created if missing. |
+| `autoLaunch` | If true, the SessionStart hook launches AnythingLLM when installed but not running. |
+| `launchTimeoutMs` | How long the hook waits for the API to become reachable after launch (advisory; the hook itself never blocks the prompt). |
+| `generation.temperature` | Default sampling temperature for `local_generate`. Keep ≤ 0.5 for code. |
+| `generation.maxTokens` | Upper bound on completion length. |
 
-**Ollama on Turing GPUs (GTX 2080 Super):** Set `OLLAMA_FLASH_ATTENTION=false` environment
-variable to avoid a known GPU crash bug. The plugin's MCP server handles this automatically
-when starting Ollama as a child process.
+## Phase reference
 
-## Performance Expectations (GTX 2080 Super)
+The SessionStart hook and `local_status` tool return one of these phases:
 
-| Quant | Throughput (est.) | First token | Note |
-|-------|-------------------|-------------|------|
-| Q4_K_M (full GPU) | 20-35 tok/s | ~200ms | Best speed |
-| Q5_K_M (full GPU) | 18-30 tok/s | ~250ms | Slightly slower, better quality |
-| Q8_0 (split -ngl 36) | 10-20 tok/s | ~400ms | Not recommended |
-
-Model load time (cold start): 10-30 seconds. Subsequent requests are instant.
-
-## Download Commands
-
-```bash
-# Q4_K_M (recommended)
-huggingface-cli download bartowski/google_gemma-4-E4B-it-GGUF \
-  --include "google_gemma-4-E4B-it-Q4_K_M.gguf" \
-  --local-dir C:/models/gemma4-e4b
-
-# Q5_K_M (higher quality)
-huggingface-cli download bartowski/google_gemma-4-E4B-it-GGUF \
-  --include "google_gemma-4-E4B-it-Q5_K_M.gguf" \
-  --local-dir C:/models/gemma4-e4b
-```
+| Phase | Meaning |
+|-------|---------|
+| `ready` | All systems go. `local_generate` is usable. |
+| `needs_api_key` | No key saved yet. Run `local-llm-setup`. |
+| `not_installed` | AnythingLLM Desktop not found on disk. |
+| `not_running` | Installed but process not up, and `autoLaunch` is disabled. |
+| `starting` | Just launched; API not yet responding. Retry on next SessionStart. |
+| `network_blocked` | Process up, but `/api/ping` fails. Enable Network Discovery in AnythingLLM Settings → API. |
+| `auth_failed` | API key rejected. Re-run setup. |
+| `configuring` | API reachable, workspace missing. Creation triggered in background. |
+| `request_failed` | A completion call failed mid-flight (MCP-only). |
 
 ## Troubleshooting
 
 | Symptom | Cause | Fix |
 |---------|-------|-----|
-| CUDA out of memory | Model + KV cache exceeds 8GB | Reduce `-c` or use smaller quant |
-| Very slow generation | Layers on CPU (split inference) | Ensure `-ngl 99` with Q4_K_M or Q5_K_M |
-| Ollama GPU crash (Xid 43/31) | Flash Attention bug on Turing | Set `OLLAMA_FLASH_ATTENTION=false` |
-| Empty/garbage output | Temperature too high | Use temperature 0.1-0.3 for code |
-| Truncated output | max_tokens too low | Increase generation.maxTokens in config |
+| `needs_api_key` loops | Key saved to a project-level config | Move it to `~/.claude/local-llm/config.json` |
+| `network_blocked` while app is open | AnythingLLM Settings → API has network access off | Toggle it on |
+| Slow first completion | Ollama is loading the model into VRAM | One-time — subsequent calls are fast |
+| `auth_failed` after a working day | User regenerated the key in AnythingLLM UI | Re-run `local-llm-setup` |
+| Garbage or truncated output | `temperature` too high or `maxTokens` too low | Adjust `generation.*` in user config |

--- a/plugins/local-llm/hooks/lib/anythingllm-config.js
+++ b/plugins/local-llm/hooks/lib/anythingllm-config.js
@@ -1,0 +1,86 @@
+/**
+ * @module anythingllm-config
+ * @version 0.1.0
+ * @plugin local-llm
+ * @description Config resolution for the local-llm plugin.
+ *   Layer order (later overrides earlier):
+ *     1. plugin defaults  — plugins/local-llm/scripts/config.json
+ *     2. project config   — <cwd>/.claude/local-llm/config.json
+ *     3. user config      — ~/.claude/local-llm/config.json
+ *
+ *   The API key is ONLY read from the user layer. Project-level API keys
+ *   are ignored to prevent accidental commits. The user config path is
+ *   also where the setup skill writes the key.
+ *
+ *   Fixed model: AnythingLLM manages the underlying LLM via its workspace
+ *   settings — the user picks Ollama + gemma4:e4b once in the AnythingLLM
+ *   UI during setup. This plugin only addresses workspaces, not models.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const PLUGIN_ROOT = process.env.CLAUDE_PLUGIN_ROOT || path.resolve(__dirname, '..', '..');
+const USER_CONFIG_DIR = path.join(os.homedir(), '.claude', 'local-llm');
+const USER_CONFIG_PATH = path.join(USER_CONFIG_DIR, 'config.json');
+
+function readJson(p) {
+  try { return JSON.parse(fs.readFileSync(p, 'utf8')); } catch { return {}; }
+}
+
+function deepMerge(base, layer) {
+  if (!layer || typeof layer !== 'object') return base;
+  const out = { ...base };
+  for (const [k, v] of Object.entries(layer)) {
+    if (v && typeof v === 'object' && !Array.isArray(v) && out[k] && typeof out[k] === 'object') {
+      out[k] = deepMerge(out[k], v);
+    } else {
+      out[k] = v;
+    }
+  }
+  return out;
+}
+
+function resolveConfig() {
+  const defaults = readJson(path.join(PLUGIN_ROOT, 'scripts', 'config.json'));
+  const project = readJson(path.join(process.cwd(), '.claude', 'local-llm', 'config.json'));
+  const user = readJson(USER_CONFIG_PATH);
+
+  let merged = deepMerge(defaults, project);
+  merged = deepMerge(merged, user);
+
+  merged.anythingllm = merged.anythingllm || {};
+  if (project?.anythingllm?.apiKey) {
+    merged.anythingllm.apiKey = user?.anythingllm?.apiKey || '';
+  }
+
+  return merged;
+}
+
+function saveApiKey(apiKey) {
+  try { fs.mkdirSync(USER_CONFIG_DIR, { recursive: true }); } catch { /* ignore */ }
+  const existing = readJson(USER_CONFIG_PATH);
+  const next = {
+    ...existing,
+    anythingllm: { ...(existing.anythingllm || {}), apiKey },
+  };
+  fs.writeFileSync(USER_CONFIG_PATH, JSON.stringify(next, null, 2), 'utf8');
+  return USER_CONFIG_PATH;
+}
+
+function hasApiKey(config) {
+  const key = config?.anythingllm?.apiKey;
+  return typeof key === 'string' && key.trim().length > 0;
+}
+
+module.exports = {
+  resolveConfig,
+  saveApiKey,
+  hasApiKey,
+  USER_CONFIG_PATH,
+  USER_CONFIG_DIR,
+  PLUGIN_ROOT,
+};

--- a/plugins/local-llm/hooks/lib/anythingllm-http.js
+++ b/plugins/local-llm/hooks/lib/anythingllm-http.js
@@ -1,0 +1,157 @@
+/**
+ * @module anythingllm-http
+ * @version 0.1.0
+ * @plugin local-llm
+ * @description Minimal HTTP client for AnythingLLM's REST API.
+ *   CommonJS, Node builtins only. Consumed by both the SessionStart hook
+ *   and the MCP server (via createRequire from ESM).
+ *
+ *   API endpoints:
+ *     GET  /api/ping                         — no auth, health probe
+ *     GET  /api/v1/auth                      — Bearer, validates the API key
+ *     GET  /api/v1/workspaces                — Bearer, list workspaces
+ *     POST /api/v1/workspace/new             — Bearer, create workspace
+ *     POST /api/v1/openai/chat/completions   — Bearer, OpenAI-compat completion
+ */
+
+'use strict';
+
+const http = require('node:http');
+const https = require('node:https');
+const { URL } = require('node:url');
+
+const HEALTH_TIMEOUT_MS = 2000;
+const REQUEST_TIMEOUT_MS = 60_000;
+const COMPLETION_TIMEOUT_MS = 120_000;
+
+function requestJson({ baseUrl, path, method = 'GET', apiKey, body, timeoutMs = REQUEST_TIMEOUT_MS }) {
+  return new Promise((resolve) => {
+    let parsed;
+    try {
+      parsed = new URL(path, baseUrl);
+    } catch {
+      resolve({ ok: false, errorType: 'bad_url', error: `Invalid URL: ${baseUrl}${path}` });
+      return;
+    }
+
+    const payload = body ? JSON.stringify(body) : null;
+    const headers = { Accept: 'application/json' };
+    if (payload) {
+      headers['Content-Type'] = 'application/json';
+      headers['Content-Length'] = Buffer.byteLength(payload);
+    }
+    if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+
+    const lib = parsed.protocol === 'https:' ? https : http;
+    const req = lib.request(
+      {
+        protocol: parsed.protocol,
+        hostname: parsed.hostname,
+        port: parsed.port || (parsed.protocol === 'https:' ? 443 : 80),
+        path: parsed.pathname + parsed.search,
+        method,
+        headers,
+        timeout: timeoutMs,
+      },
+      (res) => {
+        const chunks = [];
+        res.on('data', (c) => chunks.push(c));
+        res.on('end', () => {
+          const raw = Buffer.concat(chunks).toString('utf8');
+          let data = null;
+          try { data = raw ? JSON.parse(raw) : null; } catch { data = raw; }
+          resolve({
+            ok: res.statusCode >= 200 && res.statusCode < 300,
+            status: res.statusCode,
+            data,
+          });
+        });
+      }
+    );
+
+    req.on('timeout', () => {
+      req.destroy();
+      resolve({ ok: false, errorType: 'timeout', error: `Timeout after ${timeoutMs}ms` });
+    });
+
+    req.on('error', (err) => {
+      const code = err.code || '';
+      let errorType = 'network_unreachable';
+      if (code === 'ECONNREFUSED') errorType = 'not_running';
+      else if (code === 'ENOTFOUND' || code === 'EAI_AGAIN') errorType = 'host_not_found';
+      else if (code === 'ETIMEDOUT') errorType = 'timeout';
+      resolve({ ok: false, errorType, error: err.message });
+    });
+
+    if (payload) req.write(payload);
+    req.end();
+  });
+}
+
+async function checkHealth(baseUrl) {
+  const res = await requestJson({ baseUrl, path: '/api/ping', timeoutMs: HEALTH_TIMEOUT_MS });
+  if (res.ok) return { online: true };
+  return { online: false, errorType: res.errorType || 'unknown', error: res.error };
+}
+
+async function verifyAuth(baseUrl, apiKey) {
+  if (!apiKey) return { valid: false, errorType: 'missing_api_key' };
+  const res = await requestJson({ baseUrl, path: '/api/v1/auth', apiKey, timeoutMs: HEALTH_TIMEOUT_MS });
+  if (res.ok) return { valid: true };
+  if (res.status === 401 || res.status === 403) return { valid: false, errorType: 'auth_failed' };
+  return { valid: false, errorType: res.errorType || 'unknown', error: res.error };
+}
+
+async function getWorkspaces(baseUrl, apiKey) {
+  const res = await requestJson({ baseUrl, path: '/api/v1/workspaces', apiKey });
+  if (!res.ok) return { ok: false, errorType: res.errorType || 'unknown', error: res.error, status: res.status };
+  const list = Array.isArray(res.data?.workspaces) ? res.data.workspaces : [];
+  return { ok: true, workspaces: list };
+}
+
+async function createWorkspace(baseUrl, apiKey, name) {
+  const res = await requestJson({
+    baseUrl,
+    path: '/api/v1/workspace/new',
+    method: 'POST',
+    apiKey,
+    body: { name },
+  });
+  if (!res.ok) return { ok: false, errorType: res.errorType || 'unknown', error: res.error, status: res.status };
+  return { ok: true, workspace: res.data?.workspace || null };
+}
+
+async function chatCompletion(baseUrl, apiKey, { workspaceSlug, messages, temperature = 0.2, maxTokens = 4096 }) {
+  const res = await requestJson({
+    baseUrl,
+    path: '/api/v1/openai/chat/completions',
+    method: 'POST',
+    apiKey,
+    timeoutMs: COMPLETION_TIMEOUT_MS,
+    body: {
+      model: workspaceSlug,
+      messages,
+      temperature,
+      max_tokens: maxTokens,
+      stream: false,
+    },
+  });
+  if (!res.ok) {
+    return { ok: false, errorType: res.errorType || 'http_error', status: res.status, error: res.error || res.data };
+  }
+  const choice = res.data?.choices?.[0];
+  return {
+    ok: true,
+    content: choice?.message?.content || '',
+    finishReason: choice?.finish_reason || 'unknown',
+    tokensUsed: res.data?.usage?.total_tokens ?? null,
+  };
+}
+
+module.exports = {
+  checkHealth,
+  verifyAuth,
+  getWorkspaces,
+  createWorkspace,
+  chatCompletion,
+};

--- a/plugins/local-llm/hooks/lib/anythingllm-lifecycle.js
+++ b/plugins/local-llm/hooks/lib/anythingllm-lifecycle.js
@@ -1,0 +1,80 @@
+/**
+ * @module anythingllm-lifecycle
+ * @version 0.1.0
+ * @plugin local-llm
+ * @description Windows lifecycle helpers for AnythingLLM Desktop.
+ *   Detects an existing installation, checks whether the process is running,
+ *   and launches it detached. Does NOT wait for readiness — polling is done
+ *   by the caller via anythingllm-http.checkHealth.
+ *
+ *   All helpers return plain data structures; no throws.
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const { spawn, execFileSync } = require('node:child_process');
+
+const DOWNLOAD_URL = 'https://anythingllm.com/download';
+
+function candidatePaths() {
+  const home = os.homedir();
+  const localAppData = process.env.LOCALAPPDATA || path.join(home, 'AppData', 'Local');
+  const programFiles = process.env.ProgramFiles || 'C:\\Program Files';
+  const programFilesX86 = process.env['ProgramFiles(x86)'] || 'C:\\Program Files (x86)';
+
+  return [
+    path.join(localAppData, 'Programs', 'anythingllm-desktop', 'AnythingLLM.exe'),
+    path.join(localAppData, 'Programs', 'AnythingLLMDesktop', 'AnythingLLM.exe'),
+    path.join(localAppData, 'AnythingLLM', 'AnythingLLM.exe'),
+    path.join(programFiles, 'AnythingLLM', 'AnythingLLM.exe'),
+    path.join(programFilesX86, 'AnythingLLM', 'AnythingLLM.exe'),
+  ];
+}
+
+function detectInstallation() {
+  for (const p of candidatePaths()) {
+    try {
+      if (fs.existsSync(p)) return { installed: true, path: p };
+    } catch { /* ignore */ }
+  }
+  return { installed: false, path: null, downloadUrl: DOWNLOAD_URL };
+}
+
+function isProcessRunning() {
+  if (process.platform !== 'win32') return false;
+  try {
+    const out = execFileSync(
+      'tasklist',
+      ['/FI', 'IMAGENAME eq AnythingLLM.exe', '/NH'],
+      { encoding: 'utf8', timeout: 3000 }
+    );
+    return /AnythingLLM\.exe/i.test(out);
+  } catch {
+    return false;
+  }
+}
+
+function launch(exePath) {
+  try {
+    const child = spawn(exePath, [], {
+      detached: true,
+      stdio: 'ignore',
+      windowsHide: false,
+    });
+    child.unref();
+    return { ok: true, pid: child.pid };
+  } catch (err) {
+    return { ok: false, error: err.message };
+  }
+}
+
+module.exports = {
+  candidatePaths,
+  detectInstallation,
+  isProcessRunning,
+  launch,
+  DOWNLOAD_URL,
+};

--- a/plugins/local-llm/hooks/session-start/ss.llm.health.js
+++ b/plugins/local-llm/hooks/session-start/ss.llm.health.js
@@ -4,275 +4,153 @@
  * @version 0.2.0
  * @event SessionStart
  * @plugin local-llm
- * @description Check local LLM backend availability, auto-download model if
- *   missing, and inject delegation instructions into Claude's context.
+ * @description AnythingLLM health probe + non-blocking auto-setup.
  *
- *   Auto-download chain (tries in order):
- *   1. huggingface-cli download (resumable, verified)
- *   2. curl -L -C - (resumable, via Git for Windows)
- *   3. PowerShell Invoke-WebRequest (always available on Windows)
+ *   State machine (first match wins):
+ *     1. needs_api_key     — no API key in user config
+ *     2. not_installed     — AnythingLLM binary not found on disk
+ *     3. starting          — binary found, process absent or API not yet up;
+ *                             launch detached, return immediately
+ *     4. network_blocked   — process running but HTTP unreachable past timeout
+ *     5. auth_failed       — /api/v1/auth returned 401/403
+ *     6. configuring       — API reachable, workspace missing; create async
+ *     7. ready             — API reachable, workspace present → tool enabled
  *
- *   Model is cached in ~/.claude/local-llm/models/ so it persists across sessions.
+ *   The hook NEVER blocks the prompt for long-running work. Model loading,
+ *   workspace creation, and first-time app launches run async in the
+ *   background; the current session continues and picks up the new state on
+ *   the next SessionStart.
  *
  *   Stdout → injected into Claude's context as system instructions.
- *   Stderr → shown in hook output (collapsed).
+ *   Stderr → shown collapsed under the hook output.
  */
+
+'use strict';
 
 require('../lib/plugin-guard');
 
-const fs = require('fs');
-const path = require('path');
-const os = require('os');
-const http = require('http');
-const { execSync } = require('child_process');
+const http = require('../lib/anythingllm-http');
+const lifecycle = require('../lib/anythingllm-lifecycle');
+const { resolveConfig, hasApiKey, USER_CONFIG_PATH } = require('../lib/anythingllm-config');
 
-// ---------------------------------------------------------------------------
-// Config resolution
-// ---------------------------------------------------------------------------
+const CONFIG = resolveConfig();
+const BASE_URL = CONFIG.anythingllm?.baseUrl || 'http://localhost:3001';
+const WORKSPACE_SLUG = CONFIG.anythingllm?.workspaceSlug || 'claude-code';
+const WORKSPACE_NAME = CONFIG.anythingllm?.workspaceName || 'Claude Code';
+const AUTO_LAUNCH = CONFIG.anythingllm?.autoLaunch !== false;
+const API_KEY = CONFIG.anythingllm?.apiKey || '';
 
-function readJson(p) {
-  try { return JSON.parse(fs.readFileSync(p, 'utf8')); } catch { return {}; }
+function emit(phase, instructions) {
+  process.stdout.write(`[local-llm] phase: ${phase}\n${instructions}\n`);
 }
 
-const PLUGIN_ROOT = process.env.CLAUDE_PLUGIN_ROOT || path.resolve(__dirname, '../..');
-const defaults = readJson(path.join(PLUGIN_ROOT, 'scripts', 'config.json'));
-const globalCfg = readJson(path.join(os.homedir(), '.claude', 'local-llm', 'config.json'));
-const projectCfg = readJson(path.join(process.cwd(), '.claude', 'local-llm', 'config.json'));
-
-const backend = projectCfg.backend || globalCfg.backend || defaults.backend || 'llama-cpp';
-const port = projectCfg.server?.port || globalCfg.server?.port || defaults.server?.port || 8787;
-const host = projectCfg.server?.host || globalCfg.server?.host || defaults.server?.host || '127.0.0.1';
-
-const configuredModelPath = projectCfg['llama-cpp']?.modelPath || globalCfg['llama-cpp']?.modelPath || defaults['llama-cpp']?.modelPath;
-const ollamaModel = projectCfg.ollama?.model || globalCfg.ollama?.model || defaults.ollama?.model || 'gemma4:e4b';
-
-// Model download metadata
-const modelRepo = projectCfg.model?.repo || globalCfg.model?.repo || defaults.model?.repo || 'bartowski/google_gemma-4-E4B-it-GGUF';
-const modelFile = projectCfg.model?.file || globalCfg.model?.file || defaults.model?.file || 'google_gemma-4-E4B-it-Q4_K_M.gguf';
-const modelDisplayName = projectCfg.model?.displayName || globalCfg.model?.displayName || defaults.model?.displayName || 'Gemma 4 E4B Q4_K_M';
-
-// Cache directory for auto-downloaded models
-const MODEL_CACHE_DIR = path.join(os.homedir(), '.claude', 'local-llm', 'models');
-const CACHED_MODEL_PATH = path.join(MODEL_CACHE_DIR, modelFile);
-
-// ---------------------------------------------------------------------------
-// Model path resolution: configured > cached > download
-// ---------------------------------------------------------------------------
-
-function resolveModelPath() {
-  // 1. Explicitly configured path
-  if (configuredModelPath && fs.existsSync(configuredModelPath)) {
-    return { path: configuredModelPath, source: 'config' };
-  }
-
-  // 2. Cached download
-  if (fs.existsSync(CACHED_MODEL_PATH)) {
-    const stat = fs.statSync(CACHED_MODEL_PATH);
-    // Reject suspiciously small files (incomplete downloads)
-    if (stat.size > 1_000_000_000) {
-      return { path: CACHED_MODEL_PATH, source: 'cache' };
-    }
-    // Incomplete file — will re-download (resume if tool supports it)
-    console.error(`[local-llm] Cached model file too small (${(stat.size / 1e9).toFixed(2)} GB) — likely incomplete, re-downloading`);
-  }
-
-  return null;
+function disabledHint(reason) {
+  return (
+    `[local-llm] ${reason}\n` +
+    `Delegation to local_generate is UNAVAILABLE this session. ` +
+    `Continue normally — this does not block your current work.\n`
+  );
 }
 
-// ---------------------------------------------------------------------------
-// Auto-download: try huggingface-cli → curl → PowerShell
-// ---------------------------------------------------------------------------
-
-function hasCommand(cmd) {
-  try {
-    execSync(`where ${cmd}`, { stdio: 'pipe', timeout: 5000 });
-    return true;
-  } catch {
-    return false;
-  }
+function readyInstructions() {
+  return (
+    `[local-llm] Local LLM is ready via mcp__plugin_local-llm_dotclaude-local-llm__local_generate.\n` +
+    `Backend: AnythingLLM @ ${BASE_URL}, workspace "${WORKSPACE_SLUG}".\n` +
+    `\n` +
+    `Quick rules — delegate to local_generate ONLY when ALL are true:\n` +
+    `  1. Mechanical code generation (boilerplate, DTOs, test files, CRUD, type defs)\n` +
+    `  2. Complete, unambiguous spec writable (signature + types + behavior)\n` +
+    `  3. Output > 20 lines (below that, writing directly is faster)\n` +
+    `  4. No cross-file reasoning, debugging, security, or architecture work\n` +
+    `  5. Output will be reviewed before use\n` +
+    `NEVER delegate complex reasoning, debugging, refactoring, or ambiguous tasks.\n`
+  );
 }
-
-function downloadModel() {
-  const url = `https://huggingface.co/${modelRepo}/resolve/main/${modelFile}`;
-
-  fs.mkdirSync(MODEL_CACHE_DIR, { recursive: true });
-
-  console.error(`[local-llm] Model not found — downloading ${modelDisplayName}`);
-  console.error(`[local-llm] Source: ${modelRepo}`);
-  console.error(`[local-llm] Target: ${CACHED_MODEL_PATH}`);
-  console.error(`[local-llm] This is a one-time download (~5.4 GB). Please wait...`);
-
-  // Strategy 1: huggingface-cli (best — resumable, verified, progress bar)
-  if (hasCommand('huggingface-cli')) {
-    try {
-      console.error('[local-llm] Downloading via huggingface-cli...');
-      execSync(
-        `huggingface-cli download "${modelRepo}" --include "${modelFile}" --local-dir "${MODEL_CACHE_DIR}"`,
-        { stdio: ['pipe', 'pipe', 'inherit'], timeout: 600_000 }
-      );
-      // huggingface-cli may put the file in a subdirectory or with different name
-      // Check both direct path and repo-style path
-      if (fs.existsSync(CACHED_MODEL_PATH)) return true;
-      const altPath = path.join(MODEL_CACHE_DIR, modelFile);
-      if (fs.existsSync(altPath)) return true;
-      // Search for the .gguf file in cache dir
-      const found = findGgufFile(MODEL_CACHE_DIR);
-      if (found) {
-        if (found !== CACHED_MODEL_PATH) {
-          fs.renameSync(found, CACHED_MODEL_PATH);
-        }
-        return true;
-      }
-    } catch (err) {
-      console.error(`[local-llm] huggingface-cli failed: ${err.message}`);
-    }
-  }
-
-  // Strategy 2: curl (common via Git for Windows — resumable with -C -)
-  if (hasCommand('curl')) {
-    try {
-      console.error('[local-llm] Downloading via curl...');
-      execSync(
-        `curl -L -C - --progress-bar -o "${CACHED_MODEL_PATH}" "${url}"`,
-        { stdio: ['pipe', 'pipe', 'inherit'], timeout: 600_000 }
-      );
-      if (fs.existsSync(CACHED_MODEL_PATH)) {
-        const stat = fs.statSync(CACHED_MODEL_PATH);
-        if (stat.size > 1_000_000_000) return true;
-      }
-    } catch (err) {
-      console.error(`[local-llm] curl failed: ${err.message}`);
-    }
-  }
-
-  // Strategy 3: PowerShell Invoke-WebRequest (always available on Windows)
-  try {
-    console.error('[local-llm] Downloading via PowerShell (no resume, may be slower)...');
-    execSync(
-      `powershell -NoProfile -Command "` +
-      `$ProgressPreference = 'SilentlyContinue'; ` +
-      `Invoke-WebRequest -Uri '${url}' -OutFile '${CACHED_MODEL_PATH}' -UseBasicParsing"`,
-      { stdio: ['pipe', 'pipe', 'inherit'], timeout: 600_000 }
-    );
-    if (fs.existsSync(CACHED_MODEL_PATH)) {
-      const stat = fs.statSync(CACHED_MODEL_PATH);
-      if (stat.size > 1_000_000_000) return true;
-    }
-  } catch (err) {
-    console.error(`[local-llm] PowerShell download failed: ${err.message}`);
-  }
-
-  return false;
-}
-
-function findGgufFile(dir) {
-  try {
-    const entries = fs.readdirSync(dir, { withFileTypes: true, recursive: true });
-    for (const entry of entries) {
-      if (entry.isFile() && entry.name.endsWith('.gguf')) {
-        return path.join(entry.parentPath || entry.path || dir, entry.name);
-      }
-    }
-  } catch {}
-  return null;
-}
-
-// ---------------------------------------------------------------------------
-// Health check
-// ---------------------------------------------------------------------------
-
-function checkHealth() {
-  return new Promise((resolve) => {
-    const url = backend === 'ollama'
-      ? `http://${host}:11434/api/tags`
-      : `http://${host}:${port}/health`;
-
-    const req = http.get(url, { timeout: 2000 }, (res) => {
-      resolve(res.statusCode === 200);
-      res.resume();
-    });
-    req.on('error', () => resolve(false));
-    req.on('timeout', () => { req.destroy(); resolve(false); });
-  });
-}
-
-// ---------------------------------------------------------------------------
-// Main
-// ---------------------------------------------------------------------------
 
 (async () => {
-  let modelReady = false;
-  let resolvedPath = null;
-
-  if (backend === 'llama-cpp') {
-    // Resolve model path (configured → cached → download)
-    let resolved = resolveModelPath();
-
-    if (!resolved) {
-      // Model not found anywhere — auto-download
-      const downloaded = downloadModel();
-      if (downloaded) {
-        resolved = resolveModelPath();
-        if (resolved) {
-          console.error(`[local-llm] Download complete: ${resolved.path}`);
-        }
-      } else {
-        console.error('[local-llm] Auto-download failed. Install manually:');
-        console.error(`  huggingface-cli download ${modelRepo} --include "${modelFile}" --local-dir "${MODEL_CACHE_DIR}"`);
-        console.error('  Or set llama-cpp.modelPath in ~/.claude/local-llm/config.json');
-      }
-    }
-
-    if (resolved) {
-      resolvedPath = resolved.path;
-      modelReady = true;
-      console.error(`[local-llm] Model: ${resolvedPath} (${resolved.source})`);
-    }
-  } else {
-    // Ollama backend — model pull handled by MCP server
-    modelReady = true;
-    console.error(`[local-llm] Backend: Ollama (model: ${ollamaModel})`);
-  }
-
-  const alive = await checkHealth();
-
-  if (alive) {
-    console.error(`[local-llm] Backend running (${backend} on port ${backend === 'ollama' ? 11434 : port})`);
-  } else if (modelReady) {
-    console.error(`[local-llm] Backend not running — will start lazily on first local_generate call`);
-  }
-
-  // Write resolved model path to temp file so MCP server can pick it up
-  if (resolvedPath) {
-    try {
-      const flagPath = path.join(os.tmpdir(), 'dotclaude-local-llm-model-path');
-      fs.writeFileSync(flagPath, resolvedPath, 'utf8');
-    } catch {}
-  }
-
-  // Stdout: injected into Claude's context
-  if (!modelReady && backend === 'llama-cpp') {
-    process.stdout.write(
-      `[local-llm] Model not available — auto-download failed. ` +
-      `The local_generate MCP tool is disabled until the model is installed.\n`
-    );
+  if (!hasApiKey(CONFIG)) {
+    emit('needs_api_key', disabledHint(
+      `No AnythingLLM API key configured. Run the skill "local-llm-setup" to enter one. ` +
+      `Key is saved to ${USER_CONFIG_PATH} (user-global, outside any git repo).`
+    ));
     return;
   }
 
-  const modelName = backend === 'ollama' ? ollamaModel : modelDisplayName;
-  const status = alive ? 'running' : 'available (lazy start on first call, ~15s model load)';
+  const install = lifecycle.detectInstallation();
+  const processRunning = lifecycle.isProcessRunning();
+  const health = await http.checkHealth(BASE_URL);
 
-  process.stdout.write(
-    `[local-llm] ${modelName} is ${status} via mcp__plugin_local-llm_dotclaude-local-llm__local_generate.\n` +
-    `Read deep-knowledge/delegation-rules.md from the local-llm plugin (${PLUGIN_ROOT}/deep-knowledge/delegation-rules.md) ` +
-    `for the decision matrix on when to delegate tasks to the local LLM.\n` +
-    `\n` +
-    `Quick rules — delegate to local_generate ONLY when ALL conditions are met:\n` +
-    `  1. Task is mechanical code generation (boilerplate, DTOs, test files, CRUD, type defs)\n` +
-    `  2. You can write a COMPLETE, UNAMBIGUOUS spec (signature + types + behavior)\n` +
-    `  3. Output is >20 lines (below that, writing directly is faster)\n` +
-    `  4. Task does NOT require cross-file reasoning, debugging, security, or architecture\n` +
-    `  5. You WILL review the output before using it\n` +
-    `NEVER delegate complex reasoning, debugging, refactoring, or ambiguous tasks.\n`
-  );
+  if (health.online) {
+    const auth = await http.verifyAuth(BASE_URL, API_KEY);
+    if (!auth.valid) {
+      if (auth.errorType === 'auth_failed') {
+        emit('auth_failed', disabledHint(
+          `AnythingLLM rejected the API key (401/403). Run "local-llm-setup" to replace it.`
+        ));
+      } else {
+        emit('network_blocked', disabledHint(
+          `Auth probe failed: ${auth.error || auth.errorType}. Check AnythingLLM network settings.`
+        ));
+      }
+      return;
+    }
+
+    const ws = await http.getWorkspaces(BASE_URL, API_KEY);
+    if (!ws.ok) {
+      emit('network_blocked', disabledHint(
+        `Workspace list failed (status ${ws.status || 'n/a'}): ${ws.error || ws.errorType}`
+      ));
+      return;
+    }
+
+    const exists = ws.workspaces.some((w) => w.slug === WORKSPACE_SLUG);
+    if (exists) {
+      emit('ready', readyInstructions());
+      return;
+    }
+
+    http.createWorkspace(BASE_URL, API_KEY, WORKSPACE_NAME).catch(() => { /* fire and forget */ });
+    emit('configuring', disabledHint(
+      `AnythingLLM is reachable but workspace "${WORKSPACE_SLUG}" is missing. ` +
+      `Creation started in the background — available on next SessionStart.`
+    ));
+    return;
+  }
+
+  if (!install.installed) {
+    emit('not_installed', disabledHint(
+      `AnythingLLM Desktop is not installed. Download: ${lifecycle.DOWNLOAD_URL}\n` +
+      `After install, start it once, generate an API key in Settings → Developer API, ` +
+      `then run the skill "local-llm-setup".`
+    ));
+    return;
+  }
+
+  if (processRunning) {
+    emit('network_blocked', disabledHint(
+      `AnythingLLM process is running but /api/ping is unreachable at ${BASE_URL}. ` +
+      `Enable network access in AnythingLLM Settings → API, or check the port.`
+    ));
+    return;
+  }
+
+  if (AUTO_LAUNCH) {
+    const result = lifecycle.launch(install.path);
+    if (result.ok) {
+      emit('starting', disabledHint(
+        `AnythingLLM was not running — launched detached (pid ${result.pid}). ` +
+        `Available on next SessionStart once it has fully started.`
+      ));
+    } else {
+      emit('not_running', disabledHint(
+        `AnythingLLM is installed at ${install.path} but could not be launched: ${result.error}. ` +
+        `Start it manually.`
+      ));
+    }
+  } else {
+    emit('not_running', disabledHint(
+      `AnythingLLM is installed but not running, and autoLaunch is disabled. ` +
+      `Start the app manually.`
+    ));
+  }
 })();

--- a/plugins/local-llm/mcp-server/index.js
+++ b/plugins/local-llm/mcp-server/index.js
@@ -1,16 +1,17 @@
 #!/usr/bin/env node
 /**
  * @module dotclaude-local-llm-mcp
- * @version 0.1.0
+ * @version 0.2.0
  * @plugin local-llm
  * @description MCP server that proxies code generation requests to a local
- *   Gemma 4 E4B instance (llama-server or Ollama). Manages backend lifecycle:
- *   lazy start on first call, auto-shutdown on idle.
+ *   AnythingLLM Desktop instance over its OpenAI-compatible REST API. This
+ *   server does NOT manage any model or backend process lifecycle — that is
+ *   owned by the AnythingLLM app. We only speak HTTP to its workspace.
  *
  *   Tools:
  *   - local_generate  — send a structured coding prompt, get code back
- *   - local_status    — health check + model info
- *   - local_shutdown  — free VRAM by stopping the backend
+ *   - local_status    — phase + workspace info, no side effects
+ *   - local_shutdown  — no-op retained for backwards-compatible API surface
  *
  *   Stdout is the JSON-RPC wire — all logging goes to stderr.
  */
@@ -18,334 +19,103 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
-import { spawn } from "node:child_process";
-import { readFileSync, existsSync, writeFileSync, unlinkSync, statSync } from "node:fs";
-import { join, resolve, dirname } from "node:path";
-import { homedir, tmpdir } from "node:os";
+import { createRequire } from "node:module";
+import { writeFileSync, unlinkSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
 
+const require = createRequire(import.meta.url);
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const PLUGIN_ROOT = resolve(__dirname, "..");
+const LIB_ROOT = resolve(__dirname, "..", "hooks", "lib");
 
-// ---------------------------------------------------------------------------
-// Config resolution: project > global > plugin defaults
-// ---------------------------------------------------------------------------
-
-function readJson(p) {
-  try { return JSON.parse(readFileSync(p, "utf8")); } catch { return {}; }
-}
-
-function resolveConfig() {
-  const defaults = readJson(join(PLUGIN_ROOT, "scripts", "config.json"));
-  const global = readJson(join(homedir(), ".claude", "local-llm", "config.json"));
-  const project = readJson(join(process.cwd(), ".claude", "local-llm", "config.json"));
-
-  // Deep merge one level
-  const merged = { ...defaults };
-  for (const layer of [global, project]) {
-    for (const [k, v] of Object.entries(layer)) {
-      if (v && typeof v === "object" && !Array.isArray(v) && merged[k] && typeof merged[k] === "object") {
-        merged[k] = { ...merged[k], ...v };
-      } else {
-        merged[k] = v;
-      }
-    }
-  }
-  return merged;
-}
+const http = require(join(LIB_ROOT, "anythingllm-http.js"));
+const lifecycle = require(join(LIB_ROOT, "anythingllm-lifecycle.js"));
+const { resolveConfig, hasApiKey, USER_CONFIG_PATH } = require(join(LIB_ROOT, "anythingllm-config.js"));
 
 const CONFIG = resolveConfig();
-const PORT = CONFIG.server?.port || 8787;
-const HOST = CONFIG.server?.host || "127.0.0.1";
-const IDLE_MS = CONFIG.server?.idleShutdownMs || 600_000;
-const BASE_URL = CONFIG.backend === "ollama"
-  ? `http://${HOST}:11434`
-  : `http://${HOST}:${PORT}`;
+const BASE_URL = CONFIG.anythingllm?.baseUrl || "http://localhost:3001";
+const WORKSPACE_SLUG = CONFIG.anythingllm?.workspaceSlug || "claude-code";
+const API_KEY = CONFIG.anythingllm?.apiKey || "";
+const TEMPERATURE_DEFAULT = CONFIG.generation?.temperature ?? 0.2;
+const MAX_TOKENS_DEFAULT = CONFIG.generation?.maxTokens ?? 4096;
 
 // ---------------------------------------------------------------------------
-// Model path auto-resolution: configured > hook flag > cache dir
+// Status
 // ---------------------------------------------------------------------------
 
-const MODEL_FILE = CONFIG.model?.file || "google_gemma-4-E4B-it-Q4_K_M.gguf";
-const MODEL_CACHE_DIR = join(homedir(), ".claude", "local-llm", "models");
+async function getPhase() {
+  if (!hasApiKey(CONFIG)) {
+    return {
+      phase: "needs_api_key",
+      ready: false,
+      hint: `Run the local-llm-setup skill to store an AnythingLLM API key at ${USER_CONFIG_PATH}.`,
+    };
+  }
 
-function resolveModelPath() {
-  // 1. Explicitly configured
-  const configured = CONFIG["llama-cpp"]?.modelPath;
-  if (configured && existsSync(configured)) return configured;
-
-  // 2. Path written by SessionStart hook (temp flag file)
-  try {
-    const flagPath = join(tmpdir(), "dotclaude-local-llm-model-path");
-    if (existsSync(flagPath)) {
-      const hookPath = readFileSync(flagPath, "utf8").trim();
-      if (hookPath && existsSync(hookPath)) return hookPath;
+  const health = await http.checkHealth(BASE_URL);
+  if (!health.online) {
+    const install = lifecycle.detectInstallation();
+    if (!install.installed) {
+      return {
+        phase: "not_installed",
+        ready: false,
+        hint: `AnythingLLM Desktop is not installed. Download: ${lifecycle.DOWNLOAD_URL}`,
+      };
     }
-  } catch {}
-
-  // 3. Default cache directory
-  const cached = join(MODEL_CACHE_DIR, MODEL_FILE);
-  if (existsSync(cached)) {
-    const stat = statSync(cached);
-    if (stat.size > 1_000_000_000) return cached;
+    const running = lifecycle.isProcessRunning();
+    return {
+      phase: running ? "network_blocked" : "not_running",
+      ready: false,
+      hint: running
+        ? `AnythingLLM is running but ${BASE_URL} is unreachable. Enable network access in Settings → API.`
+        : `AnythingLLM is installed at ${install.path} but not running. Start the app.`,
+    };
   }
 
-  return null;
+  const auth = await http.verifyAuth(BASE_URL, API_KEY);
+  if (!auth.valid) {
+    return {
+      phase: auth.errorType === "auth_failed" ? "auth_failed" : "network_blocked",
+      ready: false,
+      hint: `Auth probe failed: ${auth.error || auth.errorType}. Re-run local-llm-setup.`,
+    };
+  }
+
+  const ws = await http.getWorkspaces(BASE_URL, API_KEY);
+  if (!ws.ok) {
+    return {
+      phase: "network_blocked",
+      ready: false,
+      hint: `Workspace list failed: ${ws.error || ws.errorType}`,
+    };
+  }
+  const exists = ws.workspaces.some((w) => w.slug === WORKSPACE_SLUG);
+  if (!exists) {
+    return {
+      phase: "configuring",
+      ready: false,
+      hint: `Workspace "${WORKSPACE_SLUG}" not found. It will be auto-created on the next SessionStart.`,
+    };
+  }
+
+  return { phase: "ready", ready: true, hint: null };
 }
 
 // ---------------------------------------------------------------------------
-// Backend lifecycle
-// ---------------------------------------------------------------------------
-
-let backendProcess = null;
-let idleTimer = null;
-let startedAt = null;
-let requestCount = 0;
-
-function resetIdleTimer() {
-  if (idleTimer) clearTimeout(idleTimer);
-  idleTimer = setTimeout(() => {
-    console.error("[local-llm] Idle timeout reached — shutting down backend");
-    shutdownBackend();
-  }, IDLE_MS);
-}
-
-async function isBackendAlive() {
-  try {
-    const url = CONFIG.backend === "ollama"
-      ? `${BASE_URL}/api/tags`
-      : `${BASE_URL}/health`;
-    const res = await fetch(url, { signal: AbortSignal.timeout(3000) });
-    return res.ok;
-  } catch {
-    return false;
-  }
-}
-
-function findLlamaServer() {
-  const configured = CONFIG["llama-cpp"]?.serverPath;
-  if (configured && existsSync(configured)) return configured;
-
-  // Check common Windows locations
-  const candidates = [
-    join(homedir(), "llama.cpp", "build", "bin", "Release", "llama-server.exe"),
-    join(homedir(), "llama.cpp", "build", "bin", "llama-server.exe"),
-    "C:\\llama.cpp\\build\\bin\\Release\\llama-server.exe",
-    "C:\\llama.cpp\\llama-server.exe",
-  ];
-  for (const p of candidates) {
-    if (existsSync(p)) return p;
-  }
-
-  // Assume it's in PATH
-  return "llama-server";
-}
-
-async function startBackend() {
-  if (await isBackendAlive()) {
-    console.error("[local-llm] Backend already running");
-    resetIdleTimer();
-    return true;
-  }
-
-  if (CONFIG.backend === "ollama") {
-    return startOllama();
-  }
-  return startLlamaCpp();
-}
-
-async function startLlamaCpp() {
-  const modelPath = resolveModelPath();
-  if (!modelPath) {
-    throw new Error(
-      "Model not found. The SessionStart hook should have downloaded it automatically.\n" +
-      "If this persists, download manually:\n" +
-      `  huggingface-cli download ${CONFIG.model?.repo || "bartowski/google_gemma-4-E4B-it-GGUF"} ` +
-      `--include "${MODEL_FILE}" --local-dir "${MODEL_CACHE_DIR}"\n` +
-      "Or set llama-cpp.modelPath in ~/.claude/local-llm/config.json"
-    );
-  }
-
-  const serverPath = findLlamaServer();
-  const gpuLayers = CONFIG["llama-cpp"]?.gpuLayers ?? 99;
-  const ctxSize = CONFIG["llama-cpp"]?.contextSize ?? 8192;
-  const extraArgs = CONFIG["llama-cpp"]?.extraArgs || [];
-
-  const args = [
-    "-m", modelPath,
-    "-ngl", String(gpuLayers),
-    "-c", String(ctxSize),
-    "--host", HOST,
-    "--port", String(PORT),
-  ];
-
-  // KV cache quantization (saves VRAM, enables larger context)
-  const kvK = CONFIG["llama-cpp"]?.kvCacheQuantK;
-  const kvV = CONFIG["llama-cpp"]?.kvCacheQuantV;
-  if (kvK) args.push("--ctk", kvK);
-  if (kvV) args.push("--ctv", kvV);
-
-  args.push(...extraArgs);
-
-  console.error(`[local-llm] Starting llama-server: ${serverPath} ${args.join(" ")}`);
-
-  backendProcess = spawn(serverPath, args, {
-    stdio: ["ignore", "pipe", "pipe"],
-    detached: false,
-    windowsHide: true,
-  });
-
-  backendProcess.stderr.on("data", (d) => {
-    const line = d.toString().trim();
-    if (line) console.error(`[llama-server] ${line}`);
-  });
-
-  backendProcess.on("exit", (code) => {
-    console.error(`[local-llm] llama-server exited with code ${code}`);
-    backendProcess = null;
-    startedAt = null;
-  });
-
-  // Wait for server to become ready (model loading can take 10-30s)
-  const ready = await waitForBackend(60_000);
-  if (ready) {
-    startedAt = new Date();
-    resetIdleTimer();
-  }
-  return ready;
-}
-
-async function startOllama() {
-  // Ollama manages its own server — just ensure model is available
-  const model = CONFIG.ollama?.model || "gemma4:e4b";
-
-  // Check if ollama serve is running
-  if (!(await isBackendAlive())) {
-    console.error("[local-llm] Starting ollama serve...");
-    backendProcess = spawn("ollama", ["serve"], {
-      stdio: ["ignore", "pipe", "pipe"],
-      detached: false,
-      windowsHide: true,
-      env: { ...process.env, OLLAMA_FLASH_ATTENTION: "false" },
-    });
-    backendProcess.on("exit", () => { backendProcess = null; startedAt = null; });
-
-    const ready = await waitForBackend(30_000);
-    if (!ready) return false;
-  }
-
-  // Ensure model is pulled
-  try {
-    const res = await fetch(`${BASE_URL}/api/tags`, { signal: AbortSignal.timeout(5000) });
-    const data = await res.json();
-    const models = (data.models || []).map(m => m.name);
-    if (!models.some(m => m.startsWith(model.split(":")[0]))) {
-      console.error(`[local-llm] Pulling model ${model}...`);
-      await fetch(`${BASE_URL}/api/pull`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name: model, stream: false }),
-        signal: AbortSignal.timeout(600_000),
-      });
-    }
-  } catch (err) {
-    console.error(`[local-llm] Model check/pull failed: ${err.message}`);
-  }
-
-  startedAt = new Date();
-  resetIdleTimer();
-  return true;
-}
-
-async function waitForBackend(timeoutMs) {
-  const start = Date.now();
-  while (Date.now() - start < timeoutMs) {
-    if (await isBackendAlive()) return true;
-    await new Promise(r => setTimeout(r, 1000));
-  }
-  console.error("[local-llm] Backend failed to start within timeout");
-  return false;
-}
-
-function shutdownBackend() {
-  if (idleTimer) { clearTimeout(idleTimer); idleTimer = null; }
-  if (backendProcess) {
-    console.error("[local-llm] Stopping backend process");
-    try { backendProcess.kill("SIGTERM"); } catch { /* ignore */ }
-    backendProcess = null;
-    startedAt = null;
-  }
-}
-
-// ---------------------------------------------------------------------------
-// OpenAI-compatible API client
-// ---------------------------------------------------------------------------
-
-async function generate(systemPrompt, userPrompt, opts = {}) {
-  const started = await startBackend();
-  if (!started) throw new Error("Backend not available — check config and model path");
-
-  requestCount++;
-  resetIdleTimer();
-
-  const temp = opts.temperature ?? CONFIG.generation?.temperature ?? 0.2;
-  const maxTokens = opts.maxTokens ?? CONFIG.generation?.maxTokens ?? 4096;
-
-  const url = CONFIG.backend === "ollama"
-    ? `${BASE_URL}/v1/chat/completions`
-    : `${BASE_URL}/v1/chat/completions`;
-
-  const messages = [];
-  if (systemPrompt) messages.push({ role: "system", content: systemPrompt });
-  messages.push({ role: "user", content: userPrompt });
-
-  const body = {
-    messages,
-    temperature: temp,
-    max_tokens: maxTokens,
-    stream: false,
-  };
-
-  if (CONFIG.backend === "ollama") {
-    body.model = CONFIG.ollama?.model || "gemma4:e4b";
-  }
-
-  const res = await fetch(url, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(body),
-    signal: AbortSignal.timeout(120_000),
-  });
-
-  if (!res.ok) {
-    const text = await res.text();
-    throw new Error(`Backend API error ${res.status}: ${text}`);
-  }
-
-  const data = await res.json();
-  const choice = data.choices?.[0];
-  if (!choice) throw new Error("No response from backend");
-
-  return {
-    content: choice.message?.content || "",
-    tokensUsed: data.usage?.total_tokens || null,
-    finishReason: choice.finish_reason || "unknown",
-  };
-}
-
-// ---------------------------------------------------------------------------
-// Heartbeat (same pattern as devops MCP servers)
+// Heartbeat (matches devops MCP servers)
 // ---------------------------------------------------------------------------
 
 function registerHeartbeat(name) {
   const pidFile = join(tmpdir(), `dotclaude-mcp-${name}.pid`);
   try {
     writeFileSync(pidFile, String(process.pid), "utf8");
-    const cleanup = () => { try { unlinkSync(pidFile); } catch {} };
+    const cleanup = () => { try { unlinkSync(pidFile); } catch { /* ignore */ } };
     process.on("exit", cleanup);
-    process.on("SIGINT", () => { cleanup(); shutdownBackend(); process.exit(0); });
-    process.on("SIGTERM", () => { cleanup(); shutdownBackend(); process.exit(0); });
-  } catch {}
+    process.on("SIGINT", () => { cleanup(); process.exit(0); });
+    process.on("SIGTERM", () => { cleanup(); process.exit(0); });
+  } catch { /* ignore */ }
 }
 
 // ---------------------------------------------------------------------------
@@ -354,49 +124,51 @@ function registerHeartbeat(name) {
 
 const server = new McpServer({
   name: "dotclaude-local-llm",
-  version: "0.1.0",
+  version: "0.2.0",
 });
-
-// --- Tool: local_generate ---
 
 server.registerTool(
   "local_generate",
   {
     title: "Local LLM Code Generation",
     description:
-      "Generate code using the local Gemma 4 E4B model. " +
+      "Generate code via a local AnythingLLM Desktop workspace. " +
       "Use ONLY for mechanical, well-specified coding tasks (GREEN tier): " +
-      "boilerplate, DTOs, test files from patterns, CRUD operations, " +
-      "type definitions, repetitive variations. " +
+      "boilerplate, DTOs, test files from patterns, CRUD, type definitions, " +
+      "repetitive variations. " +
       "NEVER use for: debugging, architecture, security-critical code, " +
       "cross-file reasoning, or ambiguous tasks. " +
       "Claude MUST formulate a complete, unambiguous prompt and MUST " +
-      "review the output before using it. " +
-      "Starts the backend lazily on first call (may take 10-30s for model loading).",
+      "review the output before using it.",
     inputSchema: z.object({
       task: z.string().describe(
         "Precise code generation task. Must be unambiguous and self-contained. " +
-        "Include: language, function signature, expected behavior, types, constraints. " +
-        "Example: 'TypeScript: Create an interface UserDTO with fields id (number), " +
-        "name (string), email (string), createdAt (Date), roles (string[])'."
+        "Include: language, function signature, expected behavior, types, constraints."
       ),
       context: z.string().optional().describe(
         "Relevant code context: existing types, interfaces, patterns to follow. " +
         "Keep under 2000 tokens — the local model has limited context (8K)."
       ),
       language: z.string().optional().describe(
-        "Programming language (e.g., 'typescript', 'python', 'go'). " +
-        "Helps the model produce correctly formatted output."
+        "Programming language (e.g., 'typescript', 'python', 'go')."
       ),
       temperature: z.number().min(0).max(1).optional().describe(
-        "Generation temperature. Default 0.2 (deterministic). Use 0.0 for exact patterns, " +
-        "up to 0.5 for creative variations. Never above 0.5 for code."
+        "Generation temperature. Default 0.2 (deterministic). Never above 0.5 for code."
       ),
     }),
   },
   async ({ task, context, language, temperature }) => {
-    const lang = language || "the appropriate language";
+    const phase = await getPhase();
+    if (!phase.ready) {
+      return {
+        content: [{
+          type: "text",
+          text: JSON.stringify({ error: true, phase: phase.phase, hint: phase.hint }),
+        }],
+      };
+    }
 
+    const lang = language || "the appropriate language";
     const systemPrompt =
       "You are a code generation assistant. Output ONLY the requested code — " +
       "no explanations, no markdown fences, no commentary. " +
@@ -404,120 +176,98 @@ server.registerTool(
       "Follow the coding style shown in the context if provided.";
 
     let userPrompt = `Language: ${lang}\n\nTask: ${task}`;
-    if (context) {
-      userPrompt += `\n\nContext (existing code to follow):\n${context}`;
-    }
+    if (context) userPrompt += `\n\nContext (existing code to follow):\n${context}`;
     userPrompt += "\n\nGenerate the code:";
 
-    try {
-      const result = await generate(systemPrompt, userPrompt, { temperature });
+    const result = await http.chatCompletion(BASE_URL, API_KEY, {
+      workspaceSlug: WORKSPACE_SLUG,
+      messages: [
+        { role: "system", content: systemPrompt },
+        { role: "user", content: userPrompt },
+      ],
+      temperature: temperature ?? TEMPERATURE_DEFAULT,
+      maxTokens: MAX_TOKENS_DEFAULT,
+    });
 
-      return {
-        content: [{
-          type: "text",
-          text: JSON.stringify({
-            code: result.content,
-            tokensUsed: result.tokensUsed,
-            finishReason: result.finishReason,
-            model: CONFIG.backend === "ollama"
-              ? (CONFIG.ollama?.model || "gemma4:e4b")
-              : "gemma-4-e4b",
-            note: "Review this output before using it. The local model may " +
-                  "produce incorrect code for edge cases.",
-          }),
-        }],
-      };
-    } catch (err) {
+    if (!result.ok) {
       return {
         content: [{
           type: "text",
           text: JSON.stringify({
             error: true,
-            message: err.message,
-            hint: err.message.includes("model path")
-              ? "Configure the model path in .claude/local-llm/config.json"
-              : err.message.includes("not available")
-              ? "Ensure llama-server or Ollama is installed"
-              : "Check backend logs for details",
+            phase: "request_failed",
+            status: result.status,
+            hint: result.error || result.errorType,
           }),
         }],
       };
     }
+
+    return {
+      content: [{
+        type: "text",
+        text: JSON.stringify({
+          code: result.content,
+          tokensUsed: result.tokensUsed,
+          finishReason: result.finishReason,
+          workspace: WORKSPACE_SLUG,
+          note: "Review this output before using it. The local model may " +
+                "produce incorrect code for edge cases.",
+        }),
+      }],
+    };
   }
 );
-
-// --- Tool: local_status ---
 
 server.registerTool(
   "local_status",
   {
     title: "Local LLM Status",
     description:
-      "Check if the local LLM backend is running and report model info. " +
+      "Check if the local AnythingLLM backend is reachable and the workspace is ready. " +
       "Use to verify availability before delegating tasks.",
     inputSchema: z.object({}),
   },
   async () => {
-    const alive = await isBackendAlive();
-
-    const status = {
-      running: alive,
-      backend: CONFIG.backend,
-      port: CONFIG.backend === "ollama" ? 11434 : PORT,
-      model: CONFIG.backend === "ollama"
-        ? (CONFIG.ollama?.model || "gemma4:e4b")
-        : (resolveModelPath() || "not found — restart session to trigger auto-download"),
-      startedAt: startedAt?.toISOString() || null,
-      requestCount,
-      gpuLayers: CONFIG["llama-cpp"]?.gpuLayers ?? 99,
-      contextSize: CONFIG["llama-cpp"]?.contextSize ?? 8192,
-      idleShutdownMinutes: Math.round(IDLE_MS / 60_000),
-    };
-
-    if (alive && CONFIG.backend !== "ollama") {
-      try {
-        const res = await fetch(`${BASE_URL}/health`, { signal: AbortSignal.timeout(3000) });
-        const health = await res.json();
-        status.slots = health.slots_idle ?? null;
-        status.slotsProcessing = health.slots_processing ?? null;
-      } catch {}
-    }
-
-    return {
-      content: [{ type: "text", text: JSON.stringify(status) }],
-    };
-  }
-);
-
-// --- Tool: local_shutdown ---
-
-server.registerTool(
-  "local_shutdown",
-  {
-    title: "Shutdown Local LLM",
-    description:
-      "Stop the local LLM backend to free GPU VRAM. " +
-      "Use when done with mechanical tasks or when VRAM is needed for other work. " +
-      "The backend will be restarted automatically on the next local_generate call.",
-    inputSchema: z.object({}),
-  },
-  async () => {
-    const wasRunning = backendProcess !== null || await isBackendAlive();
-    shutdownBackend();
-
+    const phase = await getPhase();
+    const install = lifecycle.detectInstallation();
     return {
       content: [{
         type: "text",
         text: JSON.stringify({
-          shutdown: true,
-          wasRunning,
-          message: wasRunning
-            ? "Backend stopped — VRAM freed. Will restart on next local_generate call."
-            : "Backend was not running.",
+          phase: phase.phase,
+          ready: phase.ready,
+          hint: phase.hint,
+          baseUrl: BASE_URL,
+          workspaceSlug: WORKSPACE_SLUG,
+          hasApiKey: hasApiKey(CONFIG),
+          installed: install.installed,
+          installPath: install.path,
+          processRunning: lifecycle.isProcessRunning(),
         }),
       }],
     };
   }
+);
+
+server.registerTool(
+  "local_shutdown",
+  {
+    title: "Shutdown (no-op)",
+    description:
+      "Retained for API compatibility. AnythingLLM Desktop manages its own " +
+      "process lifecycle — this plugin never spawns or kills the app.",
+    inputSchema: z.object({}),
+  },
+  async () => ({
+    content: [{
+      type: "text",
+      text: JSON.stringify({
+        shutdown: false,
+        message: "No-op. AnythingLLM Desktop is owned by the user, not this plugin.",
+      }),
+    }],
+  })
 );
 
 // ---------------------------------------------------------------------------

--- a/plugins/local-llm/mcp-server/package.json
+++ b/plugins/local-llm/mcp-server/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "description": "MCP server that delegates code generation to a local Gemma 4 E4B instance via llama.cpp or Ollama.",
+  "description": "MCP server that delegates code generation to a local AnythingLLM Desktop workspace.",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "zod": "^3.25.0"

--- a/plugins/local-llm/scripts/config.json
+++ b/plugins/local-llm/scripts/config.json
@@ -1,31 +1,15 @@
 {
-  "backend": "llama-cpp",
-  "model": {
-    "repo": "bartowski/google_gemma-4-E4B-it-GGUF",
-    "file": "google_gemma-4-E4B-it-Q4_K_M.gguf",
-    "displayName": "Gemma 4 E4B Q4_K_M",
-    "sizeBytes": 5810380800
-  },
-  "llama-cpp": {
-    "serverPath": null,
-    "modelPath": null,
-    "gpuLayers": 99,
-    "contextSize": 8192,
-    "kvCacheQuantK": null,
-    "kvCacheQuantV": null,
-    "extraArgs": []
-  },
-  "ollama": {
-    "model": "gemma4:e4b"
-  },
-  "server": {
-    "port": 8787,
-    "host": "127.0.0.1",
-    "idleShutdownMs": 600000
+  "anythingllm": {
+    "baseUrl": "http://localhost:3001",
+    "apiKey": "",
+    "workspaceSlug": "claude-code",
+    "workspaceName": "Claude Code",
+    "autoLaunch": true,
+    "launchTimeoutMs": 30000,
+    "pollIntervalMs": 1000
   },
   "generation": {
     "temperature": 0.2,
-    "maxTokens": 4096,
-    "stopSequences": ["```\n\n", "\n\n\n"]
+    "maxTokens": 4096
   }
 }

--- a/plugins/local-llm/scripts/save-api-key.js
+++ b/plugins/local-llm/scripts/save-api-key.js
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+/**
+ * @script save-api-key
+ * @version 0.1.0
+ * @plugin local-llm
+ * @description Save an AnythingLLM API key to the user-global config and
+ *   verify it against the running AnythingLLM instance. Used by the
+ *   local-llm-setup skill.
+ *
+ * Usage:
+ *   node save-api-key.js <api-key> [base-url]
+ *
+ * Writes to: ~/.claude/local-llm/config.json
+ *
+ * Output: single-line JSON to stdout describing the result.
+ */
+
+'use strict';
+
+const path = require('node:path');
+
+const LIB = path.resolve(__dirname, '..', 'hooks', 'lib');
+const http = require(path.join(LIB, 'anythingllm-http.js'));
+const lifecycle = require(path.join(LIB, 'anythingllm-lifecycle.js'));
+const { resolveConfig, saveApiKey, USER_CONFIG_PATH } = require(path.join(LIB, 'anythingllm-config.js'));
+
+(async () => {
+  const apiKey = (process.argv[2] || '').trim();
+  const baseUrlArg = (process.argv[3] || '').trim();
+
+  if (!apiKey) {
+    process.stdout.write(JSON.stringify({ ok: false, error: 'No API key provided.' }));
+    process.exit(1);
+  }
+
+  const config = resolveConfig();
+  const baseUrl = baseUrlArg || config.anythingllm?.baseUrl || 'http://localhost:3001';
+  const workspaceSlug = config.anythingllm?.workspaceSlug || 'claude-code';
+  const workspaceName = config.anythingllm?.workspaceName || 'Claude Code';
+
+  const savedPath = saveApiKey(apiKey);
+
+  const health = await http.checkHealth(baseUrl);
+  if (!health.online) {
+    const install = lifecycle.detectInstallation();
+    process.stdout.write(JSON.stringify({
+      ok: true,
+      saved: savedPath,
+      verified: false,
+      phase: install.installed ? 'not_running' : 'not_installed',
+      hint: install.installed
+        ? `Key saved. AnythingLLM is installed but not reachable at ${baseUrl}. Start the app, then restart the session.`
+        : `Key saved. AnythingLLM is not installed. Download: ${lifecycle.DOWNLOAD_URL}`,
+    }));
+    return;
+  }
+
+  const auth = await http.verifyAuth(baseUrl, apiKey);
+  if (!auth.valid) {
+    process.stdout.write(JSON.stringify({
+      ok: true,
+      saved: savedPath,
+      verified: false,
+      phase: auth.errorType === 'auth_failed' ? 'auth_failed' : 'network_blocked',
+      hint: `Key saved but AnythingLLM rejected it: ${auth.error || auth.errorType}. Re-run setup with a valid key.`,
+    }));
+    return;
+  }
+
+  const ws = await http.getWorkspaces(baseUrl, apiKey);
+  let workspaceReady = false;
+  if (ws.ok) {
+    const exists = ws.workspaces.some((w) => w.slug === workspaceSlug);
+    if (exists) {
+      workspaceReady = true;
+    } else {
+      const created = await http.createWorkspace(baseUrl, apiKey, workspaceName);
+      workspaceReady = created.ok;
+    }
+  }
+
+  process.stdout.write(JSON.stringify({
+    ok: true,
+    saved: savedPath,
+    verified: true,
+    phase: workspaceReady ? 'ready' : 'configuring',
+    workspace: workspaceSlug,
+    hint: workspaceReady
+      ? 'AnythingLLM is ready. Restart the session so Claude picks up the new state.'
+      : `Workspace creation failed or pending. It will retry on next SessionStart.`,
+    configPath: USER_CONFIG_PATH,
+  }));
+})().catch((err) => {
+  process.stdout.write(JSON.stringify({ ok: false, error: err.message }));
+  process.exit(1);
+});

--- a/plugins/local-llm/skills/local-llm-setup/SKILL.md
+++ b/plugins/local-llm/skills/local-llm-setup/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: local-llm-setup
+description: Interactive setup for the local-llm plugin — ask the user for their AnythingLLM API key, save it user-globally, and verify the connection. Use when the SessionStart hook reports `phase: needs_api_key`, `auth_failed`, or when the user explicitly asks to configure or reconfigure the local LLM. Triggers on "local llm setup", "anythingllm key", "local-llm configure".
+---
+
+# local-llm-setup
+
+Guided flow to connect this plugin to a running AnythingLLM Desktop instance.
+
+## What this skill does
+
+1. Confirms the user has installed AnythingLLM Desktop and generated an API key.
+2. Asks the user to paste the API key.
+3. Saves the key to `~/.claude/local-llm/config.json` (user-global, outside any git repo).
+4. Verifies the key against `GET /api/v1/auth`.
+5. Auto-creates the `claude-code` workspace if missing.
+6. Reports the resulting phase.
+
+## Step 1 — Precondition check
+
+Before asking for the key, tell the user what they need:
+
+> **AnythingLLM Desktop** must be installed and running.
+> If not yet installed: https://anythingllm.com/download
+> After install:
+>   1. Open AnythingLLM.
+>   2. Settings → **Developer API** → **Generate API Key**.
+>   3. Copy the key.
+>   4. (Recommended) Configure the LLM provider to **Ollama** with model **`gemma4:e4b`**.
+>      If Ollama is not installed, AnythingLLM can download it during the provider setup.
+
+## Step 2 — Ask for the key
+
+Ask the user **in chat** (not via `AskUserQuestion` — the key is free-form text, not a multiple choice):
+
+> Paste your AnythingLLM API key here (or type `cancel` to abort).
+
+Wait for the user's next message. If the response is `cancel`, stop and report that no changes were made.
+
+Otherwise, treat the user's message as the API key. **Do not echo the key back in chat.**
+
+## Step 3 — Save and verify
+
+Run the save-and-verify script, passing the key via argv:
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/save-api-key.js" "<paste-the-key-here>"
+```
+
+The script writes to `~/.claude/local-llm/config.json` and probes AnythingLLM. It prints a single-line JSON result to stdout with these shapes:
+
+- `{ok:true, verified:true, phase:"ready", workspace:"claude-code"}` — green path.
+- `{ok:true, verified:true, phase:"configuring"}` — key valid, workspace creation pending.
+- `{ok:true, verified:false, phase:"auth_failed"}` — key saved but rejected; ask the user to check the key.
+- `{ok:true, verified:false, phase:"not_running"}` — key saved; AnythingLLM is installed but not running.
+- `{ok:true, verified:false, phase:"not_installed"}` — key saved; AnythingLLM must be installed first.
+
+## Step 4 — Report
+
+Tell the user:
+
+- Where the key was saved (`~/.claude/local-llm/config.json`).
+- Whether verification succeeded.
+- If `ready`: ask the user to restart the session so the SessionStart hook picks up the new state.
+- If `auth_failed`: offer to retry with a fresh key.
+- If `not_installed`/`not_running`: give the download link / remind them to start the app, then restart the session.
+
+Never log or echo the API key itself — only acknowledge receipt.


### PR DESCRIPTION
## Summary

Complete backend pivot of the `local-llm` plugin: replaces the bundled `llama-server` / `llama.cpp` child-process model with a local **AnythingLLM Desktop** workspace. The plugin no longer manages any model itself — it speaks HTTP to the app's REST API on `http://localhost:3001`.

Second half of the change: integrates delegation into the implementation agents so mechanical code generation (DTOs, CRUD, schema, test boilerplate, >20 lines) can be routed to `local_generate` when ready.

## Why AnythingLLM?

- Single installer, auto-updating GUI, model manager built in — no need to ship or build `llama.cpp`.
- OpenAI-compatible endpoint with stable auth — stable contract for this plugin.
- User owns the model choice, GPU offload, KV-cache settings — all outside this plugin's scope.

## What ships

### local-llm plugin
- `hooks/lib/anythingllm-{http,lifecycle,config}.js` — shared CJS library consumed by both the SessionStart hook and the MCP server (via `createRequire` across the ESM boundary).
- `hooks/session-start/ss.llm.health.js` — non-blocking 7-phase state machine: `ready | needs_api_key | not_installed | starting | network_blocked | auth_failed | configuring`. Missing key / offline backend **never** blocks the prompt.
- `mcp-server/index.js` — thin wrapper around the HTTP client. No process lifecycle, no idle timer, no model management.
- `skills/local-llm-setup/SKILL.md` + `scripts/save-api-key.js` — interactive skill that writes the key to `~/.claude/local-llm/config.json` (user-global, outside every repo) and auto-creates the `claude-code` workspace.
- Old `llama-server` spawn, GGUF auto-download, Ollama sidecar, and all `llama-cpp.*` / `ollama.*` / `model.*` / `server.*` config fields **removed**.

### devops plugin
- `deep-knowledge/local-llm-delegation.md` — cross-cutting gate + GREEN/RED decision matrix.
- `scripts/check-local-llm.js` — single-call JSON status probe with 30s on-disk cache so parallel agents do not all probe AnythingLLM simultaneously. Resolves the local-llm library from either the source repo or the installed plugin cache.
- `agents/{core,frontend,feature,ai}.md` — each gains `local_generate` + `local_status` in its tools whitelist and a one-line rule pointing to the new deep-knowledge doc.

## Consumer setup (one-time, ~5 min)

1. Install AnythingLLM Desktop: https://anythingllm.com/download
2. Start it, Settings → Developer API → Generate API Key.
3. Pick Ollama as the LLM provider, pull `gemma4:e4b`.
4. In Claude Code: run the `local-llm-setup` skill, paste the key.
5. Restart the session. The SessionStart hook reports `phase: ready`.

## Breaking change

The old `llama-cpp` / `ollama` stack and its config fields are removed with no fallback.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 89/89 green
- [x] SessionStart hook live-run: `phase: needs_api_key` within ~100 ms, non-blocking
- [x] `check-local-llm.js` live-run: returns single-line JSON
- [x] Rebased twice onto main (commits #103 and #104) — clean
- [ ] End-to-end with a configured AnythingLLM instance (requires consumer install — covered by `local-llm-setup` skill)