### PR TITLE
feat(ship): auto-allow write to ~/.claude/devops-concepts

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.50.1"
+    "version": "0.50.2"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.50.1",
+      "version": "0.50.2",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.50.1",
+      "version": "0.50.2",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.50.2] — 2026-04-18
+
+### Added
+
+- **plugins/devops/hooks/session-start/ss.permissions.ensure.js** — new SessionStart hook that idempotently adds `Write(~/.claude/devops-concepts/**)` and `Edit(~/.claude/devops-concepts/**)` to the user's `~/.claude/settings.json` allow-list, and ensures the `~/.claude/devops-concepts/` directory exists. Eliminates repeated permission prompts when report-writing skills persist ephemeral review artifacts. Applies automatically to every consumer of the plugin — no manual per-project setup
+
+### Changed
+
+- **plugins/devops/skills/devops-repo-health** — report output (`{date}-repo-health.html` and `{date}-repo-health-decisions.json`) now writes to the user-global `~/.claude/devops-concepts/` directory instead of `{project}/.claude/devops-concept/`. Reports are ephemeral review artifacts, not repo content, and no longer pollute consumer project trees or trigger permission prompts
+
 ## [0.50.1] — 2026-04-18
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.50.1**
+**Version: 0.50.2**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.50.1",
+  "version": "0.50.2",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/hooks/hooks.json
+++ b/plugins/devops/hooks/hooks.json
@@ -5,6 +5,7 @@
       {
         "hooks": [
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-start/ss.plugin.update.js" },
+          { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-start/ss.permissions.ensure.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-start/ss.knowledge.index.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-start/ss.mcp.deps.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-start/ss.tokens.scan.js" },

--- a/plugins/devops/hooks/session-start/ss.permissions.ensure.js
+++ b/plugins/devops/hooks/session-start/ss.permissions.ensure.js
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+/**
+ * SessionStart hook: ensure user-global permission rules exist so devops
+ * skills that write ephemeral review artifacts don't trigger permission
+ * prompts on every run.
+ *
+ * Idempotent: only adds rules that are missing. Never removes anything.
+ * Scope: user-global settings at ~/.claude/settings.json — the rules apply
+ * to all projects for this user.
+ *
+ * Also ensures the target directory exists so skills can Write without
+ * first running mkdir.
+ */
+
+const { readFileSync, writeFileSync, mkdirSync, existsSync } = require("node:fs");
+const { join } = require("node:path");
+const { homedir } = require("node:os");
+
+const HOME = homedir();
+const SETTINGS_PATH = join(HOME, ".claude", "settings.json");
+const CONCEPTS_DIR = join(HOME, ".claude", "devops-concepts");
+
+const REQUIRED_RULES = [
+  "Write(~/.claude/devops-concepts/**)",
+  "Edit(~/.claude/devops-concepts/**)",
+];
+
+try {
+  mkdirSync(CONCEPTS_DIR, { recursive: true });
+} catch {
+  // Non-fatal — skills will create the dir if needed.
+}
+
+if (!existsSync(SETTINGS_PATH)) {
+  // No user settings yet — don't create one just for this. Skills will
+  // still prompt once; the user can approve and it sticks.
+  process.exit(0);
+}
+
+let settings;
+try {
+  settings = JSON.parse(readFileSync(SETTINGS_PATH, "utf8"));
+} catch {
+  process.exit(0);
+}
+
+settings.permissions ??= {};
+settings.permissions.allow ??= [];
+
+const existing = new Set(settings.permissions.allow);
+const toAdd = REQUIRED_RULES.filter((r) => !existing.has(r));
+
+if (toAdd.length === 0) process.exit(0);
+
+settings.permissions.allow.push(...toAdd);
+
+try {
+  writeFileSync(SETTINGS_PATH, JSON.stringify(settings, null, 2) + "\n");
+  console.error(
+    `[dotclaude] Added ${toAdd.length} permission rule(s) for devops report artifacts.`,
+  );
+} catch (err) {
+  console.error(`[dotclaude] Could not update ${SETTINGS_PATH}: ${err.message}`);
+}

--- a/plugins/devops/skills/devops-repo-health/SKILL.md
+++ b/plugins/devops/skills/devops-repo-health/SKILL.md
@@ -287,7 +287,11 @@ Keep text concise — one sentence max, no jargon.
 
 ### File Location
 
-Write to: `{project}/.claude/devops-concept/{date}-repo-health.html`
+Write to: `~/.claude/devops-concepts/{date}-repo-health.html`
+(resolves to `$USERPROFILE/.claude/devops-concepts/` on Windows, `$HOME/.claude/devops-concepts/` on Unix).
+User-global, not project-scoped — reports are ephemeral review artifacts, not repo content.
+The `ss.permissions.ensure.js` SessionStart hook pre-approves writes to this path so no permission prompt fires.
+Create the directory if missing: `mkdir -p ~/.claude/devops-concepts` (Unix) or `mkdir "%USERPROFILE%\.claude\devops-concepts" 2>nul` (Windows).
 
 ### Important Design Details
 
@@ -350,7 +354,7 @@ When the user submits via the concept page:
    - Show summary: "X Branches geloescht, Y uebersprungen"
    - Reset submit state for potential second round
 
-6. **Persist results** to `{project}/.claude/devops-concept/{date}-repo-health-decisions.json`
+6. **Persist results** to `~/.claude/devops-concepts/{date}-repo-health-decisions.json`
 
 ### Safety Invariants
 

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.50.1",
+  "version": "0.50.2",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

- New SessionStart hook `ss.permissions.ensure.js` idempotently adds `Write/Edit(~/.claude/devops-concepts/**)` to the user's `~/.claude/settings.json` allow-list and creates the directory. Eliminates repeated permission prompts for report-writing skills across every consumer of the plugin.
- `devops-repo-health` report output moved from `{project}/.claude/devops-concept/` to user-global `~/.claude/devops-concepts/` — reports are ephemeral review artifacts, not repo content.

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` — 91 tests pass
- [x] Hook runs idempotently (verified: second invocation is silent no-op)