### PR TITLE
fix(concept): self-pulse heartbeat from bridge server

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.54.2"
+    "version": "0.54.3"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.54.2",
+      "version": "0.54.3",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.54.2",
+      "version": "0.54.3",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.54.3] — 2026-04-19
+
+### Fixed
+
+- **plugins/devops/scripts/concept-server.py** — the concept bridge server now self-pulses `_heartbeat_ts` every 30 s from a daemon thread. Previously the browser's connection indicator relied solely on Claude's `* * * * *` heartbeat cron, but session-scoped crons only fire while the REPL is idle — exactly not the case during active concept work (building the page, opening Edge, processing submissions). The indicator flipped to "Claude ist nicht verbunden" during every multi-minute operation even though the bridge server was fully alive and submissions would have been received. The self-pulse reframes the indicator semantic to "bridge server alive", which is what the user actually cares about. Claude-side POST `/heartbeat` kept as belt-and-suspenders fallback in case the thread stalls
+- **plugins/devops/skills/devops-concept/deep-knowledge/monitoring.md** + **templates.md** — doc-sync: describe the self-pulse, correct the stale `HEARTBEAT_STALE_MS = 90000` comment (was "covers 60 s cron interval"; now "3× the 30 s self-pulse")
+
 ## [0.54.2] — 2026-04-19
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.54.2**
+**Version: 0.54.3**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.54.2",
+  "version": "0.54.3",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/scripts/concept-server.py
+++ b/plugins/devops/scripts/concept-server.py
@@ -19,6 +19,13 @@ This bypasses Chrome MCP JS injection limitations entirely. The page
 communicates with Claude through HTTP endpoints instead of requiring
 JavaScript eval injection into the browser tab.
 
+A daemon thread self-pulses `_heartbeat_ts` every 30s so the browser's
+connection indicator reflects "bridge server alive" rather than "Claude's
+REPL is currently idle". Session-based crons only fire while the REPL is
+idle, which is exactly not the case while Claude actively builds the page
+or processes submissions — the self-pulse closes that false-negative gap.
+POST /heartbeat still works for belt-and-suspenders signaling.
+
 Usage:
     python concept-server.py <port> [directory]
 
@@ -222,10 +229,25 @@ class ConceptBridgeHandler(http.server.SimpleHTTPRequestHandler):
         pass  # suppress per-request logging
 
 
+def _heartbeat_self_pulse(interval_s: int = 30):
+    global _heartbeat_ts
+    while True:
+        with _lock:
+            _heartbeat_ts = int(time.time() * 1000)
+        time.sleep(interval_s)
+
+
 if __name__ == '__main__':
     port = int(sys.argv[1]) if len(sys.argv) > 1 else 8700
     directory = sys.argv[2] if len(sys.argv) > 2 else '.'
     os.chdir(directory)
+
+    # Prime + self-pulse: the browser checks the heartbeat within 5s of page
+    # load, so set it once before serving and then refresh every 30s from a
+    # daemon thread that dies with the server process.
+    _heartbeat_ts = int(time.time() * 1000)
+    threading.Thread(target=_heartbeat_self_pulse, daemon=True).start()
+
     with http.server.HTTPServer(('', port), ConceptBridgeHandler) as httpd:
         print(f"Concept bridge server on http://localhost:{port}/")
         print(f"Serving: {os.getcwd()}")

--- a/plugins/devops/skills/devops-concept/deep-knowledge/monitoring.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/monitoring.md
@@ -124,6 +124,11 @@ curl -s -X POST http://localhost:$PORT/heartbeat
 ```
 Sent by the cron job every ~60s, and additionally on each manual poll cycle.
 
+The bridge server also self-pulses `_heartbeat_ts` every 30s from a daemon
+thread — so the indicator stays green even while Claude's REPL is busy and
+session-scoped crons can't fire. The Claude-side POSTs above are redundant
+with that self-pulse (kept as a fallback in case the thread stalls).
+
 **Check submission** (poll for user decisions):
 ```bash
 curl -s http://localhost:$PORT/decisions

--- a/plugins/devops/skills/devops-concept/deep-knowledge/templates.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/templates.md
@@ -1066,17 +1066,21 @@ The heartbeat uses the **HTTP Bridge** — the concept bridge server
 and the page communicate through.
 
 **How it works:**
-- Claude sends `curl -s -X POST localhost:{port}/heartbeat` every 60 seconds
-  (via CronCreate) plus on each monitoring poll cycle (~15s when active)
-- The page polls `GET /heartbeat` every 5 seconds via `fetch()`
-- If the heartbeat is older than 90 seconds → the submit button is disabled
-  and a warning is shown (90s threshold safely covers the 60s cron interval
-  with buffer for timing jitter)
-- If the heartbeat is fresh → submit is enabled, warning hidden
+- The bridge server self-pulses `_heartbeat_ts` every 30s from a daemon
+  thread. As long as the process is alive, the timestamp stays fresh —
+  even while Claude's REPL is busy and cron jobs can't fire.
+- Claude additionally POSTs `/heartbeat` via cron and on each monitoring
+  poll (~15s when active). Redundant with the self-pulse, kept for
+  belt-and-suspenders in case the server thread stalls.
+- The page polls `GET /heartbeat` every 5 seconds via `fetch()`.
+- If the heartbeat is older than 90 seconds → warning is shown (90s
+  comfortably covers a 30s self-pulse interval; a stale reading means
+  the server process itself is gone).
+- If the heartbeat is fresh → warning hidden.
 
 ```javascript
 // --- Claude Connection Heartbeat (HTTP Bridge) ---
-const HEARTBEAT_STALE_MS = 90000; // 90s — safely covers 60s cron interval + buffer
+const HEARTBEAT_STALE_MS = 90000; // 90s — 3× the server's 30s self-pulse; stale means the server process is gone
 const HEARTBEAT_GRACE_MS = 30000; // 30s — Claude needs time to start bridge + cron
 const _pageLoadedAt = Date.now();
 let _lastHeartbeatTs = 0;

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.54.2",
+  "version": "0.54.3",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

The concept bridge server now self-pulses `_heartbeat_ts` every 30 s from a daemon thread. Fixes the false "Claude ist nicht verbunden" warning that appeared during any multi-minute operation — session-scoped crons only fire while the REPL is idle, exactly not the case while Claude is actively building the page, starting the server, or processing submissions. The indicator now reflects "bridge server alive" (the semantic that actually matters: will my submission be received?), and Claude-side `POST /heartbeat` is kept as a belt-and-suspenders fallback.

## Test plan
- [x] Lint (eslint) — clean
- [x] Tests (vitest) — 91/91 pass
- [x] Smoke test: server running with no client POSTs → `/heartbeat` ts advances every 30 s (verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)