### PR TITLE
feat(local-llm): pin workspace model + probe/fallback + detection fix

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.50.3"
+    "version": "0.51.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.50.3",
+      "version": "0.51.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.50.3",
+      "version": "0.51.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.51.0] — 2026-04-19
+
+### Added
+
+- **plugins/local-llm/hooks/session-start/ss.llm.health.js** — SessionStart hook now pins `chatProvider`/`chatModel` on the AnythingLLM workspace via `POST /api/v1/workspace/{slug}/update` and sends a 4-token probe chat to verify the pinned model actually loads. If the primary model fails, the hook falls back to a configured secondary model; if both fail, it restores the previous pin so the workspace stays usable. Surfaces the chosen model in the `ready` instructions so agents know which LLM they are talking to
+- **plugins/local-llm/hooks/lib/anythingllm-http.js** — `getWorkspace()` and `updateWorkspace()` helpers covering the `GET /api/v1/workspace/{slug}` and `POST /api/v1/workspace/{slug}/update` endpoints
+- **plugins/local-llm/scripts/config.json** — new config keys: `chatProvider` (default `anythingllm_ollama`), `chatModel` (default `hf.co/bartowski/google_gemma-4-e4b-it-gguf:q4_k_m` — Gemma 4 E4B Q4_K_M from HuggingFace/Bartowski), `fallbackChatModel` (default `gemma3n:e4b`), `pinWorkspace` (default `true`), `probeOnPin` (default `true`)
+
+### Fixed
+
+- **plugins/local-llm/hooks/lib/anythingllm-lifecycle.js** — installation detection missed the `...\AppData\Local\Programs\AnythingLLM\AnythingLLM.exe` path (no `-desktop`/`Desktop` suffix) used by the current installer, so the SessionStart hook reported `not_installed` on machines where AnythingLLM was actually installed. Added that path and also checks the `AnythingLLMDesktop.exe` runtime image name alongside `AnythingLLM.exe` — the Electron manifest can rename the runtime image, so the installer filename and `tasklist` image name do not always match
+- **plugins/local-llm/mcp-server/index.js** — `local_generate` now strips a single outer markdown fence (```lang ... ```) from the local model's response. The small models ignore "no markdown fences" in the system prompt and consistently wrap their output, so callers were getting code they had to strip themselves. Inner fences (multi-block answers) are left intact
+
 ## [0.50.3] — 2026-04-18
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.50.3**
+**Version: 0.51.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.50.3",
+  "version": "0.51.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.50.3",
+  "version": "0.51.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/local-llm/deep-knowledge/model-config.md
+++ b/plugins/local-llm/deep-knowledge/model-config.md
@@ -1,23 +1,35 @@
 # Model Configuration Reference — AnythingLLM Backend
 
-This plugin does not manage any model itself. The local LLM is owned by
-**AnythingLLM Desktop** — the user installs it once, generates an API key,
-and configures the underlying LLM inside the AnythingLLM UI. This plugin
-just speaks HTTP to the workspace.
+The backend app is **AnythingLLM Desktop** — the user installs it once and
+generates an API key. The plugin then talks to a workspace via HTTP, **pins
+the workspace to a specific chat model** (so a system-default change does
+not silently swap the model), and falls back to a secondary model if the
+primary is unavailable.
 
 ## Recommended setup
 
 | Property | Value |
 |----------|-------|
 | Backend app | AnythingLLM Desktop (https://anythingllm.com/download) |
-| LLM provider | Ollama |
-| Model | `gemma4:e4b` (≈4.5B effective params, dense transformer) |
+| Provider key (API) | `anythingllm_ollama` (AnythingLLM's built-in native LLM) |
+| Primary model | `hf.co/bartowski/google_gemma-4-e4b-it-gguf:q4_k_m` (Gemma 4 E4B, HF/Bartowski, Q4_K_M) |
+| Fallback model | `gemma3n:e4b` (Gemma 3n 4B effective, ~7.5 GB, from Ollama registry) |
 | Plugin workspace slug | `claude-code` |
 | API port | 3001 (AnythingLLM default) |
 
-The plugin auto-creates the `claude-code` workspace on first successful
-connect. Model choice, GPU offload, KV-cache quantization, and context size
-are all managed inside AnythingLLM's settings — outside this plugin's scope.
+The plugin:
+
+1. Auto-creates the `claude-code` workspace on first successful connect.
+2. Pins `chatProvider` and `chatModel` on the workspace.
+3. Sends a 4-token probe chat. If the primary model fails, the plugin
+   re-pins the workspace to the fallback model.
+
+GPU offload, KV-cache quantization, and context size remain inside
+AnythingLLM's settings — outside this plugin's scope.
+
+> **Note on the provider name.** The API key is `anythingllm_ollama`, but
+> AnythingLLM Desktop ships its own bundled native LLM runtime. It is not
+> the standalone Ollama daemon on port 11434.
 
 ## One-time user steps
 
@@ -59,7 +71,12 @@ The setup skill always writes to the user layer.
     "workspaceName": "Claude Code",
     "autoLaunch": true,
     "launchTimeoutMs": 30000,
-    "pollIntervalMs": 1000
+    "pollIntervalMs": 1000,
+    "chatProvider": "anythingllm_ollama",
+    "chatModel": "hf.co/bartowski/google_gemma-4-e4b-it-gguf:q4_k_m",
+    "fallbackChatModel": "gemma3n:e4b",
+    "pinWorkspace": true,
+    "probeOnPin": true
   },
   "generation": {
     "temperature": 0.2,
@@ -75,6 +92,11 @@ The setup skill always writes to the user layer.
 | `workspaceSlug` | Workspace the plugin talks to. Auto-created if missing. |
 | `autoLaunch` | If true, the SessionStart hook launches AnythingLLM when installed but not running. |
 | `launchTimeoutMs` | How long the hook waits for the API to become reachable after launch (advisory; the hook itself never blocks the prompt). |
+| `chatProvider` | Provider key passed to AnythingLLM workspace update. Default `anythingllm_ollama` (built-in native LLM). |
+| `chatModel` | Primary model the workspace is pinned to. |
+| `fallbackChatModel` | Used if the probe chat against `chatModel` fails. Set to `null` to disable fallback. |
+| `pinWorkspace` | Default `true`. If `false`, plugin leaves workspace at AnythingLLM's system default. |
+| `probeOnPin` | Default `true`. After pinning, sends a 4-token chat to verify the model loads. |
 | `generation.temperature` | Default sampling temperature for `local_generate`. Keep ≤ 0.5 for code. |
 | `generation.maxTokens` | Upper bound on completion length. |
 

--- a/plugins/local-llm/hooks/lib/anythingllm-config.js
+++ b/plugins/local-llm/hooks/lib/anythingllm-config.js
@@ -12,9 +12,11 @@
  *   are ignored to prevent accidental commits. The user config path is
  *   also where the setup skill writes the key.
  *
- *   Fixed model: AnythingLLM manages the underlying LLM via its workspace
- *   settings — the user picks Ollama + gemma4:e4b once in the AnythingLLM
- *   UI during setup. This plugin only addresses workspaces, not models.
+ *   Model pinning: the plugin sets `chatProvider`/`chatModel` on the
+ *   workspace via `POST /api/v1/workspace/{slug}/update`. Primary and
+ *   fallback model tags live under `anythingllm.chatModel` and
+ *   `anythingllm.fallbackChatModel`. The SessionStart hook probes the
+ *   primary, and on failure pins the fallback.
  */
 
 'use strict';

--- a/plugins/local-llm/hooks/lib/anythingllm-http.js
+++ b/plugins/local-llm/hooks/lib/anythingllm-http.js
@@ -121,6 +121,25 @@ async function createWorkspace(baseUrl, apiKey, name) {
   return { ok: true, workspace: res.data?.workspace || null };
 }
 
+async function getWorkspace(baseUrl, apiKey, slug) {
+  const res = await requestJson({ baseUrl, path: `/api/v1/workspace/${slug}`, apiKey });
+  if (!res.ok) return { ok: false, errorType: res.errorType || 'unknown', error: res.error, status: res.status };
+  const ws = Array.isArray(res.data?.workspace) ? res.data.workspace[0] : res.data?.workspace;
+  return { ok: true, workspace: ws || null };
+}
+
+async function updateWorkspace(baseUrl, apiKey, slug, settings) {
+  const res = await requestJson({
+    baseUrl,
+    path: `/api/v1/workspace/${slug}/update`,
+    method: 'POST',
+    apiKey,
+    body: settings,
+  });
+  if (!res.ok) return { ok: false, errorType: res.errorType || 'unknown', error: res.error, status: res.status };
+  return { ok: true, workspace: res.data?.workspace || null };
+}
+
 async function chatCompletion(baseUrl, apiKey, { workspaceSlug, messages, temperature = 0.2, maxTokens = 4096 }) {
   const res = await requestJson({
     baseUrl,
@@ -152,6 +171,8 @@ module.exports = {
   checkHealth,
   verifyAuth,
   getWorkspaces,
+  getWorkspace,
   createWorkspace,
+  updateWorkspace,
   chatCompletion,
 };

--- a/plugins/local-llm/hooks/lib/anythingllm-lifecycle.js
+++ b/plugins/local-llm/hooks/lib/anythingllm-lifecycle.js
@@ -19,19 +19,34 @@ const { spawn, execFileSync } = require('node:child_process');
 
 const DOWNLOAD_URL = 'https://anythingllm.com/download';
 
+// Observed executable and process names across AnythingLLM Desktop installers.
+// The installer name (the .exe on disk) and the runtime image name (what
+// Windows reports in tasklist) are NOT guaranteed to match — the Electron
+// app manifest can rename the runtime image.
+const EXE_NAMES = ['AnythingLLM.exe', 'AnythingLLMDesktop.exe'];
+const PROCESS_NAMES = ['AnythingLLMDesktop.exe', 'AnythingLLM.exe'];
+
 function candidatePaths() {
   const home = os.homedir();
   const localAppData = process.env.LOCALAPPDATA || path.join(home, 'AppData', 'Local');
   const programFiles = process.env.ProgramFiles || 'C:\\Program Files';
   const programFilesX86 = process.env['ProgramFiles(x86)'] || 'C:\\Program Files (x86)';
 
-  return [
-    path.join(localAppData, 'Programs', 'anythingllm-desktop', 'AnythingLLM.exe'),
-    path.join(localAppData, 'Programs', 'AnythingLLMDesktop', 'AnythingLLM.exe'),
-    path.join(localAppData, 'AnythingLLM', 'AnythingLLM.exe'),
-    path.join(programFiles, 'AnythingLLM', 'AnythingLLM.exe'),
-    path.join(programFilesX86, 'AnythingLLM', 'AnythingLLM.exe'),
+  // Directory layouts observed across installer versions.
+  const dirs = [
+    path.join(localAppData, 'Programs', 'AnythingLLM'),
+    path.join(localAppData, 'Programs', 'anythingllm-desktop'),
+    path.join(localAppData, 'Programs', 'AnythingLLMDesktop'),
+    path.join(localAppData, 'AnythingLLM'),
+    path.join(programFiles, 'AnythingLLM'),
+    path.join(programFilesX86, 'AnythingLLM'),
   ];
+
+  const paths = [];
+  for (const d of dirs) {
+    for (const exe of EXE_NAMES) paths.push(path.join(d, exe));
+  }
+  return paths;
 }
 
 function detectInstallation() {
@@ -45,16 +60,17 @@ function detectInstallation() {
 
 function isProcessRunning() {
   if (process.platform !== 'win32') return false;
-  try {
-    const out = execFileSync(
-      'tasklist',
-      ['/FI', 'IMAGENAME eq AnythingLLM.exe', '/NH'],
-      { encoding: 'utf8', timeout: 3000 }
-    );
-    return /AnythingLLM\.exe/i.test(out);
-  } catch {
-    return false;
+  for (const name of PROCESS_NAMES) {
+    try {
+      const out = execFileSync(
+        'tasklist',
+        ['/FI', `IMAGENAME eq ${name}`, '/NH'],
+        { encoding: 'utf8', timeout: 3000 }
+      );
+      if (new RegExp(name.replace('.', '\\.'), 'i').test(out)) return true;
+    } catch { /* try next */ }
   }
+  return false;
 }
 
 function launch(exePath) {

--- a/plugins/local-llm/hooks/session-start/ss.llm.health.js
+++ b/plugins/local-llm/hooks/session-start/ss.llm.health.js
@@ -39,6 +39,11 @@ const WORKSPACE_SLUG = CONFIG.anythingllm?.workspaceSlug || 'claude-code';
 const WORKSPACE_NAME = CONFIG.anythingllm?.workspaceName || 'Claude Code';
 const AUTO_LAUNCH = CONFIG.anythingllm?.autoLaunch !== false;
 const API_KEY = CONFIG.anythingllm?.apiKey || '';
+const CHAT_PROVIDER = CONFIG.anythingllm?.chatProvider || 'anythingllm_ollama';
+const CHAT_MODEL = CONFIG.anythingllm?.chatModel || 'gemma4:e4b';
+const FALLBACK_CHAT_MODEL = CONFIG.anythingllm?.fallbackChatModel || 'gemma3n:e4b';
+const PIN_WORKSPACE = CONFIG.anythingllm?.pinWorkspace !== false;
+const PROBE_ON_PIN = CONFIG.anythingllm?.probeOnPin !== false;
 
 function emit(phase, instructions) {
   process.stdout.write(`[local-llm] phase: ${phase}\n${instructions}\n`);
@@ -52,10 +57,12 @@ function disabledHint(reason) {
   );
 }
 
-function readyInstructions() {
+function readyInstructions(activeModel) {
+  const modelLine = activeModel ? `Model: ${activeModel} (pinned).\n` : '';
   return (
     `[local-llm] Local LLM is ready via mcp__plugin_local-llm_dotclaude-local-llm__local_generate.\n` +
     `Backend: AnythingLLM @ ${BASE_URL}, workspace "${WORKSPACE_SLUG}".\n` +
+    modelLine +
     `\n` +
     `Quick rules — delegate to local_generate ONLY when ALL are true:\n` +
     `  1. Mechanical code generation (boilerplate, DTOs, test files, CRUD, type defs)\n` +
@@ -65,6 +72,75 @@ function readyInstructions() {
     `  5. Output will be reviewed before use\n` +
     `NEVER delegate complex reasoning, debugging, refactoring, or ambiguous tasks.\n`
   );
+}
+
+async function probeChat() {
+  const res = await http.chatCompletion(BASE_URL, API_KEY, {
+    workspaceSlug: WORKSPACE_SLUG,
+    messages: [{ role: 'user', content: 'ping' }],
+    temperature: 0,
+    maxTokens: 4,
+  });
+  return res.ok && typeof res.content === 'string';
+}
+
+async function pinWorkspace(model) {
+  const res = await http.updateWorkspace(BASE_URL, API_KEY, WORKSPACE_SLUG, {
+    chatProvider: CHAT_PROVIDER,
+    chatModel: model,
+  });
+  return res.ok && res.workspace?.chatModel === model;
+}
+
+// Try a candidate model: pin → probe. Returns model name on success, null on failure.
+async function tryModel(model) {
+  if (!model) return null;
+  const pinned = await pinWorkspace(model);
+  if (!pinned) return null;
+  if (!PROBE_ON_PIN) return model;
+  const works = await probeChat();
+  return works ? model : null;
+}
+
+async function ensureWorkspacePin() {
+  if (!PIN_WORKSPACE) return null;
+
+  const current = await http.getWorkspace(BASE_URL, API_KEY, WORKSPACE_SLUG);
+  const currentModel = current.workspace?.chatModel || null;
+
+  // Already on a configured target — trust it without re-probing (avoids
+  // burning a chat on every SessionStart).
+  if (currentModel === CHAT_MODEL || (FALLBACK_CHAT_MODEL && currentModel === FALLBACK_CHAT_MODEL)) {
+    return currentModel;
+  }
+
+  const primary = await tryModel(CHAT_MODEL);
+  if (primary) {
+    process.stderr.write(`[local-llm] pinned workspace to primary model: ${primary}\n`);
+    return primary;
+  }
+
+  if (FALLBACK_CHAT_MODEL && FALLBACK_CHAT_MODEL !== CHAT_MODEL) {
+    const fallback = await tryModel(FALLBACK_CHAT_MODEL);
+    if (fallback) {
+      process.stderr.write(
+        `[local-llm] primary model "${CHAT_MODEL}" unavailable — pinned fallback: ${fallback}\n`
+      );
+      return fallback;
+    }
+  }
+
+  // Both candidates failed. Restore the previous model so the workspace
+  // stays usable, and surface the situation on stderr.
+  if (currentModel) {
+    await pinWorkspace(currentModel);
+    process.stderr.write(
+      `[local-llm] neither "${CHAT_MODEL}" nor "${FALLBACK_CHAT_MODEL || '(none)'}" is loaded in ` +
+      `AnythingLLM. Restored "${currentModel}". Pull a configured model in AnythingLLM ` +
+      `Settings → AI Providers, or change "chatModel" in the plugin config.\n`
+    );
+  }
+  return currentModel;
 }
 
 (async () => {
@@ -105,7 +181,8 @@ function readyInstructions() {
 
     const exists = ws.workspaces.some((w) => w.slug === WORKSPACE_SLUG);
     if (exists) {
-      emit('ready', readyInstructions());
+      const activeModel = await ensureWorkspacePin();
+      emit('ready', readyInstructions(activeModel));
       return;
     }
 

--- a/plugins/local-llm/mcp-server/index.js
+++ b/plugins/local-llm/mcp-server/index.js
@@ -42,6 +42,21 @@ const TEMPERATURE_DEFAULT = CONFIG.generation?.temperature ?? 0.2;
 const MAX_TOKENS_DEFAULT = CONFIG.generation?.maxTokens ?? 4096;
 
 // ---------------------------------------------------------------------------
+// Output sanitization
+// ---------------------------------------------------------------------------
+
+// Strip a single outer markdown fence ```lang ... ``` if present. Local
+// models often ignore "no markdown" instructions and wrap their output, so
+// callers consistently get a fenced block. We unwrap exactly one outer pair
+// and leave inner fences (multi-block answers) untouched.
+function stripOuterFence(text) {
+  if (typeof text !== "string") return text;
+  const trimmed = text.trim();
+  const match = trimmed.match(/^```[a-zA-Z0-9_+\-.#]*\n([\s\S]*?)\n```$/);
+  return match ? match[1] : trimmed;
+}
+
+// ---------------------------------------------------------------------------
 // Status
 // ---------------------------------------------------------------------------
 
@@ -207,7 +222,7 @@ server.registerTool(
       content: [{
         type: "text",
         text: JSON.stringify({
-          code: result.content,
+          code: stripOuterFence(result.content),
           tokensUsed: result.tokensUsed,
           finishReason: result.finishReason,
           workspace: WORKSPACE_SLUG,

--- a/plugins/local-llm/scripts/config.json
+++ b/plugins/local-llm/scripts/config.json
@@ -6,7 +6,12 @@
     "workspaceName": "Claude Code",
     "autoLaunch": true,
     "launchTimeoutMs": 30000,
-    "pollIntervalMs": 1000
+    "pollIntervalMs": 1000,
+    "chatProvider": "anythingllm_ollama",
+    "chatModel": "hf.co/bartowski/google_gemma-4-e4b-it-gguf:q4_k_m",
+    "fallbackChatModel": "gemma3n:e4b",
+    "pinWorkspace": true,
+    "probeOnPin": true
   },
   "generation": {
     "temperature": 0.2,


### PR DESCRIPTION
## Summary

- Pin `chatProvider`/`chatModel` on the AnythingLLM workspace via `POST /api/v1/workspace/{slug}/update`, so a system-default change elsewhere in AnythingLLM cannot silently swap the model used for delegation
- Probe the pinned primary model with a 4-token chat on SessionStart; fall back to a secondary model if the primary cannot be loaded; restore the previous pin if both candidates fail (workspace stays usable)
- Strip a single outer markdown fence from `local_generate` output — the small local models consistently wrap code in ``` ```lang ... ``` ``` despite a "no fences" system prompt
- Fix Windows installation detection: current AnythingLLM installer uses `…\AppData\Local\Programs\AnythingLLM\AnythingLLM.exe` (no `-desktop`/`Desktop` suffix) and the runtime image name is `AnythingLLMDesktop.exe`, not `AnythingLLM.exe`. The old detection missed both

## Defaults

| Key | Value |
|---|---|
| `chatProvider` | `anythingllm_ollama` |
| `chatModel` | `hf.co/bartowski/google_gemma-4-e4b-it-gguf:q4_k_m` |
| `fallbackChatModel` | `gemma3n:e4b` |
| `pinWorkspace` | `true` |
| `probeOnPin` | `true` |

## Verification

- Hook end-to-end: `phase=ready`, pinned `gemma3n:e4b` after primary probe failed with "unable to load model"
- `local_generate` via MCP: HTTP 200, 23.7 TPS, valid TypeScript without fences
- `npm run lint`: passed
- `npm run test`: 91/91 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)