### PR TITLE
fix(hooks): suppress duplicate completion card on silent turns

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.54.3"
+    "version": "0.55.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.54.3",
+      "version": "0.55.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.54.3",
+      "version": "0.55.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.55.0] — 2026-04-19
+
+### Fixed
+
+- **plugins/devops/hooks/user-prompt-submit/prompt.flow.silent-turn.js** (new) + **plugins/devops/hooks/post-tool-use/post.flow.completion.js** + **plugins/devops/hooks/lib/card-guard.js** + **plugins/devops/hooks/stop/stop.flow.guard.js** + **plugins/devops/hooks/hooks.json** — suppress the duplicate completion card after every background tick. A new `UserPromptSubmit` hook flags turns whose prompt begins with `Silently run` / `Run silently` or carries the `<<autonomous-loop[-dynamic]>>` sentinel (cron git-sync, concept bridge poll, autonomous loops). On a flagged turn, `post.flow.completion` skips the card-reminder injection AND the work-happened flag write, and `stop.flow.guard` passes without enforcement (new `silent` param threaded into `decideAction`, flag cleaned up with the others on reset). Before: every git-sync cron tick after a real card forced a second card, and every concept-monitor tick during `/devops-concept` rendered its own card — the user only ever wants the card from their real interaction
+
+### Changed
+
+- **plugins/devops/hooks/lib/card-guard.test.js** + **plugins/devops/hooks/user-prompt-submit/prompt.flow.silent-turn.test.js** (new) — cover the new decision path (silent short-circuits ahead of `stop_hook_active`) and the cron-prompt pattern matcher (git-sync, concept bridge, `Run silently` alt phrasing, loop sentinels, case-insensitive, leading-whitespace-tolerant, negative cases)
+
 ## [0.54.3] — 2026-04-19
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.54.3**
+**Version: 0.55.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.54.3",
+  "version": "0.55.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/hooks/hooks.json
+++ b/plugins/devops/hooks/hooks.json
@@ -67,6 +67,7 @@
     "UserPromptSubmit": [
       {
         "hooks": [
+          { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/user-prompt-submit/prompt.flow.silent-turn.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/user-prompt-submit/prompt.knowledge.dispatch.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/user-prompt-submit/prompt.git.sync.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/user-prompt-submit/prompt.issue.detect.js" },

--- a/plugins/devops/hooks/lib/card-guard.js
+++ b/plugins/devops/hooks/lib/card-guard.js
@@ -71,9 +71,18 @@ function lastAssistantContainsCard(transcriptContent) {
  * @param {boolean} s.cardRendered   — render_completion_card was invoked
  * @param {boolean} s.stopHookActive — prior Stop hook already blocked this cycle
  * @param {boolean} s.substantial    — last assistant turn had substantial prose
+ * @param {boolean} [s.silent]       — turn was triggered by cron/autonomous loop,
+ *                                     not the user. Never enforce the card.
  * @returns {{ action: 'block' | 'pass', resetFlags: boolean, reason?: string }}
  */
-function decideAction({ workHappened, cardRendered, stopHookActive, substantial }) {
+function decideAction({ workHappened, cardRendered, stopHookActive, substantial, silent }) {
+  if (silent) {
+    // Background tick (cron git-sync, concept bridge poll, autonomous loop).
+    // The real user turn already rendered its card — forcing another here
+    // produces duplicates. Reset all flags so the next real turn starts clean.
+    return { action: 'pass', resetFlags: true };
+  }
+
   if (stopHookActive) {
     // Never block twice in a row — prevents infinite loops even if the card
     // write flag fails for whatever reason. Flags are reset so the next turn

--- a/plugins/devops/hooks/lib/card-guard.test.js
+++ b/plugins/devops/hooks/lib/card-guard.test.js
@@ -215,6 +215,35 @@ describe("decideAction", () => {
     expect(d.action).toBe("pass");
     expect(d.resetFlags).toBe(true);
   });
+
+  test("silent turn → pass + reset, regardless of work/card/substantial", () => {
+    // Background ticks (cron git-sync, concept bridge poll, autonomous loop)
+    // must never force a second card. Reset flags so the next real turn
+    // starts from a clean slate.
+    const d = decideAction({
+      workHappened: true,
+      cardRendered: false,
+      stopHookActive: false,
+      substantial: true,
+      silent: true,
+    });
+    expect(d.action).toBe("pass");
+    expect(d.resetFlags).toBe(true);
+  });
+
+  test("silent turn short-circuits before stop_hook_active check", () => {
+    // Even if stop_hook_active somehow flips, silent should take precedence
+    // and still pass cleanly.
+    const d = decideAction({
+      workHappened: true,
+      cardRendered: false,
+      stopHookActive: true,
+      substantial: false,
+      silent: true,
+    });
+    expect(d.action).toBe("pass");
+    expect(d.resetFlags).toBe(true);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/plugins/devops/hooks/post-tool-use/post.flow.completion.js
+++ b/plugins/devops/hooks/post-tool-use/post.flow.completion.js
@@ -54,6 +54,14 @@ process.stdin.on('end', () => {
   try { hook = JSON.parse(inputData); }
   catch { process.exit(0); }
 
+  // Silent turn (cron git-sync, concept bridge poll, autonomous loop tick):
+  // skip the completion-card reminder and do not mark work-happened. The real
+  // user turn already rendered its card; this background tick must not trigger
+  // a second one. Flag is written by prompt.flow.silent-turn and cleared by
+  // stop.flow.guard at turn end.
+  const silentResult = readSessionFile('dotclaude-devops-silent-turn', hook.session_id);
+  if (silentResult) process.exit(0);
+
   const toolName = hook.tool_name || '';
   const isCodeEdit = (toolName === 'Edit' || toolName === 'Write');
 

--- a/plugins/devops/hooks/stop/stop.flow.guard.js
+++ b/plugins/devops/hooks/stop/stop.flow.guard.js
@@ -40,15 +40,18 @@ process.stdin.on('end', () => {
 
   const workResult = readSessionFile('dotclaude-devops-work-happened', sessionId);
   const cardResult = readSessionFile('dotclaude-devops-card-rendered', sessionId);
+  const silentResult = readSessionFile('dotclaude-devops-silent-turn', sessionId);
 
   const workHappened = workResult !== null;
   const flagCardRendered = cardResult !== null;
+  const silent = silentResult !== null;
   const stopHookActive = hook.stop_hook_active === true;
 
   // Scan transcript when the flag state alone cannot settle the decision:
   //  - no card flag → might still have rendered the card (marker scan = backup)
   //  - no work and no card → need substantial-answer heuristic
-  const transcript = !flagCardRendered
+  // Silent turns skip the transcript scan entirely — enforcement is off.
+  const transcript = (!flagCardRendered && !silent)
     ? safeReadTranscript(hook.transcript_path)
     : '';
   const substantial = isSubstantialAnswer(transcript);
@@ -61,11 +64,13 @@ process.stdin.on('end', () => {
     cardRendered,
     stopHookActive,
     substantial,
+    silent,
   });
 
   if (decision.resetFlags) {
     if (workResult) try { fs.unlinkSync(workResult.filePath); } catch {}
     if (cardResult) try { fs.unlinkSync(cardResult.filePath); } catch {}
+    if (silentResult) try { fs.unlinkSync(silentResult.filePath); } catch {}
   }
 
   if (decision.action === 'block') {

--- a/plugins/devops/hooks/user-prompt-submit/prompt.flow.silent-turn.js
+++ b/plugins/devops/hooks/user-prompt-submit/prompt.flow.silent-turn.js
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+/**
+ * @hook prompt.flow.silent-turn
+ * @version 0.1.0
+ * @event UserPromptSubmit
+ * @plugin devops
+ * @description Detects background/cron-injected prompts and marks the turn
+ *   as "silent" so post.flow.completion skips the completion-card reminder
+ *   and stop.flow.guard skips enforcement.
+ *
+ *   Why: cron jobs (git-sync, concept bridge poll) and autonomous loops
+ *   re-enter Claude with a prompt that ALWAYS begins with a silence marker
+ *   ("Silently run", "Run silently") or with a loop sentinel
+ *   (`<<autonomous-loop>>`). Without this flag, every silent tick is
+ *   treated as a user turn — the post-tool-use hook injects the card
+ *   reminder, and the stop hook blocks the turn to force a second card.
+ *   Result: duplicate cards after every /devops-ship (git-sync cron fires
+ *   next tick) and one card per minute during a /devops-concept monitoring
+ *   loop. The user only wants the card from their REAL interaction.
+ *
+ *   The flag is a one-shot — stop.flow.guard clears it when the turn ends.
+ */
+
+require('../lib/plugin-guard');
+
+const { sessionFile, writeSessionFile } = require('../lib/session-id');
+
+const SILENT_PATTERNS = [
+  /^\s*silently\s+run\b/i,          // cron git-sync, concept bridge cron
+  /^\s*run\s+silently\b/i,          // alt phrasing used by some skills
+  /<<autonomous-loop(-dynamic)?>>/i, // /loop autonomous sentinel
+];
+
+function isSilent(prompt) {
+  if (typeof prompt !== 'string' || prompt.length === 0) return false;
+  return SILENT_PATTERNS.some(rx => rx.test(prompt));
+}
+
+let inputData = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', d => { inputData += d; });
+process.stdin.on('end', () => {
+  let hook;
+  try { hook = JSON.parse(inputData); } catch { process.exit(0); }
+
+  if (!isSilent(hook.prompt || '')) process.exit(0);
+
+  try {
+    const flagFile = sessionFile('dotclaude-devops-silent-turn', hook.session_id);
+    writeSessionFile(flagFile, '1');
+  } catch {}
+  process.exit(0);
+});
+
+module.exports = { isSilent, SILENT_PATTERNS };

--- a/plugins/devops/hooks/user-prompt-submit/prompt.flow.silent-turn.test.js
+++ b/plugins/devops/hooks/user-prompt-submit/prompt.flow.silent-turn.test.js
@@ -1,0 +1,58 @@
+import { describe, test, expect } from "vitest";
+import { isSilent } from "./prompt.flow.silent-turn.js";
+
+describe("isSilent — silent-turn prompt detector", () => {
+  test("git-sync cron prompt (starts with 'Silently run via Bash')", () => {
+    expect(
+      isSilent('Silently run via Bash: node "C:/Users/.../scripts/git-sync.js". If output contains ⚠…'),
+    ).toBe(true);
+  });
+
+  test("concept bridge cron prompt (starts with 'Silently run both steps')", () => {
+    expect(
+      isSilent(
+        "Silently run both steps for the concept bridge on port 8734:\n(1) Heartbeat POST:\n  Bash: curl -s …",
+      ),
+    ).toBe(true);
+  });
+
+  test("alt phrasing 'Run silently' is detected", () => {
+    expect(isSilent("Run silently: curl -s -X POST http://localhost:8734/heartbeat > /dev/null")).toBe(true);
+  });
+
+  test("autonomous-loop sentinel is detected", () => {
+    expect(isSilent("<<autonomous-loop>>")).toBe(true);
+  });
+
+  test("autonomous-loop-dynamic sentinel is detected", () => {
+    expect(isSilent("<<autonomous-loop-dynamic>>")).toBe(true);
+  });
+
+  test("leading whitespace does not defeat the pattern", () => {
+    expect(isSilent("   Silently run something")).toBe(true);
+    expect(isSilent("\n\nRun silently: ping")).toBe(true);
+  });
+
+  test("case-insensitive match", () => {
+    expect(isSilent("silently run Bash: whatever")).toBe(true);
+    expect(isSilent("RUN SILENTLY: curl")).toBe(true);
+  });
+
+  test("real user prompt is NOT silent", () => {
+    expect(isSilent("Bitte fix den Bug in foo.ts")).toBe(false);
+    expect(isSilent("Please run the tests and tell me what fails")).toBe(false);
+  });
+
+  test("prompt merely mentioning 'silently' in the middle is NOT silent", () => {
+    // Anchor is at line start — we must not match user prose that happens to
+    // contain the word elsewhere.
+    expect(isSilent("I noticed the script runs silently in the background")).toBe(false);
+  });
+
+  test("empty / non-string input → false", () => {
+    expect(isSilent("")).toBe(false);
+    expect(isSilent(null)).toBe(false);
+    expect(isSilent(undefined)).toBe(false);
+    expect(isSilent(42)).toBe(false);
+  });
+});

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.54.3",
+  "version": "0.55.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

Cron-injected prompts (git-sync, concept-bridge poll) and autonomous-loop sentinels triggered completion-card enforcement on every background tick — resulting in a second card after every `/devops-ship` (next git-sync tick) and one card per minute while `/devops-concept` was monitoring. The user only ever wants the card from their real interaction.

## Changes

- **New `plugins/devops/hooks/user-prompt-submit/prompt.flow.silent-turn.js`** — regex match on leading `Silently run` / `Run silently` and the `<<autonomous-loop[-dynamic]>>` sentinel; writes a per-session flag.
- **`plugins/devops/hooks/post-tool-use/post.flow.completion.js`** — early exit when the silent flag is set (no card reminder, no `work-happened` write).
- **`plugins/devops/hooks/lib/card-guard.js`** — `decideAction` gains a `silent` short-circuit (reset flags, pass) ahead of the `stop_hook_active` check.
- **`plugins/devops/hooks/stop/stop.flow.guard.js`** — threads the flag, skips the transcript scan, cleans the flag up with the others on reset.
- **`plugins/devops/hooks/hooks.json`** — registers the new hook first in the `UserPromptSubmit` chain.
- **Tests** — 10 new pattern tests (`prompt.flow.silent-turn.test.js`) + 2 new decision-path tests in `card-guard.test.js` covering the silent short-circuit.

## Test plan

- [x] `npm test` — 103/103 pass (91 pre-existing + 12 new)
- [x] `npm run lint` — clean
- [ ] Observe: next `git-sync` cron tick after a real card → no second card
- [ ] Observe: `/devops-concept` monitor loop → card only on first render + user submissions, not on silent polls