### PR TITLE
docs: extract long SKILL.md sections + fix 2 paradoxes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.50.2"
+    "version": "0.50.3"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.50.2",
+      "version": "0.50.3",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.50.2",
+      "version": "0.50.3",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [0.50.3] — 2026-04-18
+
+### Fixed
+
+- **CLAUDE.md** — "Monorepo: single plugin under `plugins/devops/`" claim contradicted the actual tree (`plugins/devops/` + `plugins/local-llm/`). Replaced with the accurate two-plugin list
+- **plugins/devops/CONVENTIONS.md** — the "Directory Structure" section listed a stale hook tree that was missing five session-start hooks (`ss.git.sync`, `ss.knowledge.index`, `ss.permissions.ensure`, `ss.plugin.update`, `ss.team.changelog`) and still showed `prompt.git.sync.js` under `user-prompt-submit/` even though that hook moved to `session-start/`. Replaced the hand-maintained tree with a one-liner pointing at `hooks/hooks.json` — the authoritative registry — so the doc cannot drift again
+
+### Changed
+
+- **plugins/devops/skills/devops-concept** — extracted the Post-Generation Validation gate (16-pattern grep table), the Concept Bridge Server + Edge setup (server launch, combined heartbeat + auto-poll cron, `/pending` rationale, cleanup), and the Iteration Tabs rules (tab-bar placement, freeze behavior, single-file invariant) into `deep-knowledge/validation-gate.md`, `deep-knowledge/bridge-server.md`, and `deep-knowledge/iteration-rules.md`. SKILL.md: 521 → 391 lines
+- **plugins/devops/skills/devops-repo-health** — extracted the full Page Structure ASCII mockup and the mandatory Tooltip Explanations table into `deep-knowledge/page-structure.md`; the Decision Schema JSON payload moved to `deep-knowledge/decision-schema.md`. SKILL.md: 408 → 277 lines
+- **plugins/devops/skills/devops-ship** — extracted the three reference `ship_release` call payloads (final-to-main, intermediate, overlap-with-merge), the direct-ship and intermediate-ship data-flow diagrams, and the hierarchical merge workflow into `deep-knowledge/call-examples.md`, `deep-knowledge/data-flow.md`, and `deep-knowledge/hierarchical-merge.md`. SKILL.md: 400 → 305 lines
+- **plugins/devops/skills/devops-autonomous** — extracted the Step 7b HTML report structure (header, completion-card widget, per-mode sections, footer) and the design guidelines into `deep-knowledge/html-report.md`. SKILL.md: 381 → 351 lines
+- **plugins/devops/skills/devops-burn** — extracted the full Step 7 composite prompt template (burn-guidance, parallelization, throughput, task ordering, consolidation) into `deep-knowledge/composite-prompt.md`. SKILL.md: 267 → 225 lines
+
+All extractions are content-preserving: every SKILL.md keeps a short pointer to its moved block, no rules or behavior changed, no test changes. 91/91 vitest green.
+
 ## [0.50.2] — 2026-04-18
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ See @.claude/project-map.md for directory structure.
 - `npm run lint:fix` — eslint autofix
 
 ## Architecture
-- Monorepo: single plugin under `plugins/devops/`
+- Monorepo: `plugins/devops/` (core) + `plugins/local-llm/` (token saver)
 - Skills, hooks, agents, MCP server, templates, deep-knowledge, scheduled-tasks
 - Versioning: SemVer in `.claude-plugin/plugin.json`, tags `v0.x.y`
 - Conventions: `plugins/devops/CONVENTIONS.md` (hook naming, skill structure, etc.)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.50.2**
+**Version: 0.50.3**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.50.2",
+  "version": "0.50.3",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/CONVENTIONS.md
+++ b/plugins/devops/CONVENTIONS.md
@@ -61,27 +61,10 @@ A hook version bumps when:
 
 ### Directory Structure
 
-```
-hooks/
-├── hooks.json                  ← Registry (declares all hooks + matchers)
-├── session-start/
-│   ├── ss.git.check.js
-│   ├── ss.mcp.deps.js
-│   ├── ss.tokens.scan.js
-│   └── ss.flow.selfcalibration.js
-├── pre-tool-use/
-│   └── pre.tokens.guard.js
-├── post-tool-use/
-│   ├── post.flow.completion.js
-│   └── post.flow.debug.js
-├── user-prompt-submit/
-│   ├── prompt.git.sync.js
-│   ├── prompt.issue.detect.js
-│   ├── prompt.ship.detect.js
-│   └── prompt.flow.appstart.js
-└── stop/
-    └── stop.flow.guard.js
-```
+Hooks are organized by event under `hooks/{event}/` (e.g. `session-start/`,
+`pre-tool-use/`, `post-tool-use/`, `user-prompt-submit/`, `stop/`).
+The authoritative list of registered hooks and their matchers is
+`hooks/hooks.json` — read that file for the current roster.
 
 ### Exit Codes
 

--- a/plugins/devops/skills/devops-autonomous/SKILL.md
+++ b/plugins/devops/skills/devops-autonomous/SKILL.md
@@ -312,42 +312,12 @@ Call `render_completion_card` (variant per status: "ship-successful" for COMPLET
 
 ### 7b — Build HTML Report
 
-Save `AUTONOMOUS-REPORT.html` to project root (replaces any previous report).
+Write a self-contained `AUTONOMOUS-REPORT.html` (inline CSS, no external deps,
+dark theme) to project root — replacing any previous report.
 
-The HTML file must be a **self-contained single file** (inline CSS, no external deps).
-Use a clean, modern dark-theme design. Structure:
-
-**Header section:**
-- Task goal, mode (Implement/Analyze), status badge (green/yellow/red)
-- Duration, branch name (implement mode), timestamp
-
-**Completion Card section:**
-- Embed the full completion card data in a styled card widget
-- Include: summary, changes, test results, build-ID, usage/battery info
-- Present it visually (not raw markdown) — use the card's data fields
-
-**`implement` mode — additional sections:**
-- **Changes** — collapsible table: file, action, summary
-- **Verification** — build status, test results, live test results
-- **Related Fixes / Blocked Actions / Warnings** — if any
-
-**`analyze` mode — additional sections:**
-- **Findings** — key observations as styled cards or list
-- **Architecture / Code Quality** — insights with visual hierarchy
-- **Recommendations** — priority-sorted table: priority, area, recommendation, effort
-- **Visual Verification** — embedded screenshots (base64 data URIs if taken)
-
-**Both modes — footer:**
-- Open questions (if any)
-- Timestamp, branch info, git status summary
-
-**Design guidelines:**
-- Dark background (#1a1a2e or similar), accent colors for status
-- Collapsible sections via `<details>/<summary>`
-- Status badge: COMPLETED = green, INTERRUPTED = amber, PARTIAL = amber, BLOCKED = red
-- INTERRUPTED section: show missing permission, saved progress, resume instructions
-- Responsive layout, readable on any screen size
-- Monospace font for code/file paths, sans-serif for prose
+See `deep-knowledge/html-report.md` for the full structure (header,
+completion-card widget, implement/analyze sections, footer) and the
+design guidelines (colors, status badges, collapsible sections, fonts).
 
 ### 7c — Open in Browser
 

--- a/plugins/devops/skills/devops-autonomous/deep-knowledge/html-report.md
+++ b/plugins/devops/skills/devops-autonomous/deep-knowledge/html-report.md
@@ -1,0 +1,41 @@
+# Autonomous HTML Report — Structure & Design
+
+Save `AUTONOMOUS-REPORT.html` to project root (replaces any previous report).
+
+The HTML file must be a **self-contained single file** (inline CSS, no
+external deps). Use a clean, modern dark-theme design.
+
+## Structure
+
+**Header section:**
+- Task goal, mode (Implement/Analyze), status badge (green/yellow/red)
+- Duration, branch name (implement mode), timestamp
+
+**Completion Card section:**
+- Embed the full completion card data in a styled card widget
+- Include: summary, changes, test results, build-ID, usage/battery info
+- Present it visually (not raw markdown) — use the card's data fields
+
+**`implement` mode — additional sections:**
+- **Changes** — collapsible table: file, action, summary
+- **Verification** — build status, test results, live test results
+- **Related Fixes / Blocked Actions / Warnings** — if any
+
+**`analyze` mode — additional sections:**
+- **Findings** — key observations as styled cards or list
+- **Architecture / Code Quality** — insights with visual hierarchy
+- **Recommendations** — priority-sorted table: priority, area, recommendation, effort
+- **Visual Verification** — embedded screenshots (base64 data URIs if taken)
+
+**Both modes — footer:**
+- Open questions (if any)
+- Timestamp, branch info, git status summary
+
+## Design Guidelines
+
+- Dark background (#1a1a2e or similar), accent colors for status
+- Collapsible sections via `<details>/<summary>`
+- Status badge: COMPLETED = green, INTERRUPTED = amber, PARTIAL = amber, BLOCKED = red
+- INTERRUPTED section: show missing permission, saved progress, resume instructions
+- Responsive layout, readable on any screen size
+- Monospace font for code/file paths, sans-serif for prose

--- a/plugins/devops/skills/devops-burn/SKILL.md
+++ b/plugins/devops/skills/devops-burn/SKILL.md
@@ -201,57 +201,15 @@ execution, reporting, shutdown).
 
 ### Composite Prompt Construction
 
-Build the autonomous task prompt as follows:
+Build the autonomous task prompt from the template in
+`deep-knowledge/composite-prompt.md` — it specifies the Hauptauftrag +
+prioritized task list + burn-guidance (browser Edge Credo, parallelization
+rules, throughput optimization, task ordering, result consolidation).
 
-```
-BURN MODE ACTIVE — Maximale Parallelisierung.
-
-## Hauptauftrag
-{user's primary task from Step 3}
-
-## Zusaetzliche Tasks (nach Prioritaet)
-{P1 tasks}
-{P2 tasks}
-{P3–P5 tasks}
-
-## Burn-Guidance
-
-### Browser — Edge Credo
-- Alle Browser-Interaktion folgt dem Edge Credo (deep-knowledge/browser-tool-strategy.md § Edge Credo)
-- Edge only, Claude Extension only, User-Context, Tab-Reuse — auch im Burn-Modus
-
-### Parallelisierung
-- IMMER die maximale Agent-Anzahl nutzen (full devops roster: core, frontend,
-  ai, windows, designer, qa, po, research — je nach Relevanz)
-- Waves wo moeglich zusammenlegen: wenn keine harte Abhaengigkeit besteht,
-  können Agents aus verschiedenen Waves parallel starten
-- Für unabhängige Tasks: separate Feature-Branches + separate Agent-Gruppen
-  die gleichzeitig laufen
-- Research-Agent im Hintergrund für alle Tasks die Kontext brauchen
-
-### Durchsatz-Optimierung
-- Keine übertriebene Planung — direkt starten
-- Bei Zweifeln: implementieren statt recherchieren
-- Tests erst am Ende als QA-Wave, nicht nach jedem Einzeltask
-- Lint/Type-Fixes können ohne eigenen Agent inline passieren
-- Kleine Tasks (< 5 Minuten geschätzt) direkt inline, nicht delegieren
-
-### Task-Reihenfolge
-- P0 und P1 Tasks starten sofort in Wave 1
-- P2+ Tasks starten parallel sobald Agents frei werden
-- Wenn ein Agent früher fertig wird: nächsten Task aus der Queue ziehen
-- Nie idle sein — immer den nächsten Task starten
-
-### Ergebnis-Konsolidierung
-- Alle Änderungen auf dem gleichen Integration-Branch sammeln
-- Sub-Branches pro Agent, sequentiell mergen
-- Ein finaler QA-Durchlauf über alle Änderungen
-- AUTONOMOUS-REPORT.html muss alle Tasks und deren Status enthalten
-```
-
-**Important:** Pass this entire prompt as `$ARGUMENTS` to the autonomous skill.
-The autonomous skill will then handle Steps 2–8 of its own flow (desktop questions,
-permission priming, execution, reporting, optional shutdown).
+**Important:** Pass the filled-in prompt as `$ARGUMENTS` to the autonomous
+skill. The autonomous skill then handles Steps 2–8 of its own flow
+(desktop questions, permission priming, execution, reporting, optional
+shutdown).
 
 ## Rules
 

--- a/plugins/devops/skills/devops-burn/deep-knowledge/composite-prompt.md
+++ b/plugins/devops/skills/devops-burn/deep-knowledge/composite-prompt.md
@@ -1,0 +1,52 @@
+# Burn — Composite Prompt Template
+
+Build the autonomous task prompt as follows, then pass it as `$ARGUMENTS`
+to `/devops-autonomous`. The autonomous skill handles Steps 2–8 of its
+own flow (desktop questions, permission priming, execution, reporting,
+optional shutdown).
+
+```
+BURN MODE ACTIVE — Maximale Parallelisierung.
+
+## Hauptauftrag
+{user's primary task from Step 3}
+
+## Zusaetzliche Tasks (nach Prioritaet)
+{P1 tasks}
+{P2 tasks}
+{P3–P5 tasks}
+
+## Burn-Guidance
+
+### Browser — Edge Credo
+- Alle Browser-Interaktion folgt dem Edge Credo (deep-knowledge/browser-tool-strategy.md § Edge Credo)
+- Edge only, Claude Extension only, User-Context, Tab-Reuse — auch im Burn-Modus
+
+### Parallelisierung
+- IMMER die maximale Agent-Anzahl nutzen (full devops roster: core, frontend,
+  ai, windows, designer, qa, po, research — je nach Relevanz)
+- Waves wo moeglich zusammenlegen: wenn keine harte Abhaengigkeit besteht,
+  können Agents aus verschiedenen Waves parallel starten
+- Für unabhängige Tasks: separate Feature-Branches + separate Agent-Gruppen
+  die gleichzeitig laufen
+- Research-Agent im Hintergrund für alle Tasks die Kontext brauchen
+
+### Durchsatz-Optimierung
+- Keine übertriebene Planung — direkt starten
+- Bei Zweifeln: implementieren statt recherchieren
+- Tests erst am Ende als QA-Wave, nicht nach jedem Einzeltask
+- Lint/Type-Fixes können ohne eigenen Agent inline passieren
+- Kleine Tasks (< 5 Minuten geschätzt) direkt inline, nicht delegieren
+
+### Task-Reihenfolge
+- P0 und P1 Tasks starten sofort in Wave 1
+- P2+ Tasks starten parallel sobald Agents frei werden
+- Wenn ein Agent früher fertig wird: nächsten Task aus der Queue ziehen
+- Nie idle sein — immer den nächsten Task starten
+
+### Ergebnis-Konsolidierung
+- Alle Änderungen auf dem gleichen Integration-Branch sammeln
+- Sub-Branches pro Agent, sequentiell mergen
+- Ein finaler QA-Durchlauf über alle Änderungen
+- AUTONOMOUS-REPORT.html muss alle Tasks und deren Status enthalten
+```

--- a/plugins/devops/skills/devops-concept/SKILL.md
+++ b/plugins/devops/skills/devops-concept/SKILL.md
@@ -189,73 +189,19 @@ Full example: `docs/concepts/2026-04-12-auth-middleware-redesign.html`
 
 ### Iteration Tabs (single file, many iterations)
 
-Every concept page is a stack of iteration tabs. The **tab bar lives in the
-decision panel at the top** of the content area (a slim strip above the
-variants, not in the right sidebar — the sidebar stays reserved for submit
-controls). Each tab shows exactly one iteration; the active one is interactive,
-all earlier ones are frozen (disabled inputs showing the user's submitted
-selections, read-only comments).
-
-| Situation | Action | Result |
-|-----------|--------|--------|
-| First generation | Write the file with `<section data-iteration="1" data-active>` and one tab "Iteration 1" | Tab 1 active |
-| Feedback loop iteration (Step 5c) | Append `<section data-iteration="N+1" data-active>` to the same file, remove `data-active` from the previous section, freeze it, add a new tab and make it active | New tab "Iteration N+1" auto-active, old tab selectable and read-only |
-| Fundamental rework ("nochmal neu") | Same as a feedback iteration — just another tab. The full history stays visible. | Another tab appended |
-
-**Rules:**
-- **Never create a second file** for iterations of the same concept — always
-  append a section to the existing file and POST `/reload` (see Step 5c).
-- The active iteration is the only one that accepts input. Submit sends
-  decisions for the active iteration only.
-- Freeze previous iterations visually: disabled tri-state buttons showing
-  which state the user submitted, read-only comment fields with the text
-  the user entered. Users can click back to earlier tabs to review their
-  own past feedback at any time.
-- Only the active tab runs the heartbeat / submit UI ("music"). Clicking
-  an older tab shows its frozen snapshot but does not re-arm submit.
-- Tab bar must stay compact (one line, horizontally scrollable if many
-  iterations) so it does not push variant content out of view.
-
-See `deep-knowledge/templates.md` § Iteration Tabs for the reference
-HTML/CSS/JS.
+Every concept page is a stack of iteration tabs — the decision-panel tab
+bar shows each iteration, only the active one accepts input, earlier ones
+freeze their submitted state. See `deep-knowledge/iteration-rules.md` for
+the full rules (tab placement, freeze behavior, single-file invariant)
+and `deep-knowledge/templates.md` § Iteration Tabs for the reference HTML.
 
 ### Post-Generation Validation (mandatory gate)
 
-After writing the HTML file, validate that all mandatory interactive patterns
-are present. **Grep the generated file** for each required pattern:
-
-| # | Pattern to grep | Purpose |
-|---|----------------|---------|
-| 1 | `concept-decisions` | Decision data JSON container |
-| 2 | `concept-submitted` | CSS class for monitoring detection signal |
-| 3 | `connection-warning` | Disconnection warning element |
-| 4 | `checkClaudeConnection` | Heartbeat checker function |
-| 5 | `HEARTBEAT_STALE_MS` | Heartbeat staleness threshold |
-| 6 | `HEARTBEAT_GRACE_MS` | Grace period — suppresses warning during startup |
-| 7 | `pollHeartbeat` | HTTP heartbeat polling function |
-| 8 | `panel-ready` | Ready-state panel element |
-| 9 | `panel-submitted` | Submitted-state panel element |
-| 10 | `localStorage` | Reload resilience (state persistence with TTL) |
-| 11 | `data-page-version` | Page version tag for localStorage invalidation |
-| 12 | `data-iteration` | Iteration section marker |
-| 13 | `iteration-tabs` | Tab bar container in the decision panel |
-| 14 | `pollReload` | Reload-signal poller (picks up file rewrites) |
-| 15 | `sec.hidden` | Tab-switch JS toggles the `hidden` attribute — prevents all iterations rendering at once |
-| 16 | `pollProcessedState` | Auto-reset poll handler — restores the ready panel when the server's `_processed_at` advances past the local `_submittedAt` |
-
+After writing the HTML file, grep it for the 16 mandatory interactive
+patterns (heartbeat, panel states, iteration tabs, reload polling, etc.).
 **If ANY pattern is missing → DO NOT open the page.** Fix the HTML first,
-then re-validate. This is a **blocking gate** — no exceptions, no "this
-page doesn't need it". Every concept page needs monitoring, every monitored
-page needs the heartbeat guard.
-
-**Common failures this gate catches:**
-- Heartbeat system omitted → submit button stays clickable without monitoring
-- Connection warning missing → user gets no feedback when Claude disconnects
-- Panel states missing → no visual transition on submit/reset cycle
-- localStorage missing → user selections lost on reload or tab close
-
-The patterns in `deep-knowledge/templates.md` (§ Claude Connection Heartbeat,
-§ Submit Handler, § State Persistence) provide the reference implementations.
+then re-validate. See `deep-knowledge/validation-gate.md` for the full
+pattern list and common failure modes.
 
 ## Step 3 — Open in Browser
 
@@ -264,90 +210,14 @@ open a separate browser window.
 
 ### Concept Bridge Server + Edge
 
-The **concept bridge server** (`scripts/concept-server.py`) serves static files
-AND provides HTTP endpoints for heartbeat and decision exchange.
+Start the bridge server (`scripts/concept-server.py`) on a random port
+(8700-8999), arm the combined heartbeat + auto-poll cron (fires every
+minute, handles heartbeat + decision pickup + conditional reset), send
+the first heartbeat, and open the page in the user's existing Edge window.
 
-1. Find the bridge server script:
-   ```bash
-   PLUGIN_ROOT=$(ls -d ~/.claude/plugins/cache/dotclaude/devops/*/scripts/concept-server.py 2>/dev/null | head -1)
-   ```
-
-2. Start the bridge server in the concept directory:
-   ```bash
-   python "$PLUGIN_ROOT" {random-port} "{concept-dir}" &
-   ```
-   Use a random port (8700-8999) to avoid conflicts. Store the port as `$PORT`.
-
-3. Set up the **combined heartbeat + auto-poll cron**. This single cron keeps
-   the connection indicator green AND automatically picks up user submissions
-   — no manual trigger needed from the user.
-
-   ```
-   CronCreate(cron: "* * * * *", recurring: true, prompt: <<EOF
-   Silently run both steps for the concept bridge on port {port}:
-
-   (1) Heartbeat POST:
-       Bash: curl -s -X POST http://localhost:{port}/heartbeat > /dev/null
-
-   (2) Pending check — use the deterministic /pending endpoint, NOT a
-       substring match on /decisions. The response is a strict JSON object
-       `{"pending": true|false, "version": N}` with no free-form content.
-       Bash (produces ONLY the literal string "true" or "false"):
-         curl -s http://localhost:{port}/pending | python -c "import sys,json; d=json.load(sys.stdin); print('true' if d.get('pending') else 'false')"
-
-       If the output is exactly "false" → produce NO user-visible output. Silent tick.
-
-       If the output is exactly "true" → fetch the full payload and process:
-         Bash: curl -s http://localhost:{port}/decisions
-         • Parse the JSON. Note `_version`. Strip `_version` and `_processed_at`
-           before treating the rest as decision data.
-         • Process per Step 5 (Live Feedback Loop) — act on the user's choices
-           (approve/tweak/reject, included options, comment-driven tweaks).
-         • After processing, reset conditionally — pass the noted version:
-           Bash: curl -s -o /dev/null -w "%{http_code}" -X POST \
-                       -H "Content-Type: application/json" \
-                       -d '{"version": <noted>}' http://localhost:{port}/reset
-         • If the HTTP code is 409 (version mismatch) → the user submitted
-           again while you were processing. Re-fetch /decisions, process the
-           new payload (which supersedes what you just finished), then retry
-           the conditional reset with the new `_version`.
-         • Report the outcome to the user. The browser's panel auto-resets
-           within 5s via the `_processed_at` heartbeat poll — no browser-eval
-           injection required.
-   EOF)
-   ```
-
-   **Why `/pending` + `python -c` instead of a substring check?** The
-   `/decisions` JSON response is formatted via Python's default
-   `json.dumps`, which emits `"submitted": true` **with** a space after the
-   colon — a literal `contains "submitted":true` test silently misses every
-   submission. `/pending` collapses the signal to a strict boolean so the
-   cron body cannot drift into false negatives between ticks.
-
-   **Why combined, not two crons?** One cron minimizes race conditions and makes
-   the contract explicit: every tick does both. Minimum cron resolution is 1 min,
-   so the max submit-to-process lag is ~60 s — acceptable for interactive flows.
-
-4. Send the first heartbeat immediately:
-   ```bash
-   curl -s -X POST http://localhost:{port}/heartbeat
-   ```
-
-5. Open in Edge (reuses the running instance, adds a tab):
-   ```bash
-   # Windows
-   start "" msedge "http://localhost:{port}/{filename}"
-   ```
-   On macOS: `open -a "Microsoft Edge" "http://…"`, on Linux: `microsoft-edge "http://…"`.
-
-   The empty `""` is required on Windows — without it, `cmd.exe` interprets
-   the first quoted argument as a window title.
-
-6. After monitoring ends, clean up:
-   ```bash
-   kill %1  # or track the PID
-   ```
-   Also delete the heartbeat cron via `CronDelete`.
+See `deep-knowledge/bridge-server.md` for the full setup — script lookup,
+launch command, cron body, rationale for `/pending` over substring checks,
+and cleanup.
 
 ### After opening, inform the user:
 

--- a/plugins/devops/skills/devops-concept/deep-knowledge/bridge-server.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/bridge-server.md
@@ -1,0 +1,86 @@
+# Concept Bridge Server + Edge
+
+The **concept bridge server** (`scripts/concept-server.py`) serves static files
+AND provides HTTP endpoints for heartbeat and decision exchange.
+
+1. Find the bridge server script:
+   ```bash
+   PLUGIN_ROOT=$(ls -d ~/.claude/plugins/cache/dotclaude/devops/*/scripts/concept-server.py 2>/dev/null | head -1)
+   ```
+
+2. Start the bridge server in the concept directory:
+   ```bash
+   python "$PLUGIN_ROOT" {random-port} "{concept-dir}" &
+   ```
+   Use a random port (8700-8999) to avoid conflicts. Store the port as `$PORT`.
+
+3. Set up the **combined heartbeat + auto-poll cron**. This single cron keeps
+   the connection indicator green AND automatically picks up user submissions
+   — no manual trigger needed from the user.
+
+   ```
+   CronCreate(cron: "* * * * *", recurring: true, prompt: <<EOF
+   Silently run both steps for the concept bridge on port {port}:
+
+   (1) Heartbeat POST:
+       Bash: curl -s -X POST http://localhost:{port}/heartbeat > /dev/null
+
+   (2) Pending check — use the deterministic /pending endpoint, NOT a
+       substring match on /decisions. The response is a strict JSON object
+       `{"pending": true|false, "version": N}` with no free-form content.
+       Bash (produces ONLY the literal string "true" or "false"):
+         curl -s http://localhost:{port}/pending | python -c "import sys,json; d=json.load(sys.stdin); print('true' if d.get('pending') else 'false')"
+
+       If the output is exactly "false" → produce NO user-visible output. Silent tick.
+
+       If the output is exactly "true" → fetch the full payload and process:
+         Bash: curl -s http://localhost:{port}/decisions
+         • Parse the JSON. Note `_version`. Strip `_version` and `_processed_at`
+           before treating the rest as decision data.
+         • Process per Step 5 (Live Feedback Loop) — act on the user's choices
+           (approve/tweak/reject, included options, comment-driven tweaks).
+         • After processing, reset conditionally — pass the noted version:
+           Bash: curl -s -o /dev/null -w "%{http_code}" -X POST \
+                       -H "Content-Type: application/json" \
+                       -d '{"version": <noted>}' http://localhost:{port}/reset
+         • If the HTTP code is 409 (version mismatch) → the user submitted
+           again while you were processing. Re-fetch /decisions, process the
+           new payload (which supersedes what you just finished), then retry
+           the conditional reset with the new `_version`.
+         • Report the outcome to the user. The browser's panel auto-resets
+           within 5s via the `_processed_at` heartbeat poll — no browser-eval
+           injection required.
+   EOF)
+   ```
+
+   **Why `/pending` + `python -c` instead of a substring check?** The
+   `/decisions` JSON response is formatted via Python's default
+   `json.dumps`, which emits `"submitted": true` **with** a space after the
+   colon — a literal `contains "submitted":true` test silently misses every
+   submission. `/pending` collapses the signal to a strict boolean so the
+   cron body cannot drift into false negatives between ticks.
+
+   **Why combined, not two crons?** One cron minimizes race conditions and makes
+   the contract explicit: every tick does both. Minimum cron resolution is 1 min,
+   so the max submit-to-process lag is ~60 s — acceptable for interactive flows.
+
+4. Send the first heartbeat immediately:
+   ```bash
+   curl -s -X POST http://localhost:{port}/heartbeat
+   ```
+
+5. Open in Edge (reuses the running instance, adds a tab):
+   ```bash
+   # Windows
+   start "" msedge "http://localhost:{port}/{filename}"
+   ```
+   On macOS: `open -a "Microsoft Edge" "http://…"`, on Linux: `microsoft-edge "http://…"`.
+
+   The empty `""` is required on Windows — without it, `cmd.exe` interprets
+   the first quoted argument as a window title.
+
+6. After monitoring ends, clean up:
+   ```bash
+   kill %1  # or track the PID
+   ```
+   Also delete the heartbeat cron via `CronDelete`.

--- a/plugins/devops/skills/devops-concept/deep-knowledge/iteration-rules.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/iteration-rules.md
@@ -1,0 +1,30 @@
+# Iteration Tabs (single file, many iterations)
+
+Every concept page is a stack of iteration tabs. The **tab bar lives in the
+decision panel at the top** of the content area (a slim strip above the
+variants, not in the right sidebar — the sidebar stays reserved for submit
+controls). Each tab shows exactly one iteration; the active one is interactive,
+all earlier ones are frozen (disabled inputs showing the user's submitted
+selections, read-only comments).
+
+| Situation | Action | Result |
+|-----------|--------|--------|
+| First generation | Write the file with `<section data-iteration="1" data-active>` and one tab "Iteration 1" | Tab 1 active |
+| Feedback loop iteration (Step 5c) | Append `<section data-iteration="N+1" data-active>` to the same file, remove `data-active` from the previous section, freeze it, add a new tab and make it active | New tab "Iteration N+1" auto-active, old tab selectable and read-only |
+| Fundamental rework ("nochmal neu") | Same as a feedback iteration — just another tab. The full history stays visible. | Another tab appended |
+
+**Rules:**
+- **Never create a second file** for iterations of the same concept — always
+  append a section to the existing file and POST `/reload` (see Step 5c).
+- The active iteration is the only one that accepts input. Submit sends
+  decisions for the active iteration only.
+- Freeze previous iterations visually: disabled tri-state buttons showing
+  which state the user submitted, read-only comment fields with the text
+  the user entered. Users can click back to earlier tabs to review their
+  own past feedback at any time.
+- Only the active tab runs the heartbeat / submit UI ("music"). Clicking
+  an older tab shows its frozen snapshot but does not re-arm submit.
+- Tab bar must stay compact (one line, horizontally scrollable if many
+  iterations) so it does not push variant content out of view.
+
+See `templates.md` § Iteration Tabs for the reference HTML/CSS/JS.

--- a/plugins/devops/skills/devops-concept/deep-knowledge/validation-gate.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/validation-gate.md
@@ -1,0 +1,37 @@
+# Post-Generation Validation Gate
+
+After writing the HTML file, validate that all mandatory interactive patterns
+are present. **Grep the generated file** for each required pattern:
+
+| # | Pattern to grep | Purpose |
+|---|----------------|---------|
+| 1 | `concept-decisions` | Decision data JSON container |
+| 2 | `concept-submitted` | CSS class for monitoring detection signal |
+| 3 | `connection-warning` | Disconnection warning element |
+| 4 | `checkClaudeConnection` | Heartbeat checker function |
+| 5 | `HEARTBEAT_STALE_MS` | Heartbeat staleness threshold |
+| 6 | `HEARTBEAT_GRACE_MS` | Grace period — suppresses warning during startup |
+| 7 | `pollHeartbeat` | HTTP heartbeat polling function |
+| 8 | `panel-ready` | Ready-state panel element |
+| 9 | `panel-submitted` | Submitted-state panel element |
+| 10 | `localStorage` | Reload resilience (state persistence with TTL) |
+| 11 | `data-page-version` | Page version tag for localStorage invalidation |
+| 12 | `data-iteration` | Iteration section marker |
+| 13 | `iteration-tabs` | Tab bar container in the decision panel |
+| 14 | `pollReload` | Reload-signal poller (picks up file rewrites) |
+| 15 | `sec.hidden` | Tab-switch JS toggles the `hidden` attribute — prevents all iterations rendering at once |
+| 16 | `pollProcessedState` | Auto-reset poll handler — restores the ready panel when the server's `_processed_at` advances past the local `_submittedAt` |
+
+**If ANY pattern is missing → DO NOT open the page.** Fix the HTML first,
+then re-validate. This is a **blocking gate** — no exceptions, no "this
+page doesn't need it". Every concept page needs monitoring, every monitored
+page needs the heartbeat guard.
+
+**Common failures this gate catches:**
+- Heartbeat system omitted → submit button stays clickable without monitoring
+- Connection warning missing → user gets no feedback when Claude disconnects
+- Panel states missing → no visual transition on submit/reset cycle
+- localStorage missing → user selections lost on reload or tab close
+
+The patterns in `templates.md` (§ Claude Connection Heartbeat,
+§ Submit Handler, § State Persistence) provide the reference implementations.

--- a/plugins/devops/skills/devops-repo-health/SKILL.md
+++ b/plugins/devops/skills/devops-repo-health/SKILL.md
@@ -132,87 +132,12 @@ Build a **self-contained HTML concept page** using the `dashboard` variant.
 Follow the design system and patterns from `/devops-concept` (see Step 2 of
 the concept skill for full HTML/CSS/JS requirements).
 
-### Page Structure
+### Page Structure & Tooltips
 
-```
-[Header]
-  Repo name (large)
-  Local path | Remote URL | Current branch | Default branch
-  Last fetch timestamp
-
-[Summary KPI Cards]
-  Total branches | Safe to delete | Needs investigation | Active worktrees (X with changes / Y clean) | Main sync status
-
-[Active Worktrees Section — DEDICATED, separate from branch list]
-  Only shown if worktrees exist. NOT part of the branch list below.
-  Per worktree card:
-    Branch name (monospace) + worktree path (smaller, muted)
-    Status badge:
-      - "Mit Aenderungen" (amber badge) if has-changes
-      - "Sauber" (gray badge) if clean
-    If has-changes:
-      File summary: "X geaendert, Y ungetrackt" (compact inline)
-      Commits ahead: "Z Commits vor main" (if any)
-      Visual: info icon, no action controls, clearly labeled read-only
-      HARD RULE: NO delete, discard, reset, or cleanup options whatsoever
-    If clean:
-      "Keine lokalen Aenderungen"
-      Optional: "Worktree entfernen" checkbox (UNCHECKED by default)
-      Tooltip on checkbox — see Tooltip section below
-  Card styling: subtle border, lower visual weight than branch cards,
-  distinct background tint (e.g. blue-gray) to avoid confusion with branches
-
-[Filter Bar]
-  Category toggles: [Sicher loeschbar] [Untersuchen] [Remote]
-  (NO worktree toggle — worktrees have their own section above)
-  Select all / Deselect all buttons (apply to visible items only)
-
-[Branch List — filterable, excludes worktree branches]
-  Per branch card:
-    Branch name (monospace, prominent)
-    Category badge (color-coded: green=safe, yellow=investigate)
-    PR reference (if exists): #123 — title
-    Merge status: merged / squash-merged / unmerged / no PR
-    Last commit: hash + message + relative date
-    Diff stats: X files changed (excluding CHANGELOG)
-    Remote status: exists / gone / n/a
-
-    [Action controls — only for safe-delete and investigate categories]:
-      Checkbox: "Loeschen" (pre-checked for safe-delete, unchecked for investigate)
-      Tooltip on checkbox — see Tooltip section below
-      Optional comment field (collapsed by default, expandable)
-
-[Main Sync Section]
-  Current status: up to date / X commits behind
-  Checkbox: "Main synchronisieren" (pre-checked if behind)
-
-[Decision Panel Sidebar]
-  Summary: "X Branches zum Loeschen ausgewaehlt"
-  Live counter updates as checkboxes change
-  Grouped summary: Y local + Z remote branches
-  Checkbox: "Remote-Branches auch loeschen" (default: checked) + tooltip
-  Checkbox: "Worktrees prunen" (default: checked) + tooltip
-  Submit button: "Aufraeumen starten"
-
-### Tooltip Explanations
-
-Every action control and global option MUST have an explanatory tooltip
-(HTML `title` attribute) so the user understands the effect before acting.
-
-| Element | Tooltip text |
-|---------|-------------|
-| "Loeschen" checkbox (safe-delete) | "Branch lokal loeschen. Arbeit ist bereits in main (merged/squash-merged)." |
-| "Loeschen" checkbox (investigate) | "Branch lokal loeschen. ACHTUNG: Aenderungen sind moeglicherweise NICHT in main!" |
-| "Remote-Branches auch loeschen" | "Loescht die Branches auch auf GitHub/origin. Betrifft nur die oben ausgewaehlten Branches." |
-| "Worktrees prunen" | "Entfernt verwaiste Worktree-Referenzen (bereits geloeschte Verzeichnisse). Aktive Worktrees werden NICHT beruehrt." |
-| "Main synchronisieren" | "Holt die neuesten Aenderungen von origin/main und aktualisiert den lokalen main-Branch." |
-| "Worktree entfernen" (clean only) | "Entfernt den Worktree und seinen Branch. Nur moeglich bei Worktrees ohne lokale Aenderungen." |
-| "Select all" button | "Alle sichtbaren Branches zum Loeschen markieren." |
-| "Deselect all" button | "Alle sichtbaren Branches abwaehlen." |
-
-Implement tooltips as `title` attributes on the label/checkbox wrapper.
-Keep text concise — one sentence max, no jargon.
-```
+The full ASCII mockup of the page (header, KPI cards, worktree section,
+filter bar, branch list, main-sync section, decision panel sidebar) and
+the mandatory tooltip table for every action control live in
+`deep-knowledge/page-structure.md`.
 
 ### Filter Behavior
 
@@ -225,65 +150,9 @@ Keep text concise — one sentence max, no jargon.
 
 ### Decision Schema
 
-```json
-{
-  "submitted": true,
-  "repo": {
-    "name": "dotclaude",
-    "path": "/path/to/repo",
-    "remote": "git@github.com:user/repo.git"
-  },
-  "filters": {
-    "safe-delete": true,
-    "investigate": true,
-    "worktree": false,
-    "remote": true
-  },
-  "decisions": [
-    {
-      "id": "branch-feature-xyz",
-      "branch": "feature/xyz",
-      "category": "safe-delete",
-      "action": "delete",
-      "scope": "local+remote"
-    },
-    {
-      "id": "branch-old-experiment",
-      "branch": "old-experiment",
-      "category": "investigate",
-      "action": "skip"
-    }
-  ],
-  "worktrees": [
-    {
-      "branch": "claude/brave-pike",
-      "path": "/repo/.claude/worktrees/brave-pike",
-      "status": "has-changes",
-      "modified": 3,
-      "untracked": 1,
-      "commits_ahead": 2,
-      "action": "keep"
-    },
-    {
-      "branch": "claude/old-session",
-      "path": "/repo/.claude/worktrees/old-session",
-      "status": "clean",
-      "modified": 0,
-      "untracked": 0,
-      "commits_ahead": 0,
-      "action": "remove"
-    }
-  ],
-  "options": {
-    "delete_remote": true,
-    "prune_worktrees": true,
-    "sync_main": true
-  },
-  "comments": [
-    { "id": "branch-old-experiment", "text": "Might need this later" }
-  ]
-}
-```
+The submit payload shape (repo metadata, filter state, per-branch decisions,
+worktree actions, global options, comments) is documented in
+`deep-knowledge/decision-schema.md`.
 
 ### File Location
 

--- a/plugins/devops/skills/devops-repo-health/deep-knowledge/decision-schema.md
+++ b/plugins/devops/skills/devops-repo-health/deep-knowledge/decision-schema.md
@@ -1,0 +1,73 @@
+# Repo-Health Decision Schema
+
+Submit payload shape collected by the concept page and POSTed back via
+the bridge server. Claude reads this in Step 9 to execute the user's
+cleanup decisions.
+
+```json
+{
+  "submitted": true,
+  "repo": {
+    "name": "dotclaude",
+    "path": "/path/to/repo",
+    "remote": "git@github.com:user/repo.git"
+  },
+  "filters": {
+    "safe-delete": true,
+    "investigate": true,
+    "worktree": false,
+    "remote": true
+  },
+  "decisions": [
+    {
+      "id": "branch-feature-xyz",
+      "branch": "feature/xyz",
+      "category": "safe-delete",
+      "action": "delete",
+      "scope": "local+remote"
+    },
+    {
+      "id": "branch-old-experiment",
+      "branch": "old-experiment",
+      "category": "investigate",
+      "action": "skip"
+    }
+  ],
+  "worktrees": [
+    {
+      "branch": "claude/brave-pike",
+      "path": "/repo/.claude/worktrees/brave-pike",
+      "status": "has-changes",
+      "modified": 3,
+      "untracked": 1,
+      "commits_ahead": 2,
+      "action": "keep"
+    },
+    {
+      "branch": "claude/old-session",
+      "path": "/repo/.claude/worktrees/old-session",
+      "status": "clean",
+      "modified": 0,
+      "untracked": 0,
+      "commits_ahead": 0,
+      "action": "remove"
+    }
+  ],
+  "options": {
+    "delete_remote": true,
+    "prune_worktrees": true,
+    "sync_main": true
+  },
+  "comments": [
+    { "id": "branch-old-experiment", "text": "Might need this later" }
+  ]
+}
+```
+
+**Notes:**
+- `action` for branches: `"delete"` or `"skip"`.
+- `action` for worktrees: `"keep"` or `"remove"` (only for `status: clean`).
+- `scope`: `"local"` or `"local+remote"` — combined with global
+  `options.delete_remote` to decide the final scope.
+- `filters` preserves the user's category selection at submit time so
+  Claude knows what was visible when the user clicked.

--- a/plugins/devops/skills/devops-repo-health/deep-knowledge/page-structure.md
+++ b/plugins/devops/skills/devops-repo-health/deep-knowledge/page-structure.md
@@ -1,0 +1,83 @@
+# Repo-Health Concept Page — Structure & Tooltips
+
+## Page Structure
+
+```
+[Header]
+  Repo name (large)
+  Local path | Remote URL | Current branch | Default branch
+  Last fetch timestamp
+
+[Summary KPI Cards]
+  Total branches | Safe to delete | Needs investigation | Active worktrees (X with changes / Y clean) | Main sync status
+
+[Active Worktrees Section — DEDICATED, separate from branch list]
+  Only shown if worktrees exist. NOT part of the branch list below.
+  Per worktree card:
+    Branch name (monospace) + worktree path (smaller, muted)
+    Status badge:
+      - "Mit Aenderungen" (amber badge) if has-changes
+      - "Sauber" (gray badge) if clean
+    If has-changes:
+      File summary: "X geaendert, Y ungetrackt" (compact inline)
+      Commits ahead: "Z Commits vor main" (if any)
+      Visual: info icon, no action controls, clearly labeled read-only
+      HARD RULE: NO delete, discard, reset, or cleanup options whatsoever
+    If clean:
+      "Keine lokalen Aenderungen"
+      Optional: "Worktree entfernen" checkbox (UNCHECKED by default)
+      Tooltip on checkbox — see Tooltip section below
+  Card styling: subtle border, lower visual weight than branch cards,
+  distinct background tint (e.g. blue-gray) to avoid confusion with branches
+
+[Filter Bar]
+  Category toggles: [Sicher loeschbar] [Untersuchen] [Remote]
+  (NO worktree toggle — worktrees have their own section above)
+  Select all / Deselect all buttons (apply to visible items only)
+
+[Branch List — filterable, excludes worktree branches]
+  Per branch card:
+    Branch name (monospace, prominent)
+    Category badge (color-coded: green=safe, yellow=investigate)
+    PR reference (if exists): #123 — title
+    Merge status: merged / squash-merged / unmerged / no PR
+    Last commit: hash + message + relative date
+    Diff stats: X files changed (excluding CHANGELOG)
+    Remote status: exists / gone / n/a
+
+    [Action controls — only for safe-delete and investigate categories]:
+      Checkbox: "Loeschen" (pre-checked for safe-delete, unchecked for investigate)
+      Tooltip on checkbox — see Tooltip section below
+      Optional comment field (collapsed by default, expandable)
+
+[Main Sync Section]
+  Current status: up to date / X commits behind
+  Checkbox: "Main synchronisieren" (pre-checked if behind)
+
+[Decision Panel Sidebar]
+  Summary: "X Branches zum Loeschen ausgewaehlt"
+  Live counter updates as checkboxes change
+  Grouped summary: Y local + Z remote branches
+  Checkbox: "Remote-Branches auch loeschen" (default: checked) + tooltip
+  Checkbox: "Worktrees prunen" (default: checked) + tooltip
+  Submit button: "Aufraeumen starten"
+```
+
+## Tooltip Explanations
+
+Every action control and global option MUST have an explanatory tooltip
+(HTML `title` attribute) so the user understands the effect before acting.
+
+| Element | Tooltip text |
+|---------|-------------|
+| "Loeschen" checkbox (safe-delete) | "Branch lokal loeschen. Arbeit ist bereits in main (merged/squash-merged)." |
+| "Loeschen" checkbox (investigate) | "Branch lokal loeschen. ACHTUNG: Aenderungen sind moeglicherweise NICHT in main!" |
+| "Remote-Branches auch loeschen" | "Loescht die Branches auch auf GitHub/origin. Betrifft nur die oben ausgewaehlten Branches." |
+| "Worktrees prunen" | "Entfernt verwaiste Worktree-Referenzen (bereits geloeschte Verzeichnisse). Aktive Worktrees werden NICHT beruehrt." |
+| "Main synchronisieren" | "Holt die neuesten Aenderungen von origin/main und aktualisiert den lokalen main-Branch." |
+| "Worktree entfernen" (clean only) | "Entfernt den Worktree und seinen Branch. Nur moeglich bei Worktrees ohne lokale Aenderungen." |
+| "Select all" button | "Alle sichtbaren Branches zum Loeschen markieren." |
+| "Deselect all" button | "Alle sichtbaren Branches abwaehlen." |
+
+Implement tooltips as `title` attributes on the label/checkbox wrapper.
+Keep text concise — one sentence max, no jargon.

--- a/plugins/devops/skills/devops-ship/SKILL.md
+++ b/plugins/devops/skills/devops-ship/SKILL.md
@@ -185,45 +185,10 @@ If `verified: false` → fix mismatches manually, then retry.
 
 Call `ship_release` MCP tool. Use the `base` from Step 1 (auto-detected or explicit).
 
-**Final ship to main:**
-```
-ship_release({
-  base: "main",
-  title: "feat(ship): add MCP server for ship pipeline",
-  body: "## Summary\n...\n\nCloses #N",
-  commitMessage: "chore(release): v0.18.0",
-  tag: "v0.18.0",
-  releaseNotes: "...",
-  prerelease: false,
-  mergeStrategy: "squash",
-  cwd: "<cwd>"
-})
-```
-
-**Intermediate ship (sub-branch → feature branch):**
-```
-ship_release({
-  base: "feat/42-video-filters",
-  title: "feat(core): add video filter data models",
-  body: "## Summary\n...",
-  commitMessage: null,
-  tag: null,
-  releaseNotes: null,
-  mergeStrategy: "squash",
-  cwd: "<cwd>"
-})
-```
-
-**With file overlap (use merge commit to preserve ancestry):**
-```
-ship_release({
-  ...
-  mergeStrategy: "merge",
-  cwd: "<cwd>"
-})
-```
-
-For intermediate merges: no tag, no release notes, no version commit. The tool automatically skips tag/release creation when `base` is not `main`.
+See `deep-knowledge/call-examples.md` for the three reference payloads
+(final ship to main, intermediate ship, overlap-with-merge-commit).
+For intermediate merges: no tag, no release notes, no version commit —
+the tool automatically skips tag/release creation when `base` is not `main`.
 
 The tool handles: commit (optional), rebase verification, push (force-with-lease after rebase), PR create (or reuse with mergeability check), merge (squash or merge commit), tag (main only), GitHub release (main only).
 
@@ -330,71 +295,11 @@ Silent memory consolidation after shipping. Runs **after** the completion card s
 - Never touch `CLAUDE.md` — only `memory/` files
 - If consolidation finds nothing to change → done, no writes needed
 
-## Data Flow Summary
+## Data Flow & Hierarchical Merges
 
-### Direct ship (branch → main)
-
-```
-ship_preflight → { ready, branch, base: "main", intermediate: false }
-      ↓
-ship_build → { success, buildId, steps }
-      ↓
-ship_version_bump → { vOld, vNew, filesUpdated, verified }
-      ↓
-ship_release → { commit, pushed, pr, merged, tag }
-      ↓
-[ExitWorktree if needed]
-      ↓
-ship_cleanup → { cleaned }
-      ↓
-render_completion_card → card markdown (VERBATIM)
-      ↓
-[memory dream — silent, only if memories touched]
-```
-
-### Intermediate ship (sub-branch → feature branch)
-
-```
-ship_preflight → { ready, branch, base: "feat/42", intermediate: true, autoDetectedBase: "feat/42" }
-      ↓
-ship_build → { success, buildId, steps }
-      ↓
-[SKIP version bump]
-      ↓
-ship_release → { commit, pushed, pr, merged: "feat/42", tag: null }
-      ↓
-[ExitWorktree if needed]
-      ↓
-ship_cleanup → { cleaned, intermediate: true }  ← feature branch preserved
-      ↓
-render_completion_card → card markdown (VERBATIM)
-      ↓
-[memory dream — silent, only if memories touched]
-```
-
-Each tool produces structured JSON that feeds directly into the next step or the completion card.
-No Bash parsing, no regex extraction — deterministic data flow.
-
-## Hierarchical Merge Workflow
-
-When multiple agents work on sub-branches of a feature branch:
-
-```
-feat/42-video-filters              ← feature branch (integration)
-├── feat/42-video-filters/core     ← sub-branch (Core agent)
-├── feat/42-video-filters/frontend ← sub-branch (Frontend agent)
-└── feat/42-video-filters/ai       ← sub-branch (AI agent)
-```
-
-Each sub-agent ships independently via `/devops-ship`. The pipeline auto-detects the parent:
-
-1. **Core finishes** → `/devops-ship` on `feat/42-video-filters/core`
-   - Preflight detects base: `feat/42-video-filters`
-   - Squash-merges into feature branch, no tag/version
-2. **Frontend finishes** → `/devops-ship` on `feat/42-video-filters/frontend`
-   - Same: intermediate merge into feature branch
-3. **All sub-branches merged** → `/devops-ship` on `feat/42-video-filters`
-   - No parent detected → ships to `main`
-   - Full release: version bump, tag, GitHub release
-
-This requires no manual `base` parameter — detection is automatic based on branch naming convention (`<parent>/<role>`).
+- **Data flow** (preflight → build → version-bump → release → cleanup →
+  completion card): see `deep-knowledge/data-flow.md` for the direct-ship
+  and intermediate-ship diagrams.
+- **Hierarchical merges** (sub-branch → feature branch → main, automatic
+  parent detection via `<parent>/<role>` naming): see
+  `deep-knowledge/hierarchical-merge.md`.

--- a/plugins/devops/skills/devops-ship/deep-knowledge/call-examples.md
+++ b/plugins/devops/skills/devops-ship/deep-knowledge/call-examples.md
@@ -1,0 +1,48 @@
+# Ship — MCP Call Examples
+
+Reference payloads for `ship_release`. Always pass `cwd` — the ship MCP
+server runs in the plugin directory, not the target repo.
+
+## Final ship to main
+
+```
+ship_release({
+  base: "main",
+  title: "feat(ship): add MCP server for ship pipeline",
+  body: "## Summary\n...\n\nCloses #N",
+  commitMessage: "chore(release): v0.18.0",
+  tag: "v0.18.0",
+  releaseNotes: "...",
+  prerelease: false,
+  mergeStrategy: "squash",
+  cwd: "<cwd>"
+})
+```
+
+## Intermediate ship (sub-branch → feature branch)
+
+```
+ship_release({
+  base: "feat/42-video-filters",
+  title: "feat(core): add video filter data models",
+  body: "## Summary\n...",
+  commitMessage: null,
+  tag: null,
+  releaseNotes: null,
+  mergeStrategy: "squash",
+  cwd: "<cwd>"
+})
+```
+
+For intermediate merges: no tag, no release notes, no version commit. The
+tool automatically skips tag/release creation when `base` is not `main`.
+
+## With file overlap (merge commit preserves ancestry)
+
+```
+ship_release({
+  ...
+  mergeStrategy: "merge",
+  cwd: "<cwd>"
+})
+```

--- a/plugins/devops/skills/devops-ship/deep-knowledge/data-flow.md
+++ b/plugins/devops/skills/devops-ship/deep-knowledge/data-flow.md
@@ -1,0 +1,45 @@
+# Ship — Data Flow
+
+Each MCP tool produces structured JSON that feeds directly into the next
+step or the completion card. No Bash parsing, no regex extraction —
+deterministic data flow.
+
+## Direct ship (branch → main)
+
+```
+ship_preflight → { ready, branch, base: "main", intermediate: false }
+      ↓
+ship_build → { success, buildId, steps }
+      ↓
+ship_version_bump → { vOld, vNew, filesUpdated, verified }
+      ↓
+ship_release → { commit, pushed, pr, merged, tag }
+      ↓
+[ExitWorktree if needed]
+      ↓
+ship_cleanup → { cleaned }
+      ↓
+render_completion_card → card markdown (VERBATIM)
+      ↓
+[memory dream — silent, only if memories touched]
+```
+
+## Intermediate ship (sub-branch → feature branch)
+
+```
+ship_preflight → { ready, branch, base: "feat/42", intermediate: true, autoDetectedBase: "feat/42" }
+      ↓
+ship_build → { success, buildId, steps }
+      ↓
+[SKIP version bump]
+      ↓
+ship_release → { commit, pushed, pr, merged: "feat/42", tag: null }
+      ↓
+[ExitWorktree if needed]
+      ↓
+ship_cleanup → { cleaned, intermediate: true }  ← feature branch preserved
+      ↓
+render_completion_card → card markdown (VERBATIM)
+      ↓
+[memory dream — silent, only if memories touched]
+```

--- a/plugins/devops/skills/devops-ship/deep-knowledge/hierarchical-merge.md
+++ b/plugins/devops/skills/devops-ship/deep-knowledge/hierarchical-merge.md
@@ -1,0 +1,25 @@
+# Hierarchical Merge Workflow
+
+When multiple agents work on sub-branches of a feature branch:
+
+```
+feat/42-video-filters              ← feature branch (integration)
+├── feat/42-video-filters/core     ← sub-branch (Core agent)
+├── feat/42-video-filters/frontend ← sub-branch (Frontend agent)
+└── feat/42-video-filters/ai       ← sub-branch (AI agent)
+```
+
+Each sub-agent ships independently via `/devops-ship`. The pipeline
+auto-detects the parent:
+
+1. **Core finishes** → `/devops-ship` on `feat/42-video-filters/core`
+   - Preflight detects base: `feat/42-video-filters`
+   - Squash-merges into feature branch, no tag/version
+2. **Frontend finishes** → `/devops-ship` on `feat/42-video-filters/frontend`
+   - Same: intermediate merge into feature branch
+3. **All sub-branches merged** → `/devops-ship` on `feat/42-video-filters`
+   - No parent detected → ships to `main`
+   - Full release: version bump, tag, GitHub release
+
+This requires no manual `base` parameter — detection is automatic based
+on branch naming convention (`<parent>/<role>`).

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.50.2",
+  "version": "0.50.3",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

Audit found two doc contradictions and five SKILL.md files over the 200-line soft cap. All content moved 1:1 into per-skill `deep-knowledge/` files; SKILL.md keeps a short pointer so nothing is lost.

### Paradoxes fixed
- `CLAUDE.md` claimed "single plugin" — repo actually has `plugins/devops/` + `plugins/local-llm/`
- `plugins/devops/CONVENTIONS.md` listed a stale hook tree (missing 5 session-start hooks, still showed migrated `prompt.git.sync.js`) — replaced with pointer to `hooks/hooks.json`

### Skill extractions (SKILL.md line counts)
| Skill | before | after | new deep-knowledge files |
|---|---|---|---|
| devops-concept | 521 | **391** | validation-gate, bridge-server, iteration-rules |
| devops-repo-health | 408 | **277** | page-structure, decision-schema |
| devops-ship | 400 | **305** | call-examples, data-flow, hierarchical-merge |
| devops-autonomous | 381 | **351** | html-report |
| devops-burn | 267 | **225** | composite-prompt |

10 new `deep-knowledge/` files, 428 lines shifted out of SKILL.md. No behavior changes, no rule changes. `devops-project-setup` (205 lines) left untouched per user request.

## Test plan
- [x] `npm run lint` → clean
- [x] `npm test` → 91/91 vitest green
- [x] grep confirms all 10 pointer references resolve to existing files