### PR TITLE
refactor(local-llm): drop model pinning, recommend via HF URL

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.53.2"
+    "version": "0.54.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.53.2",
+      "version": "0.54.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.53.2",
+      "version": "0.54.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.54.0] — 2026-04-19
+
+### Changed
+
+- **plugins/local-llm/scripts/config.json** + **plugins/local-llm/hooks/session-start/ss.llm.health.js** + **plugins/local-llm/hooks/lib/anythingllm-config.js** — dropped workspace model pinning. The plugin no longer sets `chatProvider`/`chatModel` on the workspace, no longer runs a 4-token probe, and no longer falls back to a secondary model. `local_generate` uses whatever the user configured in AnythingLLM. This removes ~60 lines of stateful pin/probe/fallback logic and the failure mode where SessionStart silently rewrites the user's model selection
+- **plugins/local-llm/deep-knowledge/model-config.md** + **plugins/local-llm/skills/local-llm-setup/SKILL.md** — docs reframed around "the user owns the model"; recommendation now cites the HuggingFace page alongside the Ollama pull tag so users can verify the source before pulling
+
+### Added
+
+- **plugins/local-llm/scripts/config.json** — new `anythingllm.recommendedModel` (Ollama pull tag) and `anythingllm.recommendedModelUrl` (HuggingFace page) fields. Used only to render the one-shot recommendation banner when the workspace has no `chatModel` set. Both overridable per user/project layer
+- **plugins/local-llm/hooks/session-start/ss.llm.health.js** — recommendation block in the ready banner (emitted only when `workspace.chatModel` is empty) listing the HF page, the Ollama tag, and the `ollama pull` command
+
+### Removed
+
+- **plugins/local-llm/scripts/config.json** — `anythingllm.chatProvider`, `anythingllm.chatModel`, `anythingllm.fallbackChatModel`, `anythingllm.pinWorkspace`, `anythingllm.probeOnPin`. Any values at user/project layer are now silently ignored — no migration needed, the plugin simply stops touching model settings
+
 ## [0.53.2] — 2026-04-19
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.53.2**
+**Version: 0.54.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.53.2",
+  "version": "0.54.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.53.2",
+  "version": "0.54.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/local-llm/deep-knowledge/model-config.md
+++ b/plugins/local-llm/deep-knowledge/model-config.md
@@ -1,44 +1,50 @@
 # Model Configuration Reference — AnythingLLM Backend
 
 The backend app is **AnythingLLM Desktop** — the user installs it once and
-generates an API key. The plugin then talks to a workspace via HTTP, **pins
-the workspace to a specific chat model** (so a system-default change does
-not silently swap the model), and falls back to a secondary model if the
-primary is unavailable.
+generates an API key. The plugin then talks to a workspace via HTTP.
+
+**The chat model is owned by the user inside AnythingLLM.** The plugin does
+not pin, swap, or probe models. Whatever the workspace is configured with is
+what `local_generate` will use. The SessionStart hook only reads the active
+`chatModel` and surfaces a recommendation when none is set.
 
 ## Recommended setup
 
 | Property | Value |
 |----------|-------|
 | Backend app | AnythingLLM Desktop (https://anythingllm.com/download) |
-| Provider key (API) | `anythingllm_ollama` (AnythingLLM's built-in native LLM) |
-| Primary model | `hf.co/bartowski/google_gemma-4-e4b-it-gguf:bf16` (Gemma 4 E4B, HF/Bartowski, bf16 full precision) |
-| Fallback model | `gemma3n:e4b` (Gemma 3n 4B effective, ~7.5 GB, from Ollama registry) |
+| Provider | Ollama (built-in native LLM in AnythingLLM) |
+| Recommended model | **Gemma 4 E4B** (Bartowski GGUF, bf16 full precision) |
+| → HuggingFace page | https://huggingface.co/bartowski/google_gemma-4-E4B-it-GGUF |
+| → Ollama pull tag | `hf.co/bartowski/google_gemma-4-e4b-it-gguf:bf16` |
 | Plugin workspace slug | `claude-code` |
 | API port | 3001 (AnythingLLM default) |
 
 The plugin:
 
 1. Auto-creates the `claude-code` workspace on first successful connect.
-2. Pins `chatProvider` and `chatModel` on the workspace.
-3. Sends a 4-token probe chat. If the primary model fails, the plugin
-   re-pins the workspace to the fallback model.
+2. Reads the workspace's `chatModel` on each SessionStart and shows it in
+   the ready banner.
+3. If no model is configured, emits a one-shot recommendation with the
+   HuggingFace GGUF URL and the `ollama pull` command. Any other model the
+   user sets in AnythingLLM also works — the plugin does not enforce.
 
-GPU offload, KV-cache quantization, and context size remain inside
-AnythingLLM's settings — outside this plugin's scope.
-
-> **Note on the provider name.** The API key is `anythingllm_ollama`, but
-> AnythingLLM Desktop ships its own bundled native LLM runtime. It is not
-> the standalone Ollama daemon on port 11434.
+GPU offload, KV-cache quantization, context size, temperature caps, and
+model selection all remain inside AnythingLLM's settings — outside this
+plugin's scope.
 
 ## One-time user steps
 
 1. Install AnythingLLM Desktop.
 2. Open it → Settings → **Developer API** → **Generate API Key**.
-3. Provider setup: pick **Ollama**, pull `hf.co/bartowski/google_gemma-4-e4b-it-gguf:bf16`
-   (HuggingFace GGUF URL — supported by Ollama ≥ v0.3.13; must be pulled via
-   the AnythingLLM UI or `ollama pull`, the AnythingLLM REST API cannot trigger
-   the download). Alternatively select another model — the plugin does not enforce.
+3. Provider setup: pick **Ollama**, pull the recommended model
+   **Gemma 4 E4B** —
+   HuggingFace page: <https://huggingface.co/bartowski/google_gemma-4-E4B-it-GGUF>,
+   Ollama pull tag: `hf.co/bartowski/google_gemma-4-e4b-it-gguf:bf16`
+   (HuggingFace GGUF — supported by Ollama ≥ v0.3.13; must be pulled via the
+   AnythingLLM UI or `ollama pull`, the AnythingLLM REST API cannot trigger
+   the download).
+   Any other model works too — the plugin uses whatever is configured.
 4. Run the `local-llm-setup` skill in Claude Code to save the API key.
 
 ## Config layering
@@ -74,11 +80,8 @@ The setup skill always writes to the user layer.
     "autoLaunch": true,
     "launchTimeoutMs": 30000,
     "pollIntervalMs": 1000,
-    "chatProvider": "anythingllm_ollama",
-    "chatModel": "hf.co/bartowski/google_gemma-4-e4b-it-gguf:bf16",
-    "fallbackChatModel": "gemma3n:e4b",
-    "pinWorkspace": true,
-    "probeOnPin": true
+    "recommendedModel": "hf.co/bartowski/google_gemma-4-e4b-it-gguf:bf16",
+    "recommendedModelUrl": "https://huggingface.co/bartowski/google_gemma-4-E4B-it-GGUF"
   },
   "generation": {
     "temperature": 0.2,
@@ -92,13 +95,11 @@ The setup skill always writes to the user layer.
 | `baseUrl` | AnythingLLM API root. Keep default unless the app runs on a different port/host. |
 | `apiKey` | User-global secret. Only read from `~/.claude/local-llm/config.json`. |
 | `workspaceSlug` | Workspace the plugin talks to. Auto-created if missing. |
+| `workspaceName` | Human-readable name used when the workspace is auto-created. |
 | `autoLaunch` | If true, the SessionStart hook launches AnythingLLM when installed but not running. |
 | `launchTimeoutMs` | How long the hook waits for the API to become reachable after launch (advisory; the hook itself never blocks the prompt). |
-| `chatProvider` | Provider key passed to AnythingLLM workspace update. Default `anythingllm_ollama` (built-in native LLM). |
-| `chatModel` | Primary model the workspace is pinned to. |
-| `fallbackChatModel` | Used if the probe chat against `chatModel` fails. Set to `null` to disable fallback. |
-| `pinWorkspace` | Default `true`. If `false`, plugin leaves workspace at AnythingLLM's system default. |
-| `probeOnPin` | Default `true`. After pinning, sends a 4-token chat to verify the model loads. |
+| `recommendedModel` | Ollama pull tag shown in the ready banner when the workspace has no `chatModel` set. Not enforced — the user's AnythingLLM selection always wins. |
+| `recommendedModelUrl` | HuggingFace page for the recommended model, shown alongside the Ollama tag in the recommendation block. |
 | `generation.temperature` | Default sampling temperature for `local_generate`. Keep ≤ 0.5 for code. |
 | `generation.maxTokens` | Upper bound on completion length. |
 
@@ -127,3 +128,4 @@ The SessionStart hook and `local_status` tool return one of these phases:
 | Slow first completion | Ollama is loading the model into VRAM | One-time — subsequent calls are fast |
 | `auth_failed` after a working day | User regenerated the key in AnythingLLM UI | Re-run `local-llm-setup` |
 | Garbage or truncated output | `temperature` too high or `maxTokens` too low | Adjust `generation.*` in user config |
+| No `Model:` line in ready banner | Workspace has no `chatModel` set | Configure a chat model in AnythingLLM → Workspace Settings → Chat Settings |

--- a/plugins/local-llm/hooks/lib/anythingllm-config.js
+++ b/plugins/local-llm/hooks/lib/anythingllm-config.js
@@ -12,11 +12,10 @@
  *   are ignored to prevent accidental commits. The user config path is
  *   also where the setup skill writes the key.
  *
- *   Model pinning: the plugin sets `chatProvider`/`chatModel` on the
- *   workspace via `POST /api/v1/workspace/{slug}/update`. Primary and
- *   fallback model tags live under `anythingllm.chatModel` and
- *   `anythingllm.fallbackChatModel`. The SessionStart hook probes the
- *   primary, and on failure pins the fallback.
+ *   Model choice: the plugin does NOT pin or override the workspace's chat
+ *   model — that is owned by the user inside AnythingLLM. The hook only
+ *   reads `chatModel` from the workspace and surfaces a recommendation via
+ *   `anythingllm.recommendedModel` when none is set.
  */
 
 'use strict';

--- a/plugins/local-llm/hooks/session-start/ss.llm.health.js
+++ b/plugins/local-llm/hooks/session-start/ss.llm.health.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * @hook ss.llm.health
- * @version 0.2.0
+ * @version 0.3.0
  * @event SessionStart
  * @plugin local-llm
  * @description AnythingLLM health probe + non-blocking auto-setup.
@@ -15,6 +15,10 @@
  *     5. auth_failed       — /api/v1/auth returned 401/403
  *     6. configuring       — API reachable, workspace missing; create async
  *     7. ready             — API reachable, workspace present → tool enabled
+ *
+ *   Model choice is owned by the user inside AnythingLLM. This hook never
+ *   pins or overrides it; it only reads whatever `chatModel` the workspace
+ *   is currently on and surfaces a recommendation if none is set.
  *
  *   The hook NEVER blocks the prompt for long-running work. Model loading,
  *   workspace creation, and first-time app launches run async in the
@@ -39,11 +43,8 @@ const WORKSPACE_SLUG = CONFIG.anythingllm?.workspaceSlug || 'claude-code';
 const WORKSPACE_NAME = CONFIG.anythingllm?.workspaceName || 'Claude Code';
 const AUTO_LAUNCH = CONFIG.anythingllm?.autoLaunch !== false;
 const API_KEY = CONFIG.anythingllm?.apiKey || '';
-const CHAT_PROVIDER = CONFIG.anythingllm?.chatProvider || 'anythingllm_ollama';
-const CHAT_MODEL = CONFIG.anythingllm?.chatModel || 'hf.co/bartowski/google_gemma-4-e4b-it-gguf:bf16';
-const FALLBACK_CHAT_MODEL = CONFIG.anythingllm?.fallbackChatModel || 'gemma3n:e4b';
-const PIN_WORKSPACE = CONFIG.anythingllm?.pinWorkspace !== false;
-const PROBE_ON_PIN = CONFIG.anythingllm?.probeOnPin !== false;
+const RECOMMENDED_MODEL = CONFIG.anythingllm?.recommendedModel || 'hf.co/bartowski/google_gemma-4-e4b-it-gguf:bf16';
+const RECOMMENDED_MODEL_URL = CONFIG.anythingllm?.recommendedModelUrl || 'https://huggingface.co/bartowski/google_gemma-4-E4B-it-GGUF';
 
 function emit(phase, instructions) {
   process.stdout.write(`[local-llm] phase: ${phase}\n${instructions}\n`);
@@ -57,16 +58,23 @@ function disabledHint(reason) {
   );
 }
 
-function readyInstructions(activeModel, primaryModel) {
-  const modelLine = activeModel ? `Model: ${activeModel} (pinned).\n` : '';
-  let warning = '';
-  if (activeModel && primaryModel && activeModel !== primaryModel) {
-    const looksLikeUrl = primaryModel.startsWith('hf.co/') || primaryModel.includes('://');
-    const howToLoad = looksLikeUrl
-      ? `AnythingLLM has not loaded the configured primary model yet. Integrate it via this link (HuggingFace GGUF — supported by Ollama ≥ v0.3.13):\n   ${primaryModel}\nPull it in AnythingLLM → Settings → AI Providers → Ollama, or from a terminal: \`ollama pull ${primaryModel}\`.`
-      : `AnythingLLM has not loaded the configured primary model "${primaryModel}". Pull it in AnythingLLM → Settings → AI Providers.`;
-    warning = `[local-llm] ⚠ Using fallback model "${activeModel}" — primary not available.\n${howToLoad}\n\n`;
-  }
+function recommendationBlock() {
+  return (
+    `[local-llm] ⚠ No chat model configured in workspace "${WORKSPACE_SLUG}".\n` +
+    `Recommended: Gemma 4 E4B (Bartowski GGUF, bf16 full precision).\n` +
+    `   HuggingFace: ${RECOMMENDED_MODEL_URL}\n` +
+    `   Ollama tag:  ${RECOMMENDED_MODEL}\n` +
+    `Pull via AnythingLLM → Settings → AI Providers → Ollama (paste the Ollama tag — ` +
+    `supported by Ollama ≥ v0.3.13), or from a terminal: \`ollama pull ${RECOMMENDED_MODEL}\`.\n` +
+    `Any other model configured in AnythingLLM will also work.\n\n`
+  );
+}
+
+function readyInstructions(activeModel) {
+  const warning = activeModel ? '' : recommendationBlock();
+  const modelLine = activeModel
+    ? `Model: ${activeModel} (as configured in AnythingLLM).\n`
+    : '';
   return (
     warning +
     `[local-llm] Local LLM is ready via mcp__plugin_local-llm_dotclaude-local-llm__local_generate.\n` +
@@ -83,73 +91,9 @@ function readyInstructions(activeModel, primaryModel) {
   );
 }
 
-async function probeChat() {
-  const res = await http.chatCompletion(BASE_URL, API_KEY, {
-    workspaceSlug: WORKSPACE_SLUG,
-    messages: [{ role: 'user', content: 'ping' }],
-    temperature: 0,
-    maxTokens: 4,
-  });
-  return res.ok && typeof res.content === 'string';
-}
-
-async function pinWorkspace(model) {
-  const res = await http.updateWorkspace(BASE_URL, API_KEY, WORKSPACE_SLUG, {
-    chatProvider: CHAT_PROVIDER,
-    chatModel: model,
-  });
-  return res.ok && res.workspace?.chatModel === model;
-}
-
-// Try a candidate model: pin → probe. Returns model name on success, null on failure.
-async function tryModel(model) {
-  if (!model) return null;
-  const pinned = await pinWorkspace(model);
-  if (!pinned) return null;
-  if (!PROBE_ON_PIN) return model;
-  const works = await probeChat();
-  return works ? model : null;
-}
-
-async function ensureWorkspacePin() {
-  if (!PIN_WORKSPACE) return null;
-
-  const current = await http.getWorkspace(BASE_URL, API_KEY, WORKSPACE_SLUG);
-  const currentModel = current.workspace?.chatModel || null;
-
-  // Already on a configured target — trust it without re-probing (avoids
-  // burning a chat on every SessionStart).
-  if (currentModel === CHAT_MODEL || (FALLBACK_CHAT_MODEL && currentModel === FALLBACK_CHAT_MODEL)) {
-    return currentModel;
-  }
-
-  const primary = await tryModel(CHAT_MODEL);
-  if (primary) {
-    process.stderr.write(`[local-llm] pinned workspace to primary model: ${primary}\n`);
-    return primary;
-  }
-
-  if (FALLBACK_CHAT_MODEL && FALLBACK_CHAT_MODEL !== CHAT_MODEL) {
-    const fallback = await tryModel(FALLBACK_CHAT_MODEL);
-    if (fallback) {
-      process.stderr.write(
-        `[local-llm] primary model "${CHAT_MODEL}" unavailable — pinned fallback: ${fallback}\n`
-      );
-      return fallback;
-    }
-  }
-
-  // Both candidates failed. Restore the previous model so the workspace
-  // stays usable, and surface the situation on stderr.
-  if (currentModel) {
-    await pinWorkspace(currentModel);
-    process.stderr.write(
-      `[local-llm] neither "${CHAT_MODEL}" nor "${FALLBACK_CHAT_MODEL || '(none)'}" is loaded in ` +
-      `AnythingLLM. Restored "${currentModel}". Pull a configured model in AnythingLLM ` +
-      `Settings → AI Providers, or change "chatModel" in the plugin config.\n`
-    );
-  }
-  return currentModel;
+async function readWorkspaceModel() {
+  const res = await http.getWorkspace(BASE_URL, API_KEY, WORKSPACE_SLUG);
+  return res.ok ? (res.workspace?.chatModel || null) : null;
 }
 
 (async () => {
@@ -190,8 +134,8 @@ async function ensureWorkspacePin() {
 
     const exists = ws.workspaces.some((w) => w.slug === WORKSPACE_SLUG);
     if (exists) {
-      const activeModel = await ensureWorkspacePin();
-      emit('ready', readyInstructions(activeModel, CHAT_MODEL));
+      const activeModel = await readWorkspaceModel();
+      emit('ready', readyInstructions(activeModel));
       return;
     }
 

--- a/plugins/local-llm/scripts/config.json
+++ b/plugins/local-llm/scripts/config.json
@@ -7,11 +7,8 @@
     "autoLaunch": true,
     "launchTimeoutMs": 30000,
     "pollIntervalMs": 1000,
-    "chatProvider": "anythingllm_ollama",
-    "chatModel": "hf.co/bartowski/google_gemma-4-e4b-it-gguf:bf16",
-    "fallbackChatModel": "gemma3n:e4b",
-    "pinWorkspace": true,
-    "probeOnPin": true
+    "recommendedModel": "hf.co/bartowski/google_gemma-4-e4b-it-gguf:bf16",
+    "recommendedModelUrl": "https://huggingface.co/bartowski/google_gemma-4-E4B-it-GGUF"
   },
   "generation": {
     "temperature": 0.2,

--- a/plugins/local-llm/skills/local-llm-setup/SKILL.md
+++ b/plugins/local-llm/skills/local-llm-setup/SKILL.md
@@ -26,9 +26,12 @@ Before asking for the key, tell the user what they need:
 >   1. Open AnythingLLM.
 >   2. Settings → **Developer API** → **Generate API Key**.
 >   3. Copy the key.
->   4. (Recommended) Configure the LLM provider to **Ollama** with model **`hf.co/bartowski/google_gemma-4-e4b-it-gguf:bf16`**
->      (HuggingFace GGUF — supported by Ollama ≥ v0.3.13; pull via the AnythingLLM UI or `ollama pull`).
+>   4. (Recommended) Configure the LLM provider to **Ollama** with **Gemma 4 E4B**:
+>      - HuggingFace page: https://huggingface.co/bartowski/google_gemma-4-E4B-it-GGUF
+>      - Ollama pull tag: `hf.co/bartowski/google_gemma-4-e4b-it-gguf:bf16`
+>        (HuggingFace GGUF — supported by Ollama ≥ v0.3.13; pull via the AnythingLLM UI or `ollama pull`).
 >      If Ollama is not installed, AnythingLLM can download it during the provider setup.
+>      Any other model configured in AnythingLLM will also work — the plugin uses whatever the workspace is set to.
 
 ## Step 2 — Ask for the key
 


### PR DESCRIPTION
## Summary

The local-llm plugin no longer pins `chatProvider`/`chatModel` on the AnythingLLM workspace, no longer runs a probe chat, and no longer falls back to a secondary model. Whatever the user configured in AnythingLLM is what `local_generate` uses. When no model is set on the workspace, the SessionStart hook emits a one-shot recommendation with the HuggingFace page URL and the Ollama pull tag for Gemma 4 E4B (bf16) — both values are overridable via the new `recommendedModel` / `recommendedModelUrl` config fields.

Motivation: eliminate the failure mode where the plugin silently rewrites the user's model selection, and simplify the SessionStart state machine (~60 lines of pin/probe/fallback logic removed).

## Changes

- **Removed** config fields `anythingllm.chatProvider`, `chatModel`, `fallbackChatModel`, `pinWorkspace`, `probeOnPin`. Values at user/project layer are silently ignored — no migration needed.
- **Added** `anythingllm.recommendedModel` + `anythingllm.recommendedModelUrl`, used only to render the recommendation banner.
- **SessionStart hook** now reads `workspace.chatModel` and shows it in the ready banner; shows the recommendation block when empty.
- **Docs** (`model-config.md`, setup skill) reframed around "the user owns the model"; HuggingFace page cited alongside the Ollama tag.

## Test plan

- [x] `npm run lint`
- [x] `npm test` — 91/91 pass
- [x] Hook smoke test — emits `ready` + active model line
- [x] HuggingFace URL verified — `bartowski/google_gemma-4-E4B-it-GGUF` exists
