### PR TITLE
fix(local-llm): repair MCP deps hook + tighten delegation thresholds

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.56.0"
+    "version": "0.56.1"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.56.0",
+      "version": "0.56.1",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.56.0",
+      "version": "0.56.1",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.56.1] — 2026-04-21
+
+### Fixed
+
+- **plugins/local-llm/hooks/session-start/ss.llm.deps.js** — the deps hook now verifies that `@modelcontextprotocol/sdk` and `zod` are actually resolvable inside `mcp-server/node_modules` before skipping install. The previous "real directory → skip" branch let a partial/corrupt install pass, which silently broke the MCP server (`ERR_MODULE_NOT_FOUND` at startup, no PID file, tool invisible to Claude) while the health hook still emitted `phase: ready`. When a corrupt real-dir is detected, it's now replaced with a junction to the authoritative `PLUGIN_DATA/node_modules`. `REQUIRED_DEPS` list lives at the top of the file so new runtime deps can be added in one place
+
+### Changed
+
+- **plugins/devops/deep-knowledge/local-llm-delegation.md** + **plugins/local-llm/deep-knowledge/delegation-rules.md** — tightened the delegation thresholds based on real-session calibration. Output gate moved from `>20` to `>60 lines of near-pure boilerplate`: the previous threshold didn't cover prompt construction + review-pass overhead. Promoted the real sweet spots (seed/migration dumps, i18n/translation expansion, fixtures, repetitive variations, DTOs from schema) to the top of the GREEN matrix — they dominate the `output_size / spec_size` leverage curve. Made "code review" an explicit RED entry with rationale: 7B produces generic noise ("consider error handling", "add types") that costs more context to process than it saves. Added an economics section explaining why break-even is higher than it looks
+
 ## [0.56.0] — 2026-04-20
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.56.0**
+**Version: 0.56.1**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.56.0",
+  "version": "0.56.1",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/deep-knowledge/local-llm-delegation.md
+++ b/plugins/devops/deep-knowledge/local-llm-delegation.md
@@ -23,11 +23,16 @@ Cache the answer in memory for the rest of the agent run. If `ready: false`, nev
 
 Delegate when ALL of these are true:
 
-1. **Mechanical.** Boilerplate, DTOs, test files from a pattern, CRUD, type defs, barrel files, enum lists, migration skeletons, serializers, fixture data.
+1. **Task falls in a sweet-spot category** (not just "mechanical"):
+   - Seed/migration dumps from a schema (N×many rows of INSERT, fixtures)
+   - i18n / translation JSON expansion (one key → N languages)
+   - DTO / type definitions from an OpenAPI/JSON schema
+   - Repetitive variations (N entities, same pattern — CRUD controllers, serializers)
+   - Barrel files, enum lists, constants from a source list
 2. **Complete spec writable.** You can state signature + types + behavior in one paragraph without hedging.
-3. **Output > 20 lines.** Below that, writing directly is faster than prompt + review.
+3. **Output > 60 lines** of near-pure boilerplate. Below that, prompt-formulation + review-pass costs more tokens than Claude emitting the code directly.
 4. **No cross-file reasoning.** The code is self-contained or follows a single pattern you can paste as context.
-5. **You will review the output.** Compile-check, type-check, spot-check the logic.
+5. **Review is trivially verifiable** (compile-check, shape-check, diff against the spec). If review needs real thought, the task is too complex for the 7B model anyway.
 
 ## Never delegate (RED tier — always direct)
 
@@ -35,8 +40,9 @@ Delegate when ALL of these are true:
 - Architectural decisions, multi-file refactors
 - Security-sensitive code (auth, crypto, input validation, SQL construction)
 - External API integration (the local model's API knowledge is stale)
-- Commit messages, PR descriptions, code review
+- Commit messages, PR descriptions, **code review** (needs reasoning about intent, edge cases, security — 7B produces generic noise that costs more to process than it saves)
 - Anything where the user's request is ambiguous
+- Short outputs (<60 lines) even if mechanical — delegation overhead dominates
 
 ## How to delegate
 

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.56.0",
+  "version": "0.56.1",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/local-llm/deep-knowledge/delegation-rules.md
+++ b/plugins/local-llm/deep-knowledge/delegation-rules.md
@@ -16,25 +16,43 @@ Broad capability assumptions:
 - **Bad at:** Multi-step reasoning, cross-file context, ambiguity resolution, API knowledge
 - **Context limit:** assume ≈8K tokens practical — keep prompts tight
 
+## Economics first
+
+Delegation is NOT free. Every call costs:
+- Prompt construction (Claude thinks + emits tokens for `task` + `context`)
+- MCP roundtrip + 7B inference latency
+- Review pass (Claude reads output + validates against spec)
+
+Break-even is higher than it looks. **Rule of thumb: delegate when the raw output would be > 60 lines of near-pure boilerplate.** Below that, Claude emitting directly beats delegation + review.
+
+Biggest wins come from tasks where the output dwarfs the spec: a 10-line schema → 500 lines of seed INSERT, a 1-line key list → 200 lines of i18n JSON, an OpenAPI operation → a full DTO + validator. When output/spec ratio is < ~5×, just write it.
+
 ## Decision Matrix
 
-### GREEN — Delegate (when output >20 lines)
+### GREEN — Delegate (output > 60 lines of boilerplate, spec is short)
 
-These tasks are mechanical, well-bounded, and benefit from delegation:
+These tasks are mechanical, well-bounded, and benefit from delegation.
+**Top sweet spots** (high output/spec ratio — delegate first):
+
+| Task | Why it pays off | Prompt pattern |
+|------|-----------------|----------------|
+| **Seed data / migration dumps** | ~10-line schema → hundreds of INSERT rows | Schema + count/list → generate rows |
+| **i18n / translation JSON expansion** | one key-list → N language files | Base JSON + target languages → generate each |
+| **Mock data / fixtures** (Faker-style) | short type → many records | Type + count → generate |
+| **Repetitive variations** (N entities, same pattern) | one template → N files | Pattern + entity list → generate each |
+| **DTO / type definitions from OpenAPI/JSON-Schema** | short schema → full DTO + validators | Schema + target format → generate |
+
+**Other valid candidates** (only if output > 60 lines):
 
 | Task | Why safe | Prompt pattern |
 |------|----------|----------------|
-| **Type/interface definitions** from a schema or description | Deterministic, no logic | List fields + types → generate |
-| **DTO / data class** generation | Mechanical mapping | Source type + target format → generate |
+| **Schema definitions** (SQL DDL, Prisma, Zod, JSON Schema) | Declarative, deterministic | Field list + constraints → generate |
+| **Serializer / deserializer** | Mechanical field mapping | Source type + target format → generate |
 | **Test file from existing pattern** | Pattern-match: copy structure, change values | Existing test + new function signature → generate |
 | **CRUD boilerplate** (repository, service, controller) | Repetitive, well-structured | Entity + framework conventions → generate |
-| **Serializer / deserializer** | Mechanical field mapping | Source type + target format → generate |
-| **Schema definitions** (SQL DDL, Prisma, Zod, JSON Schema) | Declarative, deterministic | Field list + constraints → generate |
-| **Repetitive variations** (N entities, same pattern) | Copy-paste with substitution | Pattern + list of entities → generate each |
 | **Import/export barrel files** | Mechanical listing | Directory listing → generate index |
 | **Enum / constant definitions** | Direct mapping | Value list → generate |
 | **Migration files** (adding columns, creating tables) | Declarative, reversible | Schema diff → generate up/down |
-| **Mock data / fixtures** | Creative but bounded | Types + count → generate |
 | **Simple format conversions** (JS→TS types, JSON→YAML schema) | Syntax transformation | Input format → output format |
 
 ### YELLOW — Delegate with extra review
@@ -62,9 +80,9 @@ These require frontier-model intelligence. Delegation wastes time and produces w
 | **Performance-critical hot paths** | Requires profiling knowledge and algorithmic understanding |
 | **External API integration** | Model's API knowledge is frozen and may be outdated/wrong |
 | **Error handling design** | Requires understanding failure modes in the specific system |
-| **Code review** | Requires deep reasoning about correctness and intent |
+| **Code review** | Requires reasoning about intent, edge cases, security. 7B produces generic noise ("consider error handling", "add types") that costs more context to process than it saves. |
 | **Ambiguous user requests** | Model amplifies ambiguity — garbage in, garbage out |
-| **Small tasks (<20 lines)** | Overhead of formulating prompt + reviewing output exceeds direct writing |
+| **Small tasks (<60 lines)** | Prompt-construction + review-pass tokens exceed direct writing. Threshold moved up after real-world calibration — 20 was too low. |
 | **Anything requiring project conventions** beyond what fits in the prompt | 8K context too small for whole-codebase awareness |
 | **Commit messages, PR descriptions** | Requires understanding the semantic intent of changes |
 | **Complex business logic** | Multi-step reasoning, domain knowledge |
@@ -178,6 +196,9 @@ If any check fails: **fix directly** (Claude writes the fix). Do NOT re-delegate
 
 ## Token Savings Heuristic
 
-Delegation saves tokens when: `local_model_output_lines > 20 AND prompt_construction_effort < output_size`.
+Delegation saves tokens when ALL hold:
+- `output_lines > 60` AND
+- `output_size / spec_size > 5×` (high leverage — spec dwarfed by output) AND
+- `prompt_construction_time < 30s` of Claude's thought (if longer, Claude's already almost done)
 
-Rule of thumb: if constructing the prompt takes more thought than writing the code, just write it directly.
+Rule of thumb: if constructing the prompt takes more thought than writing the code, just write it directly. And if the review pass needs real reasoning, the task was above the 7B's quality bar to begin with — rewrite inline.

--- a/plugins/local-llm/hooks/session-start/ss.llm.deps.js
+++ b/plugins/local-llm/hooks/session-start/ss.llm.deps.js
@@ -9,7 +9,7 @@
  */
 
 import { execSync } from "node:child_process";
-import { readFileSync, writeFileSync, symlinkSync, mkdirSync, existsSync, unlinkSync, lstatSync } from "node:fs";
+import { readFileSync, writeFileSync, symlinkSync, mkdirSync, existsSync, unlinkSync, lstatSync, rmSync } from "node:fs";
 import { join, resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -25,8 +25,17 @@ const SOURCE_PKG = join(PLUGIN_ROOT, "mcp-server", "package.json");
 const CACHED_PKG = join(PLUGIN_DATA, "package.json");
 const DATA_MODULES = join(PLUGIN_DATA, "node_modules");
 
+// Required top-level deps that must be present after install. Add any new
+// runtime dep here so a corrupt/partial node_modules gets detected and redone.
+const REQUIRED_DEPS = ["@modelcontextprotocol/sdk", "zod"];
+
+function dataModulesIntact() {
+  if (!existsSync(DATA_MODULES)) return false;
+  return REQUIRED_DEPS.every((dep) => existsSync(join(DATA_MODULES, dep)));
+}
+
 function needsInstall() {
-  if (!existsSync(CACHED_PKG) || !existsSync(DATA_MODULES)) return true;
+  if (!existsSync(CACHED_PKG) || !dataModulesIntact()) return true;
   try {
     const source = readFileSync(SOURCE_PKG, "utf8");
     const cached = readFileSync(CACHED_PKG, "utf8");
@@ -56,12 +65,28 @@ if (needsInstall()) {
   }
 }
 
-// Symlink node_modules for ESM resolution
+// Symlink node_modules into mcp-server/ for ESM resolution.
+// If a real directory is already there, verify it has the required deps —
+// if not, it's a stale/corrupt leftover and we replace it with a symlink
+// pointing at the authoritative PLUGIN_DATA install.
 const target = join(PLUGIN_ROOT, "mcp-server", "node_modules");
+
+function targetIsIntact(p) {
+  return REQUIRED_DEPS.every((dep) => existsSync(join(p, dep)));
+}
+
 try {
   if (existsSync(target)) {
     const stat = lstatSync(target);
-    if (stat.isSymbolicLink() || stat.isDirectory()) process.exit(0);
+    if (stat.isSymbolicLink()) process.exit(0);
+    if (stat.isDirectory()) {
+      if (targetIsIntact(target)) process.exit(0);
+      // Corrupt leftover — wipe and re-symlink.
+      console.error("[local-llm] mcp-server/node_modules is incomplete — replacing with symlink.");
+      rmSync(target, { recursive: true, force: true });
+    }
   }
   symlinkSync(DATA_MODULES, target, "junction");
-} catch {}
+} catch (err) {
+  console.error("[local-llm] Symlink step failed:", err.message);
+}


### PR DESCRIPTION
## Summary

- `ss.llm.deps.js`: verify `@modelcontextprotocol/sdk` + `zod` are actually resolvable before skipping install. Corrupt real-dir `mcp-server/node_modules` is now replaced with a junction to `PLUGIN_DATA/node_modules` instead of silently breaking the MCP server.
- Raised delegation output gate from `>20` to `>60 lines`; promoted real sweet spots (seed dumps, i18n, fixtures, DTOs from schema) to the top of the GREEN matrix; marked code review as explicit RED.

## Why

The SessionStart hook reported `phase: ready` even though the MCP server was dead on startup (`ERR_MODULE_NOT_FOUND` for `@modelcontextprotocol/sdk`). Cause: the deps hook checked `existsSync(mcp-server/node_modules)` only. A partial `npm install` leftover (54 packages, no SDK) passed that check, so the symlink-to-`PLUGIN_DATA` step was skipped and the server couldn't resolve its own imports.

Delegation thresholds were calibrated against a real multi-role session where the `>20 lines` rule never actually triggered a profitable delegation — prompt + review overhead dominated at that size.

## Test plan

- [x] `npm run lint` → clean
- [x] `npm run test` → 103/103 passing
- [x] Manual MCP server start from fixed cache → `[dotclaude-local-llm] MCP server started on stdio`
- [ ] Verify `mcp__plugin_local-llm_*` tools surface on next session
- [ ] (User action) Align AnythingLLM workspace `chatModel` with an installed Ollama model, or `ollama pull qwen2.5-coder:7b`

🤖 Generated with [Claude Code](https://claude.com/claude-code)