### PR TITLE
fix(ship): stage dotfile-first modified files in release commit

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.49.0"
+    "version": "0.50.1"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.49.0",
+      "version": "0.50.1",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.49.0",
+      "version": "0.50.1",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.50.1] — 2026-04-18
+
+### Fixed
+
+- **mcp-server/ship/lib/git.js** — `dirtyState` now parses `git status --porcelain -z` (NUL-separated, unescaped) instead of the plain porcelain output. The previous code `.trim()`-ed the full stdout and then `slice(3)`-ed each line, which silently consumed the leading space of the first porcelain line. For unstaged modifications whose path starts with `.` (notably `.claude-plugin/marketplace.json`, which sorts before any letter), the leading dot was eaten, producing `claude-plugin/marketplace.json` — a pathspec `git add --` rejects. Because the `git()` helper swallows errors, the staging failure was invisible. Symptom: v0.48.0, v0.48.1, v0.49.0, v0.50.0 ships all needed a manual rescue commit to include `marketplace.json`. Regression test added to `git.test.js`
+- **mcp-server/ship/tools/release.js** — staging switched to `git add -u :/` for tracked modifications and `git add -- :/${file}` for untracked files. The `:/` pathspec anchors at the repo root regardless of `opts.cwd`, so plugin-dev ships (cwd is a plugin subdirectory) stage correctly too. Previously `git add -- <path>` resolved `<path>` against `cwd`, while porcelain always reports repo-root-relative paths — a mismatch that silently dropped every stage call when cwd ≠ repo root
+
 ## [0.50.0] — 2026-04-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.50.0**
+**Version: 0.50.1**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.50.0",
+  "version": "0.50.1",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/mcp-server/ship/lib/git.js
+++ b/plugins/devops/mcp-server/ship/lib/git.js
@@ -48,16 +48,57 @@ export function currentBranch(opts) {
 
 /**
  * Check if working tree is dirty. Returns { dirty, untracked, modified, lines }.
+ *
+ * Uses `--porcelain -z` so the output is NUL-separated with unescaped paths.
+ * This avoids two bugs of the plain-porcelain + trim() approach:
+ *   1. `.trim()` on the whole output consumed the leading space of the first
+ *      line, shifting `slice(3)` off-by-one for dotfile paths (e.g. the first
+ *      line " M .claude-plugin/marketplace.json" became
+ *      "M .claude-plugin/..." → slice(3) = "claude-plugin/..." with the
+ *      leading dot eaten, making `git add` fail with "pathspec did not match").
+ *   2. Paths with special characters were quoted/escaped in porcelain v1.
+ *
+ * Paths are returned relative to the repository root (porcelain semantics),
+ * regardless of `opts.cwd`.
  */
 export function dirtyState(opts) {
-  const status = git("status --porcelain", opts) || "";
-  const lines = status.split("\n").filter(Boolean);
-  const untracked = lines.filter((l) => l.startsWith("??"));
-  const modified = lines.filter((l) => !l.startsWith("??"));
+  const { cwd = process.cwd(), timeout = DEFAULT_TIMEOUT } = opts || {};
+  let raw;
+  try {
+    raw = execSync("git status --porcelain -z", {
+      cwd,
+      encoding: "utf8",
+      timeout,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+  } catch {
+    return { dirty: false, untracked: [], modified: [], lines: [] };
+  }
+
+  const tokens = raw.split("\0");
+  const lines = [];
+  const untracked = [];
+  const modified = [];
+
+  for (let i = 0; i < tokens.length; i++) {
+    const tok = tokens[i];
+    if (!tok || tok.length < 3) continue;
+    const xy = tok.slice(0, 2);
+    const path = tok.slice(3);
+    lines.push(tok);
+
+    if (xy === "??") untracked.push(path);
+    else modified.push(path);
+
+    // Rename/copy entries emit the source path as a separate NUL-terminated
+    // token right after — consume it so it does not become a phantom entry.
+    if (xy[0] === "R" || xy[0] === "C" || xy[1] === "R" || xy[1] === "C") i++;
+  }
+
   return {
     dirty: lines.length > 0,
-    untracked: untracked.map((l) => l.slice(3)),
-    modified: modified.map((l) => l.slice(3)),
+    untracked,
+    modified,
     lines,
   };
 }

--- a/plugins/devops/mcp-server/ship/lib/git.test.js
+++ b/plugins/devops/mcp-server/ship/lib/git.test.js
@@ -79,21 +79,46 @@ describe("dirtyState", () => {
     expect(state.lines).toEqual([]);
   });
 
-  test("modified and untracked files", () => {
-    // Use "M " (staged) for first line — leading space in " M" gets eaten by trim()
-    execSync.mockReturnValue("M  src/index.js\n?? new-file.txt\n");
+  test("modified and untracked files (-z format)", () => {
+    // -z: NUL-terminated, first entry unstaged modification, second untracked.
+    execSync.mockReturnValue(" M src/index.js\0?? new-file.txt\0");
     const state = dirtyState();
     expect(state.dirty).toBe(true);
     expect(state.modified).toEqual(["src/index.js"]);
     expect(state.untracked).toEqual(["new-file.txt"]);
   });
 
-  test("multiple modified files", () => {
-    execSync.mockReturnValue("MM a.js\n M b.js\nA  c.js\n");
+  test("first line unstaged dotfile preserves leading dot (regression: v0.48 ship)", () => {
+    // Repro for the bug that made ship_release silently drop
+    // .claude-plugin/marketplace.json from marketplace-project release
+    // commits: the first porcelain line " M .claude-plugin/..." lost its
+    // leading space to trim(), and slice(3) then stripped the leading dot
+    // — making `git add -- claude-plugin/marketplace.json` fail silently.
+    execSync.mockReturnValue(
+      " M .claude-plugin/marketplace.json\0 M README.md\0 M plugins/devops/.claude-plugin/plugin.json\0",
+    );
+    const state = dirtyState();
+    expect(state.modified).toEqual([
+      ".claude-plugin/marketplace.json",
+      "README.md",
+      "plugins/devops/.claude-plugin/plugin.json",
+    ]);
+    expect(state.untracked).toEqual([]);
+  });
+
+  test("multiple modified files with mixed index/worktree status", () => {
+    execSync.mockReturnValue("MM a.js\0 M b.js\0A  c.js\0");
     const state = dirtyState();
     expect(state.dirty).toBe(true);
-    expect(state.modified).toHaveLength(3);
+    expect(state.modified).toEqual(["a.js", "b.js", "c.js"]);
     expect(state.untracked).toHaveLength(0);
+  });
+
+  test("rename entry consumes source-path token", () => {
+    // `R  NEW\0OLD\0` — the old path must not leak into modified[].
+    execSync.mockReturnValue("R  new.js\0old.js\0 M other.js\0");
+    const state = dirtyState();
+    expect(state.modified).toEqual(["new.js", "other.js"]);
   });
 
   test("returns empty on git failure", () => {

--- a/plugins/devops/mcp-server/ship/tools/release.js
+++ b/plugins/devops/mcp-server/ship/tools/release.js
@@ -34,15 +34,19 @@ export async function handler(params) {
     if (commitMessage) {
       const state = dirtyState(opts);
       if (state.modified.length > 0) {
-        for (const file of state.modified) {
-          git(`add -- ${file}`, opts);
-        }
+        // Stage every tracked modification across the repo in one call.
+        // The `:/` pathspec anchors at the repo root, so this works whether
+        // cwd is the repo root or a plugin subdirectory (dirtyState returns
+        // repo-root-relative paths, which `git add` from cwd would otherwise
+        // misresolve).
+        git(`add -u :/`, opts);
       }
       if (state.untracked.length > 0) {
         const safePatterns = ["CHANGELOG.md", "changelog.md"];
         for (const file of state.untracked) {
           if (safePatterns.some(p => file.endsWith(p))) {
-            git(`add -- ${file}`, opts);
+            // `:/${file}` resolves against repo root regardless of cwd.
+            git(`add -- :/${file}`, opts);
           }
         }
         const skipped = state.untracked.filter(f => !safePatterns.some(p => f.endsWith(p)));

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.50.0",
+  "version": "0.50.1",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

Both the v0.48.0 and v0.48.1 ships needed a manual `chore(release): include marketplace.json in v0.48.X bump` rescue commit because `ship_release` silently dropped `.claude-plugin/marketplace.json` from the release commit. Root cause turned out to be a subtle parsing bug, not a hardcoded file list.

## Root cause

### Bug 1 — `dirtyState` trim ate the leading space of the first porcelain line

`lib/git.js::dirtyState` ran `git status --porcelain`, `.trim()`ed the full output, then `slice(3)` on each line to extract the path. Porcelain v1 format is `XY␣PATH` (3 prefix chars). For an unstaged modification, X is a space. When the first line was unstaged, the full-output `.trim()` consumed that leading space, and `slice(3)` was off by one.

For paths starting with `.` — and `.claude-plugin/marketplace.json` sorts before any letter in porcelain output — the leading dot got eaten, producing `claude-plugin/marketplace.json`, which `git add --` rejected with `pathspec did not match`. The `git()` helper swallows errors and returns null, so the failure was invisible and the commit proceeded without the file.

The old [`git.test.js:83`](../blob/main/plugins/devops/mcp-server/ship/lib/git.test.js#L83) test had a comment acknowledging the bug and working around it (`// Use "M " (staged) for first line — leading space in " M" gets eaten by trim()`).

### Bug 2 — `git add -- <path>` was cwd-scoped while porcelain paths are repo-root-scoped

Even when paths parsed correctly, `release.js` called `git add -- ${file}` from `opts.cwd`. But `git status --porcelain` always returns paths relative to the **repo root**, not cwd. For plugin-dev ships where cwd is `plugins/devops/`, every stage call would miss.

## Fix

**[`lib/git.js`](../blob/main/plugins/devops/mcp-server/ship/lib/git.js)**: parse with `git status --porcelain -z` (NUL-separated, unescaped, no trim issue, correct rename/copy handling). Returns paths unchanged, still repo-root-relative.

**[`tools/release.js`](../blob/main/plugins/devops/mcp-server/ship/tools/release.js)**: stage tracked modifications via `git add -u :/` (one call, all repo, any cwd) and untracked files via `git add -- :/${file}`. The `:/` pathspec anchors at repo root regardless of cwd.

## Verification

- ✅ All 91 vitest tests pass
- ✅ Lint clean
- ✅ End-to-end smoke test on a synthetic dotclaude-shaped repo reproduces the old bug (marketplace.json stays unstaged) and confirms the fix (all four version-bumped files stage in one commit)
- ✅ Fix works from both repo-root cwd and plugin-subdir cwd

## Test plan

- [ ] Run `npm test` — confirm the new regression case fails on `main` and passes on this branch
- [ ] On next ship (v0.49.1+), confirm the `chore(release)` commit includes `.claude-plugin/marketplace.json` without a manual rescue

🤖 Generated with [Claude Code](https://claude.com/claude-code)