### PR TITLE
fix(local-llm): unify primary model URL + warn on fallback

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.53.0"
+    "version": "0.53.1"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.53.0",
+      "version": "0.53.1",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.53.0",
+      "version": "0.53.1",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.53.1] — 2026-04-19
+
+### Changed
+
+- **plugins/local-llm/scripts/config.json** + **plugins/local-llm/hooks/session-start/ss.llm.health.js** + **plugins/local-llm/skills/local-llm-setup/SKILL.md** + **plugins/local-llm/deep-knowledge/{delegation-rules,model-config}.md** — unified primary-model identifier across config, defaults, setup skill, and docs. Previously the config/defaults used the full HuggingFace URL while the docs recommended the short Ollama tag `gemma4:e4b` (which is not in Ollama's public registry and would never match the pinned workspace). All references now agree on `hf.co/bartowski/google_gemma-4-e4b-it-gguf:bf16` (bf16 full-precision variant, verified pullable via `ollama pull`)
+
+### Added
+
+- **plugins/local-llm/hooks/session-start/ss.llm.health.js** — `readyInstructions()` now renders a `⚠ Using fallback model` warning block in the SessionStart banner when the active model differs from the configured primary. The warning surfaces the HuggingFace link and the exact `ollama pull <url>` command so the user can load the primary model without leaving chat. Fires whenever the probe-backed pin cascade (primary → fallback) lands on anything other than the configured primary
+
 ## [0.53.0] — 2026-04-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.53.0**
+**Version: 0.53.1**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.53.0",
+  "version": "0.53.1",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.53.0",
+  "version": "0.53.1",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/local-llm/deep-knowledge/delegation-rules.md
+++ b/plugins/local-llm/deep-knowledge/delegation-rules.md
@@ -10,7 +10,7 @@ The local model is a fast code printer for mechanical tasks — it saves Claude'
 tokens on work that doesn't need frontier-model intelligence.
 
 The backend is a local AnythingLLM Desktop workspace. The actual model is
-whatever AnythingLLM is configured to use (recommended: Ollama + `gemma4:e4b`).
+whatever AnythingLLM is configured to use (recommended: Ollama + `hf.co/bartowski/google_gemma-4-e4b-it-gguf:bf16`).
 Broad capability assumptions:
 - **Good at:** Pattern completion, syntax, following exact specs, single-function code
 - **Bad at:** Multi-step reasoning, cross-file context, ambiguity resolution, API knowledge

--- a/plugins/local-llm/deep-knowledge/model-config.md
+++ b/plugins/local-llm/deep-knowledge/model-config.md
@@ -12,7 +12,7 @@ primary is unavailable.
 |----------|-------|
 | Backend app | AnythingLLM Desktop (https://anythingllm.com/download) |
 | Provider key (API) | `anythingllm_ollama` (AnythingLLM's built-in native LLM) |
-| Primary model | `hf.co/bartowski/google_gemma-4-e4b-it-gguf:q4_k_m` (Gemma 4 E4B, HF/Bartowski, Q4_K_M) |
+| Primary model | `hf.co/bartowski/google_gemma-4-e4b-it-gguf:bf16` (Gemma 4 E4B, HF/Bartowski, bf16 full precision) |
 | Fallback model | `gemma3n:e4b` (Gemma 3n 4B effective, ~7.5 GB, from Ollama registry) |
 | Plugin workspace slug | `claude-code` |
 | API port | 3001 (AnythingLLM default) |
@@ -35,8 +35,10 @@ AnythingLLM's settings — outside this plugin's scope.
 
 1. Install AnythingLLM Desktop.
 2. Open it → Settings → **Developer API** → **Generate API Key**.
-3. Provider setup: pick **Ollama**, let AnythingLLM pull `gemma4:e4b` (or
-   select another model if the user prefers; the plugin does not enforce).
+3. Provider setup: pick **Ollama**, pull `hf.co/bartowski/google_gemma-4-e4b-it-gguf:bf16`
+   (HuggingFace GGUF URL — supported by Ollama ≥ v0.3.13; must be pulled via
+   the AnythingLLM UI or `ollama pull`, the AnythingLLM REST API cannot trigger
+   the download). Alternatively select another model — the plugin does not enforce.
 4. Run the `local-llm-setup` skill in Claude Code to save the API key.
 
 ## Config layering
@@ -73,7 +75,7 @@ The setup skill always writes to the user layer.
     "launchTimeoutMs": 30000,
     "pollIntervalMs": 1000,
     "chatProvider": "anythingllm_ollama",
-    "chatModel": "hf.co/bartowski/google_gemma-4-e4b-it-gguf:q4_k_m",
+    "chatModel": "hf.co/bartowski/google_gemma-4-e4b-it-gguf:bf16",
     "fallbackChatModel": "gemma3n:e4b",
     "pinWorkspace": true,
     "probeOnPin": true

--- a/plugins/local-llm/hooks/session-start/ss.llm.health.js
+++ b/plugins/local-llm/hooks/session-start/ss.llm.health.js
@@ -40,7 +40,7 @@ const WORKSPACE_NAME = CONFIG.anythingllm?.workspaceName || 'Claude Code';
 const AUTO_LAUNCH = CONFIG.anythingllm?.autoLaunch !== false;
 const API_KEY = CONFIG.anythingllm?.apiKey || '';
 const CHAT_PROVIDER = CONFIG.anythingllm?.chatProvider || 'anythingllm_ollama';
-const CHAT_MODEL = CONFIG.anythingllm?.chatModel || 'gemma4:e4b';
+const CHAT_MODEL = CONFIG.anythingllm?.chatModel || 'hf.co/bartowski/google_gemma-4-e4b-it-gguf:bf16';
 const FALLBACK_CHAT_MODEL = CONFIG.anythingllm?.fallbackChatModel || 'gemma3n:e4b';
 const PIN_WORKSPACE = CONFIG.anythingllm?.pinWorkspace !== false;
 const PROBE_ON_PIN = CONFIG.anythingllm?.probeOnPin !== false;
@@ -57,9 +57,18 @@ function disabledHint(reason) {
   );
 }
 
-function readyInstructions(activeModel) {
+function readyInstructions(activeModel, primaryModel) {
   const modelLine = activeModel ? `Model: ${activeModel} (pinned).\n` : '';
+  let warning = '';
+  if (activeModel && primaryModel && activeModel !== primaryModel) {
+    const looksLikeUrl = primaryModel.startsWith('hf.co/') || primaryModel.includes('://');
+    const howToLoad = looksLikeUrl
+      ? `AnythingLLM has not loaded the configured primary model yet. Integrate it via this link (HuggingFace GGUF — supported by Ollama ≥ v0.3.13):\n   ${primaryModel}\nPull it in AnythingLLM → Settings → AI Providers → Ollama, or from a terminal: \`ollama pull ${primaryModel}\`.`
+      : `AnythingLLM has not loaded the configured primary model "${primaryModel}". Pull it in AnythingLLM → Settings → AI Providers.`;
+    warning = `[local-llm] ⚠ Using fallback model "${activeModel}" — primary not available.\n${howToLoad}\n\n`;
+  }
   return (
+    warning +
     `[local-llm] Local LLM is ready via mcp__plugin_local-llm_dotclaude-local-llm__local_generate.\n` +
     `Backend: AnythingLLM @ ${BASE_URL}, workspace "${WORKSPACE_SLUG}".\n` +
     modelLine +
@@ -182,7 +191,7 @@ async function ensureWorkspacePin() {
     const exists = ws.workspaces.some((w) => w.slug === WORKSPACE_SLUG);
     if (exists) {
       const activeModel = await ensureWorkspacePin();
-      emit('ready', readyInstructions(activeModel));
+      emit('ready', readyInstructions(activeModel, CHAT_MODEL));
       return;
     }
 

--- a/plugins/local-llm/scripts/config.json
+++ b/plugins/local-llm/scripts/config.json
@@ -8,7 +8,7 @@
     "launchTimeoutMs": 30000,
     "pollIntervalMs": 1000,
     "chatProvider": "anythingllm_ollama",
-    "chatModel": "hf.co/bartowski/google_gemma-4-e4b-it-gguf:q4_k_m",
+    "chatModel": "hf.co/bartowski/google_gemma-4-e4b-it-gguf:bf16",
     "fallbackChatModel": "gemma3n:e4b",
     "pinWorkspace": true,
     "probeOnPin": true

--- a/plugins/local-llm/skills/local-llm-setup/SKILL.md
+++ b/plugins/local-llm/skills/local-llm-setup/SKILL.md
@@ -26,7 +26,8 @@ Before asking for the key, tell the user what they need:
 >   1. Open AnythingLLM.
 >   2. Settings → **Developer API** → **Generate API Key**.
 >   3. Copy the key.
->   4. (Recommended) Configure the LLM provider to **Ollama** with model **`gemma4:e4b`**.
+>   4. (Recommended) Configure the LLM provider to **Ollama** with model **`hf.co/bartowski/google_gemma-4-e4b-it-gguf:bf16`**
+>      (HuggingFace GGUF — supported by Ollama ≥ v0.3.13; pull via the AnythingLLM UI or `ollama pull`).
 >      If Ollama is not installed, AnythingLLM can download it during the provider setup.
 
 ## Step 2 — Ask for the key


### PR DESCRIPTION
## Summary

- Config and docs now agree on one canonical primary-model identifier: `hf.co/bartowski/google_gemma-4-e4b-it-gguf:bf16` (previously mixed short tag `gemma4:e4b` in docs vs. HF URL in config.json — the short tag is not in Ollama's public registry and would never match the pinned workspace)
- Primary switched to the `:bf16` variant (full precision), verified pullable via `ollama pull`
- SessionStart banner now surfaces a `⚠ Using fallback model` warning with the HuggingFace link + `ollama pull` command when the probe cascade lands on the fallback, so the user sees in-chat how to load the primary
- Fallback chain (primary → `gemma3n:e4b`) is unchanged; existing `probeChat()` already guards against a broken `chatModel` string by sending a real 4-token chat completion before accepting any pinned model

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run test` — 91/91 passing
- [ ] SessionStart on a machine where the primary HF GGUF is not yet pulled → banner shows warning block with link
- [ ] SessionStart after `ollama pull hf.co/bartowski/google_gemma-4-e4b-it-gguf:bf16` → banner shows `Model: hf.co/... (pinned)` without warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)