### PR TITLE
refactor(concept): lean header, panel-top iteration tabs, section TOC

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.55.0"
+    "version": "0.56.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.55.0",
+      "version": "0.56.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.55.0",
+      "version": "0.56.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.56.0] — 2026-04-20
+
+### Changed
+
+- **plugins/devops/skills/devops-concept/SKILL.md** + **deep-knowledge/templates.md** + **deep-knowledge/iteration-rules.md** — concept page layout refactor. The `<header>` is now kept lean: `<h1>` + optional one-line subtitle, no iteration intro duplication (the iteration title/intro moves into the active `<section data-iteration="N">`). Iteration tabs relocated from the content area to the **top of the right-side decision panel** as a compact vertical chip list, so the content area stays reserved for the actual concept. Before: the header grew a second "Iteration N · …" block above `<main>`, plus the tab bar sat in the content column — both ate vertical space before the user reached the variants
+
+### Added
+
+- **plugins/devops/skills/devops-concept/deep-knowledge/templates.md** — generalised the old `.variant-nav` into a full `.section-nav` TOC. An auto-populator (`buildSectionNav()`) scans the active iteration for every `<section id="…" data-nav-label="…">` and renders a scroll anchor for each — not only variants but also Ist-Zustand, context blocks, design notes, mockups. Sections that carry a tri-state radio group (`name="eval-{id}"`) continue to mirror their current evaluation state in the nav entry. Added an `IntersectionObserver`-based ScrollSpy that highlights the TOC entry for whatever section is currently in view
+- **plugins/devops/skills/devops-concept/SKILL.md** + **deep-knowledge/templates.md** — new **freeform mode**: mark an iteration `<section data-freeform>` when the concept has nothing to evaluate as mutually-exclusive variants (design concepts, mockups, tutorials, single-track plans). Freeform iterations render full-width content, drop the tri-state summary in the decision panel, and show a single comment + submit block instead. `collectDecisions()` returns empty `decisions[]` + whatever the user typed; the section TOC still populates from nested `data-nav-label` sections
+- **plugins/devops/skills/devops-concept/deep-knowledge/validation-gate.md** — 2 new mandatory grep patterns: `section-nav` and `data-nav-label`. The gate now enforces 18 patterns instead of 16
+
 ## [0.55.0] — 2026-04-19
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.55.0**
+**Version: 0.56.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.55.0",
+  "version": "0.56.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/skills/devops-concept/SKILL.md
+++ b/plugins/devops/skills/devops-concept/SKILL.md
@@ -60,12 +60,41 @@ Build a single self-contained HTML file. Requirements:
 - Professional typography, spacing, and color palette
 - Subtle animations for interactions (toggle, expand, submit)
 
+### Page Header (keep it lean)
+
+The `<header>` inside `.concept-content` renders the concept title ONCE.
+
+- `<h1>` with the concept title
+- Optional: one short subtitle line for session context. Omit if not needed.
+- Theme toggle button
+
+**DO NOT** render the iteration title/intro in the page header — that
+duplicates context and burns vertical space before the user reaches actual
+content. The iteration title (e.g. "Iteration 3 · Visual design concept")
+and its intro paragraph live INSIDE the active `<section data-iteration="N">`,
+as a compact `.iteration-intro` block right after the opening tag.
+
 ### Decision Panel Layout
 - The decision panel (submit button + global controls) is a **fixed sidebar**
   on the right side, taking **~20% of the screen width** — NOT an overlay
 - Content area fills the remaining ~80% on the left
 - On mobile/narrow screens: decision panel collapses to bottom (sticky)
 - The panel is always visible while scrolling (position: fixed or sticky)
+
+**Panel top-to-bottom order:**
+1. **Iteration tabs** (`.iteration-tabs`) — compact vertical chip list,
+   one per iteration. Active chip = current round; older chips stay
+   clickable to review frozen snapshots.
+2. **Section TOC** (`.section-nav`) — auto-populated from EVERY
+   `<section id="…" data-nav-label="…">` inside the active iteration.
+   Not limited to variants: Ist-Zustand, context blocks, design notes,
+   mockups — anything with a nav label gets a scroll anchor here.
+3. Decision summary + submit button (or freeform comment + submit when the
+   active iteration carries `data-freeform`).
+4. Connection warning + post-submit state (unchanged).
+
+The iteration tab bar must NOT live inside the left-hand content area.
+The content area is reserved for the actual concept.
 
 ### Interactive Elements (per variant)
 - **Toggles/checkboxes**: For binary decisions (accept/reject, include/exclude)
@@ -75,8 +104,13 @@ Build a single self-contained HTML file. Requirements:
 - **Submit button**: Prominent "Entscheidungen abschicken" button in the
   decision panel sidebar
 
-### Variant Evaluation (when variants exist)
-When the concept presents multiple variants (concept, comparison, or any
+### Variant Evaluation (optional — only when variants exist)
+
+**Variants are a content pattern, not a mandatory structure.** Many concepts
+have no variants to evaluate (design concepts, mockups, tutorials, single-
+approach plans). Those pages run in **freeform mode** — see below.
+
+When the concept DOES present multiple variants (concept, comparison, or any
 multi-option output), each variant MUST include a **tri-state evaluation**:
 
 | State | Label | Type | Behavior |
@@ -100,6 +134,32 @@ BEFORE clicking what kind of effect the selection has:
   warning label directly on or below the button — the user must see this
   before submitting, so they understand clicking Submit will cause Claude to
   actively act on this choice (discard a variant, write code, update a plan, etc.)
+
+### Freeform Mode (no variant evaluation)
+
+When the iteration has nothing to evaluate as mutually-exclusive options
+(design concepts, mockups, tutorials, single-track plans), mark the
+iteration section with `data-freeform`:
+
+```html
+<section id="iter-3" data-iteration="3" data-active data-freeform
+         data-nav-label="Design concept">
+  <!-- Full-width content — no variant-card framing, no tri-state per block -->
+</section>
+```
+
+Effects:
+- Content area may use the full width/layout it needs (mockup grids,
+  full-bleed imagery, diagrams).
+- Decision panel hides the variant summary; shows a single optional
+  comment field + Submit.
+- `collectDecisions()` returns empty `decisions[]` and whatever the user
+  typed into the comment field.
+- Section TOC still auto-populates from every nested `<section id=""
+  data-nav-label="">` — use this to list Ist-Zustand, Design notes,
+  Mockups, Rationale as scroll anchors in the panel.
+
+See `deep-knowledge/templates.md` § Freeform for the CSS/JS helpers.
 
 ### Reload Resilience
 
@@ -188,16 +248,18 @@ Full example: `docs/concepts/2026-04-12-auth-middleware-redesign.html`
 
 ### Iteration Tabs (single file, many iterations)
 
-Every concept page is a stack of iteration tabs — the decision-panel tab
-bar shows each iteration, only the active one accepts input, earlier ones
-freeze their submitted state. See `deep-knowledge/iteration-rules.md` for
-the full rules (tab placement, freeze behavior, single-file invariant)
+Every concept page is a stack of iteration tabs. The tab bar lives at the
+**top of the right-side decision panel** (compact vertical chip list) —
+NOT in the left-hand content area. Only the active iteration accepts input;
+earlier ones are clickable but frozen. See `deep-knowledge/iteration-rules.md`
+for the full rules (panel placement, freeze behavior, single-file invariant)
 and `deep-knowledge/templates.md` § Iteration Tabs for the reference HTML.
 
 ### Post-Generation Validation (mandatory gate)
 
-After writing the HTML file, grep it for the 16 mandatory interactive
-patterns (heartbeat, panel states, iteration tabs, reload polling, etc.).
+After writing the HTML file, grep it for the 18 mandatory interactive
+patterns (heartbeat, panel states, iteration tabs, section TOC, reload
+polling, etc.).
 **If ANY pattern is missing → DO NOT open the page.** Fix the HTML first,
 then re-validate. See `deep-knowledge/validation-gate.md` for the full
 pattern list and common failure modes.
@@ -325,9 +387,9 @@ for the polling contract.
    `location.reload()`. The reload lands on the new active iteration
    because the HTML declares it via `data-active`.
 
-The tab bar is anchored at the top of the content area inside the decision
-panel header — it must never shift into the right-side submit sidebar, and
-it must stay on a single row (horizontal scroll if it overflows).
+The tab bar is anchored at the top of the right-side decision panel —
+above the section TOC and the submit block. It must never appear inside
+the left-hand content area. Render as a compact vertical chip list.
 
 Do NOT write a redirect file. Do NOT create a new `-v{N}` file. The entire
 concept session — first render, every iteration, "nochmal neu" reworks —

--- a/plugins/devops/skills/devops-concept/deep-knowledge/iteration-rules.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/iteration-rules.md
@@ -1,10 +1,11 @@
 # Iteration Tabs (single file, many iterations)
 
-Every concept page is a stack of iteration tabs. The **tab bar lives in the
-decision panel at the top** of the content area (a slim strip above the
-variants, not in the right sidebar — the sidebar stays reserved for submit
-controls). Each tab shows exactly one iteration; the active one is interactive,
-all earlier ones are frozen (disabled inputs showing the user's submitted
+Every concept page is a stack of iteration tabs. The **tab bar lives at the
+top of the right-side decision panel** (a compact vertical chip list, above
+the section TOC and submit block). It must NEVER render inside the left-hand
+content area — the content area is reserved for the actual concept. Each
+chip represents exactly one iteration; the active one is interactive, all
+earlier ones are frozen (disabled inputs showing the user's submitted
 selections, read-only comments).
 
 | Situation | Action | Result |
@@ -24,7 +25,8 @@ selections, read-only comments).
   own past feedback at any time.
 - Only the active tab runs the heartbeat / submit UI ("music"). Clicking
   an older tab shows its frozen snapshot but does not re-arm submit.
-- Tab bar must stay compact (one line, horizontally scrollable if many
-  iterations) so it does not push variant content out of view.
+- Tab bar must stay compact — vertical chip list in the panel header.
+  Falls back to horizontal scroll only when the panel collapses to the
+  bottom on narrow screens.
 
 See `templates.md` § Iteration Tabs for the reference HTML/CSS/JS.

--- a/plugins/devops/skills/devops-concept/deep-knowledge/templates.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/templates.md
@@ -24,6 +24,7 @@ hook) is `de`, swap the matching strings into the rendered HTML and set
 | `panel.close`           | Close                          | Schliessen |
 | `variant.include`       | Include                        | Miteinbeziehen |
 | `iteration.label`       | Iterations                     | Iterationen |
+| `nav.sections`          | Sections                       | Abschnitte |
 
 ## Common Structure (all variants)
 
@@ -41,26 +42,22 @@ hook) is `de`, swap the matching strings into the rendered HTML and set
     <!-- Main content: ~80% width -->
     <div class="concept-content">
       <header>
+        <!-- HEADER MUST STAY LEAN.
+             Keep to <h1> + ONE short subtitle line (or omit subtitle entirely).
+             Do NOT repeat the iteration title/intro here — that belongs INSIDE
+             the active <section data-iteration="N">. Double-intros (header +
+             iteration-intro) eat vertical space and duplicate context. -->
         <h1>{title}</h1>
-        <p class="subtitle">{context line}</p>
+        <p class="subtitle">{optional one-line context — omit if not needed}</p>
         <button id="theme-toggle" aria-label="Toggle theme">🌙/☀️</button>
       </header>
-
-      <!-- Iteration tabs — one entry per iteration, active = current round.
-           Older tabs are clickable but show a frozen snapshot. Anchored here
-           above <main> so the tab bar lives in the decision panel header
-           without crowding the variant content. -->
-      <nav class="iteration-tabs" role="tablist" aria-label="Iterations">
-        <!-- Auto-populated, one tab per <section data-iteration="N">:
-        <button class="iteration-tab" role="tab" data-iteration="1" aria-selected="false">Iteration 1</button>
-        <button class="iteration-tab" role="tab" data-iteration="2" aria-selected="true">Iteration 2</button>
-        -->
-      </nav>
 
       <main>
         <!-- One <section data-iteration="N"> per iteration. Exactly one has
              data-active. All others render their controls disabled/readonly
-             and preserve the values the user submitted that round. -->
+             and preserve the values the user submitted that round.
+             Each iteration section may open with its own iteration-intro
+             block (title + one paragraph) BEFORE the variant/content cards. -->
         <!--
         <section data-iteration="1" hidden>...frozen first round...</section>
         <section data-iteration="2" data-active>...current round (active)...</section>
@@ -72,19 +69,39 @@ hook) is `de`, swap the matching strings into the rendered HTML and set
     <aside class="concept-decision-panel">
       <!-- All visible strings are referenced by key in the locale table above.
            Swap to the `de` column when [ui-locale: de] is active. -->
+
+      <!-- Iteration tabs — live at the TOP of the decision panel (not in the
+           content area). Compact vertical chip list; the active tab shows
+           the current round, older tabs stay clickable but show frozen
+           snapshots when selected. Auto-populated, one entry per
+           <section data-iteration="N">. -->
+      <nav class="iteration-tabs" role="tablist" aria-label="{{iteration.label}}">
+        <!--
+        <button class="iteration-tab" role="tab" data-iteration="1" aria-selected="false">Iteration 1</button>
+        <button class="iteration-tab" role="tab" data-iteration="2" aria-selected="true">Iteration 2 · active</button>
+        -->
+      </nav>
+
       <h3>{{panel.heading}}</h3>
 
-      <!-- Variant Navigation / TOC — each entry is an anchor link -->
-      <nav class="variant-nav" id="variant-nav">
-        <!-- Auto-populated: one entry per variant. Example: -->
+      <!-- Section TOC — auto-populated from EVERY <section id="..."
+           data-nav-label="..."> inside the active iteration, not just variants.
+           Sections that carry a tri-state radio group (eval-{id}) display their
+           current state label; plain sections (Ist-Zustand, Context, Design-Notes,
+           etc.) just show the label and anchor-scroll on click. -->
+      <nav class="section-nav" id="section-nav" aria-label="{{nav.sections}}">
+        <!-- Auto-populated examples: -->
         <!--
-        <a href="#variant-a" class="variant-nav-item" data-variant="variant-a">
-          <span class="variant-nav-label">A Orbital Ring</span>
-          <span class="variant-nav-state">{{variant.include}}</span>
+        <a href="#ist-zustand" class="section-nav-item" data-section-id="ist-zustand">
+          <span class="section-nav-label">Ist-Zustand</span>
         </a>
-        <a href="#variant-b" class="variant-nav-item" data-variant="variant-b">
-          <span class="variant-nav-label">B Hexagonal</span>
-          <span class="variant-nav-state">{{variant.include}}</span>
+        <a href="#variant-a" class="section-nav-item" data-section-id="variant-a" data-variant>
+          <span class="section-nav-label">A Orbital Ring</span>
+          <span class="section-nav-state">{{variant.include}}</span>
+        </a>
+        <a href="#variant-b" class="section-nav-item" data-section-id="variant-b" data-variant>
+          <span class="section-nav-label">B Hexagonal</span>
+          <span class="section-nav-state">{{variant.include}}</span>
         </a>
         -->
       </nav>
@@ -184,11 +201,13 @@ or any content that needs maximum display area.
     <span class="fab-icon">☰</span>
   </button>
 
-  <!-- Slide-in overlay panel -->
+  <!-- Slide-in overlay panel — same content order as the sidebar variant:
+       iteration-tabs, section-nav, decision summary, submit. -->
   <aside class="concept-decision-panel overlay" id="decision-panel">
     <button id="panel-close" class="panel-close-btn" aria-label="{{panel.close}}">✕</button>
+    <nav class="iteration-tabs" role="tablist" aria-label="{{iteration.label}}"><!-- chips --></nav>
     <h3>{{panel.heading}}</h3>
-    <nav class="variant-nav" id="variant-nav"><!-- ... --></nav>
+    <nav class="section-nav" id="section-nav" aria-label="{{nav.sections}}"><!-- TOC --></nav>
     <!-- rest of panel content -->
   </aside>
   <div class="panel-backdrop" id="panel-backdrop"></div>
@@ -289,26 +308,33 @@ if (panelToggle) panelToggle.addEventListener('click', openPanel);
 if (panelClose) panelClose.addEventListener('click', closePanel);
 if (backdrop) backdrop.addEventListener('click', closePanel);
 
-// Close panel on variant nav click (scroll to section)
-document.querySelectorAll('.variant-nav-item').forEach(link => {
-  link.addEventListener('click', () => {
-    closePanel();
-    // small delay so panel closes before scroll
-    setTimeout(() => {
-      const target = document.querySelector(link.getAttribute('href'));
-      if (target) target.scrollIntoView({ behavior: 'smooth', block: 'start' });
-    }, 150);
-  });
-});
+// Close panel on section nav click (scroll to section). Delegated so it
+// works for auto-populated TOC links. Takes precedence over the default
+// smooth-scroll handler because we need to close the overlay first.
+document.addEventListener('click', e => {
+  const link = e.target.closest('.section-nav-item');
+  if (!link) return;
+  if (!document.getElementById('decision-panel')?.classList.contains('open')) return;
+  e.preventDefault();
+  e.stopPropagation();
+  closePanel();
+  setTimeout(() => {
+    const target = document.querySelector(link.getAttribute('href'));
+    if (target) target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }, 150);
+}, true);
 ```
 
-### Variant Navigation CSS (Decision Panel as TOC)
+### Section Navigation CSS (Decision Panel as TOC)
 
-The decision panel doubles as a table-of-contents. Each variant gets a
-clickable nav entry that scrolls to it and shows the current evaluation state.
+The decision panel doubles as a full table-of-contents for the active
+iteration. EVERY major `<section id="…" data-nav-label="…">` inside the
+current iteration gets a clickable nav entry — not just variants. Sections
+with a tri-state radio group additionally display the current evaluation
+state.
 
 ```css
-.variant-nav {
+.section-nav {
   display: flex;
   flex-direction: column;
   gap: 2px;
@@ -316,7 +342,7 @@ clickable nav entry that scrolls to it and shows the current evaluation state.
   border-bottom: 1px solid var(--border-color);
   padding-bottom: 1rem;
 }
-.variant-nav-item {
+.section-nav-item {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -328,22 +354,94 @@ clickable nav entry that scrolls to it and shows the current evaluation state.
   transition: background 0.15s;
   cursor: pointer;
 }
-.variant-nav-item:hover {
+.section-nav-item:hover {
   background: color-mix(in srgb, var(--accent-color, #58a6ff) 10%, transparent);
 }
-.variant-nav-state {
+/* Plain (non-variant) section: only label, centered vertically */
+.section-nav-item:not([data-variant]) .section-nav-label {
+  font-weight: 500;
+  opacity: 0.9;
+}
+/* Variant section: label + state badge */
+.section-nav-state {
   font-size: 0.8rem;
   color: var(--accent-color, #58a6ff);
   white-space: nowrap;
 }
-.variant-nav-state.state-discard { color: var(--danger-color, #f85149); }
-.variant-nav-state.state-only { color: var(--success-color, #3fb950); }
+.section-nav-state.state-discard { color: var(--danger-color, #f85149); }
+.section-nav-state.state-only { color: var(--success-color, #3fb950); }
+/* Active (scrolled-into-view) item */
+.section-nav-item.is-active {
+  background: color-mix(in srgb, var(--accent-color, #58a6ff) 18%, transparent);
+  font-weight: 600;
+}
 ```
 
-**Variant sections need matching `id` attributes:**
+**Every navigable section needs a matching `id` AND a `data-nav-label`:**
 ```html
-<section id="variant-a" class="variant-card">...</section>
-<section id="variant-b" class="variant-card">...</section>
+<!-- Plain section — TOC entry, scroll only -->
+<section id="ist-zustand" data-nav-label="Ist-Zustand">...</section>
+
+<!-- Variant section — TOC entry + tri-state evaluation -->
+<section id="variant-a" class="variant-card" data-nav-label="A Orbital Ring">...</section>
+<section id="variant-b" class="variant-card" data-nav-label="B Hexagonal">...</section>
+```
+
+Sections without `data-nav-label` are skipped by the TOC auto-populator —
+use that to hide intro/outro blocks that shouldn't appear as anchors.
+
+#### Freeform (no variant evaluation)
+
+When the concept does NOT evaluate mutually-exclusive variants — design
+concepts, mockups, tutorials, explainers, design-system walkthroughs — the
+content area may be fully free-form and the decision panel drops the
+tri-state summary in favor of a single comment + submit block.
+
+Mark the iteration section with `data-freeform`:
+
+```html
+<section id="iter-3" data-iteration="3" data-active data-freeform data-nav-label="Design concept">
+  <header class="iteration-intro">
+    <h2>Iteration 3 · Visual design concept</h2>
+    <p>Your picks from iteration 2 are locked in. This iteration shows the visual treatment.</p>
+  </header>
+
+  <!-- Free-form content: full-width mockup grid, design notes, rationale blocks.
+       Individual subsections still get id + data-nav-label so the panel TOC
+       auto-populates scroll anchors for "Ist-Zustand", "Design notes", etc. -->
+  <section id="ist-zustand" data-nav-label="Ist-Zustand">...</section>
+  <section id="design-notes" data-nav-label="Design notes">...</section>
+  <section id="mockups" data-nav-label="Mockups">...</section>
+</section>
+```
+
+Freeform signals to the panel:
+- No tri-state summary renders in `#decision-summary`
+- The submit block shows a single optional comment field + "Submit"
+- `collectDecisions()` returns `{ submitted: true, decisions: [], comments: [...] }`
+- The TOC still populates from every nested `data-nav-label` section
+
+```css
+/* Freeform iterations: allow full-width content, drop variant-card framing */
+section[data-iteration][data-freeform] {
+  display: block;
+}
+section[data-iteration][data-freeform] > section[id][data-nav-label] {
+  margin-block: 2rem;
+}
+/* Hide the tri-state decision summary when viewing a freeform iteration */
+body.viewing-freeform #decision-summary .variant-summary { display: none; }
+```
+
+```javascript
+// Toggle the freeform body class whenever the active iteration changes.
+// Hook this into showIteration() after it applies data-active / hidden.
+function syncFreeformFlag() {
+  const active = document.querySelector('section[data-iteration][data-active]:not([hidden])');
+  const visible = active || document.querySelector('section[data-iteration]:not([hidden])');
+  document.body.classList.toggle('viewing-freeform', !!(visible && visible.hasAttribute('data-freeform')));
+}
+document.addEventListener('DOMContentLoaded', syncFreeformFlag);
 ```
 
 ### Decision Panel State CSS
@@ -928,44 +1026,107 @@ function collectDecisions() {
 }
 ```
 
-### Variant Navigation JS
+### Section Navigation JS
 
-Smooth-scrolls to the variant section and keeps the evaluation state label
-in sync with the tri-state radio selection.
+Auto-populates the panel TOC from every `<section data-nav-label>` inside
+the active iteration, smooth-scrolls on click, and keeps the evaluation
+state label in sync with the tri-state radio selection (for sections that
+have one). Plain sections without tri-state just get a scroll link.
 
 ```javascript
-// --- Variant Navigation (Decision Panel as TOC) ---
-function updateVariantNav() {
-  document.querySelectorAll('.variant-nav-item').forEach(link => {
-    const variantId = link.dataset.variant;
-    const checked = document.querySelector(`input[name="eval-${variantId}"]:checked`);
+// --- Section Navigation (Decision Panel as TOC) ---
+function buildSectionNav() {
+  const nav = document.getElementById('section-nav');
+  if (!nav) return;
+  const activeIteration = document.querySelector('section[data-iteration][data-active]');
+  if (!activeIteration) return;
+  // Find every nested section with a nav label inside the active iteration.
+  // The iteration section itself is skipped (it has no data-nav-label).
+  const sections = activeIteration.querySelectorAll('section[id][data-nav-label]');
+  nav.innerHTML = '';
+  sections.forEach(sec => {
+    const id = sec.id;
+    const label = sec.dataset.navLabel;
+    const hasTriState = !!sec.querySelector(`input[name="eval-${id}"]`);
+    const link = document.createElement('a');
+    link.href = '#' + id;
+    link.className = 'section-nav-item';
+    link.dataset.sectionId = id;
+    if (hasTriState) link.setAttribute('data-variant', '');
+    const labelEl = document.createElement('span');
+    labelEl.className = 'section-nav-label';
+    labelEl.textContent = label;
+    link.appendChild(labelEl);
+    if (hasTriState) {
+      const stateEl = document.createElement('span');
+      stateEl.className = 'section-nav-state';
+      link.appendChild(stateEl);
+    }
+    nav.appendChild(link);
+  });
+  updateSectionNavState();
+}
+
+function updateSectionNavState() {
+  // i18n labels — swap via the locale table when [ui-locale: de] is active
+  const labels = { include: 'Miteinbeziehen', discard: 'Verwerfen', only: 'Exakt diese' };
+  document.querySelectorAll('.section-nav-item[data-variant]').forEach(link => {
+    const id = link.dataset.sectionId;
+    const checked = document.querySelector(`input[name="eval-${id}"]:checked`);
     const currentState = checked ? checked.value : 'include';
-    const stateEl = link.querySelector('.variant-nav-state');
+    const stateEl = link.querySelector('.section-nav-state');
     if (stateEl) {
-      const labels = { include: 'Miteinbeziehen', discard: 'Verwerfen', only: 'Exakt diese' };
       stateEl.textContent = labels[currentState] || currentState;
-      stateEl.className = 'variant-nav-state state-' + currentState;
+      stateEl.className = 'section-nav-state state-' + currentState;
     }
   });
 }
 
-// Smooth scroll on nav click
-document.querySelectorAll('.variant-nav-item').forEach(link => {
-  link.addEventListener('click', e => {
-    e.preventDefault();
-    const target = document.querySelector(link.getAttribute('href'));
-    if (target) target.scrollIntoView({ behavior: 'smooth', block: 'start' });
-  });
+// Smooth scroll on nav click (delegated — works for auto-populated links)
+document.addEventListener('click', e => {
+  const link = e.target.closest('.section-nav-item');
+  if (!link) return;
+  e.preventDefault();
+  const target = document.querySelector(link.getAttribute('href'));
+  if (target) target.scrollIntoView({ behavior: 'smooth', block: 'start' });
 });
 
+// Highlight the current section in the TOC as the user scrolls
+function installScrollSpy() {
+  const items = document.querySelectorAll('.section-nav-item');
+  if (!items.length) return;
+  const byId = new Map();
+  items.forEach(i => byId.set(i.dataset.sectionId, i));
+  const io = new IntersectionObserver(entries => {
+    entries.forEach(en => {
+      const item = byId.get(en.target.id);
+      if (!item) return;
+      if (en.isIntersecting) {
+        items.forEach(i => i.classList.remove('is-active'));
+        item.classList.add('is-active');
+      }
+    });
+  }, { rootMargin: '-30% 0px -60% 0px', threshold: 0 });
+  byId.forEach((_, id) => {
+    const sec = document.getElementById(id);
+    if (sec) io.observe(sec);
+  });
+}
+
 // Keep nav state in sync
-document.addEventListener('change', updateVariantNav);
-document.addEventListener('DOMContentLoaded', updateVariantNav);
+document.addEventListener('change', updateSectionNavState);
+document.addEventListener('DOMContentLoaded', () => {
+  buildSectionNav();
+  installScrollSpy();
+});
 ```
 
-**Important:** The `data-variant` attribute on each nav item must match the
-radio button name pattern `eval-{variant-id}`. The variant section must have
-the matching `id` attribute for the anchor link to work.
+**Important:**
+- Every navigable `<section>` needs `id` AND `data-nav-label`.
+- If a section has a tri-state radio group, its `name` MUST be `eval-{section-id}`
+  so the TOC can mirror the current state.
+- `buildSectionNav()` must run again after every iteration switch — call it
+  from the `showIteration()` handler so the TOC reflects the active round.
 
 ### Submit Handler
 ```javascript
@@ -1169,9 +1330,10 @@ review.
 ## Iteration Tabs
 
 Iterations of a concept page are appended as `<section data-iteration="N">`
-blocks inside the same HTML file. The tab bar lives **inside the content
-area's header, above `<main>`** — NOT in the right-side decision sidebar
-(which stays reserved for submit controls).
+blocks inside the same HTML file. The tab bar lives **at the top of the
+right-side decision panel** (a compact vertical chip list, rendered above
+the section TOC and submit block). It must NEVER appear inside the
+left-hand content area — the content area is reserved for the concept.
 
 ### Tab Bar HTML
 
@@ -1207,41 +1369,45 @@ Rules:
 
 ### Tab Bar CSS
 
+The tab bar lives at the TOP of the right-side decision panel — not inside
+the content area. Render as a compact vertical chip list (one chip per
+iteration). Falls back to horizontal scroll only when the panel is very
+narrow.
+
 ```css
 .iteration-tabs {
   display: flex;
+  flex-direction: column;
   gap: 4px;
-  overflow-x: auto;
-  padding: 8px 0 0;
-  border-bottom: 1px solid var(--border);
-  scrollbar-width: thin;
+  margin-bottom: 1rem;
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid var(--border-color, #30363d);
 }
 .iteration-tab {
   flex: 0 0 auto;
-  padding: 8px 16px;
-  border: 1px solid var(--border);
-  border-bottom: none;
-  border-radius: 6px 6px 0 0;
-  background: var(--bg-subtle);
-  color: var(--fg-muted);
-  font-size: 0.9rem;
+  text-align: left;
+  padding: 6px 10px;
+  border: 1px solid var(--border-color, #30363d);
+  border-radius: 6px;
+  background: var(--bg-subtle, transparent);
+  color: var(--text-secondary, #8b949e);
+  font-size: 0.85rem;
   cursor: pointer;
-  transition: background 0.15s, color 0.15s;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
 }
-.iteration-tab:hover { background: var(--bg-hover); color: var(--fg); }
+.iteration-tab:hover {
+  background: color-mix(in srgb, var(--accent-color, #58a6ff) 10%, transparent);
+  color: var(--text-color, #c9d1d9);
+}
 .iteration-tab[aria-selected="true"] {
-  background: var(--bg);
-  color: var(--fg);
-  border-color: var(--accent);
+  background: color-mix(in srgb, var(--accent-color, #58a6ff) 15%, transparent);
+  color: var(--text-color, #c9d1d9);
+  border-color: var(--accent-color, #58a6ff);
   font-weight: 600;
-  position: relative;
 }
-.iteration-tab[aria-selected="true"]::after {
-  content: "";
-  position: absolute;
-  left: 0; right: 0; bottom: -1px;
-  height: 2px;
-  background: var(--bg);
+.iteration-tab[aria-selected="true"]::before {
+  content: "● ";
+  color: var(--accent-color, #58a6ff);
 }
 /* Frozen (non-active) iteration: slightly dimmed, no pointer events on inputs */
 section[data-iteration]:not([data-active]) {
@@ -1301,6 +1467,11 @@ function showIteration(n) {
   }
   // Optional passive hint while viewing history
   if (panelFrozen) panelFrozen.style.display = isLive ? 'none' : 'block';
+  // Rebuild the section TOC so it reflects the currently-visible iteration.
+  // (Only the active iteration is navigable; frozen tabs reuse their own
+  // sections but should still be browsable.)
+  if (typeof buildSectionNav === 'function') buildSectionNav();
+  if (typeof syncFreeformFlag === 'function') syncFreeformFlag();
 }
 
 document.querySelectorAll('.iteration-tab').forEach(tab => {

--- a/plugins/devops/skills/devops-concept/deep-knowledge/validation-gate.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/validation-gate.md
@@ -21,6 +21,8 @@ are present. **Grep the generated file** for each required pattern:
 | 14 | `pollReload` | Reload-signal poller (picks up file rewrites) |
 | 15 | `sec.hidden` | Tab-switch JS toggles the `hidden` attribute — prevents all iterations rendering at once |
 | 16 | `pollProcessedState` | Auto-reset poll handler — restores the ready panel when the server's `_processed_at` advances past the local `_submittedAt` |
+| 17 | `section-nav` | Generalised panel TOC — every `data-nav-label` section (variants AND plain sections) gets a scroll anchor |
+| 18 | `data-nav-label` | Marker on nav-eligible sections — required so `buildSectionNav()` can populate the TOC |
 
 **If ANY pattern is missing → DO NOT open the page.** Fix the HTML first,
 then re-validate. This is a **blocking gate** — no exceptions, no "this

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.55.0",
+  "version": "0.56.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

Concept page layout refactor to reduce header noise and give the right-side decision panel a proper table-of-contents.

- **Lean header**: `<header>` now shows `<h1>` + optional one-line subtitle only. The "Iteration N · …" title/intro moves into the active `<section data-iteration="N">` so the user no longer sees two intro blocks stacked above the actual content.
- **Iteration tabs relocated**: compact vertical chip list at the top of the right-side decision panel (was a horizontal tab bar inside the content column). Content area stays reserved for the concept.
- **Generalised section TOC**: `.variant-nav` → `.section-nav`. `buildSectionNav()` auto-populates entries from every `<section id="…" data-nav-label="…">` in the active iteration — variants AND plain sections (Ist-Zustand, design notes, mockups). ScrollSpy via `IntersectionObserver` highlights the current section.
- **Freeform mode**: mark iteration `<section data-freeform>` when there are no mutually-exclusive variants (design concepts, mockups, single-track plans). Full-width content, single comment + submit instead of tri-state summary.
- **Validation gate**: 16 → 18 mandatory grep patterns (`section-nav`, `data-nav-label`).

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run test` — 103/103
- [ ] Next concept page generation uses the new layout end-to-end
- [ ] Section TOC populates with non-variant sections (Ist-Zustand etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)