### PR TITLE
feat: cross-platform portability + auto default-branch detection

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.52.0"
+    "version": "0.53.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.52.0",
+      "version": "0.53.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.52.0",
+      "version": "0.53.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.53.0] — 2026-04-19
+
+### Added
+
+- **plugins/local-llm/hooks/lib/anythingllm-lifecycle.js** — cross-platform support for macOS (`/Applications/AnythingLLM.app`, `~/Applications/AnythingLLM.app`, launched via `open -a`) and Linux (`.deb`/`.rpm` targets under `/usr/bin`, `/opt`, plus AppImage discovery in `~/Applications`, `~/.local/share/AnythingLLM`, `~/Downloads`). Process detection uses `pgrep -f -i anythingllm` on POSIX platforms and the existing `tasklist` probe on Windows. Unsupported platforms return `installed: false` with an `unsupported-platform:<platform>` reason so the SessionStart state machine degrades gracefully instead of silently failing
+- **plugins/devops/mcp-server/ship/lib/git.js** — `detectDefaultBranch(opts)` resolves the repository's default branch from `origin/HEAD` via `git symbolic-ref --short refs/remotes/origin/HEAD`, returning `null` when `origin/HEAD` is not set so callers can decide on a fallback
+- **README.md** — new **Supported Stacks** matrix (OS, shell, git hosting, default branch, build system, local LLM, Node runtime) documenting what is explicitly supported vs. best-effort, and an explicit **AI automation / data-loss warning** block near the top clarifying that the plugin drives shell commands, branch rewrites, and pushes on the user's behalf
+
+### Changed
+
+- **plugins/devops/mcp-server/ship/tools/preflight.js** — `base` is now optional and auto-resolved at call time. Sub-branch parent detection and the "base is default branch" checks compare against the dynamically detected default branch (from `detectDefaultBranch`) instead of a hardcoded `"main"`, so repositories using `master` or any other default branch ship correctly. Falls back to `"main"` only when `origin/HEAD` is not set
+- **plugins/devops/skills/devops-ship/SKILL.md** — preflight example now omits `base` to let the tool auto-detect it, and the auto-detection rules explain the `origin/HEAD` resolution step
+
 ## [0.52.0] — 2026-04-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@
 
 Complete DevOps automation plugin for Claude Code. Hooks, skills, agents, and templates that make shipping faster, safer, and smarter.
 
+> ## ⚠ Warning — AI automation can affect your system in ways you can't fully predict
+>
+> This plugin drives AI-powered automation (hooks, skills, agents) that runs shell commands, modifies files, rewrites branches, pushes to remotes, and launches external apps on your behalf. **Claude's behavior cannot be fully foreseen.** Under edge cases this plugin may contribute to:
+>
+> - **Data or code loss** — bad merges, overwritten work, resets to the wrong commit, deletion of uncommitted changes
+> - **Unintended external side effects** — commits, PRs, or comments published before you meant to share them; automatic app launches; dependency installs
+> - **System changes** — modified git config, installed packages, background processes
+>
+> Built-in safeguards (ship enforcement, token guards, merge-safety rules) reduce the risk but **never replace your own review**. Work in a version-controlled tree, keep backups of anything you cannot afford to lose, and read what Claude is about to do before approving a shell command or confirming a ship. **Use this plugin at your own risk** — the MIT license disclaims all warranty.
+
 ## Features
 
 - **13 Hooks** — automated guards and triggers across the full session lifecycle
@@ -199,6 +209,22 @@ Combined workflows: `/codex:rescue` for pre-ship code review, parallel investiga
 as alternative to `/devops-deep-research`, and QA-integrated review for complex changes.
 
 See [INSTALL.md](INSTALL.md#optional-codex-integration) for setup instructions.
+
+## Supported Stacks
+
+This plugin is built and actively tested against a specific stack. Outside that stack, hooks and skills may work, degrade gracefully, or not run at all — anything not listed as **supported** is best-effort.
+
+| Area | Supported | Behavior outside |
+|---|---|---|
+| **OS** | Windows, macOS, Linux | Other platforms: AnythingLLM lifecycle reports `unsupported-platform`; core git / skill flows still run via Node + git |
+| **Shell** | bash (Git-Bash on Windows), zsh | PowerShell / cmd are untested — use Git-Bash or WSL on Windows |
+| **Git hosting** | GitHub (via `gh` CLI) | GitLab / Gitea / Bitbucket / self-hosted: issue tracking, PR creation, and ship release will fail. Local / push-only flows still work |
+| **Default branch** | Auto-detected from `origin/HEAD` (`main`, `master`, or any other name) | Detached HEAD or missing `origin/HEAD`: falls back to `main` |
+| **Build system** | `npm` — auto-detects `build`, `lint`, `test` scripts in `package.json` | No `package.json`: build / lint / test steps are **silently skipped**. pnpm, yarn, pytest, cargo, go test, maven, gradle etc. are **not invoked** |
+| **Local LLM** | AnythingLLM Desktop (HTTP API) | Feature degrades gracefully — `local_generate` becomes unavailable, all main flows continue normally |
+| **Node runtime** | Node.js 20+ | Older Node: MCP server and hooks may fail to start |
+
+If your stack differs, extend the plugin per-project via the 3-layer extension model — see [Customization](#customization).
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.52.0**
+**Version: 0.53.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.52.0",
+  "version": "0.53.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/mcp-server/ship/lib/git.js
+++ b/plugins/devops/mcp-server/ship/lib/git.js
@@ -160,6 +160,21 @@ export function getWorktreeBranches(opts) {
 }
 
 /**
+ * Detect the repository's default branch (the branch `origin/HEAD` points to,
+ * typically "main" or "master"). Returns null if origin/HEAD is not set.
+ *
+ * Callers should fall back to "main" when null is returned — a repo without
+ * origin/HEAD is either a fresh local repo or one whose remote.origin.HEAD
+ * was never resolved (`git remote set-head origin --auto`).
+ */
+export function detectDefaultBranch(opts) {
+  const ref = git("symbolic-ref --short refs/remotes/origin/HEAD", opts);
+  if (!ref) return null;
+  // `symbolic-ref --short` returns e.g. "origin/main" — strip the remote prefix.
+  return ref.startsWith("origin/") ? ref.slice("origin/".length) : ref;
+}
+
+/**
  * Check if a branch exists locally or on origin.
  */
 export function branchExists(name, opts) {

--- a/plugins/devops/mcp-server/ship/tools/preflight.js
+++ b/plugins/devops/mcp-server/ship/tools/preflight.js
@@ -4,12 +4,12 @@
  */
 
 import { z } from "zod";
-import { git, currentBranch, dirtyState, commitsAhead, unpushedCommits, isWorktree, detectParentBranch, branchExists, fileOverlap, getConfig } from "../lib/git.js";
+import { git, currentBranch, dirtyState, commitsAhead, unpushedCommits, isWorktree, detectParentBranch, detectDefaultBranch, branchExists, fileOverlap, getConfig } from "../lib/git.js";
 import { readVersion, verifyVersionFiles } from "../lib/version.js";
 import { writeSentinel } from "../lib/sentinel.js";
 
 export const schema = z.object({
-  base: z.string().default("main").describe("Base branch to ship into (auto-detected from sub-branch naming if 'main')"),
+  base: z.string().optional().describe("Base branch to ship into. Omit to auto-detect: parent branch (from sub-branch naming) or the repository's default branch (origin/HEAD, typically 'main' or 'master')."),
   cwd: z.string().describe("Working directory of the target repo (required — must be passed by the caller)"),
 });
 
@@ -28,26 +28,35 @@ export async function handler(params) {
     checks.push({ name: "branch", value: branch, ok: false });
   }
 
-  // 2. Auto-detect parent branch for sub-branch → feature-branch merges
-  //    Only when base is "main" (default) and current branch has a parent.
+  // Resolve the repo's default branch once — used both as a fallback for `base`
+  // and as the reference point for the "intermediate merge" check below.
+  const defaultBranch = detectDefaultBranch(opts) || "main";
+  const baseWasExplicit = typeof base === "string" && base.length > 0;
+
+  // 2. Auto-detect parent branch for sub-branch → feature-branch merges.
+  //    Only when the caller didn't pass an explicit base.
   let autoDetectedBase = null;
-  if (base === "main" && branch && branch !== "main") {
+  if (!baseWasExplicit && branch && branch !== defaultBranch) {
     const parent = detectParentBranch(branch, opts);
     if (parent) {
       autoDetectedBase = parent.parent;
       base = parent.parent;
     }
   }
-  const intermediate = base !== "main";
+  // No explicit base and no parent detected → fall back to the repo default.
+  if (!base) base = defaultBranch;
+
+  const intermediate = base !== defaultBranch;
 
   if (branch === base) {
     errors.push(`Cannot ship from '${branch}' — already on base branch '${base}'`);
   }
   checks.push({ name: "branch", value: branch, ok: !errors.length });
 
+  checks.push({ name: "default-branch", value: defaultBranch });
   if (autoDetectedBase) {
     checks.push({ name: "auto-detected-base", value: autoDetectedBase, source: "sub-branch naming" });
-  } else if (base === "main" && branch && (branch.match(/\//g) || []).length >= 2) {
+  } else if (!baseWasExplicit && base === defaultBranch && branch && (branch.match(/\//g) || []).length >= 2) {
     checks.push({ name: "sub-branch-warning", value: branch, message: "Branch looks like a sub-branch but no parent branch was found. Push the integration branch first." });
     errors.push(`Branch '${branch}' looks like a sub-branch (2+ path segments) but no parent branch exists. Push the integration branch first, or pass an explicit base.`);
   }

--- a/plugins/devops/skills/devops-ship/SKILL.md
+++ b/plugins/devops/skills/devops-ship/SKILL.md
@@ -62,13 +62,14 @@ Run preflight, resolve any merge-safety issues autonomously, and re-check — re
 
 Call `ship_preflight` MCP tool (dotclaude-ship server).
 **CRITICAL:** Always pass `cwd` — the MCP server runs in the plugin directory, not the target repo.
+Omit `base` to let the tool auto-detect it.
 ```
-ship_preflight({ base: "main", cwd: "<current working directory>" })
+ship_preflight({ cwd: "<current working directory>" })
 ```
 
 The tool **auto-detects** the correct base branch:
 - If on a sub-branch like `feat/42-video-filters/core`, it detects `feat/42-video-filters` as the parent and uses it as base.
-- If no parent branch is found, it ships to `main` (default).
+- Otherwise it uses the repository's default branch (resolves `origin/HEAD` — typically `main`, but `master` or any other name works too). Falls back to `main` if `origin/HEAD` is not set.
 - You can override by passing an explicit base: `ship_preflight({ base: "feat/42", cwd: "<cwd>" })`.
 
 Check the result:

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.52.0",
+  "version": "0.53.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/local-llm/hooks/lib/anythingllm-lifecycle.js
+++ b/plugins/local-llm/hooks/lib/anythingllm-lifecycle.js
@@ -1,11 +1,17 @@
 /**
  * @module anythingllm-lifecycle
- * @version 0.1.0
+ * @version 0.2.0
  * @plugin local-llm
- * @description Windows lifecycle helpers for AnythingLLM Desktop.
+ * @description Cross-platform lifecycle helpers for AnythingLLM Desktop.
  *   Detects an existing installation, checks whether the process is running,
  *   and launches it detached. Does NOT wait for readiness — polling is done
  *   by the caller via anythingllm-http.checkHealth.
+ *
+ *   Supported platforms: Windows (win32), macOS (darwin), Linux. On any other
+ *   platform `detectInstallation()` reports "not installed" with an
+ *   `unsupported` reason, `isProcessRunning()` returns false, and `launch()`
+ *   returns an explicit error. The caller's state machine then surfaces the
+ *   download link and instructs the user to start the app manually.
  *
  *   All helpers return plain data structures; no throws.
  */
@@ -18,21 +24,21 @@ const os = require('node:os');
 const { spawn, execFileSync } = require('node:child_process');
 
 const DOWNLOAD_URL = 'https://anythingllm.com/download';
+const SUPPORTED_PLATFORMS = new Set(['win32', 'darwin', 'linux']);
 
-// Observed executable and process names across AnythingLLM Desktop installers.
-// The installer name (the .exe on disk) and the runtime image name (what
-// Windows reports in tasklist) are NOT guaranteed to match — the Electron
-// app manifest can rename the runtime image.
-const EXE_NAMES = ['AnythingLLM.exe', 'AnythingLLMDesktop.exe'];
-const PROCESS_NAMES = ['AnythingLLMDesktop.exe', 'AnythingLLM.exe'];
+// -------- Windows --------------------------------------------------------
 
-function candidatePaths() {
+// Installer name on disk and runtime image name reported by tasklist are NOT
+// guaranteed to match — the Electron app manifest can rename the runtime.
+const WIN_EXE_NAMES = ['AnythingLLM.exe', 'AnythingLLMDesktop.exe'];
+const WIN_PROCESS_NAMES = ['AnythingLLMDesktop.exe', 'AnythingLLM.exe'];
+
+function windowsCandidatePaths() {
   const home = os.homedir();
   const localAppData = process.env.LOCALAPPDATA || path.join(home, 'AppData', 'Local');
   const programFiles = process.env.ProgramFiles || 'C:\\Program Files';
   const programFilesX86 = process.env['ProgramFiles(x86)'] || 'C:\\Program Files (x86)';
 
-  // Directory layouts observed across installer versions.
   const dirs = [
     path.join(localAppData, 'Programs', 'AnythingLLM'),
     path.join(localAppData, 'Programs', 'anythingllm-desktop'),
@@ -44,23 +50,13 @@ function candidatePaths() {
 
   const paths = [];
   for (const d of dirs) {
-    for (const exe of EXE_NAMES) paths.push(path.join(d, exe));
+    for (const exe of WIN_EXE_NAMES) paths.push(path.join(d, exe));
   }
   return paths;
 }
 
-function detectInstallation() {
-  for (const p of candidatePaths()) {
-    try {
-      if (fs.existsSync(p)) return { installed: true, path: p };
-    } catch { /* ignore */ }
-  }
-  return { installed: false, path: null, downloadUrl: DOWNLOAD_URL };
-}
-
-function isProcessRunning() {
-  if (process.platform !== 'win32') return false;
-  for (const name of PROCESS_NAMES) {
+function isRunningWindows() {
+  for (const name of WIN_PROCESS_NAMES) {
     try {
       const out = execFileSync(
         'tasklist',
@@ -73,8 +69,137 @@ function isProcessRunning() {
   return false;
 }
 
-function launch(exePath) {
+// -------- macOS ----------------------------------------------------------
+
+function macOSCandidatePaths() {
+  const home = os.homedir();
+  const bundles = [
+    '/Applications/AnythingLLM.app',
+    path.join(home, 'Applications', 'AnythingLLM.app'),
+  ];
+  // Mach-O binary inside the .app bundle. Electron apps may use either the
+  // app name or a "Desktop" variant — include both.
+  const binNames = ['AnythingLLM', 'AnythingLLM Desktop'];
+  const paths = [];
+  for (const bundle of bundles) {
+    for (const name of binNames) paths.push(path.join(bundle, 'Contents', 'MacOS', name));
+  }
+  return paths;
+}
+
+// -------- Linux ----------------------------------------------------------
+
+function linuxCandidatePaths() {
+  const home = os.homedir();
+  const paths = [];
+
+  // .deb / .rpm / tarball system targets
+  const systemBins = [
+    '/usr/bin/anythingllm-desktop',
+    '/usr/bin/AnythingLLM',
+    '/usr/local/bin/anythingllm-desktop',
+    '/opt/AnythingLLM/anythingllm-desktop',
+    '/opt/AnythingLLM/AnythingLLM',
+  ];
+  paths.push(...systemBins);
+
+  // Per-user install locations. AppImage is the typical distribution channel
+  // for AnythingLLM Desktop on Linux, and users commonly drop it into one of
+  // these directories without installing system-wide.
+  const userDirs = [
+    path.join(home, 'Applications'),
+    path.join(home, '.local', 'share', 'AnythingLLM'),
+    path.join(home, 'Downloads'),
+  ];
+  for (const dir of userDirs) {
+    try {
+      if (!fs.existsSync(dir)) continue;
+      for (const entry of fs.readdirSync(dir)) {
+        if (/^anythingllm.*\.appimage$/i.test(entry)) {
+          paths.push(path.join(dir, entry));
+        } else if (/^anythingllm(-desktop)?$/i.test(entry)) {
+          paths.push(path.join(dir, entry));
+        }
+      }
+    } catch { /* unreadable dir — skip */ }
+  }
+
+  return paths;
+}
+
+// pgrep ships on every mainstream macOS and Linux distro. If it's missing
+// (minimal container image) the caller's state machine still handles an
+// unreachable /api/ping by prompting the user to start the app.
+function isRunningPosix() {
   try {
+    execFileSync('pgrep', ['-f', '-i', 'anythingllm'], {
+      encoding: 'utf8',
+      timeout: 3000,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// -------- Public API -----------------------------------------------------
+
+function candidatePaths() {
+  switch (process.platform) {
+    case 'win32': return windowsCandidatePaths();
+    case 'darwin': return macOSCandidatePaths();
+    case 'linux': return linuxCandidatePaths();
+    default: return [];
+  }
+}
+
+function detectInstallation() {
+  if (!SUPPORTED_PLATFORMS.has(process.platform)) {
+    return {
+      installed: false,
+      path: null,
+      downloadUrl: DOWNLOAD_URL,
+      reason: `unsupported-platform:${process.platform}`,
+    };
+  }
+  for (const p of candidatePaths()) {
+    try {
+      if (fs.existsSync(p)) return { installed: true, path: p };
+    } catch { /* ignore */ }
+  }
+  return { installed: false, path: null, downloadUrl: DOWNLOAD_URL };
+}
+
+function isProcessRunning() {
+  switch (process.platform) {
+    case 'win32': return isRunningWindows();
+    case 'darwin':
+    case 'linux': return isRunningPosix();
+    default: return false;
+  }
+}
+
+function launch(exePath) {
+  if (!SUPPORTED_PLATFORMS.has(process.platform)) {
+    return { ok: false, error: `unsupported platform: ${process.platform}` };
+  }
+  try {
+    // On macOS, prefer `open -a <AppBundle>` so LaunchServices handles
+    // activation, Dock icon, and Gatekeeper. Spawning the Mach-O directly
+    // works but bypasses all of that.
+    if (process.platform === 'darwin') {
+      const bundle = exePath.match(/^(.*\.app)\/Contents\/MacOS\//);
+      if (bundle) {
+        const child = spawn('open', ['-a', bundle[1]], {
+          detached: true,
+          stdio: 'ignore',
+        });
+        child.unref();
+        return { ok: true, pid: child.pid };
+      }
+    }
+
     const child = spawn(exePath, [], {
       detached: true,
       stdio: 'ignore',


### PR DESCRIPTION
## Summary
- **local-llm** — AnythingLLM lifecycle now supports Windows, macOS, and Linux (candidate paths, `pgrep` process detection, `open -a` launch on darwin) with graceful fallback on unsupported platforms.
- **devops/ship** — new `detectDefaultBranch()` resolves `origin/HEAD`; `ship_preflight` no longer hardcodes `main` and ships correctly on `master` or any other default branch. Sub-branch parent detection compares against the resolved default.
- **README** — new **Supported Stacks** matrix and an explicit AI-automation / data-loss warning block.

## Motivation
Makes the plugin portable for anyone, not just the author's Windows + GitHub + `main`-branch setup, while keeping the stability and UX on the supported stack untouched.

## Test plan
- [x] `npm run lint` clean
- [x] `npm test` — 91/91 pass
- [x] `ship_preflight` green, `ship_build` green on this branch
- [ ] Verify `detectDefaultBranch` on a `master` repo (manual, post-merge)
- [ ] Verify `anythingllm-lifecycle` on macOS / Linux (manual, post-merge)
