### PR TITLE
feat(codex): hard 5-min timeout wrapper for all Codex calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.50.0] — 2026-04-18
+
+### Added
+
+- **plugins/devops/scripts/codex-safe.sh** — Bash wrapper around `codex exec` with a hard 5-minute wall-clock ceiling (override via `CODEX_SAFE_TIMEOUT` env var) and deterministic exit codes: `0` = output, `124` = timeout, `126` = disabled via `DEVOPS_DISABLE_CODEX=1`, `127` = `codex` CLI missing. Prevents the main Claude session from hanging when the user's Codex usage limit is exhausted, auth expires, or the upstream service stalls
+- **plugins/devops/deep-knowledge/codex-integration.md** — new mandatory "Hard Timeout & Failure-Tolerance" section documenting the wrapper contract, exit-code matrix, and the `DEVOPS_DISABLE_CODEX` kill-switch for `.claude/settings.local.json`
+
+### Changed
+
+- **plugins/devops/skills/devops-ship** — Codex review gate now invokes `codex-safe.sh` via Bash (not `/codex:rescue` via the Agent tool). `rc=124` (5-min timeout) explicitly proceeds without review rather than blocking the ship; `rc=126/127` skip silently; other non-zero surfaces stderr and continues
+- **plugins/devops/skills/devops-flow** — unclear-root-cause branch calls Codex through the wrapper with the same exit-code handling
+- **plugins/devops/skills/devops-deep-research** — parallel sub-question delegation goes through the wrapper
+- **plugins/devops/agents/{qa,research}.md** — both agents now use the wrapper with background Bash where applicable
+
 ## [0.49.0] — 2026-04-18
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.49.0**
+**Version: 0.50.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.49.0",
+  "version": "0.50.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/agents/qa.md
+++ b/plugins/devops/agents/qa.md
@@ -17,7 +17,7 @@ Verify that changes work correctly. Run in parallel with implementation.
 
 ## Context
 
-Before starting, read `{PLUGIN_ROOT}/deep-knowledge/codex-integration.md` §4 (QA Agent). If codex-plugin-cc is installed, Codex review via `/codex:rescue` is **mandatory** for complex changes — not optional.
+Before starting, read `{PLUGIN_ROOT}/deep-knowledge/codex-integration.md` §4 (QA Agent) AND the "Hard Timeout & Failure-Tolerance" section. If codex-plugin-cc is installed, Codex review is **mandatory** for complex changes — not optional — but MUST be invoked via the `codex-safe.sh` wrapper (5-min hard timeout), never via the `/codex:rescue` Agent call.
 
 ## Responsibilities
 
@@ -26,7 +26,7 @@ Before starting, read `{PLUGIN_ROOT}/deep-knowledge/codex-integration.md` §4 (Q
 - Take screenshots of UI changes
 - Check console logs for errors
 - Generate build-ID after successful build
-- **Automatically run** `/codex:rescue` for complex or high-risk changes (multi-file, architectural, security-sensitive). Skip for trivial single-file fixes. If codex-plugin-cc is not installed → skip silently.
+- **Automatically run** Codex review via Bash: `bash "${CLAUDE_PLUGIN_ROOT}/scripts/codex-safe.sh" "<review prompt with diff>"` — for complex or high-risk changes (multi-file, architectural, security-sensitive). Skip for trivial single-file fixes. Handle exit codes per codex-integration.md: rc=124 → log timeout and continue without findings; rc=126/127 → skip silently; other non-zero → note and continue. **Never** invoke `/codex:rescue` via the Agent tool.
 - Report findings in structured format
 
 ## Output format

--- a/plugins/devops/agents/research.md
+++ b/plugins/devops/agents/research.md
@@ -18,14 +18,14 @@ Deep-dive into a topic and return structured findings.
 
 ## Context
 
-Before starting, read `{PLUGIN_ROOT}/deep-knowledge/codex-integration.md` §5 (Research Agent). If codex-plugin-cc is installed, parallel delegation to Codex is **mandatory** for 3+ research angles — not optional.
+Before starting, read `{PLUGIN_ROOT}/deep-knowledge/codex-integration.md` §5 (Research Agent) AND the "Hard Timeout & Failure-Tolerance" section. If codex-plugin-cc is installed, parallel delegation to Codex is **mandatory** for 3+ research angles — not optional — but MUST go through the `codex-safe.sh` wrapper (5-min hard timeout), never via the `/codex:rescue` Agent call.
 
 ## Responsibilities
 
 - Break topic into 3-5 research angles
 - Search web and local codebase
 - Cross-reference sources
-- **Automatically delegate** 1-2 independent sub-questions to `/codex:rescue` for parallel investigation when the topic breaks into 3+ angles. If codex-plugin-cc is not installed → skip silently.
+- **Automatically delegate** 1-2 independent sub-questions to Codex via Bash: `bash "${CLAUDE_PLUGIN_ROOT}/scripts/codex-safe.sh" "<sub-question prompt>"` — when the topic breaks into 3+ angles. Run in parallel (background Bash is fine). Handle exit codes per codex-integration.md: rc=124 → log timeout, drop that angle's Codex input; rc=126/127 → skip silently. **Never** invoke `/codex:rescue` via the Agent tool.
 - Return structured report (clearly attribute Codex-sourced findings)
 
 ## Output format

--- a/plugins/devops/deep-knowledge/codex-integration.md
+++ b/plugins/devops/deep-knowledge/codex-integration.md
@@ -10,6 +10,47 @@ Before calling any `/codex:*` skill, check availability. The simplest method:
 attempt to invoke the skill and handle graceful failure. Do NOT block workflows
 if Codex is unavailable.
 
+## Hard Timeout & Failure-Tolerance (MANDATORY)
+
+Codex calls **MUST** be wrapped so they cannot stall the main session. The
+`/codex:rescue` subagent and `codex-companion.mjs task` helper have no built-in
+wall-clock ceiling — when the user's Codex usage limit is exhausted, auth
+expires, or the upstream service stalls, the Codex process hangs silently and
+the calling devops workflow waits forever.
+
+**Rule:** From every devops integration point (skills and agents), invoke
+Codex via the plugin wrapper `{PLUGIN_ROOT}/scripts/codex-safe.sh` using the
+Bash tool — NOT via `Agent(subagent_type: "codex:codex-rescue")` and NOT via
+raw `node codex-companion.mjs` calls.
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/codex-safe.sh" "<prompt text>"
+# or with a custom ceiling / model:
+CODEX_SAFE_TIMEOUT=180 bash "${CLAUDE_PLUGIN_ROOT}/scripts/codex-safe.sh" \
+  --model gpt-5.3-codex "<prompt text>"
+```
+
+The wrapper enforces a **5-minute** default ceiling
+(`CODEX_SAFE_TIMEOUT`, seconds) and exits deterministically:
+
+| rc   | Meaning                          | Required Action                                                 |
+|------|----------------------------------|-----------------------------------------------------------------|
+| 0    | Codex returned output            | Use stdout as advisory input                                    |
+| 124  | Timeout exceeded                 | **Continue without Codex findings.** Log "Codex timed out — proceeding without review." Do NOT retry. |
+| 126  | `DEVOPS_DISABLE_CODEX=1`         | Skip silently                                                   |
+| 127  | `codex` CLI missing              | Skip silently (graceful unavailability)                         |
+| *    | Codex error (auth, quota, etc.)  | Skip Codex findings, note stderr briefly, continue              |
+
+**Hard constraints:**
+
+- Never retry on rc=124. One shot, then move on.
+- Never block the user on a Codex result — all findings are advisory.
+- Do NOT call `/codex:rescue` via the Agent tool from inside any devops
+  skill or agent. The Agent tool has no timeout; if Codex hangs, the whole
+  session hangs.
+- Users can preemptively disable Codex integration for a session by setting
+  `DEVOPS_DISABLE_CODEX=1` in `.claude/settings.local.json` env.
+
 **Pattern used across all integration points:**
 
 ```

--- a/plugins/devops/scripts/codex-safe.sh
+++ b/plugins/devops/scripts/codex-safe.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# codex-safe.sh — hard-timeout wrapper for `codex` CLI invocations from the
+# devops plugin. Prevents main Claude sessions from hanging when Codex usage
+# limits are exhausted, auth expired, or the Codex process stalls.
+#
+# Usage (args are forwarded to `codex exec`):
+#   codex-safe.sh "<prompt>"
+#   codex-safe.sh --model gpt-5.3-codex "<prompt>"
+#   echo "$PROMPT" | codex-safe.sh -
+#
+# Environment:
+#   CODEX_SAFE_TIMEOUT     timeout in seconds (default: 300 = 5 min)
+#   DEVOPS_DISABLE_CODEX   if "1", skip invocation entirely (exit 126)
+#   CODEX_SAFE_SUBCOMMAND  override subcommand (default: exec; e.g. "review")
+#
+# Exit codes:
+#   0    Codex returned a result on stdout
+#   124  Timeout — caller MUST continue WITHOUT Codex findings
+#   126  Disabled via DEVOPS_DISABLE_CODEX=1 — skip silently
+#   127  `codex` CLI not installed — skip silently
+#   *    Codex error (auth, quota, rate-limit) — surface stderr, continue
+
+set -u
+
+TIMEOUT_SECONDS="${CODEX_SAFE_TIMEOUT:-300}"
+SUBCOMMAND="${CODEX_SAFE_SUBCOMMAND:-exec}"
+
+if [[ "${DEVOPS_DISABLE_CODEX:-0}" == "1" ]]; then
+  echo "codex-safe: DEVOPS_DISABLE_CODEX=1 — skipping." >&2
+  exit 126
+fi
+
+if ! command -v codex >/dev/null 2>&1; then
+  echo "codex-safe: \`codex\` CLI not found on PATH — skipping." >&2
+  exit 127
+fi
+
+if ! command -v timeout >/dev/null 2>&1; then
+  echo "codex-safe: GNU \`timeout\` not available — running without ceiling." >&2
+  codex "${SUBCOMMAND}" "$@"
+  exit $?
+fi
+
+timeout --kill-after=10 "${TIMEOUT_SECONDS}" codex "${SUBCOMMAND}" "$@"
+rc=$?
+
+if [[ $rc -eq 124 || $rc -eq 137 ]]; then
+  echo "codex-safe: Codex exceeded ${TIMEOUT_SECONDS}s — aborted, continue without Codex findings." >&2
+  exit 124
+fi
+
+exit $rc

--- a/plugins/devops/skills/devops-deep-research/SKILL.md
+++ b/plugins/devops/skills/devops-deep-research/SKILL.md
@@ -27,7 +27,7 @@ Do NOT call Read on files that may not exist — skip missing files silently (no
 2. Project: `{project}/.claude/skills/deep-research/SKILL.md` + `reference.md`
 3. Merge: project > global > plugin defaults
 
-4. Codex context: Read `{PLUGIN_ROOT}/deep-knowledge/codex-integration.md` — this skill auto-delegates sub-questions to Codex for parallel research (§5 in that doc). Detect Codex availability now so Step 3 can act on it.
+4. Codex context: Read `{PLUGIN_ROOT}/deep-knowledge/codex-integration.md` — this skill auto-delegates sub-questions to Codex for parallel research (§5 in that doc). Codex **MUST** be invoked via `{PLUGIN_ROOT}/scripts/codex-safe.sh` (5-min hard timeout, see "Hard Timeout & Failure-Tolerance" section), NEVER via the `/codex:rescue` Agent tool. Detect Codex availability now so Step 3 can act on it.
 
 ## Step 1 — Depth check
 

--- a/plugins/devops/skills/devops-flow/SKILL.md
+++ b/plugins/devops/skills/devops-flow/SKILL.md
@@ -29,7 +29,7 @@ Do NOT call Read on files that may not exist — skip missing files silently (no
 Project extensions define framework-specific log paths (e.g., Electron logs in
 `%APPDATA%/<app>/logs/`, Angular dev server console, etc.).
 
-4. Codex context: Read `{PLUGIN_ROOT}/deep-knowledge/codex-integration.md` — this skill auto-invokes `/codex:rescue` on unclear root cause (§2 in that doc). Detect Codex availability now so Step 6 can act on it.
+4. Codex context: Read `{PLUGIN_ROOT}/deep-knowledge/codex-integration.md` — this skill auto-invokes Codex on unclear root cause (§2 in that doc). Codex **MUST** be called via `{PLUGIN_ROOT}/scripts/codex-safe.sh` (5-min hard timeout, see "Hard Timeout & Failure-Tolerance" section), NEVER via the `/codex:rescue` Agent tool. Detect Codex availability now so Step 6 can act on it.
 
 ## Step 1 — Triage: what broke?
 
@@ -74,7 +74,7 @@ Find the actual broken invariant — not just the symptom. Ask:
 | **Trivial fix** (typo, missing import, off-by-one) | Fix immediately, report what was wrong |
 | **Clear root cause, low risk** (single file) | Fix immediately, explain root cause |
 | **Clear root cause, medium risk** (multiple files) | Propose fix via `AskUserQuestion` |
-| **Unclear root cause** | Present findings, propose 2-3 hypotheses, ask user. **Automatically invoke** `/codex:rescue` for parallel independent investigation (if codex-plugin-cc installed — skip silently if not) |
+| **Unclear root cause** | Present findings, propose 2-3 hypotheses, ask user. **Automatically invoke** Codex via Bash: `bash "${CLAUDE_PLUGIN_ROOT}/scripts/codex-safe.sh" "<investigation prompt>"` for parallel independent investigation. Handle exit codes per codex-integration.md "Hard Timeout" section: rc=124 → continue without Codex findings, note "Codex timed out"; rc=126/127 → skip silently. Never use the `/codex:rescue` Agent tool. |
 | **Architectural issue** | Report root cause, do NOT fix — recommend planned approach |
 
 ## Step 7 — Implement fix (if appropriate)

--- a/plugins/devops/skills/devops-ship/SKILL.md
+++ b/plugins/devops/skills/devops-ship/SKILL.md
@@ -53,7 +53,7 @@ Do NOT call Read on files that may not exist — skip missing files silently (no
 
 Project extensions define: quality gate commands, deploy targets, version files, CI specifics.
 
-4. Codex context: Read `{PLUGIN_ROOT}/deep-knowledge/codex-integration.md` — this skill has a **mandatory** Codex review gate (§1 in that doc). Detect Codex availability now so Step 2 can act on it.
+4. Codex context: Read `{PLUGIN_ROOT}/deep-knowledge/codex-integration.md` — this skill has a **mandatory** Codex review gate (§1 in that doc), which MUST be called via `{PLUGIN_ROOT}/scripts/codex-safe.sh` (5-min hard timeout, see "Hard Timeout & Failure-Tolerance" section), NEVER via the `/codex:rescue` Agent tool. Detect Codex availability now so Step 2 can act on it.
 
 ## Step 1 — Pre-Flight & Rebase Loop
 
@@ -146,12 +146,15 @@ If `success: false` → call `render_completion_card` with variant `ship-blocked
 
 **MUST run** if codex-plugin-cc is installed — not optional, not suggested.
 
-1. Invoke `/codex:rescue` with the diff as context for independent code review
-2. Evaluate findings:
-   - **No findings / clean** → continue to Step 3
-   - **Auto-fixable** (typos, missing imports, style) → fix inline, continue
-   - **Judgment required** (design concerns, logic flaws, security) →
+1. Invoke Codex via Bash with hard timeout: `bash "${CLAUDE_PLUGIN_ROOT}/scripts/codex-safe.sh" "<review prompt containing git diff>"`. Do NOT use the `/codex:rescue` Agent tool.
+2. Evaluate by exit code (see `deep-knowledge/codex-integration.md` "Hard Timeout & Failure-Tolerance"):
+   - **rc=0, no findings / clean** → continue to Step 3
+   - **rc=0, auto-fixable** (typos, missing imports, style) → fix inline, continue
+   - **rc=0, judgment required** (design concerns, logic flaws, security) →
      AskUserQuestion with findings + options: "Fixen", "Ignorieren", "Abbrechen"
+   - **rc=124** (timeout, 5 min) → log "Codex review timed out — proceeding without review" in the ship log, continue to Step 3. Do NOT retry, do NOT block the ship.
+   - **rc=126** (`DEVOPS_DISABLE_CODEX=1`) or **rc=127** (codex CLI missing) → skip silently
+   - **other non-zero** → surface first line of stderr, continue to Step 3
 3. If codex-plugin-cc not installed → skip silently
 
 ## Step 3 — Version Bump

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.49.0",
+  "version": "0.50.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

- Prevents main Claude sessions from hanging indefinitely when the user's Codex usage limit is exhausted, auth expires, or the upstream stalls
- New `plugins/devops/scripts/codex-safe.sh` wraps `codex exec` with GNU `timeout` (300s default, override via `CODEX_SAFE_TIMEOUT`) and deterministic exit codes: `0` output, `124` timeout, `126` disabled, `127` missing CLI
- All devops Codex integration points (ship review, flow rescue, QA agent, research agent, deep-research) now go through the wrapper via Bash instead of `/codex:rescue` via the Agent tool — the Agent tool has no timeout, which is the root cause of the hang
- New "Hard Timeout & Failure-Tolerance" section in `deep-knowledge/codex-integration.md` documents the contract and the `DEVOPS_DISABLE_CODEX=1` kill-switch

## Dogfooding

While shipping this PR the ship pipeline's own Codex review gate triggered the scenario it fixes — the usage limit was exhausted mid-call. With the wrapper in place the review aborted within seconds with `rc=1` and the ship proceeded without review per the new contract, instead of hanging the session.

## Test plan

- [x] `plugins/devops/scripts/codex-safe.sh --help` → passes through to `codex exec --help`
- [x] Lint + tests pass (89/89 vitest tests, eslint clean)
- [x] End-to-end: ship pipeline handled real `codex` rate-limit gracefully
- [ ] Manual follow-up: verify `DEVOPS_DISABLE_CODEX=1` short-circuits in the next ship
- [ ] Manual follow-up: verify timeout path (`CODEX_SAFE_TIMEOUT=2`) returns `rc=124`