### PR TITLE
feat(concept): 3 page templates with bi-state + dual-action submit

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.56.1"
+    "version": "0.57.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.56.1",
+      "version": "0.57.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.56.1",
+      "version": "0.57.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [0.57.0] — 2026-04-22
+
+### Changed
+
+- **plugins/devops/skills/devops-concept/SKILL.md** + **deep-knowledge/templates.md** + **deep-knowledge/validation-gate.md** — concept skill reorganised around three explicit **page templates** with strict ordered auto-selection (prototype → decision → free). `decision` is the canonical multi-variant flow (sidebar layout + bi-state eval per variant); `prototype` is a fullscreen single-screen click-dummy with overlay decision panel (☰, FAB right) + collapsible feedback dock (💬, bottom) holding a context-sensitive per-screen textarea and a persistent general-notes field; `free` is a Claude-authored freeform body with opt-in bi-state per section. Content variants (analysis, plan, concept, comparison, dashboard, creative) are now scoped under the decision template as sub-structures, not separate page templates
+- **plugins/devops/skills/devops-concept/SKILL.md** Step 5b — tri-state "Exakt diese / only" collapsed to **bi-state** (Verwerfen / Miteinbeziehen). `collectDecisions()` now emits an explicit `action: "iterate" | "implement"` field driven by two separate submit buttons. The primary "Zur nächsten Iteration" button NEVER causes code changes — it only feeds feedback into the next concept iteration. The secondary "Mit Feedback implementieren" button (warning-colored, separated by a mandatory 2rem gap, confirm dialog) is the only path that triggers real file/code changes. This removes the old "Claude setzt um" ambiguity on individual evaluation options
+
+### Added
+
+- **plugins/devops/skills/devops-concept/deep-knowledge/templates.md** — connection-overlay now has **two states**: an accent-pulsing "Claude verbindet sich" overlay shown during the 30s grace period after page load, and a warning-colored "Claude ist nicht verbunden" overlay once the heartbeat stays stale past grace. Overlay uses `pointer-events: none` so the submit buttons remain clickable — clicks queue in `localStorage` and auto-deliver on reconnect. Wording matches the actual behaviour ("Klick wird gespeichert", not "Submit pausiert")
+- **plugins/devops/skills/devops-concept/SKILL.md** Step 2 Localisation — explicit mandate: read `[ui-locale: xx]` hint, set `<html lang="{locale}">`, pull every user-facing string from the expanded UI locale table in templates.md. If the user's locale is not yet a column, Claude translates all keys inline AND appends the column to templates.md so the next session has it cached
+- **plugins/devops/skills/devops-concept/deep-knowledge/templates.md** — prototype template new mechanics: fullscreen body with exactly one `<section data-screen>` visible at a time, screen-nav in the ☰ panel, click-dummy wiring via `data-screen-link="next|prev|{screen-id}"`, per-screen textareas stay in the DOM (only active one shown) so each screen's notes persist independently. Feedback dock closes on outside click; general-notes textarea stays visible across all screens
+- **docs/concepts/2026-04-21-template-example-{decision,prototype,free}.html** — three reference example pages exercising the full new stack (bi-state eval where applicable, dual-action submit, connecting/disconnected overlay, click-dummy with screen navigation, localisation scaffolding)
+- **plugins/devops/skills/devops-concept/deep-knowledge/validation-gate.md** — gate now enforces 20 shared patterns (adds `submit-iterate-btn`, `submit-implement-btn`, `connection-connecting`) plus template-specific patterns per decision/prototype/free
+
 ## [0.56.1] — 2026-04-21
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.56.1**
+**Version: 0.57.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/docs/concepts/2026-04-21-template-example-decision.html
+++ b/docs/concepts/2026-04-21-template-example-decision.html
@@ -1,0 +1,463 @@
+<!DOCTYPE html>
+<html lang="de" data-theme="dark" data-page-version="2026-04-21T10:00:00" data-template="decision">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Concept — Auth-Middleware Redesign (decision)</title>
+<style>
+:root {
+  --bg: #0d1117; --text: #c9d1d9; --text-secondary: #8b949e;
+  --panel-bg: #161b22; --border-color: #30363d; --input-bg: #0d1117;
+  --accent-color: #58a6ff; --success-color: #3fb950; --warning-color: #d29922; --danger-color: #f85149;
+}
+html[data-theme="light"] {
+  --bg: #ffffff; --text: #24292f; --text-secondary: #57606a;
+  --panel-bg: #f6f8fa; --border-color: #d0d7de; --input-bg: #ffffff;
+  --accent-color: #0969da;
+}
+* { box-sizing: border-box; }
+body { margin: 0; background: var(--bg); color: var(--text);
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; line-height: 1.6; }
+h1, h2, h3 { font-weight: 600; letter-spacing: -0.01em; }
+button { font-family: inherit; }
+
+.concept-layout { display: flex; min-height: 100vh; }
+.concept-content { flex: 1; padding: 2rem; overflow-y: auto; }
+.concept-decision-panel {
+  width: 20%; min-width: 260px; max-width: 360px;
+  position: sticky; top: 0; height: 100vh; overflow-y: auto;
+  padding: 1.5rem; border-left: 1px solid var(--border-color); background: var(--panel-bg);
+}
+@media (max-width: 768px) {
+  .concept-layout { flex-direction: column; }
+  .concept-decision-panel { width: 100%; max-width: none; height: auto;
+    position: sticky; bottom: 0; border-left: none; border-top: 1px solid var(--border-color); }
+}
+
+header { display: flex; align-items: center; gap: 1rem; margin-bottom: 2rem;
+  border-bottom: 1px solid var(--border-color); padding-bottom: 1rem; }
+header h1 { margin: 0; font-size: 1.75rem; }
+header .subtitle { color: var(--text-secondary); margin: 0; flex: 1; }
+#theme-toggle { background: none; border: 1px solid var(--border-color); color: var(--text);
+  padding: 0.5rem 0.75rem; border-radius: 8px; cursor: pointer; }
+
+.iteration-intro { border-left: 3px solid var(--accent-color); padding: 0.75rem 1rem;
+  margin-bottom: 2rem; background: color-mix(in srgb, var(--accent-color) 8%, transparent); border-radius: 0 8px 8px 0; }
+.iteration-intro h2 { margin: 0 0 0.25rem 0; font-size: 1.1rem; }
+.iteration-intro p { margin: 0; color: var(--text-secondary); }
+
+.variant-card { border: 1px solid var(--border-color); border-radius: 10px;
+  padding: 1.5rem; margin-bottom: 2rem; background: color-mix(in srgb, var(--panel-bg) 50%, transparent); }
+.variant-card h3 { margin-top: 0; }
+.variant-card .procons { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin: 1rem 0; }
+.variant-card .procons ul { margin: 0; padding-left: 1.2rem; font-size: 0.9rem; }
+.variant-card .procons .pros li { color: var(--success-color); }
+.variant-card .procons .cons li { color: var(--danger-color); }
+
+.tri-state-group { display: flex; gap: 0; border: 1px solid var(--border-color);
+  border-radius: 8px; overflow: hidden; margin-top: 1rem; }
+.tri-state-option { flex: 1; display: flex; flex-direction: column; align-items: center;
+  padding: 0.75rem 1rem; cursor: pointer; text-align: center; position: relative;
+  border-right: 1px solid var(--border-color); transition: background 0.2s, box-shadow 0.2s; }
+.tri-state-option:last-child { border-right: none; }
+.tri-state-option:hover { background: color-mix(in srgb, var(--accent-color) 10%, transparent); }
+.tri-state-option input { display: none; }
+.tri-state-option:has(input:checked) .tri-state-label { font-weight: 700; }
+.tri-state-hint { font-size: 0.72rem; margin-top: 0.25rem; opacity: 0.5; transition: opacity 0.2s; }
+.tri-state-option:has(input:checked) .tri-state-hint { opacity: 1; }
+.tri-state-hint.feedback { color: var(--accent-color); }
+.tri-state-hint.action { color: var(--warning-color); }
+.tri-state-label { font-size: 0.9rem; transition: font-weight 0.15s; }
+.tri-state-option:has(input:checked)::after {
+  content: '✓'; position: absolute; top: 4px; right: 6px; font-size: 0.7rem; font-weight: 700;
+  width: 18px; height: 18px; display: flex; align-items: center; justify-content: center;
+  border-radius: 50%; pointer-events: none; }
+.tri-state-option:has(input[value="include"]:checked) {
+  background: color-mix(in srgb, var(--accent-color) 15%, transparent);
+  box-shadow: inset 0 0 0 2px var(--accent-color); }
+.tri-state-option:has(input[value="include"]:checked)::after { background: var(--accent-color); color: white; }
+.tri-state-option:has(input[value="discard"]:checked) {
+  background: color-mix(in srgb, var(--danger-color) 12%, transparent);
+  box-shadow: inset 0 0 0 2px var(--danger-color); }
+.tri-state-option:has(input[value="discard"]:checked)::after { background: var(--danger-color); color: white; }
+.tri-state-option:has(input[value="discard"]:checked) .tri-state-label { color: var(--danger-color); }
+.tri-state-option:has(input[value="only"]:checked) {
+  background: color-mix(in srgb, var(--success-color) 15%, transparent);
+  box-shadow: inset 0 0 0 2px var(--success-color); }
+.tri-state-option:has(input[value="only"]:checked)::after { background: var(--success-color); color: white; }
+.tri-state-option:has(input[value="only"]:checked) .tri-state-label { color: var(--success-color); }
+.tri-state-option:has(input:not(:checked)) { opacity: 0.7; }
+.tri-state-option:has(input:not(:checked)):hover { opacity: 1; }
+
+.comment-field { margin-top: 1rem; }
+.comment-field textarea { width: 100%; min-height: 80px; padding: 0.75rem;
+  border: 1px solid var(--border-color); border-radius: 8px; background: var(--input-bg);
+  color: var(--text); font-family: inherit; font-size: 0.9rem; line-height: 1.5; resize: vertical; }
+.comment-field textarea:focus { outline: none; border-color: var(--accent-color); }
+
+.iteration-tabs { display: flex; flex-direction: column; gap: 4px; margin-bottom: 1rem;
+  padding-bottom: 0.75rem; border-bottom: 1px solid var(--border-color); }
+.iteration-tab { flex: 0 0 auto; text-align: left; padding: 6px 10px;
+  border: 1px solid var(--border-color); border-radius: 6px; background: transparent;
+  color: var(--text-secondary); font-size: 0.85rem; cursor: pointer;
+  transition: background 0.15s, color 0.15s, border-color 0.15s; }
+.iteration-tab:hover { background: color-mix(in srgb, var(--accent-color) 10%, transparent); color: var(--text); }
+.iteration-tab[aria-selected="true"] { background: color-mix(in srgb, var(--accent-color) 15%, transparent);
+  color: var(--text); border-color: var(--accent-color); font-weight: 600; }
+.iteration-tab[aria-selected="true"]::before { content: "● "; color: var(--accent-color); }
+
+.section-nav { display: flex; flex-direction: column; gap: 2px; margin-bottom: 1.5rem;
+  border-bottom: 1px solid var(--border-color); padding-bottom: 1rem; }
+.section-nav-item { display: flex; align-items: center; justify-content: space-between;
+  padding: 0.5rem 0.75rem; border-radius: 6px; text-decoration: none; color: var(--text);
+  font-size: 0.9rem; transition: background 0.15s; cursor: pointer; }
+.section-nav-item:hover { background: color-mix(in srgb, var(--accent-color) 10%, transparent); }
+.section-nav-state { font-size: 0.8rem; color: var(--accent-color); white-space: nowrap; }
+.section-nav-state.state-discard { color: var(--danger-color); }
+.section-nav-state.state-only { color: var(--success-color); }
+.section-nav-item.is-active { background: color-mix(in srgb, var(--accent-color) 18%, transparent); font-weight: 600; }
+
+#panel-ready { position: relative; }
+.panel-warning {
+  position: absolute; inset: 0; z-index: 5;
+  display: flex; flex-direction: column; align-items: center; justify-content: center;
+  gap: 0.75rem; text-align: center; padding: 1.5rem;
+  border-radius: 10px; border: 1px solid var(--warning-color);
+  background: color-mix(in srgb, var(--panel-bg) 94%, transparent);
+  backdrop-filter: blur(4px); -webkit-backdrop-filter: blur(4px);
+  color: var(--text); }
+.panel-warning .warning-icon { font-size: 2.25rem; color: var(--warning-color); line-height: 1; }
+.panel-warning strong { color: var(--warning-color); font-size: 1rem; }
+.panel-warning .warning-message { font-size: 0.88rem; color: var(--text-secondary);
+  line-height: 1.5; max-width: 280px; margin: 0; }
+/* Connecting variant — same overlay, accent color + pulsing icon */
+.panel-warning--connecting { border-color: var(--accent-color); }
+.panel-warning--connecting .warning-icon { color: var(--accent-color); animation: pulse-connect 1.4s ease-in-out infinite; }
+.panel-warning--connecting strong { color: var(--accent-color); }
+@keyframes pulse-connect { 0%, 100% { opacity: 0.45; } 50% { opacity: 1; } }
+.submitted-indicator { display: flex; align-items: center; gap: 0.5rem; padding: 1rem;
+  margin-bottom: 0.75rem; border-radius: 8px;
+  background: color-mix(in srgb, var(--success-color) 15%, transparent);
+  border: 1px solid var(--success-color); }
+.submitted-indicator .check-icon { font-size: 1.3rem; color: var(--success-color); }
+.submitted-hint { font-size: 0.9rem; line-height: 1.5; color: var(--text-secondary); margin-bottom: 1rem; }
+.waiting-animation { display: flex; gap: 6px; justify-content: center; padding: 0.5rem 0; }
+.waiting-animation .dot { width: 8px; height: 8px; border-radius: 50%; background: var(--accent-color);
+  animation: pulse 1.4s ease-in-out infinite; }
+.waiting-animation .dot:nth-child(2) { animation-delay: 0.2s; }
+.waiting-animation .dot:nth-child(3) { animation-delay: 0.4s; }
+@keyframes pulse { 0%, 80%, 100% { opacity: 0.3; transform: scale(0.8); } 40% { opacity: 1; transform: scale(1); } }
+.submit-btn, .implement-btn { width: 100%; padding: 0.8rem 1rem; border-radius: 10px;
+  font-weight: 600; font-size: 0.95rem; cursor: pointer; margin-top: 0.5rem; font-family: inherit; }
+.submit-btn { border: none; background: var(--accent-color); color: white; }
+.submit-btn:disabled, .implement-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.submit-gap { height: 2rem; }
+.implement-btn { background: transparent; color: var(--warning-color);
+  border: 1px solid var(--warning-color);
+  display: flex; align-items: center; justify-content: center; gap: 0.5rem; }
+.implement-btn:hover { background: color-mix(in srgb, var(--warning-color) 15%, transparent); }
+.implement-btn .warn-icon { font-size: 1rem; }
+.hint-warn { color: var(--warning-color); }
+.hint { font-size: 0.8rem; color: var(--text-secondary); margin: 0.5rem 0 0 0; }
+h3 { margin-top: 1rem; font-size: 1rem; }
+</style>
+</head>
+<body>
+<div class="concept-layout">
+  <div class="concept-content">
+    <header>
+      <h1>Auth-Middleware Redesign</h1>
+      <p class="subtitle">Entscheidung zwischen drei Authentifizierungsansätzen</p>
+      <button id="theme-toggle" aria-label="Toggle theme">🌙/☀️</button>
+    </header>
+    <main>
+      <section id="iter-1" data-iteration="1" data-active>
+        <header class="iteration-intro">
+          <h2>Iteration 1 · Variantenvergleich</h2>
+          <p>Drei Middleware-Ansätze für die neue Auth-Schicht. Stimme pro Variante ab — "Exakt diese" wählt genau eine aus und verwirft die anderen.</p>
+        </header>
+
+        <section id="variant-jwt" class="variant-card" data-nav-label="A · JWT stateless">
+          <h3>Variante A · JWT stateless</h3>
+          <p>Token wird client-seitig gehalten, Signatur via Edge-Worker verifiziert. Keine Session-Tabelle.</p>
+          <div class="procons">
+            <div class="pros"><strong>Pros</strong><ul><li>Horizontal skalierbar</li><li>Kein DB-Roundtrip</li><li>Stateless Edge-Ready</li></ul></div>
+            <div class="cons"><strong>Cons</strong><ul><li>Revocation kompliziert</li><li>Token-Größe</li><li>Kein serverseitiger Logout</li></ul></div>
+          </div>
+          <div class="tri-state-group" data-decision="variant-jwt" data-label="A · JWT stateless">
+            <label class="tri-state-option"><input type="radio" name="eval-variant-jwt" value="discard"><span class="tri-state-label">Verwerfen</span></label>
+            <label class="tri-state-option"><input type="radio" name="eval-variant-jwt" value="include" checked><span class="tri-state-label">Miteinbeziehen</span></label>
+          </div>
+          <div class="comment-field"><textarea data-comment="variant-jwt" placeholder="Anmerkungen zu JWT…"></textarea></div>
+        </section>
+
+        <section id="variant-session" class="variant-card" data-nav-label="B · Session Cookie">
+          <h3>Variante B · Session Cookie (Redis-backed)</h3>
+          <p>Klassisches Session-Cookie mit signed ID, Mapping in Redis.</p>
+          <div class="procons">
+            <div class="pros"><strong>Pros</strong><ul><li>Einfacher Logout</li><li>Revocation sofort</li><li>Klein auf Wire</li></ul></div>
+            <div class="cons"><strong>Cons</strong><ul><li>Redis als SPOF</li><li>Session-Sticky-Routing nötig</li></ul></div>
+          </div>
+          <div class="tri-state-group" data-decision="variant-session" data-label="B · Session Cookie">
+            <label class="tri-state-option"><input type="radio" name="eval-variant-session" value="discard"><span class="tri-state-label">Verwerfen</span></label>
+            <label class="tri-state-option"><input type="radio" name="eval-variant-session" value="include" checked><span class="tri-state-label">Miteinbeziehen</span></label>
+          </div>
+          <div class="comment-field"><textarea data-comment="variant-session" placeholder="Anmerkungen zu Session Cookies…"></textarea></div>
+        </section>
+
+        <section id="variant-oauth" class="variant-card" data-nav-label="C · OAuth Delegation">
+          <h3>Variante C · OAuth Delegation (Auth0/Clerk)</h3>
+          <p>Delegation an externen Identity Provider, nur Token-Validierung lokal.</p>
+          <div class="procons">
+            <div class="pros"><strong>Pros</strong><ul><li>Compliance out-of-the-box</li><li>SSO + MFA gratis</li><li>Weniger Eigenbetrieb</li></ul></div>
+            <div class="cons"><strong>Cons</strong><ul><li>Vendor-Lock</li><li>Kostenfaktor pro MAU</li><li>Externe Latenz</li></ul></div>
+          </div>
+          <div class="tri-state-group" data-decision="variant-oauth" data-label="C · OAuth Delegation">
+            <label class="tri-state-option"><input type="radio" name="eval-variant-oauth" value="discard"><span class="tri-state-label">Verwerfen</span></label>
+            <label class="tri-state-option"><input type="radio" name="eval-variant-oauth" value="include" checked><span class="tri-state-label">Miteinbeziehen</span></label>
+          </div>
+          <div class="comment-field"><textarea data-comment="variant-oauth" placeholder="Anmerkungen zu OAuth…"></textarea></div>
+        </section>
+      </section>
+    </main>
+  </div>
+
+  <aside class="concept-decision-panel">
+    <nav class="iteration-tabs" role="tablist" aria-label="Iterationen">
+      <button class="iteration-tab" role="tab" data-iteration="1" aria-selected="true" aria-controls="iter-1">Iteration 1 · aktiv</button>
+    </nav>
+    <h3>Entscheidungen</h3>
+    <nav class="section-nav" id="section-nav" aria-label="Abschnitte"></nav>
+    <div id="panel-ready">
+      <div id="decision-summary"></div>
+      <div id="connection-connecting" class="panel-warning panel-warning--connecting" style="display: flex;">
+        <span class="warning-icon" aria-hidden="true">⋯</span>
+        <strong>Claude verbindet sich</strong>
+        <p class="warning-message">Einen Moment — die Verbindung wird aufgebaut.</p>
+      </div>
+      <div id="connection-warning" class="panel-warning" style="display: none;">
+        <span class="warning-icon" aria-hidden="true">⚠</span>
+        <strong>Claude ist nicht verbunden</strong>
+        <p class="warning-message">Submit ist pausiert, bis die Verbindung wieder steht. Deine Eingaben bleiben erhalten.</p>
+      </div>
+      <button id="submit-iterate-btn" class="primary submit-btn">Zur nächsten Iteration</button>
+      <p class="hint">Deine Auswahl geht an Claude für die nächste Iteration. Es wird kein Code geschrieben.</p>
+      <div class="submit-gap" aria-hidden="true"></div>
+      <button id="submit-implement-btn" class="implement-btn">
+        <span class="warn-icon" aria-hidden="true">⚠</span>
+        Mit Feedback implementieren
+      </button>
+      <p class="hint hint-warn">Claude setzt die Auswahl jetzt in echte Änderungen um.</p>
+    </div>
+    <div id="panel-submitted" style="display: none;">
+      <div class="submitted-indicator"><span class="check-icon">✓</span><strong>Entscheidungen übermittelt</strong></div>
+      <p class="submitted-hint">Claude verarbeitet deine Auswahl. Wechsle zum <strong>Claude Chat</strong>.</p>
+      <div class="waiting-animation"><span class="dot"></span><span class="dot"></span><span class="dot"></span></div>
+    </div>
+  </aside>
+</div>
+
+<script type="application/json" id="concept-decisions">
+{"submitted": false, "decisions": [], "comments": []}
+</script>
+<script>
+// --- State Persistence ---
+const STORAGE_KEY = 'concept-state-' + location.pathname.split('/').pop().replace('.html', '');
+const STATE_TTL_MS = 24 * 60 * 60 * 1000;
+function saveState() {
+  const state = { _savedAt: Date.now(), _pageVersion: document.documentElement.dataset.pageVersion || '' };
+  document.querySelectorAll('input[type="checkbox"], input[type="radio"]').forEach(el => {
+    if (el.name || el.id) state['input:' + (el.name || el.id) + ':' + el.value] = el.checked; });
+  document.querySelectorAll('textarea, input[type="text"]').forEach(el => {
+    if (el.id || el.dataset.comment) state['text:' + (el.id || el.dataset.comment)] = el.value; });
+  state['theme'] = document.documentElement.getAttribute('data-theme');
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+}
+function restoreState() {
+  const raw = localStorage.getItem(STORAGE_KEY); if (!raw) return;
+  try { const state = JSON.parse(raw);
+    if (state._savedAt && (Date.now() - state._savedAt) > STATE_TTL_MS) { localStorage.removeItem(STORAGE_KEY); return; }
+    const currentVersion = document.documentElement.dataset.pageVersion || '';
+    if (state._pageVersion && state._pageVersion !== currentVersion) { localStorage.removeItem(STORAGE_KEY); return; }
+    if (state.theme) document.documentElement.setAttribute('data-theme', state.theme);
+    Object.entries(state).forEach(([key, value]) => {
+      if (key.startsWith('_')) return;
+      const [type, ...rest] = key.split(':');
+      if (type === 'input') { const [name, val] = [rest.slice(0, -1).join(':'), rest[rest.length - 1]];
+        const el = document.querySelector(`input[name="${name}"][value="${val}"]`); if (el) el.checked = value; }
+      else if (type === 'text') { const id = rest.join(':');
+        const el = document.querySelector(`[data-comment="${id}"]`) || document.getElementById(id); if (el) el.value = value; }
+    });
+  } catch (e) {}
+}
+document.addEventListener('DOMContentLoaded', restoreState);
+document.addEventListener('change', saveState);
+document.addEventListener('input', saveState);
+
+// --- Section Nav ---
+function buildSectionNav() {
+  const nav = document.getElementById('section-nav'); if (!nav) return;
+  const activeIteration = document.querySelector('section[data-iteration][data-active]'); if (!activeIteration) return;
+  const sections = activeIteration.querySelectorAll('section[id][data-nav-label]');
+  nav.innerHTML = '';
+  sections.forEach(sec => {
+    const id = sec.id, label = sec.dataset.navLabel;
+    const hasTriState = !!sec.querySelector(`input[name="eval-${id}"]`);
+    const link = document.createElement('a');
+    link.href = '#' + id; link.className = 'section-nav-item'; link.dataset.sectionId = id;
+    if (hasTriState) link.setAttribute('data-variant', '');
+    const labelEl = document.createElement('span'); labelEl.className = 'section-nav-label'; labelEl.textContent = label;
+    link.appendChild(labelEl);
+    if (hasTriState) { const s = document.createElement('span'); s.className = 'section-nav-state'; link.appendChild(s); }
+    nav.appendChild(link);
+  });
+  updateSectionNavState();
+}
+function updateSectionNavState() {
+  const labels = { include: 'Miteinbeziehen', discard: 'Verwerfen', only: 'Exakt diese' };
+  document.querySelectorAll('.section-nav-item[data-variant]').forEach(link => {
+    const id = link.dataset.sectionId;
+    const checked = document.querySelector(`input[name="eval-${id}"]:checked`);
+    const currentState = checked ? checked.value : 'include';
+    const stateEl = link.querySelector('.section-nav-state');
+    if (stateEl) { stateEl.textContent = labels[currentState] || currentState; stateEl.className = 'section-nav-state state-' + currentState; }
+  });
+}
+document.addEventListener('click', e => {
+  const link = e.target.closest('.section-nav-item'); if (!link) return;
+  e.preventDefault();
+  const target = document.querySelector(link.getAttribute('href'));
+  if (target) target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+});
+document.addEventListener('change', updateSectionNavState);
+
+// --- Iteration tabs + freeze ---
+function showIteration(n) {
+  document.querySelectorAll('section[data-iteration]').forEach(sec => { sec.hidden = String(sec.dataset.iteration) !== String(n); });
+  document.querySelectorAll('.iteration-tab').forEach(tab => {
+    tab.setAttribute('aria-selected', String(tab.dataset.iteration) === String(n) ? 'true' : 'false'); });
+  const activeSec = document.querySelector('section[data-iteration][data-active]');
+  const isLive = activeSec && String(activeSec.dataset.iteration) === String(n);
+  document.body.classList.toggle('viewing-frozen', !isLive);
+  const panelReady = document.getElementById('panel-ready');
+  const panelSubmitted = document.getElementById('panel-submitted');
+  if (panelReady) panelReady.style.display = isLive ? 'block' : 'none';
+  if (panelSubmitted) {
+    const submitted = document.body.classList.contains('concept-submitted');
+    panelSubmitted.style.display = (isLive && submitted) ? 'block' : 'none';
+  }
+  buildSectionNav();
+  document.dispatchEvent(new CustomEvent('iteration:changed'));
+}
+document.querySelectorAll('.iteration-tab').forEach(tab => tab.addEventListener('click', () => showIteration(tab.dataset.iteration)));
+document.addEventListener('DOMContentLoaded', () => {
+  const active = document.querySelector('section[data-iteration][data-active]');
+  if (active) showIteration(active.dataset.iteration);
+});
+
+// --- Theme ---
+document.getElementById('theme-toggle').addEventListener('click', () => {
+  const html = document.documentElement;
+  html.setAttribute('data-theme', html.getAttribute('data-theme') === 'dark' ? 'light' : 'dark');
+});
+
+// --- collectDecisions (decision branch) ---
+function collectDecisions(action = 'iterate') {
+  const decisions = [], comments = [];
+  document.querySelectorAll('[data-decision]').forEach(el => {
+    const id = el.dataset.decision;
+    const checked = document.querySelector(`input[name="eval-${id}"]:checked`);
+    decisions.push({ id, label: el.dataset.label || '', evaluation: checked ? checked.value : 'include' });
+  });
+  document.querySelectorAll('[data-comment]').forEach(el => {
+    if (el.value.trim()) comments.push({ id: el.dataset.comment, text: el.value.trim() });
+  });
+  return { submitted: true, template: 'decision', action, decisions, comments };
+}
+
+// --- Submit + heartbeat (degrades gracefully if bridge offline) ---
+let _submittedAt = 0;
+async function submitWithAction(action) {
+  const data = collectDecisions(action);
+  document.getElementById('concept-decisions').textContent = JSON.stringify(data);
+  document.body.classList.add('concept-submitted');
+  _submittedAt = Date.now();
+  document.getElementById('panel-ready').style.display = 'none';
+  document.getElementById('panel-submitted').style.display = 'block';
+  try { await fetch('/decisions', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(data) }); }
+  catch (e) { localStorage.setItem(STORAGE_KEY + '-pending', JSON.stringify(data)); }
+  saveState();
+}
+document.getElementById('submit-iterate-btn').addEventListener('click', () => submitWithAction('iterate'));
+document.getElementById('submit-implement-btn').addEventListener('click', () => {
+  if (!confirm('Mit Feedback echt implementieren? Claude schreibt jetzt Code-Änderungen.')) return;
+  submitWithAction('implement');
+});
+async function retryPendingSubmission() {
+  const pending = localStorage.getItem(STORAGE_KEY + '-pending'); if (!pending) return;
+  try { const res = await fetch('/decisions', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: pending });
+    if (res.ok) localStorage.removeItem(STORAGE_KEY + '-pending'); } catch (e) {}
+}
+function restorePanelToReady() {
+  document.getElementById('panel-submitted').style.display = 'none';
+  document.getElementById('panel-ready').style.display = 'block';
+  ['submit-iterate-btn', 'submit-implement-btn'].forEach(id => {
+    const btn = document.getElementById(id); if (btn) btn.disabled = false;
+  });
+  document.body.classList.remove('concept-submitted'); _submittedAt = 0;
+  localStorage.removeItem(STORAGE_KEY);
+}
+const HEARTBEAT_STALE_MS = 90000, HEARTBEAT_GRACE_MS = 30000;
+const _pageLoadedAt = Date.now(); let _lastHeartbeatTs = 0;
+async function pollHeartbeat() {
+  try { const res = await fetch('/heartbeat', { cache: 'no-store' }); const data = await res.json(); _lastHeartbeatTs = data.ts || 0; }
+  catch (e) {}
+}
+async function pollProcessedState() {
+  if (!_submittedAt) return;
+  try { const res = await fetch('/decisions', { cache: 'no-store' }); const data = await res.json();
+    const processedIso = data && data._processed_at; if (!processedIso) return;
+    const processedMs = Date.parse(processedIso);
+    if (Number.isFinite(processedMs) && processedMs > _submittedAt) restorePanelToReady();
+  } catch (e) {}
+}
+function checkClaudeConnection() {
+  const isConnected = _lastHeartbeatTs && (Date.now() - _lastHeartbeatTs) < HEARTBEAT_STALE_MS;
+  const inGrace = Date.now() - _pageLoadedAt < HEARTBEAT_GRACE_MS;
+  const connecting = document.getElementById('connection-connecting');
+  const warning = document.getElementById('connection-warning');
+  const btns = ['submit-iterate-btn', 'submit-implement-btn']
+    .map(id => document.getElementById(id)).filter(Boolean);
+  const panelSubmitted = document.getElementById('panel-submitted');
+  if (panelSubmitted && panelSubmitted.style.display !== 'none') return;
+  if (isConnected) {
+    if (connecting) connecting.style.display = 'none';
+    if (warning) warning.style.display = 'none';
+    btns.forEach(b => b.disabled = false);
+    retryPendingSubmission();
+  } else if (inGrace) {
+    if (connecting) connecting.style.display = 'flex';
+    if (warning) warning.style.display = 'none';
+    btns.forEach(b => b.disabled = false);
+  } else {
+    if (connecting) connecting.style.display = 'none';
+    if (warning) warning.style.display = 'flex';
+    btns.forEach(b => b.disabled = false);
+  }
+}
+setInterval(async () => { await pollHeartbeat(); checkClaudeConnection(); await pollProcessedState(); }, 5000);
+
+// --- Reload poller ---
+let _bootReloadCounter = null;
+async function pollReload() {
+  try { const res = await fetch('/reload', { cache: 'no-store' }); if (!res.ok) return;
+    const { counter } = await res.json();
+    if (_bootReloadCounter === null) { _bootReloadCounter = counter; return; }
+    if (counter > _bootReloadCounter) location.reload();
+  } catch (e) {}
+}
+setInterval(pollReload, 3000);
+document.addEventListener('DOMContentLoaded', pollReload);
+</script>
+</body>
+</html>

--- a/docs/concepts/2026-04-21-template-example-decision.html
+++ b/docs/concepts/2026-04-21-template-example-decision.html
@@ -120,11 +120,12 @@ header .subtitle { color: var(--text-secondary); margin: 0; flex: 1; }
 #panel-ready { position: relative; }
 .panel-warning {
   position: absolute; inset: 0; z-index: 5;
+  pointer-events: none;
   display: flex; flex-direction: column; align-items: center; justify-content: center;
   gap: 0.75rem; text-align: center; padding: 1.5rem;
   border-radius: 10px; border: 1px solid var(--warning-color);
-  background: color-mix(in srgb, var(--panel-bg) 94%, transparent);
-  backdrop-filter: blur(4px); -webkit-backdrop-filter: blur(4px);
+  background: color-mix(in srgb, var(--panel-bg) 70%, transparent);
+  backdrop-filter: blur(2px); -webkit-backdrop-filter: blur(2px);
   color: var(--text); }
 .panel-warning .warning-icon { font-size: 2.25rem; color: var(--warning-color); line-height: 1; }
 .panel-warning strong { color: var(--warning-color); font-size: 1rem; }
@@ -238,7 +239,7 @@ h3 { margin-top: 1rem; font-size: 1rem; }
       <div id="connection-warning" class="panel-warning" style="display: none;">
         <span class="warning-icon" aria-hidden="true">⚠</span>
         <strong>Claude ist nicht verbunden</strong>
-        <p class="warning-message">Submit ist pausiert, bis die Verbindung wieder steht. Deine Eingaben bleiben erhalten.</p>
+        <p class="warning-message">Du kannst trotzdem absenden — der Klick wird gespeichert und gesendet, sobald Claude wieder da ist.</p>
       </div>
       <button id="submit-iterate-btn" class="primary submit-btn">Zur nächsten Iteration</button>
       <p class="hint">Deine Auswahl geht an Claude für die nächste Iteration. Es wird kein Code geschrieben.</p>
@@ -297,8 +298,10 @@ document.addEventListener('input', saveState);
 // --- Section Nav ---
 function buildSectionNav() {
   const nav = document.getElementById('section-nav'); if (!nav) return;
-  const activeIteration = document.querySelector('section[data-iteration][data-active]'); if (!activeIteration) return;
-  const sections = activeIteration.querySelectorAll('section[id][data-nav-label]');
+  // Use :not([hidden]) so the nav reflects the CURRENTLY VISIBLE iteration
+  // (may be a frozen tab the user clicked back to), not the live one.
+  const visibleIteration = document.querySelector('section[data-iteration]:not([hidden])'); if (!visibleIteration) return;
+  const sections = visibleIteration.querySelectorAll('section[id][data-nav-label]');
   nav.innerHTML = '';
   sections.forEach(sec => {
     const id = sec.id, label = sec.dataset.navLabel;

--- a/docs/concepts/2026-04-21-template-example-free.html
+++ b/docs/concepts/2026-04-21-template-example-free.html
@@ -1,0 +1,491 @@
+<!DOCTYPE html>
+<html lang="de" data-theme="dark" data-page-version="2026-04-21T10:00:00" data-template="free">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Concept — Incident 2026-04-18 Retro</title>
+<style>
+:root {
+  --bg: #0d1117; --text: #c9d1d9; --text-secondary: #8b949e;
+  --panel-bg: #161b22; --border-color: #30363d; --input-bg: #0d1117;
+  --accent-color: #58a6ff; --success-color: #3fb950; --warning-color: #d29922; --danger-color: #f85149;
+}
+html[data-theme="light"] {
+  --bg: #ffffff; --text: #24292f; --text-secondary: #57606a;
+  --panel-bg: #f6f8fa; --border-color: #d0d7de; --input-bg: #ffffff;
+  --accent-color: #0969da;
+}
+* { box-sizing: border-box; }
+body { margin: 0; background: var(--bg); color: var(--text);
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; line-height: 1.6; }
+h1, h2, h3 { font-weight: 600; letter-spacing: -0.01em; }
+button { font-family: inherit; }
+
+.concept-layout { display: flex; min-height: 100vh; }
+.concept-content { flex: 1; padding: 2rem; overflow-y: auto; }
+.concept-decision-panel {
+  width: 20%; min-width: 260px; max-width: 360px;
+  position: sticky; top: 0; height: 100vh; overflow-y: auto;
+  padding: 1.5rem; border-left: 1px solid var(--border-color); background: var(--panel-bg);
+}
+@media (max-width: 768px) {
+  .concept-layout { flex-direction: column; }
+  .concept-decision-panel { width: 100%; max-width: none; height: auto;
+    position: sticky; bottom: 0; border-left: none; border-top: 1px solid var(--border-color); }
+}
+
+header.page-header { display: flex; align-items: center; gap: 1rem; margin-bottom: 2rem;
+  border-bottom: 1px solid var(--border-color); padding-bottom: 1rem; }
+header.page-header h1 { margin: 0; font-size: 1.75rem; }
+header.page-header .subtitle { color: var(--text-secondary); margin: 0; flex: 1; }
+#theme-toggle { background: none; border: 1px solid var(--border-color); color: var(--text);
+  padding: 0.5rem 0.75rem; border-radius: 8px; cursor: pointer; }
+
+.iteration-intro { border-left: 3px solid var(--accent-color); padding: 0.75rem 1rem;
+  margin-bottom: 2rem; background: color-mix(in srgb, var(--accent-color) 8%, transparent); border-radius: 0 8px 8px 0; }
+.iteration-intro h2 { margin: 0 0 0.25rem 0; font-size: 1.1rem; }
+.iteration-intro p { margin: 0; color: var(--text-secondary); }
+
+section[id][data-nav-label] { margin-bottom: 2.5rem; padding: 1.5rem;
+  border: 1px solid var(--border-color); border-radius: 10px;
+  background: color-mix(in srgb, var(--panel-bg) 40%, transparent); }
+section[id][data-nav-label] h3 { margin-top: 0; }
+
+.metric-row { display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); gap: 1rem; margin: 1rem 0; }
+.metric-card { padding: 1rem; border-radius: 8px; background: var(--panel-bg);
+  border: 1px solid var(--border-color); }
+.metric-card .label { font-size: 0.8rem; color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.05em; }
+.metric-card .value { font-size: 1.5rem; font-weight: 700; margin-top: 0.25rem; }
+.metric-card.critical .value { color: var(--danger-color); }
+.metric-card.warn .value { color: var(--warning-color); }
+
+.timeline { border-left: 2px solid var(--border-color); margin-left: 1rem; padding-left: 1.25rem; }
+.timeline li { margin-bottom: 1rem; list-style: none; position: relative; }
+.timeline li::before { content: "●"; position: absolute; left: -1.75rem; color: var(--accent-color); }
+.timeline time { color: var(--accent-color); font-weight: 600; margin-right: 0.75rem; }
+
+.tri-state-group { display: flex; gap: 0; border: 1px solid var(--border-color);
+  border-radius: 8px; overflow: hidden; margin-top: 1rem; }
+.tri-state-option { flex: 1; display: flex; flex-direction: column; align-items: center;
+  padding: 0.75rem 1rem; cursor: pointer; text-align: center; position: relative;
+  border-right: 1px solid var(--border-color); transition: background 0.2s, box-shadow 0.2s; }
+.tri-state-option:last-child { border-right: none; }
+.tri-state-option:hover { background: color-mix(in srgb, var(--accent-color) 10%, transparent); }
+.tri-state-option input { display: none; }
+.tri-state-option:has(input:checked) .tri-state-label { font-weight: 700; }
+.tri-state-hint { font-size: 0.72rem; margin-top: 0.25rem; opacity: 0.5; transition: opacity 0.2s; }
+.tri-state-option:has(input:checked) .tri-state-hint { opacity: 1; }
+.tri-state-hint.feedback { color: var(--accent-color); }
+.tri-state-hint.action { color: var(--warning-color); }
+.tri-state-option:has(input:checked)::after {
+  content: '✓'; position: absolute; top: 4px; right: 6px; font-size: 0.7rem; font-weight: 700;
+  width: 18px; height: 18px; display: flex; align-items: center; justify-content: center;
+  border-radius: 50%; pointer-events: none; }
+.tri-state-option:has(input[value="include"]:checked) {
+  background: color-mix(in srgb, var(--accent-color) 15%, transparent);
+  box-shadow: inset 0 0 0 2px var(--accent-color); }
+.tri-state-option:has(input[value="include"]:checked)::after { background: var(--accent-color); color: white; }
+.tri-state-option:has(input[value="discard"]:checked) {
+  background: color-mix(in srgb, var(--danger-color) 12%, transparent);
+  box-shadow: inset 0 0 0 2px var(--danger-color); }
+.tri-state-option:has(input[value="discard"]:checked)::after { background: var(--danger-color); color: white; }
+.tri-state-option:has(input[value="only"]:checked) {
+  background: color-mix(in srgb, var(--success-color) 15%, transparent);
+  box-shadow: inset 0 0 0 2px var(--success-color); }
+.tri-state-option:has(input[value="only"]:checked)::after { background: var(--success-color); color: white; }
+.tri-state-option:has(input:not(:checked)) { opacity: 0.7; }
+.tri-state-option:has(input:not(:checked)):hover { opacity: 1; }
+
+.comment-field { margin-top: 1rem; }
+.comment-field textarea { width: 100%; min-height: 80px; padding: 0.75rem;
+  border: 1px solid var(--border-color); border-radius: 8px; background: var(--input-bg);
+  color: var(--text); font-family: inherit; font-size: 0.9rem; line-height: 1.5; resize: vertical; }
+.comment-field textarea:focus { outline: none; border-color: var(--accent-color); }
+
+.iteration-tabs { display: flex; flex-direction: column; gap: 4px; margin-bottom: 1rem;
+  padding-bottom: 0.75rem; border-bottom: 1px solid var(--border-color); }
+.iteration-tab { flex: 0 0 auto; text-align: left; padding: 6px 10px;
+  border: 1px solid var(--border-color); border-radius: 6px; background: transparent;
+  color: var(--text-secondary); font-size: 0.85rem; cursor: pointer; }
+.iteration-tab[aria-selected="true"] { background: color-mix(in srgb, var(--accent-color) 15%, transparent);
+  color: var(--text); border-color: var(--accent-color); font-weight: 600; }
+.iteration-tab[aria-selected="true"]::before { content: "● "; color: var(--accent-color); }
+
+.section-nav { display: flex; flex-direction: column; gap: 2px; margin-bottom: 1.5rem;
+  border-bottom: 1px solid var(--border-color); padding-bottom: 1rem; }
+.section-nav-item { display: flex; align-items: center; justify-content: space-between;
+  padding: 0.5rem 0.75rem; border-radius: 6px; text-decoration: none; color: var(--text);
+  font-size: 0.9rem; transition: background 0.15s; cursor: pointer; }
+.section-nav-item:hover { background: color-mix(in srgb, var(--accent-color) 10%, transparent); }
+.section-nav-state { font-size: 0.8rem; color: var(--accent-color); white-space: nowrap; }
+.section-nav-state.state-discard { color: var(--danger-color); }
+.section-nav-state.state-only { color: var(--success-color); }
+
+#panel-ready { position: relative; }
+.panel-warning {
+  position: absolute; inset: 0; z-index: 5;
+  display: flex; flex-direction: column; align-items: center; justify-content: center;
+  gap: 0.75rem; text-align: center; padding: 1.5rem;
+  border-radius: 10px; border: 1px solid var(--warning-color);
+  background: color-mix(in srgb, var(--panel-bg) 94%, transparent);
+  backdrop-filter: blur(4px); -webkit-backdrop-filter: blur(4px);
+  color: var(--text); }
+.panel-warning .warning-icon { font-size: 2.25rem; color: var(--warning-color); line-height: 1; }
+.panel-warning strong { color: var(--warning-color); font-size: 1rem; }
+.panel-warning .warning-message { font-size: 0.88rem; color: var(--text-secondary);
+  line-height: 1.5; max-width: 280px; margin: 0; }
+.panel-warning--connecting { border-color: var(--accent-color); }
+.panel-warning--connecting .warning-icon { color: var(--accent-color); animation: pulse-connect 1.4s ease-in-out infinite; }
+.panel-warning--connecting strong { color: var(--accent-color); }
+@keyframes pulse-connect { 0%, 100% { opacity: 0.45; } 50% { opacity: 1; } }
+.submitted-indicator { display: flex; align-items: center; gap: 0.5rem; padding: 1rem;
+  margin-bottom: 0.75rem; border-radius: 8px;
+  background: color-mix(in srgb, var(--success-color) 15%, transparent);
+  border: 1px solid var(--success-color); }
+.submitted-indicator .check-icon { font-size: 1.3rem; color: var(--success-color); }
+.submitted-hint { font-size: 0.9rem; color: var(--text-secondary); margin-bottom: 1rem; }
+.waiting-animation { display: flex; gap: 6px; justify-content: center; padding: 0.5rem 0; }
+.waiting-animation .dot { width: 8px; height: 8px; border-radius: 50%;
+  background: var(--accent-color); animation: pulse 1.4s ease-in-out infinite; }
+.waiting-animation .dot:nth-child(2) { animation-delay: 0.2s; }
+.waiting-animation .dot:nth-child(3) { animation-delay: 0.4s; }
+@keyframes pulse { 0%, 80%, 100% { opacity: 0.3; transform: scale(0.8); } 40% { opacity: 1; transform: scale(1); } }
+.submit-btn, .implement-btn { width: 100%; padding: 0.8rem 1rem; border-radius: 10px;
+  font-weight: 600; font-size: 0.95rem; cursor: pointer; margin-top: 0.5rem; font-family: inherit; }
+.submit-btn { border: none; background: var(--accent-color); color: white; }
+.submit-btn:disabled, .implement-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.submit-gap { height: 2rem; }
+.implement-btn { background: transparent; color: var(--warning-color);
+  border: 1px solid var(--warning-color);
+  display: flex; align-items: center; justify-content: center; gap: 0.5rem; }
+.implement-btn:hover { background: color-mix(in srgb, var(--warning-color) 15%, transparent); }
+.implement-btn .warn-icon { font-size: 1rem; }
+.hint-warn { color: var(--warning-color); }
+.hint { font-size: 0.8rem; color: var(--text-secondary); margin: 0.5rem 0 0 0; }
+h3 { margin-top: 1rem; font-size: 1rem; }
+.eval-hint { display: inline-block; font-size: 0.75rem; padding: 0.2rem 0.6rem;
+  border-radius: 999px; background: color-mix(in srgb, var(--accent-color) 20%, transparent);
+  color: var(--accent-color); margin-left: 0.5rem; }
+</style>
+</head>
+<body>
+<div class="concept-layout">
+  <div class="concept-content">
+    <header class="page-header">
+      <h1>Incident 2026-04-18 · Retro</h1>
+      <p class="subtitle">API-Latenz-Spike nach Deployment — Root-Cause-Analyse & Action Items</p>
+      <button id="theme-toggle">🌙/☀️</button>
+    </header>
+    <main>
+      <section id="iter-1" data-iteration="1" data-active>
+        <header class="iteration-intro">
+          <h2>Iteration 1 · Post-Mortem-Analyse</h2>
+          <p>Freies Layout: Kontext, Timeline, Findings, Actions. Nur ausgewählte Sections haben Tri-State-Eval (mit <span class="eval-hint">Bewertung</span> markiert) — der Rest ist nur-lesen.</p>
+        </header>
+
+        <section id="summary" data-nav-label="Summary">
+          <h3>Kurzfassung</h3>
+          <div class="metric-row">
+            <div class="metric-card critical"><div class="label">p99 Peak</div><div class="value">14.2 s</div></div>
+            <div class="metric-card warn"><div class="label">Dauer</div><div class="value">47 min</div></div>
+            <div class="metric-card"><div class="label">Betroffene Requests</div><div class="value">~310 k</div></div>
+            <div class="metric-card"><div class="label">Customer-Tickets</div><div class="value">8</div></div>
+          </div>
+          <p>Nach Deployment v2026.04.18-rc3 stieg die p99-Latenz aller <code>/api/search</code>-Endpoints von 280 ms auf &gt; 12 s. Rollback brachte Erholung innerhalb von 4 min.</p>
+        </section>
+
+        <section id="timeline" data-nav-label="Timeline">
+          <h3>Timeline</h3>
+          <ul class="timeline">
+            <li><time>10:14</time>Deploy v2026.04.18-rc3 (Search-Service)</li>
+            <li><time>10:19</time>Erste p99-Spikes auf Grafana-Dashboard (api-latency)</li>
+            <li><time>10:23</time>Automatischer PagerDuty-Alert (Threshold 2 s überschritten)</li>
+            <li><time>10:31</time>Incident-Lead übernimmt, Slack-Kanal <code>#inc-20260418</code> eröffnet</li>
+            <li><time>10:58</time>Rollback auf v2026.04.17 eingeleitet</li>
+            <li><time>11:02</time>Metriken normalisieren sich — Incident geschlossen</li>
+          </ul>
+        </section>
+
+        <section id="finding-index" data-nav-label="Finding: DB-Index">
+          <h3>Finding: Fehlender Composite-Index <span class="eval-hint">Bewertung</span></h3>
+          <p>Die neue Query in <code>SearchRepo.findByTenantAndStatus</code> benutzt <code>tenant_id</code> + <code>status</code>, aber nur <code>tenant_id</code> ist indexiert. Bei &gt; 2 M Rows pro Tenant führt das zu Sequential Scans.</p>
+          <p><strong>Evidenz:</strong> <code>EXPLAIN ANALYZE</code> zeigt 11.8 s Scan-Zeit für Tenant 14.</p>
+          <div class="tri-state-group">
+            <label class="tri-state-option"><input type="radio" name="eval-finding-index" value="discard"><span class="tri-state-label">Verwerfen</span></label>
+            <label class="tri-state-option"><input type="radio" name="eval-finding-index" value="include" checked><span class="tri-state-label">Miteinbeziehen</span></label>
+          </div>
+          <div class="comment-field"><textarea data-comment="finding-index" placeholder="Anmerkung zu diesem Finding…"></textarea></div>
+        </section>
+
+        <section id="finding-deploy" data-nav-label="Finding: Deploy-Gate">
+          <h3>Finding: Kein Canary für Search-Service <span class="eval-hint">Bewertung</span></h3>
+          <p>Der Search-Service wird ohne Canary-Phase direkt auf 100 % Traffic ausgerollt. Ein 5-%-Canary hätte den Spike innerhalb von 90 s sichtbar gemacht, bevor alle Nutzer betroffen sind.</p>
+          <div class="tri-state-group">
+            <label class="tri-state-option"><input type="radio" name="eval-finding-deploy" value="discard"><span class="tri-state-label">Verwerfen</span></label>
+            <label class="tri-state-option"><input type="radio" name="eval-finding-deploy" value="include" checked><span class="tri-state-label">Miteinbeziehen</span></label>
+          </div>
+          <div class="comment-field"><textarea data-comment="finding-deploy" placeholder="Anmerkung zu diesem Finding…"></textarea></div>
+        </section>
+
+        <section id="lessons" data-nav-label="Lessons learned">
+          <h3>Lessons learned (nur zur Kenntnis)</h3>
+          <ul>
+            <li>Grafana-Alerts reagieren zuverlässig — der Feedback-Loop zum On-Call funktioniert.</li>
+            <li>Rollback ist schnell (4 min), Time-to-Detect aber 9 min — hier liegt der Hebel.</li>
+            <li>Das Code-Review hat die fehlende Index-Migration übersehen, weil sie in einer Sub-PR stand.</li>
+          </ul>
+        </section>
+
+        <section id="general-comments" data-nav-label="Allgemeine Anmerkungen">
+          <h3>Allgemeine Anmerkungen</h3>
+          <div class="comment-field"><textarea data-comment="general" placeholder="Hast du weitere Gedanken zur Retro?"></textarea></div>
+        </section>
+      </section>
+    </main>
+  </div>
+
+  <aside class="concept-decision-panel">
+    <nav class="iteration-tabs" role="tablist" aria-label="Iterationen">
+      <button class="iteration-tab" role="tab" data-iteration="1" aria-selected="true">Iteration 1 · aktiv</button>
+    </nav>
+    <h3>Entscheidungen</h3>
+    <nav class="section-nav" id="section-nav" aria-label="Abschnitte"></nav>
+    <div id="panel-ready">
+      <div id="decision-summary"></div>
+      <div id="connection-connecting" class="panel-warning panel-warning--connecting" style="display: flex;">
+        <span class="warning-icon" aria-hidden="true">⋯</span>
+        <strong>Claude verbindet sich</strong>
+        <p class="warning-message">Einen Moment — die Verbindung wird aufgebaut.</p>
+      </div>
+      <div id="connection-warning" class="panel-warning" style="display: none;">
+        <span class="warning-icon" aria-hidden="true">⚠</span>
+        <strong>Claude ist nicht verbunden</strong>
+        <p class="warning-message">Submit ist pausiert, bis die Verbindung wieder steht. Deine Eingaben bleiben erhalten.</p>
+      </div>
+      <button id="submit-iterate-btn" class="primary submit-btn">Zur nächsten Iteration</button>
+      <p class="hint">Deine Auswahl geht an Claude für die nächste Iteration. Es wird kein Code geschrieben.</p>
+      <div class="submit-gap" aria-hidden="true"></div>
+      <button id="submit-implement-btn" class="implement-btn">
+        <span class="warn-icon" aria-hidden="true">⚠</span>
+        Mit Feedback implementieren
+      </button>
+      <p class="hint hint-warn">Claude setzt die Miteinbeziehen-Findings jetzt in echte Änderungen um.</p>
+    </div>
+    <div id="panel-submitted" style="display: none;">
+      <div class="submitted-indicator"><span class="check-icon">✓</span><strong>Entscheidungen übermittelt</strong></div>
+      <p class="submitted-hint">Claude verarbeitet deine Auswahl.</p>
+      <div class="waiting-animation"><span class="dot"></span><span class="dot"></span><span class="dot"></span></div>
+    </div>
+  </aside>
+</div>
+
+<script type="application/json" id="concept-decisions">
+{"submitted": false, "decisions": [], "comments": []}
+</script>
+<script>
+// --- State persistence ---
+const STORAGE_KEY = 'concept-state-' + location.pathname.split('/').pop().replace('.html', '');
+const STATE_TTL_MS = 24 * 60 * 60 * 1000;
+function saveState() {
+  const state = { _savedAt: Date.now(), _pageVersion: document.documentElement.dataset.pageVersion || '' };
+  document.querySelectorAll('input[type="checkbox"], input[type="radio"]').forEach(el => {
+    if (el.name || el.id) state['input:' + (el.name || el.id) + ':' + el.value] = el.checked; });
+  document.querySelectorAll('textarea, input[type="text"]').forEach(el => {
+    if (el.id || el.dataset.comment) state['text:' + (el.id || el.dataset.comment)] = el.value; });
+  state['theme'] = document.documentElement.getAttribute('data-theme');
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+}
+function restoreState() {
+  const raw = localStorage.getItem(STORAGE_KEY); if (!raw) return;
+  try { const state = JSON.parse(raw);
+    if (state._savedAt && (Date.now() - state._savedAt) > STATE_TTL_MS) { localStorage.removeItem(STORAGE_KEY); return; }
+    if (state._pageVersion && state._pageVersion !== (document.documentElement.dataset.pageVersion || '')) { localStorage.removeItem(STORAGE_KEY); return; }
+    if (state.theme) document.documentElement.setAttribute('data-theme', state.theme);
+    Object.entries(state).forEach(([key, value]) => {
+      if (key.startsWith('_')) return;
+      const [type, ...rest] = key.split(':');
+      if (type === 'input') {
+        const [name, val] = [rest.slice(0, -1).join(':'), rest[rest.length - 1]];
+        const el = document.querySelector(`input[name="${name}"][value="${val}"]`); if (el) el.checked = value;
+      } else if (type === 'text') {
+        const id = rest.join(':');
+        const el = document.querySelector(`[data-comment="${id}"]`) || document.getElementById(id); if (el) el.value = value;
+      }
+    });
+  } catch (e) {}
+}
+document.addEventListener('DOMContentLoaded', restoreState);
+document.addEventListener('change', saveState);
+document.addEventListener('input', saveState);
+
+// --- Section nav (free template — detects opt-in tri-state) ---
+function buildSectionNav() {
+  const nav = document.getElementById('section-nav'); if (!nav) return;
+  const active = document.querySelector('section[data-iteration][data-active]'); if (!active) return;
+  const sections = active.querySelectorAll('section[id][data-nav-label]');
+  nav.innerHTML = '';
+  sections.forEach(sec => {
+    const id = sec.id, label = sec.dataset.navLabel;
+    const hasTriState = !!sec.querySelector(`input[name="eval-${id}"]`);
+    const link = document.createElement('a');
+    link.href = '#' + id; link.className = 'section-nav-item'; link.dataset.sectionId = id;
+    if (hasTriState) link.setAttribute('data-variant', '');
+    const labelEl = document.createElement('span'); labelEl.className = 'section-nav-label'; labelEl.textContent = label;
+    link.appendChild(labelEl);
+    if (hasTriState) { const s = document.createElement('span'); s.className = 'section-nav-state'; link.appendChild(s); }
+    nav.appendChild(link);
+  });
+  updateSectionNavState();
+}
+function updateSectionNavState() {
+  const labels = { include: 'Miteinbeziehen', discard: 'Verwerfen', only: 'Exakt diese' };
+  document.querySelectorAll('.section-nav-item[data-variant]').forEach(link => {
+    const id = link.dataset.sectionId;
+    const checked = document.querySelector(`input[name="eval-${id}"]:checked`);
+    const currentState = checked ? checked.value : 'include';
+    const stateEl = link.querySelector('.section-nav-state');
+    if (stateEl) { stateEl.textContent = labels[currentState] || currentState; stateEl.className = 'section-nav-state state-' + currentState; }
+  });
+}
+document.addEventListener('click', e => {
+  const link = e.target.closest('.section-nav-item'); if (!link) return;
+  e.preventDefault();
+  const target = document.querySelector(link.getAttribute('href'));
+  if (target) target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+});
+document.addEventListener('change', updateSectionNavState);
+
+// --- Iteration tabs ---
+function showIteration(n) {
+  document.querySelectorAll('section[data-iteration]').forEach(sec => { sec.hidden = String(sec.dataset.iteration) !== String(n); });
+  document.querySelectorAll('.iteration-tab').forEach(tab => {
+    tab.setAttribute('aria-selected', String(tab.dataset.iteration) === String(n) ? 'true' : 'false'); });
+  const activeSec = document.querySelector('section[data-iteration][data-active]');
+  const isLive = activeSec && String(activeSec.dataset.iteration) === String(n);
+  const panelReady = document.getElementById('panel-ready');
+  const panelSubmitted = document.getElementById('panel-submitted');
+  if (panelReady) panelReady.style.display = isLive ? 'block' : 'none';
+  if (panelSubmitted) {
+    const submitted = document.body.classList.contains('concept-submitted');
+    panelSubmitted.style.display = (isLive && submitted) ? 'block' : 'none';
+  }
+  buildSectionNav();
+  document.dispatchEvent(new CustomEvent('iteration:changed'));
+}
+document.querySelectorAll('.iteration-tab').forEach(tab => tab.addEventListener('click', () => showIteration(tab.dataset.iteration)));
+document.addEventListener('DOMContentLoaded', () => {
+  const active = document.querySelector('section[data-iteration][data-active]');
+  if (active) showIteration(active.dataset.iteration);
+});
+
+// --- Theme ---
+document.getElementById('theme-toggle').addEventListener('click', () => {
+  const html = document.documentElement;
+  html.setAttribute('data-theme', html.getAttribute('data-theme') === 'dark' ? 'light' : 'dark');
+});
+
+// --- collectDecisions (free branch) ---
+function collectFreeDecisions() {
+  const decisions = [];
+  document.querySelectorAll('section[id][data-nav-label]').forEach(sec => {
+    const radio = sec.querySelector(`input[name="eval-${CSS.escape(sec.id)}"]:checked`);
+    if (!radio) return;
+    decisions.push({ id: sec.id, label: sec.dataset.navLabel || sec.id, evaluation: radio.value });
+  });
+  const comments = [];
+  document.querySelectorAll('[data-comment]').forEach(el => {
+    if (el.value.trim()) comments.push({ id: el.dataset.comment, text: el.value.trim() });
+  });
+  return { submitted: true, template: 'free', decisions, comments };
+}
+function collectDecisions(action = 'iterate') {
+  const data = collectFreeDecisions();
+  data.action = action;
+  return data;
+}
+
+// --- Submit + heartbeat ---
+let _submittedAt = 0;
+async function submitWithAction(action) {
+  const data = collectDecisions(action);
+  document.getElementById('concept-decisions').textContent = JSON.stringify(data);
+  document.body.classList.add('concept-submitted');
+  _submittedAt = Date.now();
+  document.getElementById('panel-ready').style.display = 'none';
+  document.getElementById('panel-submitted').style.display = 'block';
+  try { await fetch('/decisions', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(data) }); }
+  catch (e) { localStorage.setItem(STORAGE_KEY + '-pending', JSON.stringify(data)); }
+  saveState();
+}
+document.getElementById('submit-iterate-btn').addEventListener('click', () => submitWithAction('iterate'));
+document.getElementById('submit-implement-btn').addEventListener('click', () => {
+  if (!confirm('Mit Feedback echt implementieren? Claude schreibt jetzt Code-Änderungen.')) return;
+  submitWithAction('implement');
+});
+async function retryPendingSubmission() {
+  const pending = localStorage.getItem(STORAGE_KEY + '-pending'); if (!pending) return;
+  try { const res = await fetch('/decisions', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: pending });
+    if (res.ok) localStorage.removeItem(STORAGE_KEY + '-pending'); } catch (e) {}
+}
+function restorePanelToReady() {
+  document.getElementById('panel-submitted').style.display = 'none';
+  document.getElementById('panel-ready').style.display = 'block';
+  ['submit-iterate-btn', 'submit-implement-btn'].forEach(id => {
+    const btn = document.getElementById(id); if (btn) btn.disabled = false;
+  });
+  document.body.classList.remove('concept-submitted'); _submittedAt = 0;
+  localStorage.removeItem(STORAGE_KEY);
+}
+const HEARTBEAT_STALE_MS = 90000, HEARTBEAT_GRACE_MS = 30000;
+const _pageLoadedAt = Date.now(); let _lastHeartbeatTs = 0;
+async function pollHeartbeat() {
+  try { const res = await fetch('/heartbeat', { cache: 'no-store' }); const data = await res.json(); _lastHeartbeatTs = data.ts || 0; } catch (e) {}
+}
+async function pollProcessedState() {
+  if (!_submittedAt) return;
+  try { const res = await fetch('/decisions', { cache: 'no-store' }); const data = await res.json();
+    const processedIso = data && data._processed_at; if (!processedIso) return;
+    const processedMs = Date.parse(processedIso);
+    if (Number.isFinite(processedMs) && processedMs > _submittedAt) restorePanelToReady();
+  } catch (e) {}
+}
+function checkClaudeConnection() {
+  const isConnected = _lastHeartbeatTs && (Date.now() - _lastHeartbeatTs) < HEARTBEAT_STALE_MS;
+  const inGrace = Date.now() - _pageLoadedAt < HEARTBEAT_GRACE_MS;
+  const connecting = document.getElementById('connection-connecting');
+  const warning = document.getElementById('connection-warning');
+  const btns = ['submit-iterate-btn', 'submit-implement-btn']
+    .map(id => document.getElementById(id)).filter(Boolean);
+  const panelSubmitted = document.getElementById('panel-submitted');
+  if (panelSubmitted && panelSubmitted.style.display !== 'none') return;
+  if (isConnected) {
+    if (connecting) connecting.style.display = 'none';
+    if (warning) warning.style.display = 'none';
+    btns.forEach(b => b.disabled = false);
+    retryPendingSubmission();
+  } else if (inGrace) {
+    if (connecting) connecting.style.display = 'flex';
+    if (warning) warning.style.display = 'none';
+    btns.forEach(b => b.disabled = false);
+  } else {
+    if (connecting) connecting.style.display = 'none';
+    if (warning) warning.style.display = 'flex';
+    btns.forEach(b => b.disabled = false);
+  }
+}
+setInterval(async () => { await pollHeartbeat(); checkClaudeConnection(); await pollProcessedState(); }, 5000);
+
+// --- Reload poller ---
+let _bootReloadCounter = null;
+async function pollReload() {
+  try { const res = await fetch('/reload', { cache: 'no-store' }); if (!res.ok) return;
+    const { counter } = await res.json();
+    if (_bootReloadCounter === null) { _bootReloadCounter = counter; return; }
+    if (counter > _bootReloadCounter) location.reload();
+  } catch (e) {}
+}
+setInterval(pollReload, 3000);
+document.addEventListener('DOMContentLoaded', pollReload);
+</script>
+</body>
+</html>

--- a/docs/concepts/2026-04-21-template-example-free.html
+++ b/docs/concepts/2026-04-21-template-example-free.html
@@ -124,11 +124,12 @@ section[id][data-nav-label] h3 { margin-top: 0; }
 #panel-ready { position: relative; }
 .panel-warning {
   position: absolute; inset: 0; z-index: 5;
+  pointer-events: none;
   display: flex; flex-direction: column; align-items: center; justify-content: center;
   gap: 0.75rem; text-align: center; padding: 1.5rem;
   border-radius: 10px; border: 1px solid var(--warning-color);
-  background: color-mix(in srgb, var(--panel-bg) 94%, transparent);
-  backdrop-filter: blur(4px); -webkit-backdrop-filter: blur(4px);
+  background: color-mix(in srgb, var(--panel-bg) 70%, transparent);
+  backdrop-filter: blur(2px); -webkit-backdrop-filter: blur(2px);
   color: var(--text); }
 .panel-warning .warning-icon { font-size: 2.25rem; color: var(--warning-color); line-height: 1; }
 .panel-warning strong { color: var(--warning-color); font-size: 1rem; }
@@ -260,7 +261,7 @@ h3 { margin-top: 1rem; font-size: 1rem; }
       <div id="connection-warning" class="panel-warning" style="display: none;">
         <span class="warning-icon" aria-hidden="true">⚠</span>
         <strong>Claude ist nicht verbunden</strong>
-        <p class="warning-message">Submit ist pausiert, bis die Verbindung wieder steht. Deine Eingaben bleiben erhalten.</p>
+        <p class="warning-message">Du kannst trotzdem absenden — der Klick wird gespeichert und gesendet, sobald Claude wieder da ist.</p>
       </div>
       <button id="submit-iterate-btn" class="primary submit-btn">Zur nächsten Iteration</button>
       <p class="hint">Deine Auswahl geht an Claude für die nächste Iteration. Es wird kein Code geschrieben.</p>
@@ -321,8 +322,9 @@ document.addEventListener('input', saveState);
 // --- Section nav (free template — detects opt-in tri-state) ---
 function buildSectionNav() {
   const nav = document.getElementById('section-nav'); if (!nav) return;
-  const active = document.querySelector('section[data-iteration][data-active]'); if (!active) return;
-  const sections = active.querySelectorAll('section[id][data-nav-label]');
+  // Use :not([hidden]) so the nav reflects the VISIBLE iteration, not live.
+  const visible = document.querySelector('section[data-iteration]:not([hidden])'); if (!visible) return;
+  const sections = visible.querySelectorAll('section[id][data-nav-label]');
   nav.innerHTML = '';
   sections.forEach(sec => {
     const id = sec.id, label = sec.dataset.navLabel;

--- a/docs/concepts/2026-04-21-template-example-prototype.html
+++ b/docs/concepts/2026-04-21-template-example-prototype.html
@@ -1,0 +1,645 @@
+<!DOCTYPE html>
+<html lang="de" data-theme="dark" data-page-version="2026-04-21T10:00:00" data-template="prototype">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Concept — Onboarding-Flow Prototype</title>
+<style>
+:root {
+  --bg: #0d1117; --text: #c9d1d9; --text-secondary: #8b949e;
+  --panel-bg: #161b22; --border-color: #30363d; --input-bg: #0d1117;
+  --accent-color: #58a6ff; --success-color: #3fb950; --warning-color: #d29922; --danger-color: #f85149;
+}
+html[data-theme="light"] {
+  --bg: #ffffff; --text: #24292f; --text-secondary: #57606a;
+  --panel-bg: #f6f8fa; --border-color: #d0d7de; --input-bg: #ffffff;
+  --accent-color: #0969da;
+}
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; height: 100%; }
+body { background: var(--bg); color: var(--text);
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; line-height: 1.6;
+  overflow: hidden; }
+button { font-family: inherit; }
+
+.concept-layout.prototype.fullscreen { display: block; width: 100vw; height: 100vh; overflow: hidden; }
+.concept-layout.prototype .concept-content { position: absolute; inset: 0; overflow: hidden; }
+
+/* Each iteration fills the full viewport. Only the active iteration is
+   shown; within the active iteration, exactly one screen is visible. */
+section[data-iteration] { position: absolute; inset: 0; }
+section[data-iteration][hidden] { display: none; }
+
+/* Full-viewport prototype screens — one visible at a time */
+section[data-screen] {
+  position: absolute; inset: 0;
+  display: flex; align-items: center; justify-content: center;
+  padding: 2rem;
+  background: linear-gradient(135deg,
+    color-mix(in srgb, var(--accent-color) 6%, var(--bg)),
+    var(--bg));
+  overflow-y: auto;
+}
+section[data-screen][hidden] { display: none; }
+
+/* Device-like frame that holds the mocked screen content */
+.device-frame {
+  width: 100%; max-width: 420px;
+  background: var(--panel-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 24px;
+  box-shadow: 0 24px 80px rgba(0,0,0,0.55), 0 2px 0 color-mix(in srgb, var(--accent-color) 30%, transparent) inset;
+  padding: 2rem;
+  display: flex; flex-direction: column; gap: 1rem;
+}
+.device-frame h4 { margin: 0; font-size: 1.3rem; }
+.device-frame p { margin: 0; color: var(--text-secondary); font-size: 0.95rem; }
+.mock-input { padding: 0.75rem 1rem; border: 1px solid var(--border-color); border-radius: 10px;
+  background: var(--input-bg); color: var(--text-secondary); font-size: 0.95rem; }
+.mock-btn { padding: 0.8rem 1rem; border: none; border-radius: 10px; background: var(--accent-color);
+  color: white; font-weight: 600; font-size: 1rem; text-align: center; cursor: pointer; }
+.mock-btn.secondary { background: transparent; color: var(--accent-color); border: 1px solid var(--accent-color); }
+.mock-divider { height: 1px; background: var(--border-color); margin: 0.5rem 0; }
+.mock-check { display: flex; align-items: center; gap: 0.6rem; font-size: 0.9rem; color: var(--text-secondary); }
+.mock-check::before { content: "☐"; font-size: 1.1rem; }
+.mock-hero { display: flex; align-items: center; justify-content: center;
+  padding: 2rem; font-size: 4rem; border-radius: 14px;
+  background: color-mix(in srgb, var(--accent-color) 12%, transparent); }
+.mock-hero.success { background: color-mix(in srgb, var(--success-color) 14%, transparent); }
+
+/* Subtle screen-counter overlay (top-left) */
+.screen-indicator {
+  position: fixed; top: 1rem; left: 1rem; z-index: 90;
+  padding: 0.4rem 0.75rem; border-radius: 999px;
+  background: color-mix(in srgb, var(--panel-bg) 85%, transparent);
+  border: 1px solid var(--border-color);
+  color: var(--text-secondary); font-size: 0.8rem;
+  backdrop-filter: blur(6px);
+}
+.screen-indicator strong { color: var(--text); }
+
+/* ── Panel FAB + overlay ── */
+.panel-fab, .feedback-fab {
+  position: fixed; width: 56px; height: 56px; border-radius: 50%; border: none;
+  color: white; font-size: 1.5rem; cursor: pointer;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.35); z-index: 100;
+  transition: transform 0.2s, opacity 0.2s;
+  display: flex; align-items: center; justify-content: center; }
+.panel-fab { bottom: 2rem; right: 2rem; background: var(--accent-color); }
+.feedback-fab { bottom: 2rem; left: 2rem; background: var(--warning-color); }
+.panel-fab:hover, .feedback-fab:hover { transform: scale(1.1); }
+.panel-fab.hidden, .feedback-fab.hidden { opacity: 0; pointer-events: none; }
+
+.concept-layout.prototype .concept-decision-panel {
+  display: flex; flex-direction: column;
+  position: fixed; top: 0; right: -440px; width: 400px; max-width: 92vw;
+  height: 100vh; padding: 1.5rem;
+  background: var(--panel-bg); border-left: 1px solid var(--border-color);
+  z-index: 200; overflow-y: auto; transition: right 0.3s ease; }
+.concept-layout.prototype .concept-decision-panel.open { right: 0; }
+.panel-close-btn, .feedback-close-btn { align-self: flex-end; background: none; border: none;
+  color: var(--text); font-size: 1.5rem; cursor: pointer; padding: 0.25rem; }
+.panel-backdrop { display: none; position: fixed; inset: 0;
+  background: rgba(0,0,0,0.55); z-index: 150; }
+.panel-backdrop.visible { display: block; }
+
+/* ── Screen navigation (inside ☰ panel) ── */
+.screen-nav { display: flex; flex-direction: column; gap: 4px;
+  margin-bottom: 1.5rem; padding-bottom: 1rem; border-bottom: 1px solid var(--border-color); }
+.screen-nav-item { display: flex; align-items: center; justify-content: space-between;
+  padding: 0.6rem 0.85rem; border-radius: 8px; text-decoration: none; color: var(--text);
+  font-size: 0.95rem; border: 1px solid var(--border-color); background: transparent;
+  cursor: pointer; transition: all 0.15s; text-align: left; }
+.screen-nav-item:hover { background: color-mix(in srgb, var(--accent-color) 10%, transparent); }
+.screen-nav-item[data-active="true"] { background: color-mix(in srgb, var(--accent-color) 18%, transparent);
+  border-color: var(--accent-color); font-weight: 600; }
+.screen-nav-item .screen-idx { color: var(--accent-color); font-weight: 600; margin-right: 0.5rem; }
+.screen-nav-item .has-notes { color: var(--warning-color); font-size: 0.75rem; }
+
+/* ── Feedback dock ── */
+.feedback-dock {
+  position: fixed; left: 0; right: 0; bottom: -100%; max-height: 70vh;
+  padding: 1.5rem; background: var(--panel-bg);
+  border-top: 1px solid var(--border-color);
+  box-shadow: 0 -6px 20px rgba(0,0,0,0.35); z-index: 180; overflow-y: auto;
+  transition: bottom 0.3s ease; display: flex; flex-direction: column; gap: 1.25rem; }
+.feedback-dock[data-open="true"] { bottom: 0; }
+.feedback-dock-header { display: flex; justify-content: space-between; align-items: center; }
+.feedback-dock-header strong { font-size: 1.05rem; }
+.feedback-section { display: flex; flex-direction: column; gap: 0.4rem; }
+.feedback-section label { font-size: 0.9rem; color: var(--text-secondary); font-weight: 500; }
+.feedback-section label strong { color: var(--accent-color); }
+.feedback-section textarea { width: 100%; padding: 0.8rem; border: 1px solid var(--border-color);
+  border-radius: 10px; background: var(--input-bg); color: var(--text);
+  font-family: inherit; font-size: 0.95rem; line-height: 1.5; resize: vertical; min-height: 90px; }
+.feedback-section textarea:focus { outline: none; border-color: var(--accent-color); }
+.feedback-divider { height: 1px; background: var(--border-color); margin: 0.25rem 0; }
+
+/* ── Iteration tabs in ☰ panel ── */
+.iteration-tabs { display: flex; flex-direction: column; gap: 4px; margin-bottom: 1rem;
+  padding-bottom: 0.75rem; border-bottom: 1px solid var(--border-color); }
+.iteration-tab { flex: 0 0 auto; text-align: left; padding: 6px 10px;
+  border: 1px solid var(--border-color); border-radius: 6px; background: transparent;
+  color: var(--text-secondary); font-size: 0.85rem; cursor: pointer; }
+.iteration-tab[aria-selected="true"] { background: color-mix(in srgb, var(--accent-color) 15%, transparent);
+  color: var(--text); border-color: var(--accent-color); font-weight: 600; }
+.iteration-tab[aria-selected="true"]::before { content: "● "; color: var(--accent-color); }
+
+/* Panel header (title + theme toggle) */
+.panel-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 1rem; }
+.panel-header h3 { margin: 0; font-size: 1rem; }
+.panel-header .panel-subtitle { margin: 0; font-size: 0.85rem; color: var(--text-secondary); }
+#theme-toggle { background: none; border: 1px solid var(--border-color); color: var(--text);
+  padding: 0.4rem 0.6rem; border-radius: 6px; cursor: pointer; font-size: 0.85rem; }
+
+#panel-ready { position: relative; }
+.panel-warning {
+  position: absolute; inset: 0; z-index: 5;
+  display: flex; flex-direction: column; align-items: center; justify-content: center;
+  gap: 0.75rem; text-align: center; padding: 1.5rem;
+  border-radius: 10px; border: 1px solid var(--warning-color);
+  background: color-mix(in srgb, var(--panel-bg) 94%, transparent);
+  backdrop-filter: blur(4px); -webkit-backdrop-filter: blur(4px);
+  color: var(--text); }
+.panel-warning .warning-icon { font-size: 2.25rem; color: var(--warning-color); line-height: 1; }
+.panel-warning strong { color: var(--warning-color); font-size: 1rem; }
+.panel-warning .warning-message { font-size: 0.88rem; color: var(--text-secondary);
+  line-height: 1.5; max-width: 280px; margin: 0; }
+.panel-warning--connecting { border-color: var(--accent-color); }
+.panel-warning--connecting .warning-icon { color: var(--accent-color); animation: pulse-connect 1.4s ease-in-out infinite; }
+.panel-warning--connecting strong { color: var(--accent-color); }
+@keyframes pulse-connect { 0%, 100% { opacity: 0.45; } 50% { opacity: 1; } }
+.submitted-indicator { display: flex; align-items: center; gap: 0.5rem; padding: 1rem;
+  margin-bottom: 0.75rem; border-radius: 8px;
+  background: color-mix(in srgb, var(--success-color) 15%, transparent);
+  border: 1px solid var(--success-color); }
+.submitted-indicator .check-icon { font-size: 1.3rem; color: var(--success-color); }
+.submitted-hint { font-size: 0.9rem; color: var(--text-secondary); margin-bottom: 1rem; }
+.waiting-animation { display: flex; gap: 6px; justify-content: center; padding: 0.5rem 0; }
+.waiting-animation .dot { width: 8px; height: 8px; border-radius: 50%;
+  background: var(--accent-color); animation: pulse 1.4s ease-in-out infinite; }
+.waiting-animation .dot:nth-child(2) { animation-delay: 0.2s; }
+.waiting-animation .dot:nth-child(3) { animation-delay: 0.4s; }
+@keyframes pulse { 0%, 80%, 100% { opacity: 0.3; transform: scale(0.8); } 40% { opacity: 1; transform: scale(1); } }
+.submit-btn, .implement-btn { width: 100%; padding: 0.85rem 1rem; border-radius: 10px;
+  font-weight: 600; font-size: 0.95rem; cursor: pointer; margin-top: 0.5rem; font-family: inherit; }
+.submit-btn { border: none; background: var(--accent-color); color: white; }
+.submit-btn:disabled, .implement-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.submit-gap { height: 2rem; }
+.implement-btn { background: transparent; color: var(--warning-color);
+  border: 1px solid var(--warning-color);
+  display: flex; align-items: center; justify-content: center; gap: 0.5rem; }
+.implement-btn:hover { background: color-mix(in srgb, var(--warning-color) 15%, transparent); }
+.implement-btn .warn-icon { font-size: 1rem; }
+.hint-warn { color: var(--warning-color); }
+.hint { font-size: 0.8rem; color: var(--text-secondary); margin: 0.5rem 0 0 0; }
+
+/* Screen transitions */
+section[data-screen] { animation: screen-in 0.25s ease; }
+@keyframes screen-in { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: translateY(0); } }
+
+.section-nav { display: none; }
+
+/* Single-screen prototype: hide screen-nav + per-screen feedback */
+body[data-single-screen="true"] #screen-nav,
+body[data-single-screen="true"] .feedback-section:has(#screen-textareas) { display: none; }
+</style>
+</head>
+<body>
+<div class="concept-layout prototype fullscreen">
+  <div class="concept-content">
+    <main>
+      <section data-iteration="1" data-active>
+        <section id="screen-welcome" data-screen data-nav-label="Welcome" data-screen-active="true">
+          <div class="device-frame">
+            <div class="mock-hero">👋</div>
+            <h4>Willkommen bei Orbit</h4>
+            <p>Starte in wenigen Schritten — wir holen dich dort ab, wo du bist.</p>
+            <div class="mock-divider"></div>
+            <button class="mock-btn" data-screen-link="screen-credentials">Los geht's →</button>
+            <button class="mock-btn secondary" data-screen-link="screen-success">Bereits Konto? Anmelden</button>
+          </div>
+        </section>
+
+        <section id="screen-credentials" data-screen data-nav-label="Credentials" hidden>
+          <div class="device-frame">
+            <h4>Account anlegen</h4>
+            <p>E-Mail und Passwort wählen.</p>
+            <div class="mock-input">name@firma.de</div>
+            <div class="mock-input">••••••••</div>
+            <div class="mock-check">Ich akzeptiere AGB & Datenschutz</div>
+            <div class="mock-divider"></div>
+            <button class="mock-btn" data-screen-link="screen-success">Konto erstellen →</button>
+            <button class="mock-btn secondary" data-screen-link="prev">← Zurück</button>
+          </div>
+        </section>
+
+        <section id="screen-success" data-screen data-nav-label="Success" hidden>
+          <div class="device-frame">
+            <div class="mock-hero success">✓</div>
+            <h4>Alles bereit</h4>
+            <p>Dein Workspace ist eingerichtet. Wir haben dir eine Willkommens-Mail geschickt.</p>
+            <div class="mock-divider"></div>
+            <button class="mock-btn" data-screen-link="screen-welcome">Zum Dashboard ↺</button>
+            <p style="text-align:center; font-size:0.85rem; color:var(--text-secondary); margin: 0;">Demo: "Zum Dashboard" startet den Flow von vorn.</p>
+          </div>
+        </section>
+      </section>
+    </main>
+  </div>
+
+  <!-- Screen counter overlay -->
+  <div class="screen-indicator">
+    Screen <strong id="active-screen-idx">1</strong> / <span id="total-screens">3</span> · <span id="active-screen-label">Welcome</span>
+  </div>
+
+  <!-- FABs -->
+  <button id="panel-toggle" class="panel-fab" aria-label="Entscheidungen öffnen">☰</button>
+  <button id="feedback-toggle" class="feedback-fab" aria-label="Feedback öffnen">💬</button>
+
+  <!-- Decision panel (☰) -->
+  <aside class="concept-decision-panel" id="decision-panel">
+    <button id="panel-close" class="panel-close-btn" aria-label="Schliessen">✕</button>
+    <div class="panel-header">
+      <div>
+        <h3>Onboarding-Flow</h3>
+        <p class="panel-subtitle">3-Schritt Registrierung</p>
+      </div>
+      <button id="theme-toggle">🌙/☀️</button>
+    </div>
+    <nav class="iteration-tabs" role="tablist" aria-label="Iterationen">
+      <button class="iteration-tab" role="tab" data-iteration="1" aria-selected="true">Iteration 1 · aktiv</button>
+    </nav>
+    <nav class="screen-nav" id="screen-nav" aria-label="Screens">
+      <!-- auto-populated -->
+    </nav>
+    <div id="panel-ready">
+      <div id="connection-connecting" class="panel-warning panel-warning--connecting" style="display: flex;">
+        <span class="warning-icon" aria-hidden="true">⋯</span>
+        <strong>Claude verbindet sich</strong>
+        <p class="warning-message">Einen Moment — die Verbindung wird aufgebaut.</p>
+      </div>
+      <div id="connection-warning" class="panel-warning" style="display: none;">
+        <span class="warning-icon" aria-hidden="true">⚠</span>
+        <strong>Claude ist nicht verbunden</strong>
+        <p class="warning-message">Submit ist pausiert, bis die Verbindung wieder steht. Deine Eingaben bleiben erhalten.</p>
+      </div>
+      <button id="submit-iterate-btn" class="primary submit-btn">Zur nächsten Iteration</button>
+      <p class="hint">Per-Screen-Notizen + allgemeine Anmerkungen gehen an Claude. Kein Code wird geschrieben.</p>
+      <div class="submit-gap" aria-hidden="true"></div>
+      <button id="submit-implement-btn" class="implement-btn">
+        <span class="warn-icon" aria-hidden="true">⚠</span>
+        Mit Feedback implementieren
+      </button>
+      <p class="hint hint-warn">Claude baut den Prototyp jetzt als echten Code um.</p>
+    </div>
+    <div id="panel-submitted" style="display: none;">
+      <div class="submitted-indicator"><span class="check-icon">✓</span><strong>Feedback übermittelt</strong></div>
+      <p class="submitted-hint">Claude verarbeitet deine Notizen.</p>
+      <div class="waiting-animation"><span class="dot"></span><span class="dot"></span><span class="dot"></span></div>
+    </div>
+  </aside>
+  <div class="panel-backdrop" id="panel-backdrop"></div>
+
+  <!-- Feedback dock (💬) — current screen + general -->
+  <aside class="feedback-dock" id="feedback-dock" data-open="false">
+    <div class="feedback-dock-header">
+      <strong>Feedback</strong>
+      <button id="feedback-close" class="feedback-close-btn" aria-label="Schliessen">✕</button>
+    </div>
+
+    <div class="feedback-section">
+      <label>Aktueller Screen: <strong id="dock-screen-label">Welcome</strong></label>
+      <!-- One textarea per screen; only the active one is visible. They all
+           live in the DOM so their state is independently persisted. -->
+      <div id="screen-textareas">
+        <!-- auto-populated, one textarea per data-screen -->
+      </div>
+    </div>
+
+    <div class="feedback-divider"></div>
+
+    <div class="feedback-section">
+      <label>Allgemeine Anmerkungen (screen-übergreifend)</label>
+      <textarea id="proto-general-feedback" data-comment="general"
+                placeholder="Allgemeine Gedanken zum Prototyp — bleibt bei jedem Screen sichtbar."></textarea>
+    </div>
+  </aside>
+
+  <section class="section-nav" id="section-nav" aria-hidden="true"></section>
+</div>
+
+<script type="application/json" id="concept-decisions">
+{"submitted": false, "decisions": [], "comments": []}
+</script>
+<script>
+// --- State persistence ---
+const STORAGE_KEY = 'concept-state-' + location.pathname.split('/').pop().replace('.html', '');
+const STATE_TTL_MS = 24 * 60 * 60 * 1000;
+function saveState() {
+  const state = {
+    _savedAt: Date.now(),
+    _pageVersion: document.documentElement.dataset.pageVersion || '',
+    _activeScreen: document.querySelector('[data-screen][data-screen-active="true"]')?.id || ''
+  };
+  document.querySelectorAll('textarea, input[type="text"]').forEach(el => {
+    if (el.id || el.dataset.comment) state['text:' + (el.id || el.dataset.comment)] = el.value;
+  });
+  state['theme'] = document.documentElement.getAttribute('data-theme');
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+}
+function restoreState() {
+  const raw = localStorage.getItem(STORAGE_KEY); if (!raw) return null;
+  try {
+    const state = JSON.parse(raw);
+    if (state._savedAt && (Date.now() - state._savedAt) > STATE_TTL_MS) { localStorage.removeItem(STORAGE_KEY); return null; }
+    if (state._pageVersion && state._pageVersion !== (document.documentElement.dataset.pageVersion || '')) { localStorage.removeItem(STORAGE_KEY); return null; }
+    if (state.theme) document.documentElement.setAttribute('data-theme', state.theme);
+    Object.entries(state).forEach(([key, value]) => {
+      if (key.startsWith('_')) return;
+      const [type, ...rest] = key.split(':');
+      if (type === 'text') {
+        const id = rest.join(':');
+        const el = document.querySelector(`[data-comment="${id}"]`) || document.getElementById(id);
+        if (el) el.value = value;
+      }
+    });
+    return state;
+  } catch (e) { return null; }
+}
+document.addEventListener('change', saveState);
+document.addEventListener('input', saveState);
+
+// --- Build screen textareas and screen-nav ---
+function buildScreenUI() {
+  const active = document.querySelector('section[data-iteration][data-active]'); if (!active) return;
+  const screens = [...active.querySelectorAll('section[data-screen][id]')];
+  const total = screens.length;
+  document.getElementById('total-screens').textContent = total;
+
+  // Single-screen: hide screen-nav + per-screen feedback (only general notes)
+  document.body.dataset.singleScreen = total <= 1 ? 'true' : 'false';
+  if (total <= 1) {
+    const indicator = document.querySelector('.screen-indicator');
+    if (indicator) indicator.style.display = 'none';
+  }
+
+  // Screen-nav in ☰
+  const nav = document.getElementById('screen-nav'); nav.innerHTML = '';
+  screens.forEach((sec, idx) => {
+    const btn = document.createElement('button');
+    btn.className = 'screen-nav-item'; btn.dataset.screenId = sec.id;
+    btn.innerHTML = `<span><span class="screen-idx">${idx + 1}.</span>${sec.dataset.navLabel || sec.id}</span>
+      <span class="has-notes" data-note-marker></span>`;
+    btn.addEventListener('click', () => { showScreen(sec.id); closePanel(); });
+    nav.appendChild(btn);
+  });
+
+  // Per-screen textareas in feedback dock
+  const container = document.getElementById('screen-textareas'); container.innerHTML = '';
+  screens.forEach(sec => {
+    const ta = document.createElement('textarea');
+    ta.dataset.comment = sec.id; ta.dataset.screenComment = sec.id;
+    ta.placeholder = `Notiz zu ${sec.dataset.navLabel || sec.id}…`;
+    ta.hidden = true;
+    container.appendChild(ta);
+  });
+}
+
+function showScreen(id) {
+  const screens = document.querySelectorAll('section[data-iteration][data-active] section[data-screen][id]');
+  let idx = 0;
+  screens.forEach((s, i) => {
+    const match = s.id === id;
+    s.hidden = !match;
+    s.dataset.screenActive = match ? 'true' : 'false';
+    if (match) idx = i;
+  });
+  // Indicator
+  const screen = document.getElementById(id);
+  const label = screen?.dataset.navLabel || id;
+  document.getElementById('active-screen-label').textContent = label;
+  document.getElementById('active-screen-idx').textContent = idx + 1;
+  document.getElementById('dock-screen-label').textContent = label;
+  // Dock: show matching textarea
+  document.querySelectorAll('[data-screen-comment]').forEach(ta => {
+    ta.hidden = ta.dataset.screenComment !== id;
+  });
+  // Nav: active
+  document.querySelectorAll('.screen-nav-item').forEach(item => {
+    item.dataset.active = String(item.dataset.screenId === id);
+  });
+  updateNoteMarkers();
+  saveState();
+}
+
+function updateNoteMarkers() {
+  document.querySelectorAll('.screen-nav-item').forEach(item => {
+    const id = item.dataset.screenId;
+    const ta = document.querySelector(`[data-screen-comment="${id}"]`);
+    const marker = item.querySelector('[data-note-marker]');
+    if (marker) marker.textContent = (ta && ta.value.trim()) ? '● Notiz' : '';
+  });
+}
+
+// --- Panel toggle ---
+const panel = document.getElementById('decision-panel');
+const panelToggle = document.getElementById('panel-toggle');
+const panelCloseBtn = document.getElementById('panel-close');
+const backdrop = document.getElementById('panel-backdrop');
+function openPanel() { panel.classList.add('open'); backdrop.classList.add('visible'); panelToggle.classList.add('hidden'); }
+function closePanel() { panel.classList.remove('open'); backdrop.classList.remove('visible'); panelToggle.classList.remove('hidden'); }
+panelToggle.addEventListener('click', openPanel);
+panelCloseBtn.addEventListener('click', closePanel);
+backdrop.addEventListener('click', closePanel);
+
+// Dock toggle
+const dock = document.getElementById('feedback-dock');
+const dockToggle = document.getElementById('feedback-toggle');
+const dockClose = document.getElementById('feedback-close');
+function closeDock() { dock.dataset.open = 'false'; dockToggle.classList.remove('hidden'); }
+dockToggle.addEventListener('click', () => { dock.dataset.open = 'true'; dockToggle.classList.add('hidden'); });
+dockClose.addEventListener('click', closeDock);
+
+// Click outside the dock (anywhere on the prototype screen) closes it.
+// Uses capture so it runs before other handlers; returns early when the
+// click originated inside the dock or on its toggle FAB.
+document.addEventListener('click', (e) => {
+  if (dock.dataset.open !== 'true') return;
+  if (e.target.closest('#feedback-dock')) return;
+  if (e.target.closest('#feedback-toggle')) return;
+  closeDock();
+}, true);
+
+// --- Iteration tabs (single iteration here but same mechanism) ---
+function showIteration(n) {
+  document.querySelectorAll('section[data-iteration]').forEach(sec => {
+    sec.hidden = String(sec.dataset.iteration) !== String(n);
+  });
+  document.querySelectorAll('.iteration-tab').forEach(tab => {
+    tab.setAttribute('aria-selected', String(tab.dataset.iteration) === String(n) ? 'true' : 'false');
+  });
+  buildScreenUI();
+  // Default: first screen active
+  const firstScreen = document.querySelector('section[data-iteration][data-active] section[data-screen]');
+  if (firstScreen) showScreen(firstScreen.id);
+}
+document.querySelectorAll('.iteration-tab').forEach(tab => tab.addEventListener('click', () => showIteration(tab.dataset.iteration)));
+
+// --- Theme ---
+document.getElementById('theme-toggle').addEventListener('click', () => {
+  const html = document.documentElement;
+  html.setAttribute('data-theme', html.getAttribute('data-theme') === 'dark' ? 'light' : 'dark');
+  saveState();
+});
+
+// --- Init ---
+document.addEventListener('DOMContentLoaded', () => {
+  buildScreenUI();
+  const state = restoreState();
+  const active = document.querySelector('section[data-iteration][data-active]');
+  if (active) {
+    const firstScreen = active.querySelector('section[data-screen]');
+    const restored = state && state._activeScreen && document.getElementById(state._activeScreen);
+    showScreen(restored ? state._activeScreen : (firstScreen ? firstScreen.id : ''));
+  }
+  updateNoteMarkers();
+  document.addEventListener('input', updateNoteMarkers);
+});
+
+// --- collectDecisions (prototype) ---
+function collectPrototypeDecisions() {
+  const comments = [];
+  const general = document.getElementById('proto-general-feedback');
+  if (general && general.value.trim()) comments.push({ id: 'general', text: general.value.trim() });
+  document.querySelectorAll('[data-screen-comment]').forEach(el => {
+    if (!el.value.trim()) return;
+    const id = el.dataset.screenComment;
+    const screenEl = document.getElementById(id);
+    comments.push({ id, label: screenEl ? (screenEl.dataset.navLabel || id) : id, text: el.value.trim() });
+  });
+  return { submitted: true, template: 'prototype', decisions: [], comments };
+}
+function collectDecisions(action = 'iterate') {
+  const data = collectPrototypeDecisions();
+  data.action = action;
+  return data;
+}
+
+// --- Submit + heartbeat ---
+let _submittedAt = 0;
+async function submitWithAction(action) {
+  const data = collectDecisions(action);
+  document.getElementById('concept-decisions').textContent = JSON.stringify(data);
+  document.body.classList.add('concept-submitted');
+  _submittedAt = Date.now();
+  document.getElementById('panel-ready').style.display = 'none';
+  document.getElementById('panel-submitted').style.display = 'block';
+  try { await fetch('/decisions', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(data) }); }
+  catch (e) { localStorage.setItem(STORAGE_KEY + '-pending', JSON.stringify(data)); }
+  saveState();
+}
+document.getElementById('submit-iterate-btn').addEventListener('click', () => submitWithAction('iterate'));
+document.getElementById('submit-implement-btn').addEventListener('click', () => {
+  if (!confirm('Prototyp jetzt in echten Code umsetzen? Claude schreibt Code-Änderungen.')) return;
+  submitWithAction('implement');
+});
+async function retryPendingSubmission() {
+  const pending = localStorage.getItem(STORAGE_KEY + '-pending'); if (!pending) return;
+  try { const res = await fetch('/decisions', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: pending });
+    if (res.ok) localStorage.removeItem(STORAGE_KEY + '-pending'); } catch (e) {}
+}
+function restorePanelToReady() {
+  document.getElementById('panel-submitted').style.display = 'none';
+  document.getElementById('panel-ready').style.display = 'block';
+  ['submit-iterate-btn', 'submit-implement-btn'].forEach(id => {
+    const btn = document.getElementById(id); if (btn) btn.disabled = false;
+  });
+  document.body.classList.remove('concept-submitted'); _submittedAt = 0;
+  localStorage.removeItem(STORAGE_KEY);
+}
+const HEARTBEAT_STALE_MS = 90000, HEARTBEAT_GRACE_MS = 30000;
+const _pageLoadedAt = Date.now(); let _lastHeartbeatTs = 0;
+async function pollHeartbeat() {
+  try { const res = await fetch('/heartbeat', { cache: 'no-store' }); const data = await res.json(); _lastHeartbeatTs = data.ts || 0; } catch (e) {}
+}
+async function pollProcessedState() {
+  if (!_submittedAt) return;
+  try { const res = await fetch('/decisions', { cache: 'no-store' }); const data = await res.json();
+    const processedIso = data && data._processed_at; if (!processedIso) return;
+    const processedMs = Date.parse(processedIso);
+    if (Number.isFinite(processedMs) && processedMs > _submittedAt) restorePanelToReady();
+  } catch (e) {}
+}
+function checkClaudeConnection() {
+  const isConnected = _lastHeartbeatTs && (Date.now() - _lastHeartbeatTs) < HEARTBEAT_STALE_MS;
+  const inGrace = Date.now() - _pageLoadedAt < HEARTBEAT_GRACE_MS;
+  const connecting = document.getElementById('connection-connecting');
+  const warning = document.getElementById('connection-warning');
+  const btns = ['submit-iterate-btn', 'submit-implement-btn']
+    .map(id => document.getElementById(id)).filter(Boolean);
+  const panelSubmitted = document.getElementById('panel-submitted');
+  if (panelSubmitted && panelSubmitted.style.display !== 'none') return;
+  if (isConnected) {
+    if (connecting) connecting.style.display = 'none';
+    if (warning) warning.style.display = 'none';
+    btns.forEach(b => b.disabled = false);
+    retryPendingSubmission();
+  } else if (inGrace) {
+    if (connecting) connecting.style.display = 'flex';
+    if (warning) warning.style.display = 'none';
+    btns.forEach(b => b.disabled = false);
+  } else {
+    if (connecting) connecting.style.display = 'none';
+    if (warning) warning.style.display = 'flex';
+    btns.forEach(b => b.disabled = false);
+  }
+}
+setInterval(async () => { await pollHeartbeat(); checkClaudeConnection(); await pollProcessedState(); }, 5000);
+
+// --- Reload poller ---
+let _bootReloadCounter = null;
+async function pollReload() {
+  try { const res = await fetch('/reload', { cache: 'no-store' }); if (!res.ok) return;
+    const { counter } = await res.json();
+    if (_bootReloadCounter === null) { _bootReloadCounter = counter; return; }
+    if (counter > _bootReloadCounter) location.reload();
+  } catch (e) {}
+}
+setInterval(pollReload, 3000);
+document.addEventListener('DOMContentLoaded', pollReload);
+
+// Click-through: buttons with data-screen-link navigate between screens
+document.addEventListener('click', e => {
+  const link = e.target.closest('[data-screen-link]');
+  if (!link) return;
+  const dest = link.dataset.screenLink;
+  const screens = [...document.querySelectorAll('section[data-iteration][data-active] section[data-screen]')];
+  const currentIdx = screens.findIndex(s => s.dataset.screenActive === 'true');
+  let targetId = null;
+  if (dest === 'next') targetId = screens[Math.min(currentIdx + 1, screens.length - 1)]?.id;
+  else if (dest === 'prev') targetId = screens[Math.max(currentIdx - 1, 0)]?.id;
+  else targetId = dest;
+  if (!targetId || !document.getElementById(targetId)) return;
+  e.preventDefault();
+  closePanel();
+  showScreen(targetId);
+});
+
+// Keyboard: arrow keys jump between screens
+document.addEventListener('keydown', e => {
+  if (dock.dataset.open === 'true' || panel.classList.contains('open')) return;
+  if (e.target.matches('textarea, input')) return;
+  const screens = [...document.querySelectorAll('section[data-iteration][data-active] section[data-screen]')];
+  const currentIdx = screens.findIndex(s => s.dataset.screenActive === 'true');
+  if (currentIdx < 0) return;
+  let nextIdx = currentIdx;
+  if (e.key === 'ArrowRight' || e.key === ' ') nextIdx = Math.min(currentIdx + 1, screens.length - 1);
+  else if (e.key === 'ArrowLeft') nextIdx = Math.max(currentIdx - 1, 0);
+  else return;
+  e.preventDefault();
+  showScreen(screens[nextIdx].id);
+});
+</script>
+</body>
+</html>

--- a/docs/concepts/2026-04-21-template-example-prototype.html
+++ b/docs/concepts/2026-04-21-template-example-prototype.html
@@ -155,11 +155,12 @@ section[data-screen][hidden] { display: none; }
 #panel-ready { position: relative; }
 .panel-warning {
   position: absolute; inset: 0; z-index: 5;
+  pointer-events: none;
   display: flex; flex-direction: column; align-items: center; justify-content: center;
   gap: 0.75rem; text-align: center; padding: 1.5rem;
   border-radius: 10px; border: 1px solid var(--warning-color);
-  background: color-mix(in srgb, var(--panel-bg) 94%, transparent);
-  backdrop-filter: blur(4px); -webkit-backdrop-filter: blur(4px);
+  background: color-mix(in srgb, var(--panel-bg) 70%, transparent);
+  backdrop-filter: blur(2px); -webkit-backdrop-filter: blur(2px);
   color: var(--text); }
 .panel-warning .warning-icon { font-size: 2.25rem; color: var(--warning-color); line-height: 1; }
 .panel-warning strong { color: var(--warning-color); font-size: 1rem; }
@@ -282,7 +283,7 @@ body[data-single-screen="true"] .feedback-section:has(#screen-textareas) { displ
       <div id="connection-warning" class="panel-warning" style="display: none;">
         <span class="warning-icon" aria-hidden="true">⚠</span>
         <strong>Claude ist nicht verbunden</strong>
-        <p class="warning-message">Submit ist pausiert, bis die Verbindung wieder steht. Deine Eingaben bleiben erhalten.</p>
+        <p class="warning-message">Du kannst trotzdem absenden — der Klick wird gespeichert und gesendet, sobald Claude wieder da ist.</p>
       </div>
       <button id="submit-iterate-btn" class="primary submit-btn">Zur nächsten Iteration</button>
       <p class="hint">Per-Screen-Notizen + allgemeine Anmerkungen gehen an Claude. Kein Code wird geschrieben.</p>
@@ -372,8 +373,9 @@ document.addEventListener('input', saveState);
 
 // --- Build screen textareas and screen-nav ---
 function buildScreenUI() {
-  const active = document.querySelector('section[data-iteration][data-active]'); if (!active) return;
-  const screens = [...active.querySelectorAll('section[data-screen][id]')];
+  // Read from the VISIBLE iteration so frozen tabs rebuild correctly.
+  const visible = document.querySelector('section[data-iteration]:not([hidden])'); if (!visible) return;
+  const screens = [...visible.querySelectorAll('section[data-screen][id]')];
   const total = screens.length;
   document.getElementById('total-screens').textContent = total;
 
@@ -407,7 +409,7 @@ function buildScreenUI() {
 }
 
 function showScreen(id) {
-  const screens = document.querySelectorAll('section[data-iteration][data-active] section[data-screen][id]');
+  const screens = document.querySelectorAll('section[data-iteration]:not([hidden]) section[data-screen][id]');
   let idx = 0;
   screens.forEach((s, i) => {
     const match = s.id === id;
@@ -480,9 +482,14 @@ function showIteration(n) {
     tab.setAttribute('aria-selected', String(tab.dataset.iteration) === String(n) ? 'true' : 'false');
   });
   buildScreenUI();
-  // Default: first screen active
-  const firstScreen = document.querySelector('section[data-iteration][data-active] section[data-screen]');
-  if (firstScreen) showScreen(firstScreen.id);
+  // Try to preserve the previously active screen if it still exists in the
+  // newly visible iteration; otherwise fall back to the first screen.
+  const visible = document.querySelector('section[data-iteration]:not([hidden])');
+  const prevId = document.querySelector('[data-screen][data-screen-active="true"]')?.id;
+  const stillThere = prevId && visible?.querySelector(`section[data-screen]#${CSS.escape(prevId)}`);
+  const firstScreen = visible?.querySelector('section[data-screen]');
+  const target = stillThere ? prevId : firstScreen?.id;
+  if (target) showScreen(target);
 }
 document.querySelectorAll('.iteration-tab').forEach(tab => tab.addEventListener('click', () => showIteration(tab.dataset.iteration)));
 
@@ -614,7 +621,7 @@ document.addEventListener('click', e => {
   const link = e.target.closest('[data-screen-link]');
   if (!link) return;
   const dest = link.dataset.screenLink;
-  const screens = [...document.querySelectorAll('section[data-iteration][data-active] section[data-screen]')];
+  const screens = [...document.querySelectorAll('section[data-iteration]:not([hidden]) section[data-screen]')];
   const currentIdx = screens.findIndex(s => s.dataset.screenActive === 'true');
   let targetId = null;
   if (dest === 'next') targetId = screens[Math.min(currentIdx + 1, screens.length - 1)]?.id;
@@ -630,7 +637,7 @@ document.addEventListener('click', e => {
 document.addEventListener('keydown', e => {
   if (dock.dataset.open === 'true' || panel.classList.contains('open')) return;
   if (e.target.matches('textarea, input')) return;
-  const screens = [...document.querySelectorAll('section[data-iteration][data-active] section[data-screen]')];
+  const screens = [...document.querySelectorAll('section[data-iteration]:not([hidden]) section[data-screen]')];
   const currentIdx = screens.findIndex(s => s.dataset.screenActive === 'true');
   if (currentIdx < 0) return;
   let nextIdx = currentIdx;

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.56.1",
+  "version": "0.57.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/skills/devops-concept/SKILL.md
+++ b/plugins/devops/skills/devops-concept/SKILL.md
@@ -29,29 +29,121 @@ Do NOT call Read on files that may not exist — skip missing files silently (no
 2. Project: `{project}/.claude/skills/concept/SKILL.md` + `reference.md`
 3. Merge: project > global > plugin defaults
 
-## Step 1 — Determine Variant
+## Step 1 — Pick Template, then Content Variant
 
-Assess the content and select the appropriate variant:
+### 1a. Pick the page template (layout mode)
+
+Every concept page uses one of three layout **templates**. Pick via the
+**strict ordered check below** — first matching template wins, free is the
+explicit fallback when neither of the first two applies. Do NOT skip the
+order; `free` must never be chosen while `prototype` or `decision` would
+also fit.
+
+**Order of evaluation (mandatory):**
+
+1. **Is this a PROTOTYPE?**
+   Visual mockup, wireframe, click-through flow, screen-by-screen UI design,
+   any "design me / sketch / lay out a UI" task. If the output needs maximum
+   viewport real estate and per-screen feedback → `prototype`. **Stop.**
+
+   **Prototype is almost always a click-dummy.** If there are 2+ screens,
+   the mockup's own buttons/links MUST be wired to navigate between screens
+   (not just styled rectangles) — clicking "Continue" on screen 1 lands on
+   screen 2, "Back" returns, etc. See `deep-knowledge/templates.md`
+   § Template: prototype for the `data-screen-link` attribute pattern.
+
+   **"Screen" is a logical state, not a full page.** A screen can be a
+   distinct view (welcome → credentials → success), but it can also be a
+   meaningful state of the same view (modal closed → modal open → form
+   submitted, tab A → tab B, collapsed drawer → expanded drawer, empty
+   list → populated list). Every state the user should be able to give
+   feedback on separately becomes its own `<section data-screen>`.
+
+   **Single-screen prototype (exactly one `data-screen`):** no screen-nav,
+   no per-screen feedback textarea — the dock shows ONLY the general-notes
+   textarea. A static single-screen prototype needs no click-dummy wiring.
+   Do NOT invent artificial "screens" to justify the template; if the
+   artefact has no meaningful secondary states, one screen is correct.
+
+   **Design system:** the prototype MUST follow the project's existing
+   design system (colors, typography, component shapes, spacing) unless
+   the user explicitly asks for a different style in the request. Check
+   `design-tokens.*`, `theme.*`, `tailwind.config.*`, Figma tokens via
+   the design MCP, or the existing UI code before inventing a look.
+
+2. **Is this a DECISION?**
+   Multi-option evaluation where the user must pick from 2+ mutually-exclusive
+   alternatives (architecture, tech, strategy, library, approach, …). If there
+   are explicit variants A/B/C with pros/cons to weigh → `decision`. **Stop.**
+
+3. **Otherwise → FREE.**
+   Only reach this step after 1 AND 2 have both been ruled out. Analysis,
+   walkthrough, brainstorm, explainer, timeline, status deep-dive, retro,
+   post-mortem — structured content that has no forced variant framing.
+   Tri-state is opt-in per section (Claude adds it only where a finding
+   genuinely needs user evaluation).
+
+| Template | Layout signature |
+|---|---|
+| **prototype** | Fullscreen content, overlay decision panel (FAB right), bottom feedback dock (per-screen comments) |
+| **decision** | Sidebar (~80/~20), variant cards, tri-state per variant |
+| **free** | Sidebar (~80/~20), Claude-authored freeform body, optional tri-state per section |
+
+**Tie-breakers:**
+- A page with variants AND mockups (rare) is a `decision` with inline mockups,
+  not a `prototype` — prototype is reserved for single-artefact presentation.
+- A page that presents one recommended approach (no alternatives) is `free`,
+  not `decision` — decision requires ≥2 mutually-exclusive options.
+
+Set `<html data-template="...">` on the generated file so `collectDecisions`
+picks the right branch and template-specific CSS/JS activates. See
+`deep-knowledge/templates.md` for the full layout reference.
+
+### 1b. If template is `decision`: pick a content variant
+
+The decision template has six content sub-variants that shape the variant
+cards:
 
 | Variant | When to use | Interactive elements |
 |---------|------------|---------------------|
-| **analysis** | Data analysis, metrics review, findings | Toggles to accept/reject findings, priority selectors |
-| **plan** | Implementation plans, roadmaps, migration strategies | Checkboxes to approve/skip steps, reorder drag, comments per step |
-| **concept** | Architecture concepts, design proposals, feature specs | Toggle variants on/off, rate options, comment fields |
-| **comparison** | Technology comparison, option evaluation | Side-by-side toggles, winner selection, weight sliders |
-| **prototype** | UI mockups, flow prototypes, wireframes | Interactive UI elements, click-through flows |
+| **analysis** | Data analysis, metrics review, findings | Tri-state per finding, priority selectors |
+| **plan** | Implementation plans, roadmaps, migration strategies | Checkboxes to approve/skip steps, effort tags, comments per step |
+| **concept** | Architecture concepts, design proposals, feature specs | Tri-state per variant, rate options, comment fields |
+| **comparison** | Technology comparison, option evaluation | Criteria matrix, weight sliders, winner selection, tri-state per option |
 | **dashboard** | Status overviews, metric dashboards, health checks | Filters, toggles, expandable sections |
 | **creative** | Brainstorming, ideation, mind maps | Add/remove ideas, grouping, voting |
 
-These variants are **recommendations, not rigid categories**. Mix elements
-across variants, create hybrid layouts, or invent new structures when the
-content calls for it. The table above is a starting point — adapt freely.
+Prototype and free templates have no sub-variants — their body is
+content-specific (prototype = visual mockup; free = Claude-authored).
 
-See `deep-knowledge/templates.md` for layout inspiration (also non-mandatory).
+These are **recommendations, not rigid categories**. Mix elements across
+variants, create hybrid layouts, or invent new structures when the content
+calls for it.
 
 ## Step 2 — Generate HTML
 
 Build a single self-contained HTML file. Requirements:
+
+### Localisation (mandatory — do NOT hard-code German/English)
+
+Read the `[ui-locale: xx]` hint injected by `prompt.knowledge.dispatch`. If
+the hint is absent, infer from the user's chat language (the language they
+are writing to Claude in THIS conversation). Then:
+
+1. Set `<html lang="{locale}">` on the generated page.
+2. Render every user-facing label (decision panel, buttons, feedback dock,
+   screen counter, warnings, confirms, placeholders) from the matching
+   column of the UI Locale table in `deep-knowledge/templates.md` § UI Locale.
+3. If the user's locale isn't a column in the table yet (`fr`, `hi`, `ja`,
+   `pt-br`, `zh`, …), Claude MUST translate every key inline at generation
+   time and also append a new column to the table in `templates.md` so the
+   next session has it cached. Fallback per-key: `en` value if translation
+   is impossible.
+
+User-authored content (concept title, subtitle, variant descriptions,
+pro/con lists, mockup copy, finding text, …) is always in the user's
+language — same rule, same locale hint. Do not mix languages inside one
+page.
 
 ### Design
 - Modern, clean design with dark/light mode toggle
@@ -74,14 +166,20 @@ content. The iteration title (e.g. "Iteration 3 · Visual design concept")
 and its intro paragraph live INSIDE the active `<section data-iteration="N">`,
 as a compact `.iteration-intro` block right after the opening tag.
 
-### Decision Panel Layout
-- The decision panel (submit button + global controls) is a **fixed sidebar**
-  on the right side, taking **~20% of the screen width** — NOT an overlay
-- Content area fills the remaining ~80% on the left
-- On mobile/narrow screens: decision panel collapses to bottom (sticky)
-- The panel is always visible while scrolling (position: fixed or sticky)
+### Decision Panel Layout (template-specific)
 
-**Panel top-to-bottom order:**
+Panel layout depends on the template picked in Step 1a:
+
+| Template | Panel mode | Extras |
+|---|---|---|
+| **decision** | Fixed sticky sidebar (~20% screen width), always visible | — |
+| **prototype** | Overlay panel (360px slide-in from right), FAB-toggled | Collapsible **feedback dock** at the bottom with per-screen comments |
+| **free** | Fixed sticky sidebar (~20%), always visible | — |
+
+On narrow screens (<768px), sidebar-mode panels collapse to a sticky bottom
+bar. Overlay panels already work on mobile via the FAB.
+
+**Panel top-to-bottom order (identical across all templates):**
 1. **Iteration tabs** (`.iteration-tabs`) — compact vertical chip list,
    one per iteration. Active chip = current round; older chips stay
    clickable to review frozen snapshots.
@@ -89,11 +187,10 @@ as a compact `.iteration-intro` block right after the opening tag.
    `<section id="…" data-nav-label="…">` inside the active iteration.
    Not limited to variants: Ist-Zustand, context blocks, design notes,
    mockups — anything with a nav label gets a scroll anchor here.
-3. Decision summary + submit button (or freeform comment + submit when the
-   active iteration carries `data-freeform`).
-4. Connection warning + post-submit state (unchanged).
+3. Decision summary + submit button.
+4. Connection warning + post-submit state.
 
-The iteration tab bar must NOT live inside the left-hand content area.
+The iteration tab bar must NEVER live inside the left-hand content area.
 The content area is reserved for the actual concept.
 
 ### Interactive Elements (per variant)
@@ -104,62 +201,65 @@ The content area is reserved for the actual concept.
 - **Submit button**: Prominent "Entscheidungen abschicken" button in the
   decision panel sidebar
 
-### Variant Evaluation (optional — only when variants exist)
+### Evaluation Rules (by template) — bi-state
 
-**Variants are a content pattern, not a mandatory structure.** Many concepts
-have no variants to evaluate (design concepts, mockups, tutorials, single-
-approach plans). Those pages run in **freeform mode** — see below.
+Variant/section evaluation uses a **bi-state selector** (not tri-state):
 
-When the concept DOES present multiple variants (concept, comparison, or any
-multi-option output), each variant MUST include a **tri-state evaluation**:
+| Template | Evaluation behavior |
+|---|---|
+| **decision** | **Mandatory per variant card.** Every variant MUST carry the bi-state selector. |
+| **prototype** | **No evaluation.** Feedback is collected via the bottom feedback dock (per-screen textareas + general notes). |
+| **free** | **Opt-in per section.** Claude decides per section whether user evaluation is useful; sections with an `eval-{id}` radio group get evaluated, plain sections just show content. |
 
-| State | Label | Type | Behavior |
-|-------|-------|------|----------|
-| **Miteinbeziehen** | "Miteinbeziehen" (default) | Feedback | Informs Claude's decision — no immediate action taken |
-| **Verwerfen** | "Verwerfen" | ⚠️ Claude setzt um | Claude actively discards this variant and excludes it from all further steps |
-| **Nur diese** | "Exakt diese Variante" | ⚠️ Claude setzt um | Claude proceeds with only this variant and discards all others |
+**The two states:**
 
-- Default state for all variants: **Miteinbeziehen**
-- "Nur diese" is exclusive — selecting it for one variant auto-sets all others
-  to "Verwerfen" (with visual feedback and undo option)
-- Each variant can ADDITIONALLY have rating, comments, and other controls
-- The overall submit sends the tri-state per variant PLUS any additional ratings
+| State | Label | Behavior |
+|-------|-------|----------|
+| **Miteinbeziehen** | "Miteinbeziehen" (default) | Claude considers this variant/finding in the next iteration or implementation |
+| **Verwerfen** | "Verwerfen" | Claude discards this variant/finding and excludes it from all further steps |
 
-**Visual indicators on the generated HTML page (mandatory):**
-Each tri-state option button MUST show a visual indicator so the user sees
-BEFORE clicking what kind of effect the selection has:
-- **Miteinbeziehen**: show a subtle info icon (ℹ) or "(Feedback)" label —
-  this is passive input, Claude will consider it but take no direct action
-- **Verwerfen** and **Exakt diese Variante**: show a `⚠️ Claude setzt um`
-  warning label directly on or below the button — the user must see this
-  before submitting, so they understand clicking Submit will cause Claude to
-  actively act on this choice (discard a variant, write code, update a plan, etc.)
+- Default: **Miteinbeziehen** for every variant/section
+- No "Nur diese"/"only" option — the user implicitly picks a single option by
+  setting all other variants to "Verwerfen"
+- No "Claude setzt um" / "Feedback" hint labels — bi-state makes the intent
+  self-explanatory, and the action-vs-feedback distinction is now handled by
+  the two submit buttons, not the evaluation selector
+- Each variant/section can ADDITIONALLY have rating, comments, and other controls
 
-### Freeform Mode (no variant evaluation)
+### Submit actions — iterate vs. implement
 
-When the iteration has nothing to evaluate as mutually-exclusive options
-(design concepts, mockups, tutorials, single-track plans), mark the
-iteration section with `data-freeform`:
+The decision panel always shows **two submit buttons**, never one. A
+decision-panel submit by itself MUST NEVER trigger code changes — that only
+happens when the user explicitly clicks the implement button.
 
-```html
-<section id="iter-3" data-iteration="3" data-active data-freeform
-         data-nav-label="Design concept">
-  <!-- Full-width content — no variant-card framing, no tri-state per block -->
-</section>
-```
+| Button | Label (de / en) | Action | Style |
+|---|---|---|---|
+| Primary | "Zur nächsten Iteration" / "Next iteration" | `action: "iterate"` — Claude processes the feedback and appends a new iteration section (no code changes) | Full-width, accent color |
+| Secondary | "Mit Feedback implementieren" / "Implement with feedback" | `action: "implement"` — Claude applies the selections as actual code/file changes | Warning-colored border, extra top margin (~2rem) so the user cannot misclick, ⚠ icon |
 
-Effects:
-- Content area may use the full width/layout it needs (mockup grids,
-  full-bleed imagery, diagrams).
-- Decision panel hides the variant summary; shows a single optional
-  comment field + Submit.
-- `collectDecisions()` returns empty `decisions[]` and whatever the user
-  typed into the comment field.
-- Section TOC still auto-populates from every nested `<section id=""
-  data-nav-label="">` — use this to list Ist-Zustand, Design notes,
-  Mockups, Rationale as scroll anchors in the panel.
+The click-away handler in the feedback dock does NOT apply to these buttons
+— they are explicit commits. The extra gap before the implement button is
+mandatory: the user must move the mouse deliberately to reach it.
 
-See `deep-knowledge/templates.md` § Freeform for the CSS/JS helpers.
+`collectDecisions()` adds `action: "iterate" | "implement"` to the payload
+based on which button was clicked. Claude reads that field and either runs
+another iteration (Step 5c) or executes code changes (Step 5b).
+
+This applies to **all three templates** — even prototype (implement = "build
+what we prototyped with the feedback") and free (implement = "act on the
+findings I marked Miteinbeziehen").
+
+### Prototype Feedback Dock
+
+The prototype template has no tri-state. Instead, a collapsible **feedback
+dock** at the bottom of the viewport holds structured feedback:
+
+- A top-level textarea for general notes on the prototype
+- One textarea per `<section data-screen>` inside the active iteration,
+  auto-populated by the dock (label = `data-nav-label` of that screen)
+
+The dock is toggled via a floating action button (bottom-left). See
+`deep-knowledge/templates.md` § Template: prototype for the full HTML/CSS/JS.
 
 ### Reload Resilience
 
@@ -341,18 +441,34 @@ User submits → Claude reads → Claude processes → Claude updates page → U
 1. Read the JSON from `#concept-decisions`
 2. Parse into structured decisions and comments
 
-### 5b. Process & Act
+### 5b. Process & Act — branch by `action`
+
+The submit payload carries an `action` field (`"iterate"` or `"implement"`).
+Branch on it:
+
+**`action: "iterate"` (default — "Zur nächsten Iteration" button):**
 1. **Summarize** what was selected/rejected/commented
-2. **Execute** the decisions immediately — "Execute" means **Claude acts** based
-   on the submitted feedback. The concept page itself does nothing when the user
-   clicks Submit; it only records the decisions and signals Claude. It is Claude
-   who then reads those decisions and takes the actual action (writes code, updates
-   a plan, archives alternatives, etc.). The page is the input channel — Claude
-   is the actor:
-   - For plans: proceed with approved steps, skip rejected ones
-   - For analysis: focus on accepted findings, deprioritize rejected ones
-   - For concepts: develop chosen variant, archive alternatives
-   - For comparisons: proceed with selected winner
+2. **Do NOT modify code, files, or external systems** — iterate ONLY updates
+   the concept page
+3. Proceed to Step 5c (append next iteration with refined options that
+   reflect the Miteinbeziehen/Verwerfen choices)
+
+**`action: "implement"` ("Mit Feedback implementieren" button):**
+1. **Summarize** what was selected/rejected/commented
+2. **Execute** the decisions as real changes — "Execute" means Claude acts:
+   - For plans: implement the approved steps
+   - For concepts: develop the chosen variant, archive alternatives
+   - For comparisons: proceed with the implicitly-selected winner (all
+     others marked Verwerfen)
+   - For free-template findings: apply the Miteinbeziehen findings as fixes
+   - For prototypes: build the designed UI/flow with the feedback applied
+3. After the implementation is done, still append a new iteration that
+   shows "implementiert — siehe commit {hash}" as a frozen record, so the
+   concept page stays the source of truth for what happened
+
+**Critical invariant:** a submit with `action: "iterate"` MUST NEVER cause
+code or file changes outside of the concept HTML file itself. The user
+relies on that guarantee to explore ideas safely.
 ### 5c. Update the Page
 After processing, **append a new iteration tab** to the same HTML file and
 signal the browser to reload. This is the ONLY update path — there is no

--- a/plugins/devops/skills/devops-concept/deep-knowledge/templates.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/templates.md
@@ -4,9 +4,9 @@ Three page-level **templates** (layout modes) cover every concept use case:
 
 | Template | Layout | When to use |
 |---|---|---|
-| **decision** | Sidebar (~80/~20), multi-variant cards | Multi-option evaluation, trade-offs, architecture or tech decisions — the canonical "pick one" flow with tri-state per variant and multiple iterations |
+| **decision** | Sidebar (~80/~20), multi-variant cards | Multi-option evaluation, trade-offs, architecture or tech decisions — the canonical "pick one" flow with bi-state (Verwerfen / Miteinbeziehen) per variant and multiple iterations |
 | **prototype** | Fullscreen content + overlay decision panel (FAB-toggled, right) + collapsible feedback dock (bottom, per-screen comments) | UI mockups, wireframes, visual design concepts, click-through flows — one artefact that needs maximum screen real estate, plus structured per-screen feedback |
-| **free** | Sidebar (~80/~20), freeform body content | Analysis, walkthrough, brainstorm, explainer, timeline — structured content without forced variant framing. Tri-state evaluation is optional (opt-in per section) |
+| **free** | Sidebar (~80/~20), freeform body content | Analysis, walkthrough, brainstorm, explainer, timeline — structured content without forced variant framing. Bi-state evaluation is optional (opt-in per section) |
 
 **Content variants (analysis, plan, concept, comparison, dashboard, creative)
 are sub-structures of the decision template** — they describe how to lay out
@@ -54,7 +54,7 @@ must see their own language. The locale hint is authoritative.
 | `panel.submitted`              | Decisions submitted            | Entscheidungen übermittelt |
 | `panel.submitted_hint`         | Claude is processing your selection. Switch to the **Claude chat** to follow progress. | Claude verarbeitet deine Auswahl. Wechsle zum **Claude Chat** um den Fortschritt zu sehen. |
 | `panel.disconnected_title`     | Claude is not connected        | Claude ist nicht verbunden |
-| `panel.disconnected_hint`      | Submit is paused until the connection is back. Your input stays. | Submit ist pausiert, bis die Verbindung wieder steht. Deine Eingaben bleiben erhalten. |
+| `panel.disconnected_hint`      | You can still submit — your click is queued and delivered as soon as Claude is back. | Du kannst trotzdem absenden — der Klick wird gespeichert und gesendet, sobald Claude wieder da ist. |
 | `panel.connecting_title`       | Claude is connecting           | Claude verbindet sich |
 | `panel.connecting_hint`        | One moment — establishing the connection. | Einen Moment — die Verbindung wird aufgebaut. |
 | `panel.toggle_open`            | Open decisions                 | Entscheidungen öffnen |
@@ -139,7 +139,7 @@ the `[ui-locale: ...]` hint produced.
 
       <!-- Section TOC — auto-populated from EVERY <section id="..."
            data-nav-label="..."> inside the active iteration, not just variants.
-           Sections that carry a tri-state radio group (eval-{id}) display their
+           Sections that carry a bi-state radio group (eval-{id}) display their
            current state label; plain sections (Ist-Zustand, Context, Design-Notes,
            etc.) just show the label and anchor-scroll on click. -->
       <nav class="section-nav" id="section-nav" aria-label="{{nav.sections}}">
@@ -209,7 +209,7 @@ Set `data-template` on the `<html>` element to one of `decision` | `prototype` |
 # Template: decision
 
 Multi-variant evaluation with sidebar layout. This is the canonical flow:
-Claude presents 2+ options, user picks tri-state per variant, submits,
+Claude presents 2+ options, user picks bi-state per variant, submits,
 Claude iterates.
 
 ## Layout — Sidebar
@@ -503,7 +503,7 @@ of the variant cards — not a different page layout.
 [Decision panel sidebar: summary + submit]
 ```
 
-Each option in the comparison gets the same **tri-state evaluation** as
+Each option in the comparison gets the same **bi-state evaluation** as
 concept variants. Decision schema matches the decision template schema, with
 additional `weight-*` entries for weight sliders.
 
@@ -890,11 +890,12 @@ DOM (just hidden), so each one's value persists independently via
   if (document.documentElement.dataset.template !== 'prototype') return;
 
   // Build screen-nav buttons (☰) and per-screen textareas (💬) from every
-  // <section data-screen> inside the active iteration.
+  // <section data-screen> inside the VISIBLE iteration (may be a frozen
+  // tab the user clicked back to, not necessarily the live one).
   function buildScreenUI() {
-    const active = document.querySelector('section[data-iteration][data-active]');
-    if (!active) return;
-    const screens = [...active.querySelectorAll('section[data-screen][id]')];
+    const visible = document.querySelector('section[data-iteration]:not([hidden])');
+    if (!visible) return;
+    const screens = [...visible.querySelectorAll('section[data-screen][id]')];
     document.getElementById('total-screens').textContent = screens.length;
 
     // Single-screen prototypes: hide screen-nav + per-screen feedback.
@@ -931,7 +932,7 @@ DOM (just hidden), so each one's value persists independently via
 
   window.showScreen = function(id) {
     const screens = document.querySelectorAll(
-      'section[data-iteration][data-active] section[data-screen][id]');
+      'section[data-iteration]:not([hidden]) section[data-screen][id]');
     let idx = 0;
     screens.forEach((s, i) => {
       const match = s.id === id;
@@ -1013,10 +1014,16 @@ DOM (just hidden), so each one's value persists independently via
   });
 
   // Rebuild after iteration switches (fresh screens, fresh textareas).
+  // Preserve the previously active screen if it still exists in the newly
+  // visible iteration; otherwise fall back to the first screen.
   document.addEventListener('iteration:changed', () => {
     buildScreenUI();
-    const first = document.querySelector('section[data-iteration][data-active] section[data-screen]');
-    if (first) showScreen(first.id);
+    const visible = document.querySelector('section[data-iteration]:not([hidden])');
+    const prevId = document.querySelector('[data-screen][data-screen-active="true"]')?.id;
+    const stillThere = prevId && visible?.querySelector(`section[data-screen]#${CSS.escape(prevId)}`);
+    const first = visible?.querySelector('section[data-screen]');
+    const target = stillThere ? prevId : first?.id;
+    if (target) showScreen(target);
   });
 
   // Keyboard: Arrow Left/Right (and Space) jump between screens when no
@@ -1025,7 +1032,7 @@ DOM (just hidden), so each one's value persists independently via
     if (dock.dataset.open === 'true' || panel.classList.contains('open')) return;
     if (e.target.matches('textarea, input')) return;
     const screens = [...document.querySelectorAll(
-      'section[data-iteration][data-active] section[data-screen]')];
+      'section[data-iteration]:not([hidden]) section[data-screen]')];
     const currentIdx = screens.findIndex(s => s.dataset.screenActive === 'true');
     if (currentIdx < 0) return;
     let nextIdx = currentIdx;
@@ -1054,7 +1061,7 @@ document.addEventListener('click', e => {
   if (!link) return;
   const dest = link.dataset.screenLink;
   const screens = [...document.querySelectorAll(
-    'section[data-iteration][data-active] section[data-screen]')];
+    'section[data-iteration]:not([hidden]) section[data-screen]')];
   const currentIdx = screens.findIndex(s => s.dataset.screenActive === 'true');
   let targetId = null;
   if (dest === 'next') targetId = screens[Math.min(currentIdx + 1, screens.length - 1)]?.id;
@@ -1159,7 +1166,7 @@ sense.
 
 Identical to the decision layout (sticky sidebar, ~80/~20 split). The
 difference is in the body: no forced variant-card framing, no mandatory
-tri-state. Claude chooses the structure that fits the content.
+bi-state. Claude chooses the structure that fits the content.
 
 ```html
 <html data-template="free">
@@ -1187,31 +1194,24 @@ tri-state. Claude chooses the structure that fits the content.
 
           <section id="finding-1" data-nav-label="Finding: latency spike">
             <p>…</p>
-            <!-- OPT-IN tri-state: only present when Claude wants the user to
+            <!-- OPT-IN bi-state: only present when Claude wants the user to
                  confirm the finding is valid. Section id MUST match the
                  radio name suffix (eval-{id}). -->
             <div class="tri-state-group">
               <label class="tri-state-option">
                 <input type="radio" name="eval-finding-1" value="discard">
                 <span class="tri-state-label">Verwerfen</span>
-                <span class="tri-state-hint feedback">Feedback</span>
               </label>
               <label class="tri-state-option">
                 <input type="radio" name="eval-finding-1" value="include" checked>
                 <span class="tri-state-label">Miteinbeziehen</span>
-                <span class="tri-state-hint feedback">Feedback</span>
-              </label>
-              <label class="tri-state-option">
-                <input type="radio" name="eval-finding-1" value="only">
-                <span class="tri-state-label">Exakt diese</span>
-                <span class="tri-state-hint action">Claude setzt um</span>
               </label>
             </div>
             <textarea data-comment="finding-1" placeholder="Anmerkung…"></textarea>
           </section>
 
           <section id="recommendation" data-nav-label="Recommendation">
-            <!-- plain section, no tri-state — just content -->
+            <!-- plain section, no bi-state — just content -->
             <p>…</p>
           </section>
         </section>
@@ -1227,16 +1227,16 @@ tri-state. Claude chooses the structure that fits the content.
 </html>
 ```
 
-## Optional tri-state auto-detection
+## Optional bi-state auto-detection
 
 The section nav auto-detects whether a `<section data-nav-label>` contains an
 `eval-{id}` radio group and mirrors its current state (Miteinbeziehen /
-Verwerfen / Exakt diese). Sections without a radio group just get a scroll
-anchor. See Shared Systems § Section Navigation for the implementation.
+Verwerfen). Sections without a radio group just get a scroll anchor. See
+Shared Systems § Section Navigation for the implementation.
 
 ## Decision schema
 
-The free template emits **only the sections that actually have tri-state
+The free template emits **only the sections that actually have bi-state
 radios**, plus whatever comments the user typed:
 
 ```json
@@ -1252,7 +1252,7 @@ radios**, plus whatever comments the user typed:
 }
 ```
 
-If no section has tri-state markers, `decisions` is an empty array and the
+If no section has bi-state markers, `decisions` is an empty array and the
 submit payload is effectively a general-notes post.
 
 ## collectDecisions (free branch)
@@ -1291,7 +1291,7 @@ applies uniformly.
 The decision panel doubles as a full table-of-contents for the active
 iteration. EVERY major `<section id="…" data-nav-label="…">` inside the
 current iteration gets a clickable nav entry — not just variants. Sections
-with a tri-state radio group additionally display the current evaluation
+with a bi-state radio group additionally display the current evaluation
 state.
 
 ```css
@@ -1340,7 +1340,7 @@ state.
 <!-- Plain section — TOC entry, scroll only -->
 <section id="ist-zustand" data-nav-label="Ist-Zustand">...</section>
 
-<!-- Variant section — TOC entry + tri-state evaluation -->
+<!-- Variant section — TOC entry + bi-state evaluation -->
 <section id="variant-a" class="variant-card" data-nav-label="A Orbital Ring">...</section>
 ```
 
@@ -1351,7 +1351,9 @@ Sections without `data-nav-label` are skipped by the TOC auto-populator.
 function buildSectionNav() {
   const nav = document.getElementById('section-nav');
   if (!nav) return;
-  const activeIteration = document.querySelector('section[data-iteration][data-active]');
+  // Use :not([hidden]) so the nav reflects the VISIBLE iteration (may be
+  // a frozen tab the user is reviewing), not the live/latest one.
+  const activeIteration = document.querySelector('section[data-iteration]:not([hidden])');
   if (!activeIteration) return;
   const sections = activeIteration.querySelectorAll('section[id][data-nav-label]');
   nav.innerHTML = '';
@@ -1379,7 +1381,7 @@ function buildSectionNav() {
 }
 
 function updateSectionNavState() {
-  const labels = { include: 'Miteinbeziehen', discard: 'Verwerfen', only: 'Exakt diese' };
+  const labels = { include: 'Miteinbeziehen', discard: 'Verwerfen' };
   document.querySelectorAll('.section-nav-item[data-variant]').forEach(link => {
     const id = link.dataset.sectionId;
     const checked = document.querySelector(`input[name="eval-${id}"]:checked`);
@@ -1430,25 +1432,29 @@ document.addEventListener('DOMContentLoaded', () => {
 
 **Important:**
 - Every navigable `<section>` needs `id` AND `data-nav-label`.
-- If a section has a tri-state radio group, its `name` MUST be `eval-{section-id}`.
+- If a section has a bi-state radio group, its `name` MUST be `eval-{section-id}`.
 - `buildSectionNav()` must run again after every iteration switch.
 
 ## Decision Panel State CSS
 
 ```css
 /* Connection warning — overlays the submit area when Claude is offline.
-   Requires #panel-ready to be position: relative. */
+   Requires #panel-ready to be position: relative.
+   pointer-events: none so the user can still click the submit buttons
+   through the overlay — clicks land in the offline queue and are
+   auto-delivered on reconnect. */
 #panel-ready { position: relative; }
 .panel-warning {
   position: absolute; inset: 0; z-index: 5;
+  pointer-events: none;
   display: flex; flex-direction: column;
   align-items: center; justify-content: center;
   gap: 0.75rem; text-align: center; padding: 1.5rem;
   border-radius: 10px;
   border: 1px solid var(--warning-color, #d29922);
-  background: color-mix(in srgb, var(--panel-bg, #161b22) 94%, transparent);
-  backdrop-filter: blur(4px);
-  -webkit-backdrop-filter: blur(4px);
+  background: color-mix(in srgb, var(--panel-bg, #161b22) 70%, transparent);
+  backdrop-filter: blur(2px);
+  -webkit-backdrop-filter: blur(2px);
   color: var(--text-color, #c9d1d9);
 }
 .panel-warning .warning-icon { font-size: 2.25rem; color: var(--warning-color, #d29922); line-height: 1; }
@@ -1972,7 +1978,7 @@ When appending iteration N+1, Claude must freeze the previous section:
 1. Remove `data-active`, add `hidden` to the previous `<section>`.
 2. On every `input`, `textarea`, `select`, `button` inside it: set `disabled`.
 3. On every `textarea`, `input[type="text"]`: set `readonly`.
-4. For tri-state buttons: keep the `aria-pressed`/selected class exactly as
+4. For bi-state buttons: keep the `aria-pressed`/selected class exactly as
    the user submitted it — do NOT clear selections.
 5. Add a small "Eingefroren — Iteration N" banner at the top (optional).
 

--- a/plugins/devops/skills/devops-concept/deep-knowledge/templates.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/templates.md
@@ -1,36 +1,86 @@
 # Concept HTML Templates
 
+Three page-level **templates** (layout modes) cover every concept use case:
+
+| Template | Layout | When to use |
+|---|---|---|
+| **decision** | Sidebar (~80/~20), multi-variant cards | Multi-option evaluation, trade-offs, architecture or tech decisions — the canonical "pick one" flow with tri-state per variant and multiple iterations |
+| **prototype** | Fullscreen content + overlay decision panel (FAB-toggled, right) + collapsible feedback dock (bottom, per-screen comments) | UI mockups, wireframes, visual design concepts, click-through flows — one artefact that needs maximum screen real estate, plus structured per-screen feedback |
+| **free** | Sidebar (~80/~20), freeform body content | Analysis, walkthrough, brainstorm, explainer, timeline — structured content without forced variant framing. Tri-state evaluation is optional (opt-in per section) |
+
+**Content variants (analysis, plan, concept, comparison, dashboard, creative)
+are sub-structures of the decision template** — they describe how to lay out
+the cards inside a decision page, not separate page templates.
+
+All three templates share the same monitoring backbone (heartbeat, submit
+handler, state persistence, iteration tabs, section TOC, reload polling,
+theme toggle) — see the "Shared Systems" section at the bottom of this file.
+
 **These are recommendations, not mandatory structures.** Claude should adapt
 layout, elements, and design to fit the specific content. Use these as
 starting points and inspiration — deviate freely when the content calls for it.
 
 ## UI Locale
 
-Every UI string below has English (default) and German variants. When the
-session locale (`[ui-locale: ...]` injected by the prompt-knowledge-dispatch
-hook) is `de`, swap the matching strings into the rendered HTML and set
-`<html lang="de">`. For `en` (default) keep the English strings and
-`<html lang="en">`. Add more locales by extending the table.
+**Every user-facing string on the rendered concept page comes from the
+locale table below.** Claude picks the locale from the `[ui-locale: xx]`
+hint injected by the `prompt.knowledge.dispatch` hook at session start,
+which in turn derives the user's language from their profile/chat language.
+
+**How to use:**
+1. Read the locale code from `[ui-locale: xx]` (e.g. `de`, `en`, `fr`, `hi`, `ja`).
+2. Set `<html lang="{locale}">` on the generated page.
+3. Swap every UI string from the matching column of the table below. Never
+   hard-code German/English text — always reference the table.
+4. **If the locale is not in the table yet:** Claude MUST add the missing
+   column inline (translating all keys at generation time) and also persist
+   that column back into this file so future generations have it. Fallback
+   for truly unreachable translations: use the `en` column and document it
+   in a comment.
+
+Do NOT assume "English-only" — users in India, Japan, France, Brazil etc.
+must see their own language. The locale hint is authoritative.
 
 | Key | en | de |
 |---|---|---|
-| `panel.heading`         | Decisions                      | Entscheidungen |
-| `panel.submit`          | Submit decisions               | Entscheidungen abschicken |
-| `panel.submit_hint`     | Your selection goes straight to Claude. | Deine Auswahl wird direkt an Claude übermittelt. |
-| `panel.submitted`       | Decisions submitted            | Entscheidungen übermittelt |
-| `panel.submitted_hint`  | Claude is processing your selection. Switch to the **Claude chat** to follow progress. | Claude verarbeitet deine Auswahl. Wechsle zum **Claude Chat** um den Fortschritt zu sehen. |
-| `panel.disconnected`    | Claude is not connected. Make sure the Claude extension is active. | Claude ist nicht verbunden. Stelle sicher, dass die Claude-Extension aktiv ist. |
-| `panel.toggle_open`     | Open decisions                 | Entscheidungen öffnen |
-| `panel.close`           | Close                          | Schliessen |
-| `variant.include`       | Include                        | Miteinbeziehen |
-| `iteration.label`       | Iterations                     | Iterationen |
-| `nav.sections`          | Sections                       | Abschnitte |
+| `panel.heading`                | Decisions                      | Entscheidungen |
+| `panel.submit`                 | Submit decisions               | Entscheidungen abschicken |
+| `panel.submit_hint`            | Your selection goes straight to Claude. | Deine Auswahl wird direkt an Claude übermittelt. |
+| `panel.submit_iterate`         | Next iteration                 | Zur nächsten Iteration |
+| `panel.submit_iterate_hint`    | Your selection goes to Claude for the next iteration. No code changes. | Deine Auswahl geht an Claude für die nächste Iteration. Es wird kein Code geschrieben. |
+| `panel.submit_implement`       | Implement with feedback       | Mit Feedback implementieren |
+| `panel.submit_implement_hint`  | Claude applies the selection as real changes now. | Claude setzt die Auswahl jetzt in echte Änderungen um. |
+| `panel.submit_implement_confirm` | Implement with feedback now? Claude will write code changes. | Mit Feedback jetzt implementieren? Claude schreibt jetzt Code-Änderungen. |
+| `panel.submitted`              | Decisions submitted            | Entscheidungen übermittelt |
+| `panel.submitted_hint`         | Claude is processing your selection. Switch to the **Claude chat** to follow progress. | Claude verarbeitet deine Auswahl. Wechsle zum **Claude Chat** um den Fortschritt zu sehen. |
+| `panel.disconnected_title`     | Claude is not connected        | Claude ist nicht verbunden |
+| `panel.disconnected_hint`      | Submit is paused until the connection is back. Your input stays. | Submit ist pausiert, bis die Verbindung wieder steht. Deine Eingaben bleiben erhalten. |
+| `panel.connecting_title`       | Claude is connecting           | Claude verbindet sich |
+| `panel.connecting_hint`        | One moment — establishing the connection. | Einen Moment — die Verbindung wird aufgebaut. |
+| `panel.toggle_open`            | Open decisions                 | Entscheidungen öffnen |
+| `panel.close`                  | Close                          | Schliessen |
+| `variant.include`              | Include                        | Miteinbeziehen |
+| `variant.discard`              | Discard                        | Verwerfen |
+| `iteration.label`              | Iterations                     | Iterationen |
+| `iteration.active_suffix`      | · active                       | · aktiv |
+| `nav.sections`                 | Sections                       | Abschnitte |
+| `proto.feedback_title`         | Feedback                       | Feedback |
+| `proto.feedback_toggle`        | Open feedback                  | Feedback öffnen |
+| `proto.feedback_general`       | General notes on this prototype | Allgemeine Anmerkungen zum Prototyp |
+| `proto.feedback_general_hint`  | Persists across all screens    | Screen-übergreifend persistent |
+| `proto.feedback_current`       | Current screen                 | Aktueller Screen |
+| `proto.feedback_placeholder`   | Write a note on this screen…   | Notiz zu diesem Screen… |
+| `proto.screen_counter`         | Screen {n} / {total}           | Screen {n} / {total} |
 
-## Common Structure (all variants)
+**Locale tag example on `<html>`:** `<html lang="de">`, `<html lang="en">`,
+`<html lang="fr">`, `<html lang="hi">`, `<html lang="ja">`. Match whatever
+the `[ui-locale: ...]` hint produced.
+
+## Common Structure (all templates)
 
 ```html
 <!DOCTYPE html>
-<html lang="en" data-theme="dark" data-page-version="{generation-timestamp}">
+<html lang="en" data-theme="dark" data-page-version="{generation-timestamp}" data-template="decision">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -39,7 +89,7 @@ hook) is `de`, swap the matching strings into the rendered HTML and set
 </head>
 <body>
   <div class="concept-layout">
-    <!-- Main content: ~80% width -->
+    <!-- Main content -->
     <div class="concept-content">
       <header>
         <!-- HEADER MUST STAY LEAN.
@@ -65,7 +115,10 @@ hook) is `de`, swap the matching strings into the rendered HTML and set
       </main>
     </div>
 
-    <!-- Decision panel: ~20% width, fixed sidebar, NOT overlay -->
+    <!-- Decision panel. Layout varies per template:
+         decision: sticky sidebar, always visible.
+         prototype: overlay, FAB-toggled.
+         free: sticky sidebar (same as decision). -->
     <aside class="concept-decision-panel">
       <!-- All visible strings are referenced by key in the locale table above.
            Swap to the `de` column when [ui-locale: de] is active. -->
@@ -90,35 +143,43 @@ hook) is `de`, swap the matching strings into the rendered HTML and set
            current state label; plain sections (Ist-Zustand, Context, Design-Notes,
            etc.) just show the label and anchor-scroll on click. -->
       <nav class="section-nav" id="section-nav" aria-label="{{nav.sections}}">
-        <!-- Auto-populated examples: -->
-        <!--
-        <a href="#ist-zustand" class="section-nav-item" data-section-id="ist-zustand">
-          <span class="section-nav-label">Ist-Zustand</span>
-        </a>
-        <a href="#variant-a" class="section-nav-item" data-section-id="variant-a" data-variant>
-          <span class="section-nav-label">A Orbital Ring</span>
-          <span class="section-nav-state">{{variant.include}}</span>
-        </a>
-        <a href="#variant-b" class="section-nav-item" data-section-id="variant-b" data-variant>
-          <span class="section-nav-label">B Hexagonal</span>
-          <span class="section-nav-state">{{variant.include}}</span>
-        </a>
-        -->
+        <!-- auto-populated -->
       </nav>
 
-      <!-- Connection warning — shown when Claude heartbeat is stale -->
-      <div id="connection-warning" class="panel-warning" style="display: none;">
-        <span class="warning-icon">⚠</span>
-        <span>{{panel.disconnected}}</span>
-      </div>
-
-      <!-- Normal state: decision summary + submit -->
+      <!-- Normal state: decision summary + two submit buttons.
+           The disconnected warning lives INSIDE #panel-ready and covers
+           the submit area as an overlay when Claude is offline. -->
       <div id="panel-ready">
         <div id="decision-summary">
           <!-- Auto-populated summary of current selections -->
         </div>
-        <button id="submit-btn" class="primary">{{panel.submit}}</button>
-        <p class="hint">{{panel.submit_hint}}</p>
+
+        <!-- Connection overlays. Three possible states:
+             1. Page just loaded, heartbeat not yet confirmed → #connection-connecting
+                visible (default), warning hidden.
+             2. Heartbeat confirmed fresh → both hidden.
+             3. Past grace period AND heartbeat stale → #connection-warning
+                visible, connecting hidden.
+             Both are absolute overlays on top of #panel-ready. -->
+        <div id="connection-connecting" class="panel-warning panel-warning--connecting" style="display: flex;">
+          <span class="warning-icon" aria-hidden="true">⋯</span>
+          <strong>{{panel.connecting_title}}</strong>
+          <p class="warning-message">{{panel.connecting_hint}}</p>
+        </div>
+        <div id="connection-warning" class="panel-warning" style="display: none;">
+          <span class="warning-icon" aria-hidden="true">⚠</span>
+          <strong>{{panel.disconnected_title}}</strong>
+          <p class="warning-message">{{panel.disconnected_hint}}</p>
+        </div>
+
+        <button id="submit-iterate-btn" class="primary submit-btn">{{panel.submit_iterate}}</button>
+        <p class="hint">{{panel.submit_iterate_hint}}</p>
+        <div class="submit-gap" aria-hidden="true"></div>
+        <button id="submit-implement-btn" class="implement-btn">
+          <span class="warn-icon" aria-hidden="true">⚠</span>
+          {{panel.submit_implement}}
+        </button>
+        <p class="hint hint-warn">{{panel.submit_implement_hint}}</p>
       </div>
 
       <!-- Post-submit state: waiting for Claude -->
@@ -141,11 +202,20 @@ hook) is `de`, swap the matching strings into the rendered HTML and set
 </html>
 ```
 
-### Layout Modes
+Set `data-template` on the `<html>` element to one of `decision` | `prototype` | `free`. This is the single source of truth that drives template-specific CSS (`.concept-layout[data-template="prototype"]`) and JS branches (`collectDecisions`).
 
-#### Sidebar (default)
+---
 
-Content left (~80%), decision panel right (~20%). Best for most concepts.
+# Template: decision
+
+Multi-variant evaluation with sidebar layout. This is the canonical flow:
+Claude presents 2+ options, user picks tri-state per variant, submits,
+Claude iterates.
+
+## Layout — Sidebar
+
+Content left (~80%), decision panel right (~20%), always visible. Best for
+structured evaluation where the user wants to see the panel at all times.
 
 ```css
 .concept-layout {
@@ -184,67 +254,518 @@ Content left (~80%), decision panel right (~20%). Best for most concepts.
 }
 ```
 
-#### Fullscreen + Overlay
+## Bi-State Variant Evaluation
 
-Content fills 100% of the viewport. Decision panel slides in from the right
-via a floating action button. Best for visual prototypes, mockups, previews,
-or any content that needs maximum display area.
+Every variant in a decision page MUST include a **bi-state** selector with
+exactly two options.
+
+| State | Label | Behavior |
+|-------|-------|----------|
+| **Miteinbeziehen** | "Miteinbeziehen" (default) | Claude considers this variant in the next iteration or implementation |
+| **Verwerfen** | "Verwerfen" | Claude discards this variant and excludes it from all further steps |
+
+- Default state for all variants: **Miteinbeziehen**
+- No "Nur diese" / "only" option — the user implicitly picks a single
+  variant by setting all others to "Verwerfen"
+- No "Claude setzt um" / "Feedback" hint labels — the action-vs-feedback
+  distinction is now expressed by the two submit buttons (iterate vs.
+  implement), NOT by the evaluation selector
+- Each variant can ADDITIONALLY have rating, comments, and other controls
+
+### HTML
 
 ```html
-<div class="concept-layout fullscreen">
-  <div class="concept-content">
-    <!-- Full-width content: mockups, previews, diagrams -->
+<div class="variant-evaluation" data-decision="variant-a" data-label="Variant A">
+  <div class="eval-group">
+    <label class="eval-option">
+      <input type="radio" name="eval-variant-a" value="discard">
+      <span class="eval-label">Verwerfen</span>
+    </label>
+    <label class="eval-option">
+      <input type="radio" name="eval-variant-a" value="include" checked>
+      <span class="eval-label">Miteinbeziehen</span>
+    </label>
   </div>
-
-  <!-- Floating toggle button -->
-  <button id="panel-toggle" class="panel-fab" aria-label="{{panel.toggle_open}}">
-    <span class="fab-icon">☰</span>
-  </button>
-
-  <!-- Slide-in overlay panel — same content order as the sidebar variant:
-       iteration-tabs, section-nav, decision summary, submit. -->
-  <aside class="concept-decision-panel overlay" id="decision-panel">
-    <button id="panel-close" class="panel-close-btn" aria-label="{{panel.close}}">✕</button>
-    <nav class="iteration-tabs" role="tablist" aria-label="{{iteration.label}}"><!-- chips --></nav>
-    <h3>{{panel.heading}}</h3>
-    <nav class="section-nav" id="section-nav" aria-label="{{nav.sections}}"><!-- TOC --></nav>
-    <!-- rest of panel content -->
-  </aside>
-  <div class="panel-backdrop" id="panel-backdrop"></div>
 </div>
 ```
 
+Legacy class names `tri-state-group` / `tri-state-option` / `tri-state-label`
+are deprecated but still accepted by the CSS selectors below for backward
+compatibility.
+
+### CSS
+
 ```css
-.concept-layout.fullscreen .concept-content {
-  width: 100%;
-  padding: 2rem;
+/* Bi-state — legacy tri-state-* class names still supported */
+.eval-group, .tri-state-group {
+  display: flex;
+  gap: 0;
+  border: 1px solid var(--border-color, #30363d);
+  border-radius: 8px;
+  overflow: hidden;
 }
-.concept-layout.fullscreen .concept-decision-panel {
-  display: none;  /* hidden by default */
+.eval-option, .tri-state-option {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  cursor: pointer;
+  text-align: center;
+  position: relative;
+  border-right: 1px solid var(--border-color, #30363d);
+  transition: background 0.2s, box-shadow 0.2s;
+}
+.eval-option:last-child, .tri-state-option:last-child { border-right: none; }
+
+.eval-option:hover, .tri-state-option:hover {
+  background: color-mix(in srgb, var(--accent-color, #58a6ff) 10%, transparent);
 }
 
-/* Floating action button */
-.panel-fab {
-  position: fixed;
-  bottom: 2rem;
-  right: 2rem;
-  width: 56px;
-  height: 56px;
+.eval-option input, .tri-state-option input { display: none; }
+
+.eval-option:has(input:checked) .eval-label,
+.tri-state-option:has(input:checked) .tri-state-label {
+  font-weight: 700;
+}
+
+.eval-label, .tri-state-label { font-size: 0.9rem; transition: font-weight 0.15s; }
+
+/* Checkmark badge on the selected option */
+.eval-option:has(input:checked)::after,
+.tri-state-option:has(input:checked)::after {
+  content: '✓';
+  position: absolute;
+  top: 4px;
+  right: 6px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  width: 18px;
+  height: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   border-radius: 50%;
-  border: none;
+  pointer-events: none;
+}
+
+/* Miteinbeziehen (default, accent) */
+.eval-option:has(input[value="include"]:checked),
+.tri-state-option:has(input[value="include"]:checked) {
+  background: color-mix(in srgb, var(--accent-color, #58a6ff) 15%, transparent);
+  box-shadow: inset 0 0 0 2px var(--accent-color, #58a6ff);
+}
+.eval-option:has(input[value="include"]:checked)::after,
+.tri-state-option:has(input[value="include"]:checked)::after {
   background: var(--accent-color, #58a6ff);
   color: white;
-  font-size: 1.5rem;
-  cursor: pointer;
-  box-shadow: 0 4px 12px rgba(0,0,0,0.3);
-  z-index: 100;
-  transition: transform 0.2s, opacity 0.2s;
 }
-.panel-fab:hover { transform: scale(1.1); }
-.panel-fab.hidden { opacity: 0; pointer-events: none; }
 
-/* Slide-in panel overlay */
-.concept-decision-panel.overlay {
+/* Verwerfen (danger) */
+.eval-option:has(input[value="discard"]:checked),
+.tri-state-option:has(input[value="discard"]:checked) {
+  background: color-mix(in srgb, var(--danger-color, #f85149) 12%, transparent);
+  box-shadow: inset 0 0 0 2px var(--danger-color, #f85149);
+}
+.eval-option:has(input[value="discard"]:checked)::after,
+.tri-state-option:has(input[value="discard"]:checked)::after {
+  background: var(--danger-color, #f85149);
+  color: white;
+}
+.eval-option:has(input[value="discard"]:checked) .eval-label,
+.tri-state-option:has(input[value="discard"]:checked) .tri-state-label {
+  color: var(--danger-color, #f85149);
+}
+
+/* Unselected state */
+.eval-option:has(input:not(:checked)),
+.tri-state-option:has(input:not(:checked)) {
+  opacity: 0.7;
+}
+.eval-option:has(input:not(:checked)):hover,
+.tri-state-option:has(input:not(:checked)):hover {
+  opacity: 1;
+}
+```
+
+**Behavior:**
+- Default: "Miteinbeziehen" (all variants considered)
+- "Verwerfen": grays out the variant card visually (still accessible)
+- To pick a single variant, set all others to "Verwerfen" manually
+
+### Decision schema
+
+```json
+{
+  "template": "decision",
+  "action": "iterate",
+  "decisions": [
+    { "id": "variant-a", "label": "...", "evaluation": "include", "rating": 4 },
+    { "id": "variant-b", "label": "...", "evaluation": "discard", "rating": 2 },
+    { "id": "variant-c", "label": "...", "evaluation": "include", "rating": 5 }
+  ],
+  "comments": [
+    { "id": "variant-a", "text": "..." }
+  ]
+}
+```
+
+`evaluation` values: `"discard"` | `"include"`
+`action` values: `"iterate"` | `"implement"` — determined by which submit
+button the user clicked. See § Two-Button Submit below.
+
+## Content Variants (within the decision template)
+
+The decision template has six content sub-variants. They describe the shape
+of the variant cards — not a different page layout.
+
+### Variant: analysis
+
+**Purpose:** Present findings from a data analysis with accept/reject controls.
+
+```
+[Header: Analysis title + date]
+[Summary card: key metrics / TL;DR]
+
+[Finding 1]
+  ├── Description + evidence
+  ├── [Tri-state: Verwerfen / Miteinbeziehen (default) / Nur diese]
+  ├── [Priority: Hoch / Mittel / Niedrig]
+  └── [Comment field: "Anmerkung..."]
+
+[Finding 2]
+  └── ...
+
+[Submit button]
+```
+
+### Variant: plan
+
+**Purpose:** Present an implementation plan with step approval controls.
+
+```
+[Header: Plan title]
+[Overview card: goal, scope, timeline]
+
+[Phase 1: Name]
+  [Step 1.1]
+    ├── Description + rationale
+    ├── [Checkbox: Einschliessen]
+    ├── [Effort indicator: S / M / L / XL]
+    └── [Comment field]
+
+  [Step 1.2]
+    └── ...
+
+[Submit button]
+```
+
+### Variant: concept
+
+**Purpose:** Present architecture or design variants for evaluation.
+
+```
+[Header: Concept title]
+[Context card: problem statement]
+
+[Variant A: Name]
+  ├── Description + diagram/illustration
+  ├── Pro/Con list
+  ├── [Tri-state: Verwerfen / Miteinbeziehen (default) / Nur diese]
+  ├── [Rating: 1-5 stars or slider]
+  └── [Comment field (wide, min-height: 80px)]
+
+[Variant B: Name]
+  └── ...
+
+[Decision panel sidebar: summary + submit]
+```
+
+### Variant: comparison
+
+**Purpose:** Side-by-side comparison of options with winner selection.
+
+```
+[Header: Comparison title]
+
+[Criteria table / matrix]
+  ├── Row per criterion
+  ├── Column per option
+  ├── [Weight slider per criterion]
+  └── Auto-calculated weighted scores
+
+[Per-option detail cards]
+  ├── Strengths
+  ├── Weaknesses
+  ├── [Tri-state: Verwerfen / Miteinbeziehen (default) / Nur diese]
+  └── [Comment field (wide)]
+
+[Decision panel sidebar: summary + submit]
+```
+
+Each option in the comparison gets the same **tri-state evaluation** as
+concept variants. Decision schema matches the decision template schema, with
+additional `weight-*` entries for weight sliders.
+
+### Variant: dashboard
+
+**Purpose:** Status overview or metric dashboard with filters.
+
+```
+[Header + date range]
+[KPI cards row: 3-5 key metrics]
+
+[Filter bar: toggles for categories/segments]
+
+[Expandable sections]
+  ├── Section title + summary stat
+  ├── Expanded: detail table or chart
+  └── [Comment field per section]
+
+[Action items section]
+  ├── [Checkbox per item]
+  └── [Comment field]
+
+[Submit button]
+```
+
+### Variant: creative
+
+**Purpose:** Brainstorming, ideation, collecting ideas.
+
+```
+[Header: Topic]
+[Context / constraints]
+
+[Idea cards grid]
+  ├── Idea title + description
+  ├── [Vote: thumbs up/down]
+  ├── [Tag selector: category]
+  └── [Comment field]
+
+[Add new idea button → inline form]
+[Submit button]
+```
+
+---
+
+# Template: prototype
+
+**One visual artefact, one screen at a time, 100 % viewport.** The body shows
+exactly one screen from the flow. The user switches between screens via the
+screen-nav inside the ☰ decision panel, keyboard arrows, OR by clicking
+buttons inside the mockup itself (click-dummy behaviour). The viewport
+has no header bar, no sidebars — just the current screen and two floating
+buttons:
+
+## Rules
+
+- **Click-dummy by default (2+ screens):** buttons/links inside the mockup
+  MUST navigate between screens when clicked. A real "Continue" button on
+  screen 1 takes the user to screen 2; "Back" goes to screen 1; etc. The
+  user can thereby click through the whole flow as if it were a real app.
+- **"Screen" = logical state, not necessarily full page.** A screen is any
+  user-distinguishable state the reviewer should be able to annotate
+  separately:
+  - Full-page transitions (welcome / credentials / success)
+  - Modal / drawer / dialog toggles (main view without modal vs. with
+    modal open)
+  - Tab or accordion selections (tab A content vs. tab B content)
+  - Empty / loading / populated / error states of the same component
+  - Before / after user action (form empty vs. form submitted)
+
+  Each such state becomes its own `<section data-screen>`. The click-dummy
+  wiring with `data-screen-link` handles the transition like any other
+  screen switch.
+- **Single-screen prototype (exactly one `<section data-screen>`):**
+  - No screen-nav rendered inside the ☰ panel
+  - Feedback dock shows ONLY the general-notes textarea (no
+    per-screen section, no "Aktueller Screen" label)
+  - No click-dummy wiring required — nothing to navigate to
+  - The screen-indicator overlay can be hidden or simplified
+  - `buildScreenUI()` detects `screens.length === 1` and sets
+    `document.body.dataset.singleScreen = 'true'` so CSS can hide the
+    per-screen UI. CSS adds: `body[data-single-screen="true"] #screen-nav,
+    body[data-single-screen="true"] .feedback-section:has(#screen-textareas)
+    { display: none }`.
+- **Do NOT invent artificial screens** to make the template fit. If the
+  artefact has no meaningful secondary state, leave it as a single screen
+  and let the dock collapse to general notes only.
+- **Design system alignment:** the prototype MUST use the project's existing
+  design tokens (colors, typography, spacing, component shapes) unless the
+  user explicitly requests a different look. Read `design-tokens.*`,
+  Tailwind config, Figma variables via the design MCP, or the existing UI
+  layer before inventing a style. The example in this file uses the generic
+  GitHub-style palette only because dotclaude has no project-specific
+  tokens — consumer projects will differ.
+
+## Click-through wiring (`data-screen-link`)
+
+Buttons inside a mockup get `data-screen-link` to declare their navigation:
+
+```html
+<div class="device-frame">
+  <h4>Welcome</h4>
+  <button class="mock-btn" data-screen-link="screen-credentials">Los geht's</button>
+  <button class="mock-btn secondary" data-screen-link="screen-login">Anmelden</button>
+</div>
+```
+
+Values:
+- `data-screen-link="screen-id"` — jump to the screen with that id
+- `data-screen-link="next"` — advance to the next screen in DOM order
+- `data-screen-link="prev"` — go to the previous screen
+- Omit the attribute entirely for decorative / terminal buttons
+
+The wiring is a single delegated click handler installed alongside
+`showScreen` — see § Click-through Handler below.
+
+- `☰` (bottom-right) → Decision panel: iteration tabs, screen navigation, submit
+- `💬` (bottom-left) → Feedback dock: **context-sensitive** textarea for the
+  currently-visible screen + a persistent "general notes" textarea below
+
+### Feedback behaviour (strict)
+
+- The 💬 dock always shows **one textarea for the currently-active screen**
+  (label: "Aktueller Screen: {screen-label}"). Its content is private to that
+  screen.
+- Below a divider, a **second textarea for general notes** stays visible
+  regardless of the active screen — the user can append from any screen.
+- When the user switches screens (via ☰ or keyboard), the screen textarea
+  swaps to the new screen's notes. Previous screen's notes are preserved and
+  come back when the user returns.
+- `localStorage` persists all screen notes independently + the general notes
+  + the active-screen id, so refresh / tab-close / browser-restart don't
+  lose state.
+- After Submit, a new iteration is appended (like decision). The user can
+  switch back to iteration N via the iteration-tabs and re-read their frozen
+  notes per screen.
+
+## Layout — Fullscreen single-screen + Overlay Panel + Feedback Dock
+
+```html
+<html data-template="prototype">
+<body style="overflow: hidden">
+  <div class="concept-layout prototype fullscreen">
+    <div class="concept-content">
+      <main>
+        <section data-iteration="1" data-active>
+          <!-- All screens live here. Exactly one carries data-screen-active="true"
+               (others get `hidden`). Every screen is position: absolute; inset: 0
+               so it fills the viewport. A <div class="device-frame"> inside
+               holds the actual mock content. -->
+          <section id="screen-1" data-screen data-nav-label="Welcome" data-screen-active="true">
+            <div class="device-frame">…mock…</div>
+          </section>
+          <section id="screen-2" data-screen data-nav-label="Credentials" hidden>
+            <div class="device-frame">…mock…</div>
+          </section>
+          <section id="screen-3" data-screen data-nav-label="Success" hidden>
+            <div class="device-frame">…mock…</div>
+          </section>
+        </section>
+      </main>
+    </div>
+
+    <!-- Minimal screen counter (top-left overlay) — NOT a header bar.
+         Shows "Screen N / Total · {label}" so the user always knows where
+         they are. -->
+    <div class="screen-indicator">
+      Screen <strong id="active-screen-idx">1</strong> / <span id="total-screens">3</span>
+      · <span id="active-screen-label">Welcome</span>
+    </div>
+
+    <!-- Two FABs — the only floating UI besides the screen itself. -->
+    <button id="panel-toggle" class="panel-fab" aria-label="{{panel.toggle_open}}">☰</button>
+    <button id="feedback-toggle" class="feedback-fab" aria-label="{{proto.feedback_toggle}}">💬</button>
+
+    <!-- Decision panel (☰) — contains: iteration-tabs, screen-nav, submit.
+         No section-TOC here: the screen-nav replaces it for prototype. -->
+    <aside class="concept-decision-panel overlay" id="decision-panel">
+      <button id="panel-close" class="panel-close-btn" aria-label="{{panel.close}}">✕</button>
+      <nav class="iteration-tabs" role="tablist" aria-label="{{iteration.label}}"><!-- chips --></nav>
+      <nav class="screen-nav" id="screen-nav" aria-label="Screens">
+        <!-- auto-populated: one button per <section data-screen>.
+             Each shows the screen index, label, and a ● marker when that
+             screen has unsubmitted notes. Clicking switches the active screen
+             AND closes the panel. -->
+      </nav>
+      <div id="panel-ready">
+        <button id="submit-iterate-btn" class="primary submit-btn">{{panel.submit_iterate}}</button>
+        <p class="hint">{{panel.submit_iterate_hint}}</p>
+        <div class="submit-gap" aria-hidden="true"></div>
+        <button id="submit-implement-btn" class="implement-btn">
+          <span class="warn-icon" aria-hidden="true">⚠</span>
+          {{panel.submit_implement}}
+        </button>
+        <p class="hint hint-warn">{{panel.submit_implement_hint}}</p>
+      </div>
+      <div id="panel-submitted" style="display: none;"><!-- waiting state --></div>
+    </aside>
+    <div class="panel-backdrop" id="panel-backdrop"></div>
+
+    <!-- Feedback dock (💬) — context-sensitive.
+         * Top: ONE textarea for the active screen (swapped on navigation).
+         * Bottom: ONE textarea for general notes, always visible. -->
+    <aside class="feedback-dock" id="feedback-dock" data-open="false">
+      <div class="feedback-dock-header">
+        <strong>Feedback</strong>
+        <button id="feedback-close" class="feedback-close-btn" aria-label="{{panel.close}}">✕</button>
+      </div>
+      <div class="feedback-section">
+        <label>Aktueller Screen: <strong id="dock-screen-label">Welcome</strong></label>
+        <!-- One hidden textarea per screen. Only the active one is shown.
+             Each carries data-comment="{screen-id}" AND
+             data-screen-comment="{screen-id}" — so saveState/restoreState
+             treats it like any comment field. -->
+        <div id="screen-textareas"><!-- auto-populated --></div>
+      </div>
+      <div class="feedback-divider"></div>
+      <div class="feedback-section">
+        <label>{{proto.feedback_general}}</label>
+        <textarea id="proto-general-feedback" data-comment="general"
+                  placeholder="{{proto.feedback_general}}"></textarea>
+      </div>
+    </aside>
+  </div>
+</body>
+</html>
+```
+
+## Layout CSS
+
+```css
+/* Fullscreen prototype — no body scroll, exactly one screen fills viewport */
+html, body { margin: 0; padding: 0; height: 100%; overflow: hidden; }
+.concept-layout.prototype.fullscreen { display: block; width: 100vw; height: 100vh; overflow: hidden; }
+.concept-layout.prototype .concept-content { position: absolute; inset: 0; overflow: hidden; }
+
+/* Iteration sections fill the viewport. Screens inside do too —
+   only the active one is visible (hidden attribute on the others). */
+section[data-iteration] { position: absolute; inset: 0; }
+section[data-iteration][hidden] { display: none; }
+section[data-screen] {
+  position: absolute; inset: 0;
+  display: flex; align-items: center; justify-content: center;
+  padding: 2rem; overflow-y: auto;
+  animation: screen-in 0.25s ease;
+}
+section[data-screen][hidden] { display: none; }
+@keyframes screen-in { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: translateY(0); } }
+
+/* Minimal screen counter — NOT a header bar */
+.screen-indicator {
+  position: fixed; top: 1rem; left: 1rem; z-index: 90;
+  padding: 0.4rem 0.75rem; border-radius: 999px;
+  background: color-mix(in srgb, var(--panel-bg) 85%, transparent);
+  border: 1px solid var(--border-color);
+  color: var(--text-secondary); font-size: 0.8rem;
+  backdrop-filter: blur(6px);
+}
+.screen-indicator strong { color: var(--text); }
+
+/* Overlay decision panel — hidden by default, same slide-in as non-prototype overlay */
+.concept-layout.prototype .concept-decision-panel {
   display: flex;
   flex-direction: column;
   position: fixed;
@@ -260,10 +781,33 @@ or any content that needs maximum display area.
   overflow-y: auto;
   transition: right 0.3s ease;
 }
-.concept-decision-panel.overlay.open {
+.concept-layout.prototype .concept-decision-panel.open {
   right: 0;
 }
-.panel-close-btn {
+
+.panel-fab,
+.feedback-fab {
+  position: fixed;
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  border: none;
+  color: white;
+  font-size: 1.5rem;
+  cursor: pointer;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.3);
+  z-index: 100;
+  transition: transform 0.2s, opacity 0.2s;
+}
+.panel-fab { bottom: 2rem; right: 2rem; background: var(--accent-color, #58a6ff); }
+.feedback-fab { bottom: 2rem; left: 2rem; background: var(--warning-color, #d29922); }
+.panel-fab:hover,
+.feedback-fab:hover { transform: scale(1.1); }
+.panel-fab.hidden,
+.feedback-fab.hidden { opacity: 0; pointer-events: none; }
+
+.panel-close-btn,
+.feedback-close-btn {
   align-self: flex-end;
   background: none;
   border: none;
@@ -273,7 +817,6 @@ or any content that needs maximum display area.
   padding: 0.25rem;
 }
 
-/* Backdrop */
 .panel-backdrop {
   display: none;
   position: fixed;
@@ -281,51 +824,469 @@ or any content that needs maximum display area.
   background: rgba(0,0,0,0.5);
   z-index: 150;
 }
-.panel-backdrop.visible {
-  display: block;
+.panel-backdrop.visible { display: block; }
+
+/* ── Screen navigation inside the ☰ panel ── */
+.screen-nav { display: flex; flex-direction: column; gap: 4px;
+  margin-bottom: 1.5rem; padding-bottom: 1rem; border-bottom: 1px solid var(--border-color); }
+.screen-nav-item { display: flex; align-items: center; justify-content: space-between;
+  padding: 0.6rem 0.85rem; border-radius: 8px; text-decoration: none;
+  color: var(--text-color, #c9d1d9); font-size: 0.95rem;
+  border: 1px solid var(--border-color); background: transparent;
+  cursor: pointer; transition: all 0.15s; text-align: left; }
+.screen-nav-item:hover { background: color-mix(in srgb, var(--accent-color) 10%, transparent); }
+.screen-nav-item[data-active="true"] {
+  background: color-mix(in srgb, var(--accent-color) 18%, transparent);
+  border-color: var(--accent-color); font-weight: 600;
+}
+.screen-nav-item .screen-idx { color: var(--accent-color); font-weight: 600; margin-right: 0.5rem; }
+.screen-nav-item .has-notes { color: var(--warning-color); font-size: 0.75rem; }
+
+/* ── Feedback Dock (bottom, collapsible, context-sensitive) ── */
+.feedback-dock {
+  position: fixed; left: 0; right: 0; bottom: -100%; max-height: 70vh;
+  padding: 1.5rem; background: var(--panel-bg, #161b22);
+  border-top: 1px solid var(--border-color, #30363d);
+  box-shadow: 0 -6px 20px rgba(0,0,0,0.35); z-index: 180; overflow-y: auto;
+  transition: bottom 0.3s ease;
+  display: flex; flex-direction: column; gap: 1.25rem;
+}
+.feedback-dock[data-open="true"] { bottom: 0; }
+.feedback-dock-header { display: flex; justify-content: space-between; align-items: center; }
+.feedback-section { display: flex; flex-direction: column; gap: 0.4rem; }
+.feedback-section label { font-size: 0.9rem; color: var(--text-secondary); font-weight: 500; }
+.feedback-section label strong { color: var(--accent-color); }
+.feedback-section textarea {
+  width: 100%; padding: 0.8rem;
+  border: 1px solid var(--border-color); border-radius: 10px;
+  background: var(--input-bg, #0d1117); color: var(--text-color, #c9d1d9);
+  font-family: inherit; font-size: 0.95rem; line-height: 1.5; resize: vertical; min-height: 90px;
+}
+.feedback-section textarea:focus { outline: none; border-color: var(--accent-color); }
+.feedback-divider { height: 1px; background: var(--border-color); margin: 0.25rem 0; }
+
+/* Hidden per-screen textareas inside #screen-textareas: only active shown */
+#screen-textareas textarea[hidden] { display: none; }
+
+/* Single-screen prototype: hide screen-nav + per-screen feedback section.
+   Only general notes remain visible. */
+body[data-single-screen="true"] #screen-nav,
+body[data-single-screen="true"] .feedback-section:has(#screen-textareas),
+body[data-single-screen="true"] .feedback-divider:has(+ .feedback-section #proto-general-feedback) {
+  display: none;
 }
 ```
+
+## Layout JS — single-screen navigation + context-sensitive feedback
+
+Only one screen is visible at a time. `showScreen(id)` swaps the active
+screen, updates the counter overlay, and swaps the feedback-dock textarea
+to the matching per-screen `<textarea>`. Per-screen textareas stay in the
+DOM (just hidden), so each one's value persists independently via
+`localStorage` (same mechanism as any `data-comment` field).
 
 ```javascript
-// --- Fullscreen Overlay Panel ---
-const panelToggle = document.getElementById('panel-toggle');
-const panelClose = document.getElementById('panel-close');
-const panel = document.getElementById('decision-panel');
-const backdrop = document.getElementById('panel-backdrop');
+(function wirePrototypeLayout() {
+  if (document.documentElement.dataset.template !== 'prototype') return;
 
-function openPanel() {
-  panel.classList.add('open');
-  backdrop.classList.add('visible');
-  panelToggle.classList.add('hidden');
-}
-function closePanel() {
-  panel.classList.remove('open');
-  backdrop.classList.remove('visible');
-  panelToggle.classList.remove('hidden');
-}
+  // Build screen-nav buttons (☰) and per-screen textareas (💬) from every
+  // <section data-screen> inside the active iteration.
+  function buildScreenUI() {
+    const active = document.querySelector('section[data-iteration][data-active]');
+    if (!active) return;
+    const screens = [...active.querySelectorAll('section[data-screen][id]')];
+    document.getElementById('total-screens').textContent = screens.length;
 
-if (panelToggle) panelToggle.addEventListener('click', openPanel);
-if (panelClose) panelClose.addEventListener('click', closePanel);
-if (backdrop) backdrop.addEventListener('click', closePanel);
+    // Single-screen prototypes: hide screen-nav + per-screen feedback.
+    // CSS keys off body[data-single-screen="true"].
+    document.body.dataset.singleScreen = screens.length <= 1 ? 'true' : 'false';
+    if (screens.length <= 1) {
+      const indicator = document.querySelector('.screen-indicator');
+      if (indicator) indicator.style.display = 'none';
+    }
 
-// Close panel on section nav click (scroll to section). Delegated so it
-// works for auto-populated TOC links. Takes precedence over the default
-// smooth-scroll handler because we need to close the overlay first.
-document.addEventListener('click', e => {
-  const link = e.target.closest('.section-nav-item');
-  if (!link) return;
-  if (!document.getElementById('decision-panel')?.classList.contains('open')) return;
-  e.preventDefault();
-  e.stopPropagation();
-  closePanel();
-  setTimeout(() => {
-    const target = document.querySelector(link.getAttribute('href'));
-    if (target) target.scrollIntoView({ behavior: 'smooth', block: 'start' });
-  }, 150);
-}, true);
+    const nav = document.getElementById('screen-nav');
+    nav.innerHTML = '';
+    screens.forEach((sec, idx) => {
+      const btn = document.createElement('button');
+      btn.className = 'screen-nav-item';
+      btn.dataset.screenId = sec.id;
+      btn.innerHTML = `<span><span class="screen-idx">${idx + 1}.</span>${sec.dataset.navLabel || sec.id}</span>
+        <span class="has-notes" data-note-marker></span>`;
+      btn.addEventListener('click', () => { showScreen(sec.id); closePanel(); });
+      nav.appendChild(btn);
+    });
+
+    const container = document.getElementById('screen-textareas');
+    container.innerHTML = '';
+    screens.forEach(sec => {
+      const ta = document.createElement('textarea');
+      ta.dataset.comment = sec.id;
+      ta.dataset.screenComment = sec.id;
+      ta.placeholder = `Notiz zu ${sec.dataset.navLabel || sec.id}…`;
+      ta.hidden = true;
+      container.appendChild(ta);
+    });
+  }
+
+  window.showScreen = function(id) {
+    const screens = document.querySelectorAll(
+      'section[data-iteration][data-active] section[data-screen][id]');
+    let idx = 0;
+    screens.forEach((s, i) => {
+      const match = s.id === id;
+      s.hidden = !match;
+      s.dataset.screenActive = match ? 'true' : 'false';
+      if (match) idx = i;
+    });
+    const screen = document.getElementById(id);
+    const label = screen?.dataset.navLabel || id;
+    document.getElementById('active-screen-label').textContent = label;
+    document.getElementById('active-screen-idx').textContent = idx + 1;
+    document.getElementById('dock-screen-label').textContent = label;
+    document.querySelectorAll('[data-screen-comment]').forEach(ta => {
+      ta.hidden = ta.dataset.screenComment !== id;
+    });
+    document.querySelectorAll('.screen-nav-item').forEach(item => {
+      item.dataset.active = String(item.dataset.screenId === id);
+    });
+    updateNoteMarkers();
+    if (typeof saveState === 'function') saveState();
+  };
+
+  function updateNoteMarkers() {
+    document.querySelectorAll('.screen-nav-item').forEach(item => {
+      const id = item.dataset.screenId;
+      const ta = document.querySelector(`[data-screen-comment="${id}"]`);
+      const marker = item.querySelector('[data-note-marker]');
+      if (marker) marker.textContent = (ta && ta.value.trim()) ? '● Notiz' : '';
+    });
+  }
+  window.updateNoteMarkers = updateNoteMarkers;
+
+  // Panel + dock toggles
+  const panel = document.getElementById('decision-panel');
+  const panelToggle = document.getElementById('panel-toggle');
+  const panelCloseBtn = document.getElementById('panel-close');
+  const backdrop = document.getElementById('panel-backdrop');
+  window.openPanel = () => { panel.classList.add('open'); backdrop.classList.add('visible'); panelToggle.classList.add('hidden'); };
+  window.closePanel = () => { panel.classList.remove('open'); backdrop.classList.remove('visible'); panelToggle.classList.remove('hidden'); };
+  panelToggle.addEventListener('click', openPanel);
+  panelCloseBtn.addEventListener('click', closePanel);
+  backdrop.addEventListener('click', closePanel);
+
+  const dock = document.getElementById('feedback-dock');
+  const dockToggle = document.getElementById('feedback-toggle');
+  const dockClose = document.getElementById('feedback-close');
+  function closeDock() { dock.dataset.open = 'false'; dockToggle.classList.remove('hidden'); }
+  window.closeDock = closeDock;
+  dockToggle.addEventListener('click', () => { dock.dataset.open = 'true'; dockToggle.classList.add('hidden'); });
+  dockClose.addEventListener('click', closeDock);
+
+  // Click outside the dock (anywhere on the prototype screen) closes it.
+  // The ✕ button still works — this just adds click-away as an alternative
+  // dismissal. Uses capture so it runs before the screen-link handler,
+  // which is fine: the click also triggers navigation if it hit a
+  // data-screen-link element, and dismissing the dock first is harmless.
+  document.addEventListener('click', (e) => {
+    if (dock.dataset.open !== 'true') return;
+    if (e.target.closest('#feedback-dock')) return;
+    if (e.target.closest('#feedback-toggle')) return;
+    closeDock();
+  }, true);
+
+  document.addEventListener('DOMContentLoaded', () => {
+    buildScreenUI();
+    const active = document.querySelector('section[data-iteration][data-active]');
+    if (active) {
+      // Restore last active screen from localStorage if available,
+      // otherwise default to the first screen.
+      let restored = null;
+      try {
+        const raw = localStorage.getItem(STORAGE_KEY);
+        if (raw) restored = JSON.parse(raw)._activeScreen;
+      } catch (e) {}
+      const first = active.querySelector('section[data-screen]');
+      showScreen(restored && document.getElementById(restored) ? restored : (first ? first.id : ''));
+    }
+    document.addEventListener('input', updateNoteMarkers);
+  });
+
+  // Rebuild after iteration switches (fresh screens, fresh textareas).
+  document.addEventListener('iteration:changed', () => {
+    buildScreenUI();
+    const first = document.querySelector('section[data-iteration][data-active] section[data-screen]');
+    if (first) showScreen(first.id);
+  });
+
+  // Keyboard: Arrow Left/Right (and Space) jump between screens when no
+  // textarea/input is focused and no overlay is open.
+  document.addEventListener('keydown', e => {
+    if (dock.dataset.open === 'true' || panel.classList.contains('open')) return;
+    if (e.target.matches('textarea, input')) return;
+    const screens = [...document.querySelectorAll(
+      'section[data-iteration][data-active] section[data-screen]')];
+    const currentIdx = screens.findIndex(s => s.dataset.screenActive === 'true');
+    if (currentIdx < 0) return;
+    let nextIdx = currentIdx;
+    if (e.key === 'ArrowRight' || e.key === ' ') nextIdx = Math.min(currentIdx + 1, screens.length - 1);
+    else if (e.key === 'ArrowLeft') nextIdx = Math.max(currentIdx - 1, 0);
+    else return;
+    e.preventDefault();
+    showScreen(screens[nextIdx].id);
+  });
+})();
 ```
 
-### Section Navigation CSS (Decision Panel as TOC)
+**Persistence extension:** the prototype's `saveState()` must also write
+`_activeScreen: '{current-screen-id}'` into the localStorage payload so the
+restore path on page load lands the user back on the last-viewed screen.
+
+## Click-through Handler
+
+Single delegated listener that interprets `data-screen-link` on any element
+inside a `[data-screen]` section. Closes the ☰ panel (harmless no-op if
+it's not open) and fires `showScreen()`.
+
+```javascript
+document.addEventListener('click', e => {
+  const link = e.target.closest('[data-screen-link]');
+  if (!link) return;
+  const dest = link.dataset.screenLink;
+  const screens = [...document.querySelectorAll(
+    'section[data-iteration][data-active] section[data-screen]')];
+  const currentIdx = screens.findIndex(s => s.dataset.screenActive === 'true');
+  let targetId = null;
+  if (dest === 'next') targetId = screens[Math.min(currentIdx + 1, screens.length - 1)]?.id;
+  else if (dest === 'prev') targetId = screens[Math.max(currentIdx - 1, 0)]?.id;
+  else targetId = dest;
+  if (!targetId || !document.getElementById(targetId)) return;
+  e.preventDefault();
+  if (typeof closePanel === 'function') closePanel();
+  showScreen(targetId);
+});
+```
+
+## Screen-pattern markup
+
+Each logical screen in the prototype is a `<section>` with `data-screen`:
+
+```html
+<section data-iteration="1" data-active>
+  <header class="iteration-intro">
+    <h2>Iteration 1 · Login flow mockup</h2>
+    <p>High-fidelity walkthrough of the three-step sign-in flow.</p>
+  </header>
+
+  <section id="screen-welcome" data-nav-label="Welcome" data-screen>
+    <div class="prototype-frame">…mockup HTML for welcome screen…</div>
+  </section>
+
+  <section id="screen-credentials" data-nav-label="Credentials" data-screen>
+    <div class="prototype-frame">…mockup HTML for credentials screen…</div>
+  </section>
+
+  <section id="screen-success" data-nav-label="Success" data-screen>
+    <div class="prototype-frame">…mockup HTML for success screen…</div>
+  </section>
+</section>
+```
+
+**Rules:**
+- `data-screen` marks a block as a "feedback target" — it appears as a
+  per-screen textarea in the dock. Use it only for screens worth commenting on.
+- Every `data-screen` section MUST also have `id` and `data-nav-label` so
+  the panel TOC and the feedback dock can reference it.
+- The prototype iteration section can still contain non-screen `<section>`s
+  (e.g. `id="design-notes" data-nav-label="Design notes"`). Those appear in
+  the TOC but NOT in the feedback dock.
+- Iteration tabs still apply — when Claude iterates on feedback, a new
+  `<section data-iteration="N+1">` is appended with updated screens and the
+  old one is frozen (see Shared Systems § Iteration Tabs).
+
+## Decision schema
+
+Prototype submit payload has **no variant evaluations** — only comments:
+
+```json
+{
+  "template": "prototype",
+  "decisions": [],
+  "comments": [
+    { "id": "general", "text": "..." },
+    { "id": "screen-welcome", "label": "Welcome", "text": "..." },
+    { "id": "screen-credentials", "label": "Credentials", "text": "..." }
+  ]
+}
+```
+
+## collectDecisions (prototype branch)
+
+```javascript
+// Called by the shared submit handler; `data-template` picks the branch.
+function collectPrototypeDecisions() {
+  const comments = [];
+  // General notes
+  const general = document.getElementById('proto-general-feedback');
+  if (general && general.value.trim()) {
+    comments.push({ id: 'general', text: general.value.trim() });
+  }
+  // Per-screen comments
+  document.querySelectorAll('[data-screen-comment]').forEach(el => {
+    if (!el.value.trim()) return;
+    const id = el.dataset.screenComment;
+    const screenEl = document.getElementById(id);
+    comments.push({
+      id,
+      label: screenEl ? (screenEl.dataset.navLabel || id) : id,
+      text: el.value.trim()
+    });
+  });
+  return { submitted: true, template: 'prototype', decisions: [], comments };
+}
+```
+
+---
+
+# Template: free
+
+A sidebar layout (same as decision) but the body is Claude-authored free
+content: analysis, walkthrough, brainstorm, explainer, timeline. Tri-state
+evaluation is **opt-in** per section — Claude adds it only where it makes
+sense.
+
+## Layout — Sidebar, freeform body
+
+Identical to the decision layout (sticky sidebar, ~80/~20 split). The
+difference is in the body: no forced variant-card framing, no mandatory
+tri-state. Claude chooses the structure that fits the content.
+
+```html
+<html data-template="free">
+<body>
+  <div class="concept-layout">
+    <div class="concept-content">
+      <header>
+        <h1>{title}</h1>
+        <p class="subtitle">{optional}</p>
+        <button id="theme-toggle">🌙/☀️</button>
+      </header>
+      <main>
+        <section data-iteration="1" data-active>
+          <header class="iteration-intro">
+            <h2>Iteration 1 · {subject}</h2>
+            <p>Short intro paragraph.</p>
+          </header>
+
+          <!-- Freeform body. Every nested <section id data-nav-label> gets
+               a scroll anchor in the panel TOC. A section becomes "evaluable"
+               by adding an eval-{id} radio group inside it (optional). -->
+          <section id="context" data-nav-label="Context">
+            <p>…</p>
+          </section>
+
+          <section id="finding-1" data-nav-label="Finding: latency spike">
+            <p>…</p>
+            <!-- OPT-IN tri-state: only present when Claude wants the user to
+                 confirm the finding is valid. Section id MUST match the
+                 radio name suffix (eval-{id}). -->
+            <div class="tri-state-group">
+              <label class="tri-state-option">
+                <input type="radio" name="eval-finding-1" value="discard">
+                <span class="tri-state-label">Verwerfen</span>
+                <span class="tri-state-hint feedback">Feedback</span>
+              </label>
+              <label class="tri-state-option">
+                <input type="radio" name="eval-finding-1" value="include" checked>
+                <span class="tri-state-label">Miteinbeziehen</span>
+                <span class="tri-state-hint feedback">Feedback</span>
+              </label>
+              <label class="tri-state-option">
+                <input type="radio" name="eval-finding-1" value="only">
+                <span class="tri-state-label">Exakt diese</span>
+                <span class="tri-state-hint action">Claude setzt um</span>
+              </label>
+            </div>
+            <textarea data-comment="finding-1" placeholder="Anmerkung…"></textarea>
+          </section>
+
+          <section id="recommendation" data-nav-label="Recommendation">
+            <!-- plain section, no tri-state — just content -->
+            <p>…</p>
+          </section>
+        </section>
+      </main>
+    </div>
+
+    <aside class="concept-decision-panel">
+      <!-- Same structure as decision. Panel TOC auto-detects which sections
+           have eval-{id} radios and mirrors their current state. -->
+    </aside>
+  </div>
+</body>
+</html>
+```
+
+## Optional tri-state auto-detection
+
+The section nav auto-detects whether a `<section data-nav-label>` contains an
+`eval-{id}` radio group and mirrors its current state (Miteinbeziehen /
+Verwerfen / Exakt diese). Sections without a radio group just get a scroll
+anchor. See Shared Systems § Section Navigation for the implementation.
+
+## Decision schema
+
+The free template emits **only the sections that actually have tri-state
+radios**, plus whatever comments the user typed:
+
+```json
+{
+  "template": "free",
+  "decisions": [
+    { "id": "finding-1", "label": "Finding: latency spike", "evaluation": "include" }
+  ],
+  "comments": [
+    { "id": "finding-1", "text": "..." },
+    { "id": "recommendation", "text": "..." }
+  ]
+}
+```
+
+If no section has tri-state markers, `decisions` is an empty array and the
+submit payload is effectively a general-notes post.
+
+## collectDecisions (free branch)
+
+```javascript
+function collectFreeDecisions() {
+  const decisions = [];
+  document.querySelectorAll('section[id][data-nav-label]').forEach(sec => {
+    const radio = sec.querySelector(`input[name="eval-${CSS.escape(sec.id)}"]:checked`);
+    if (!radio) return;
+    decisions.push({
+      id: sec.id,
+      label: sec.dataset.navLabel || sec.id,
+      evaluation: radio.value
+    });
+  });
+  const comments = [];
+  document.querySelectorAll('[data-comment]').forEach(el => {
+    if (el.value.trim()) comments.push({ id: el.dataset.comment, text: el.value.trim() });
+  });
+  return { submitted: true, template: 'free', decisions, comments };
+}
+```
+
+---
+
+# Shared Systems (all templates)
+
+All three templates reuse the same iteration, persistence, heartbeat, submit
+handler, and navigation plumbing. The only template-specific parts are the
+layout CSS and `collectDecisions` branch shown above. Everything below
+applies uniformly.
+
+## Section Navigation (Decision Panel as TOC)
 
 The decision panel doubles as a full table-of-contents for the active
 iteration. EVERY major `<section id="…" data-nav-label="…">` inside the
@@ -357,12 +1318,10 @@ state.
 .section-nav-item:hover {
   background: color-mix(in srgb, var(--accent-color, #58a6ff) 10%, transparent);
 }
-/* Plain (non-variant) section: only label, centered vertically */
 .section-nav-item:not([data-variant]) .section-nav-label {
   font-weight: 500;
   opacity: 0.9;
 }
-/* Variant section: label + state badge */
 .section-nav-state {
   font-size: 0.8rem;
   color: var(--accent-color, #58a6ff);
@@ -370,7 +1329,6 @@ state.
 }
 .section-nav-state.state-discard { color: var(--danger-color, #f85149); }
 .section-nav-state.state-only { color: var(--success-color, #3fb950); }
-/* Active (scrolled-into-view) item */
 .section-nav-item.is-active {
   background: color-mix(in srgb, var(--accent-color, #58a6ff) 18%, transparent);
   font-weight: 600;
@@ -384,83 +1342,132 @@ state.
 
 <!-- Variant section — TOC entry + tri-state evaluation -->
 <section id="variant-a" class="variant-card" data-nav-label="A Orbital Ring">...</section>
-<section id="variant-b" class="variant-card" data-nav-label="B Hexagonal">...</section>
 ```
 
-Sections without `data-nav-label` are skipped by the TOC auto-populator —
-use that to hide intro/outro blocks that shouldn't appear as anchors.
-
-#### Freeform (no variant evaluation)
-
-When the concept does NOT evaluate mutually-exclusive variants — design
-concepts, mockups, tutorials, explainers, design-system walkthroughs — the
-content area may be fully free-form and the decision panel drops the
-tri-state summary in favor of a single comment + submit block.
-
-Mark the iteration section with `data-freeform`:
-
-```html
-<section id="iter-3" data-iteration="3" data-active data-freeform data-nav-label="Design concept">
-  <header class="iteration-intro">
-    <h2>Iteration 3 · Visual design concept</h2>
-    <p>Your picks from iteration 2 are locked in. This iteration shows the visual treatment.</p>
-  </header>
-
-  <!-- Free-form content: full-width mockup grid, design notes, rationale blocks.
-       Individual subsections still get id + data-nav-label so the panel TOC
-       auto-populates scroll anchors for "Ist-Zustand", "Design notes", etc. -->
-  <section id="ist-zustand" data-nav-label="Ist-Zustand">...</section>
-  <section id="design-notes" data-nav-label="Design notes">...</section>
-  <section id="mockups" data-nav-label="Mockups">...</section>
-</section>
-```
-
-Freeform signals to the panel:
-- No tri-state summary renders in `#decision-summary`
-- The submit block shows a single optional comment field + "Submit"
-- `collectDecisions()` returns `{ submitted: true, decisions: [], comments: [...] }`
-- The TOC still populates from every nested `data-nav-label` section
-
-```css
-/* Freeform iterations: allow full-width content, drop variant-card framing */
-section[data-iteration][data-freeform] {
-  display: block;
-}
-section[data-iteration][data-freeform] > section[id][data-nav-label] {
-  margin-block: 2rem;
-}
-/* Hide the tri-state decision summary when viewing a freeform iteration */
-body.viewing-freeform #decision-summary .variant-summary { display: none; }
-```
+Sections without `data-nav-label` are skipped by the TOC auto-populator.
 
 ```javascript
-// Toggle the freeform body class whenever the active iteration changes.
-// Hook this into showIteration() after it applies data-active / hidden.
-function syncFreeformFlag() {
-  const active = document.querySelector('section[data-iteration][data-active]:not([hidden])');
-  const visible = active || document.querySelector('section[data-iteration]:not([hidden])');
-  document.body.classList.toggle('viewing-freeform', !!(visible && visible.hasAttribute('data-freeform')));
+// --- Section Navigation (Decision Panel as TOC) ---
+function buildSectionNav() {
+  const nav = document.getElementById('section-nav');
+  if (!nav) return;
+  const activeIteration = document.querySelector('section[data-iteration][data-active]');
+  if (!activeIteration) return;
+  const sections = activeIteration.querySelectorAll('section[id][data-nav-label]');
+  nav.innerHTML = '';
+  sections.forEach(sec => {
+    const id = sec.id;
+    const label = sec.dataset.navLabel;
+    const hasTriState = !!sec.querySelector(`input[name="eval-${id}"]`);
+    const link = document.createElement('a');
+    link.href = '#' + id;
+    link.className = 'section-nav-item';
+    link.dataset.sectionId = id;
+    if (hasTriState) link.setAttribute('data-variant', '');
+    const labelEl = document.createElement('span');
+    labelEl.className = 'section-nav-label';
+    labelEl.textContent = label;
+    link.appendChild(labelEl);
+    if (hasTriState) {
+      const stateEl = document.createElement('span');
+      stateEl.className = 'section-nav-state';
+      link.appendChild(stateEl);
+    }
+    nav.appendChild(link);
+  });
+  updateSectionNavState();
 }
-document.addEventListener('DOMContentLoaded', syncFreeformFlag);
+
+function updateSectionNavState() {
+  const labels = { include: 'Miteinbeziehen', discard: 'Verwerfen', only: 'Exakt diese' };
+  document.querySelectorAll('.section-nav-item[data-variant]').forEach(link => {
+    const id = link.dataset.sectionId;
+    const checked = document.querySelector(`input[name="eval-${id}"]:checked`);
+    const currentState = checked ? checked.value : 'include';
+    const stateEl = link.querySelector('.section-nav-state');
+    if (stateEl) {
+      stateEl.textContent = labels[currentState] || currentState;
+      stateEl.className = 'section-nav-state state-' + currentState;
+    }
+  });
+}
+
+document.addEventListener('click', e => {
+  const link = e.target.closest('.section-nav-item');
+  if (!link) return;
+  e.preventDefault();
+  const target = document.querySelector(link.getAttribute('href'));
+  if (target) target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+});
+
+function installScrollSpy() {
+  const items = document.querySelectorAll('.section-nav-item');
+  if (!items.length) return;
+  const byId = new Map();
+  items.forEach(i => byId.set(i.dataset.sectionId, i));
+  const io = new IntersectionObserver(entries => {
+    entries.forEach(en => {
+      const item = byId.get(en.target.id);
+      if (!item) return;
+      if (en.isIntersecting) {
+        items.forEach(i => i.classList.remove('is-active'));
+        item.classList.add('is-active');
+      }
+    });
+  }, { rootMargin: '-30% 0px -60% 0px', threshold: 0 });
+  byId.forEach((_, id) => {
+    const sec = document.getElementById(id);
+    if (sec) io.observe(sec);
+  });
+}
+
+document.addEventListener('change', updateSectionNavState);
+document.addEventListener('DOMContentLoaded', () => {
+  buildSectionNav();
+  installScrollSpy();
+});
 ```
 
-### Decision Panel State CSS
+**Important:**
+- Every navigable `<section>` needs `id` AND `data-nav-label`.
+- If a section has a tri-state radio group, its `name` MUST be `eval-{section-id}`.
+- `buildSectionNav()` must run again after every iteration switch.
+
+## Decision Panel State CSS
 
 ```css
-/* Connection warning */
+/* Connection warning — overlays the submit area when Claude is offline.
+   Requires #panel-ready to be position: relative. */
+#panel-ready { position: relative; }
 .panel-warning {
-  display: flex;
-  align-items: flex-start;
-  gap: 0.5rem;
-  padding: 0.75rem;
-  margin-bottom: 1rem;
-  border-radius: 8px;
-  background: color-mix(in srgb, var(--warning-color, #d29922) 15%, transparent);
+  position: absolute; inset: 0; z-index: 5;
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: center;
+  gap: 0.75rem; text-align: center; padding: 1.5rem;
+  border-radius: 10px;
   border: 1px solid var(--warning-color, #d29922);
-  font-size: 0.85rem;
-  line-height: 1.4;
+  background: color-mix(in srgb, var(--panel-bg, #161b22) 94%, transparent);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  color: var(--text-color, #c9d1d9);
 }
-.panel-warning .warning-icon { font-size: 1.1rem; flex-shrink: 0; }
+.panel-warning .warning-icon { font-size: 2.25rem; color: var(--warning-color, #d29922); line-height: 1; }
+.panel-warning strong { color: var(--warning-color, #d29922); font-size: 1rem; }
+.panel-warning .warning-message {
+  font-size: 0.88rem; color: var(--text-secondary, #8b949e);
+  line-height: 1.5; max-width: 280px; margin: 0;
+}
+/* Connecting variant — same overlay, accent color + pulsing icon */
+.panel-warning--connecting { border-color: var(--accent-color, #58a6ff); }
+.panel-warning--connecting .warning-icon {
+  color: var(--accent-color, #58a6ff);
+  animation: pulse-connect 1.4s ease-in-out infinite;
+}
+.panel-warning--connecting strong { color: var(--accent-color, #58a6ff); }
+@keyframes pulse-connect {
+  0%, 100% { opacity: 0.45; }
+  50% { opacity: 1; }
+}
 
 /* Submitted state */
 .submitted-indicator {
@@ -504,399 +1511,14 @@ document.addEventListener('DOMContentLoaded', syncFreeformFlag);
   40% { opacity: 1; transform: scale(1); }
 }
 
-/* Disabled submit button when disconnected */
-#submit-btn:disabled {
+#submit-iterate-btn:disabled,
+#submit-implement-btn:disabled {
   opacity: 0.5;
   cursor: not-allowed;
 }
 ```
 
-## Design System
-
-### Colors
-- Dark mode: `#0d1117` background, `#c9d1d9` text, `#58a6ff` accent
-- Light mode: `#ffffff` background, `#24292f` text, `#0969da` accent
-- Success: `#3fb950` / `#1a7f37`
-- Warning: `#d29922` / `#9a6700`
-- Danger: `#f85149` / `#cf222e`
-
-### Typography
-- System font stack: `-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif`
-- Headings: 600 weight, tight letter-spacing
-- Body: 400 weight, 1.6 line-height
-- Code: `'Cascadia Code', 'Fira Code', monospace`
-
-### Spacing
-- Section gap: `2rem`
-- Card padding: `1.5rem`
-- Element gap: `0.75rem`
-
-### Interactive Elements
-- Toggle switches: 44px wide, smooth transition, clear on/off state
-- Checkboxes: custom styled, visible check mark
-- Comment fields: `width: 100%` within their container, `min-height: 80px`,
-  auto-expanding textarea, subtle border, placeholder text. Never narrow —
-  users must be able to type comfortably
-- Text inputs: `width: 100%` within container, generous padding (`0.75rem`)
-- Submit button: in decision panel sidebar, full-width within panel
-- Sliders: labeled endpoints, current value display, full container width
-
-## Variant: analysis
-
-**Purpose:** Present findings from a data analysis with accept/reject controls.
-
-**Structure:**
-```
-[Header: Analysis title + date]
-[Summary card: key metrics / TL;DR]
-
-[Finding 1]
-  ├── Description + evidence
-  ├── [Toggle: Akzeptieren / Ablehnen]
-  ├── [Priority: Hoch / Mittel / Niedrig]
-  └── [Comment field: "Anmerkung..."]
-
-[Finding 2]
-  └── ...
-
-[Submit button]
-```
-
-**Decision schema:**
-```json
-{
-  "decisions": [
-    { "id": "finding-1", "label": "...", "accepted": true, "priority": "high" }
-  ],
-  "comments": [
-    { "id": "finding-1", "text": "..." }
-  ]
-}
-```
-
-## Variant: plan
-
-**Purpose:** Present an implementation plan with step approval controls.
-
-**Structure:**
-```
-[Header: Plan title]
-[Overview card: goal, scope, timeline]
-
-[Phase 1: Name]
-  [Step 1.1]
-    ├── Description + rationale
-    ├── [Checkbox: Einschliessen]
-    ├── [Effort indicator: S / M / L / XL]
-    └── [Comment field]
-
-  [Step 1.2]
-    └── ...
-
-[Phase 2: Name]
-  └── ...
-
-[Submit button]
-```
-
-**Decision schema:**
-```json
-{
-  "decisions": [
-    { "id": "step-1-1", "label": "...", "included": true, "effort": "M" }
-  ]
-}
-```
-
-## Variant: concept
-
-**Purpose:** Present architecture or design variants for evaluation.
-
-**Structure:**
-```
-[Header: Concept title]
-[Context card: problem statement]
-
-[Variant A: Name]
-  ├── Description + diagram/illustration
-  ├── Pro/Con list
-  ├── [Tri-state: Verwerfen / Miteinbeziehen (default) / Nur diese]
-  ├── [Rating: 1-5 stars or slider]
-  └── [Comment field (wide, min-height: 80px)]
-
-[Variant B: Name]
-  └── ...
-
-[Decision panel sidebar: summary + submit]
-```
-
-### Tri-State Variant Evaluation
-
-Every variant MUST include a tri-state selector:
-
-```html
-<div class="variant-evaluation" data-decision="variant-a" data-label="Variant A">
-  <div class="tri-state-group">
-    <label class="tri-state-option">
-      <input type="radio" name="eval-variant-a" value="discard">
-      <span class="tri-state-label">Verwerfen</span>
-      <span class="tri-state-hint feedback">Feedback</span>
-    </label>
-    <label class="tri-state-option">
-      <input type="radio" name="eval-variant-a" value="include" checked>
-      <span class="tri-state-label">Miteinbeziehen</span>
-      <span class="tri-state-hint feedback">Feedback</span>
-    </label>
-    <label class="tri-state-option">
-      <input type="radio" name="eval-variant-a" value="only">
-      <span class="tri-state-label">Exakt diese</span>
-      <span class="tri-state-hint action">Claude setzt um</span>
-    </label>
-  </div>
-</div>
-```
-
-```css
-.tri-state-group {
-  display: flex;
-  gap: 0;
-  border: 1px solid var(--border-color, #30363d);
-  border-radius: 8px;
-  overflow: hidden;
-}
-.tri-state-option {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  padding: 0.75rem 1rem;
-  cursor: pointer;
-  text-align: center;
-  position: relative;
-  border-right: 1px solid var(--border-color, #30363d);
-  transition: background 0.2s, box-shadow 0.2s;
-}
-.tri-state-option:last-child { border-right: none; }
-
-/* Unselected hover — shows "you can click me" */
-.tri-state-option:hover {
-  background: color-mix(in srgb, var(--accent-color, #58a6ff) 10%, transparent);
-}
-
-.tri-state-option input { display: none; }
-
-/* Selected label — bold + color */
-.tri-state-option:has(input:checked) .tri-state-label {
-  font-weight: 700;
-}
-
-/* Hint always visible but faded; full opacity when selected */
-.tri-state-hint {
-  font-size: 0.75rem;
-  margin-top: 0.25rem;
-  opacity: 0.5;
-  transition: opacity 0.2s;
-}
-.tri-state-option:has(input:checked) .tri-state-hint { opacity: 1; }
-.tri-state-hint.feedback { color: var(--accent-color, #58a6ff); }
-.tri-state-hint.action { color: var(--warning-color, #d29922); }
-
-.tri-state-label { font-size: 0.9rem; transition: font-weight 0.15s; }
-
-/* Checkmark badge on the selected option */
-.tri-state-option:has(input:checked)::after {
-  content: '✓';
-  position: absolute;
-  top: 4px;
-  right: 6px;
-  font-size: 0.7rem;
-  font-weight: 700;
-  width: 18px;
-  height: 18px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 50%;
-  pointer-events: none;
-}
-
-/* ── Active state backgrounds + ring + checkmark colors ── */
-
-/* Miteinbeziehen (default, info) */
-.tri-state-option:has(input[value="include"]:checked) {
-  background: color-mix(in srgb, var(--accent-color, #58a6ff) 15%, transparent);
-  box-shadow: inset 0 0 0 2px var(--accent-color, #58a6ff);
-}
-.tri-state-option:has(input[value="include"]:checked)::after {
-  background: var(--accent-color, #58a6ff);
-  color: white;
-}
-
-/* Verwerfen (discard, muted) */
-.tri-state-option:has(input[value="discard"]:checked) {
-  background: color-mix(in srgb, var(--danger-color, #f85149) 12%, transparent);
-  box-shadow: inset 0 0 0 2px var(--danger-color, #f85149);
-}
-.tri-state-option:has(input[value="discard"]:checked)::after {
-  background: var(--danger-color, #f85149);
-  color: white;
-}
-.tri-state-option:has(input[value="discard"]:checked) .tri-state-label {
-  color: var(--danger-color, #f85149);
-}
-
-/* Exakt diese (only, success/action) */
-.tri-state-option:has(input[value="only"]:checked) {
-  background: color-mix(in srgb, var(--success-color, #3fb950) 15%, transparent);
-  box-shadow: inset 0 0 0 2px var(--success-color, #3fb950);
-}
-.tri-state-option:has(input[value="only"]:checked)::after {
-  background: var(--success-color, #3fb950);
-  color: white;
-}
-.tri-state-option:has(input[value="only"]:checked) .tri-state-label {
-  color: var(--success-color, #3fb950);
-}
-
-/* ── Unselected state — clearly "not chosen" ── */
-.tri-state-option:has(input:not(:checked)) {
-  opacity: 0.7;
-}
-.tri-state-option:has(input:not(:checked)):hover {
-  opacity: 1;
-}
-```
-
-**Indicator rules (strict):**
-- **Verwerfen** and **Miteinbeziehen**: show "(Feedback)" — passive input
-- **Exakt diese** only: show "Claude setzt um" — this is the only option
-  that triggers direct action (proceed with this variant, discard all others)
-
-**Behavior:**
-- Default: "Miteinbeziehen" (all variants considered)
-- "Exakt diese": auto-sets ALL other variants to "Verwerfen",
-  shows visual feedback + undo button per auto-changed variant
-- "Verwerfen": grays out the variant card visually (but keeps it accessible)
-
-**Decision schema:**
-```json
-{
-  "decisions": [
-    { "id": "variant-a", "label": "...", "evaluation": "include", "rating": 4 },
-    { "id": "variant-b", "label": "...", "evaluation": "discard", "rating": 2 },
-    { "id": "variant-c", "label": "...", "evaluation": "only", "rating": 5 }
-  ]
-}
-```
-
-**evaluation values:** `"discard"` | `"include"` | `"only"`
-
-## Variant: comparison
-
-**Purpose:** Side-by-side comparison of options with winner selection.
-
-**Structure:**
-```
-[Header: Comparison title]
-
-[Criteria table / matrix]
-  ├── Row per criterion
-  ├── Column per option
-  ├── [Weight slider per criterion]
-  └── Auto-calculated weighted scores
-
-[Per-option detail cards]
-  ├── Strengths
-  ├── Weaknesses
-  ├── [Tri-state: Verwerfen / Miteinbeziehen (default) / Nur diese]
-  └── [Comment field (wide)]
-
-[Decision panel sidebar: summary + submit]
-```
-
-Each option in the comparison gets the same **tri-state evaluation** as
-concept variants (see above): Verwerfen / Miteinbeziehen / Exakt diese.
-
-**Decision schema:**
-```json
-{
-  "decisions": [
-    { "id": "option-a", "label": "...", "evaluation": "include" },
-    { "id": "option-b", "label": "...", "evaluation": "only" },
-    { "id": "weight-performance", "value": 0.8 },
-    { "id": "weight-cost", "value": 0.4 }
-  ]
-}
-```
-
-## Variant: prototype
-
-**Purpose:** Interactive UI mockup or flow prototype.
-
-**Structure:**
-- Variant-specific — depends on what's being prototyped
-- Must include navigation between screens/states
-- Clickable elements should log interactions
-- Include a floating feedback button on each screen
-
-**Decision schema:**
-```json
-{
-  "decisions": [
-    { "id": "screen-1-approve", "approved": true },
-    { "id": "flow-alternative", "selected": "option-a" }
-  ],
-  "comments": [
-    { "id": "screen-2", "text": "Button placement too low" }
-  ]
-}
-```
-
-## Variant: dashboard
-
-**Purpose:** Status overview or metric dashboard with filters.
-
-**Structure:**
-```
-[Header + date range]
-[KPI cards row: 3-5 key metrics]
-
-[Filter bar: toggles for categories/segments]
-
-[Expandable sections]
-  ├── Section title + summary stat
-  ├── Expanded: detail table or chart
-  └── [Comment field per section]
-
-[Action items section]
-  ├── [Checkbox per item]
-  └── [Comment field]
-
-[Submit button]
-```
-
-## Variant: creative
-
-**Purpose:** Brainstorming, ideation, collecting ideas.
-
-**Structure:**
-```
-[Header: Topic]
-[Context / constraints]
-
-[Idea cards grid]
-  ├── Idea title + description
-  ├── [Vote: thumbs up/down]
-  ├── [Tag selector: category]
-  └── [Comment field]
-
-[Add new idea button → inline form]
-[Submit button]
-```
-
-## JavaScript Patterns
-
-### State Persistence
+## State Persistence (localStorage + TTL)
 
 Interactive element state MUST survive page reloads AND accidental tab closes
 via `localStorage` with a time-to-live (TTL). This prevents the user from
@@ -906,7 +1528,6 @@ losing selections, comments, and ratings.
 **TTL:** 24 hours — auto-clears stale state from previous days
 
 ```javascript
-// --- State Persistence (localStorage + TTL) ---
 const STORAGE_KEY = 'concept-state-' + location.pathname.split('/').pop().replace('.html', '');
 const STATE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
 
@@ -915,23 +1536,18 @@ function saveState() {
     _savedAt: Date.now(),
     _pageVersion: document.documentElement.dataset.pageVersion || ''
   };
-  // Save toggles, checkboxes, radios
   document.querySelectorAll('input[type="checkbox"], input[type="radio"]').forEach(el => {
     if (el.name || el.id) state['input:' + (el.name || el.id) + ':' + el.value] = el.checked;
   });
-  // Save text inputs, textareas
   document.querySelectorAll('textarea, input[type="text"], input[type="number"]').forEach(el => {
     if (el.id || el.dataset.comment) state['text:' + (el.id || el.dataset.comment)] = el.value;
   });
-  // Save sliders
   document.querySelectorAll('input[type="range"]').forEach(el => {
     if (el.id || el.name) state['range:' + (el.id || el.name)] = el.value;
   });
-  // Save select elements
   document.querySelectorAll('select').forEach(el => {
     if (el.id || el.name) state['select:' + (el.id || el.name)] = el.value;
   });
-  // Save theme preference
   state['theme'] = document.documentElement.getAttribute('data-theme');
   localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
 }
@@ -941,25 +1557,18 @@ function restoreState() {
   if (!raw) return;
   try {
     const state = JSON.parse(raw);
-    // TTL check — discard state older than 24 hours
     if (state._savedAt && (Date.now() - state._savedAt) > STATE_TTL_MS) {
       localStorage.removeItem(STORAGE_KEY);
       return;
     }
-    // Version check — discard state from a different page version
-    // (Claude sets data-page-version on <html> when generating the page;
-    // iteration appends keep the same value so frozen-tab state survives;
-    // only a fresh concept session for the same slug bumps the value)
     const currentVersion = document.documentElement.dataset.pageVersion || '';
     if (state._pageVersion && state._pageVersion !== currentVersion) {
       localStorage.removeItem(STORAGE_KEY);
       return;
     }
-    // Restore theme first (prevents flash)
     if (state.theme) document.documentElement.setAttribute('data-theme', state.theme);
-    // Restore inputs
     Object.entries(state).forEach(([key, value]) => {
-      if (key.startsWith('_')) return; // skip metadata keys
+      if (key.startsWith('_')) return;
       const [type, ...rest] = key.split(':');
       if (type === 'input') {
         const [name, val] = [rest.slice(0, -1).join(':'), rest[rest.length - 1]];
@@ -967,7 +1576,6 @@ function restoreState() {
         if (el) el.checked = value;
       } else if (type === 'text') {
         const id = rest.join(':');
-        // data-comment first — getElementById can collide with section IDs
         const el = document.querySelector(`[data-comment="${id}"]`) || document.querySelector(`textarea#${CSS.escape(id)}, input#${CSS.escape(id)}`);
         if (el) el.value = value;
       } else if (type === 'range') {
@@ -980,28 +1588,39 @@ function restoreState() {
         if (el) el.value = value;
       }
     });
-  } catch (e) { /* corrupt storage — ignore, user starts fresh */ }
+  } catch (e) { /* corrupt storage — ignore */ }
 }
 
-// Restore on load, save on every interaction
 document.addEventListener('DOMContentLoaded', restoreState);
 document.addEventListener('change', saveState);
 document.addEventListener('input', saveState);
 ```
 
 **Rules:**
-- Use `localStorage` with a 24-hour TTL — survives tab close, browser restart,
-  and accidental reloads. Stale state auto-clears after 24h so old concept
-  sessions don't pollute new ones
+- Use `localStorage` with a 24-hour TTL
 - Save on every `change` and `input` event — not just on submit
 - Restore runs on `DOMContentLoaded` — before the user sees the page
-- The `concept-submitted` class is deliberately NOT persisted — after a reload
-  the page is back to "not yet submitted" (correct behavior)
+- The `concept-submitted` class is NOT persisted
 - Theme preference IS persisted — prevents dark/light flash on reload
 
-### Collect Decisions
+## collectDecisions (dispatcher)
+
+The submit handler picks the branch based on `data-template` on `<html>`.
+An `action` (`iterate` | `implement`) is passed in from the button that was
+clicked and merged into the payload.
+
 ```javascript
-function collectDecisions() {
+function collectDecisions(action = 'iterate') {
+  const template = document.documentElement.dataset.template || 'decision';
+  let payload;
+  if (template === 'prototype') payload = collectPrototypeDecisions();
+  else if (template === 'free') payload = collectFreeDecisions();
+  else payload = collectDecisionDecisions();
+  payload.action = action;
+  return payload;
+}
+
+function collectDecisionDecisions() {
   const decisions = [];
   const comments = [];
 
@@ -1022,131 +1641,106 @@ function collectDecisions() {
     }
   });
 
-  return { submitted: true, decisions, comments };
+  return { submitted: true, template: 'decision', decisions, comments };
 }
 ```
 
-### Section Navigation JS
+## Two-Button Submit (iterate vs. implement)
 
-Auto-populates the panel TOC from every `<section data-nav-label>` inside
-the active iteration, smooth-scrolls on click, and keeps the evaluation
-state label in sync with the tri-state radio selection (for sections that
-have one). Plain sections without tri-state just get a scroll link.
+Every decision panel carries **two** submit buttons, not one. The primary
+button ("Zur nächsten Iteration") is always visible and fires
+`action: "iterate"` — a Claude turn that never touches code. The secondary
+button ("Mit Feedback implementieren") sits below a visible gap and fires
+`action: "implement"` — a Claude turn that DOES apply real file/code
+changes. The gap is mandatory so the user has to move the mouse
+deliberately to reach the implement button.
 
-```javascript
-// --- Section Navigation (Decision Panel as TOC) ---
-function buildSectionNav() {
-  const nav = document.getElementById('section-nav');
-  if (!nav) return;
-  const activeIteration = document.querySelector('section[data-iteration][data-active]');
-  if (!activeIteration) return;
-  // Find every nested section with a nav label inside the active iteration.
-  // The iteration section itself is skipped (it has no data-nav-label).
-  const sections = activeIteration.querySelectorAll('section[id][data-nav-label]');
-  nav.innerHTML = '';
-  sections.forEach(sec => {
-    const id = sec.id;
-    const label = sec.dataset.navLabel;
-    const hasTriState = !!sec.querySelector(`input[name="eval-${id}"]`);
-    const link = document.createElement('a');
-    link.href = '#' + id;
-    link.className = 'section-nav-item';
-    link.dataset.sectionId = id;
-    if (hasTriState) link.setAttribute('data-variant', '');
-    const labelEl = document.createElement('span');
-    labelEl.className = 'section-nav-label';
-    labelEl.textContent = label;
-    link.appendChild(labelEl);
-    if (hasTriState) {
-      const stateEl = document.createElement('span');
-      stateEl.className = 'section-nav-state';
-      link.appendChild(stateEl);
-    }
-    nav.appendChild(link);
-  });
-  updateSectionNavState();
-}
+### HTML
 
-function updateSectionNavState() {
-  // i18n labels — swap via the locale table when [ui-locale: de] is active
-  const labels = { include: 'Miteinbeziehen', discard: 'Verwerfen', only: 'Exakt diese' };
-  document.querySelectorAll('.section-nav-item[data-variant]').forEach(link => {
-    const id = link.dataset.sectionId;
-    const checked = document.querySelector(`input[name="eval-${id}"]:checked`);
-    const currentState = checked ? checked.value : 'include';
-    const stateEl = link.querySelector('.section-nav-state');
-    if (stateEl) {
-      stateEl.textContent = labels[currentState] || currentState;
-      stateEl.className = 'section-nav-state state-' + currentState;
-    }
-  });
-}
+```html
+<div id="panel-ready">
+  <div id="decision-summary"><!-- auto-summary --></div>
 
-// Smooth scroll on nav click (delegated — works for auto-populated links)
-document.addEventListener('click', e => {
-  const link = e.target.closest('.section-nav-item');
-  if (!link) return;
-  e.preventDefault();
-  const target = document.querySelector(link.getAttribute('href'));
-  if (target) target.scrollIntoView({ behavior: 'smooth', block: 'start' });
-});
+  <!-- Primary: safe, never implements -->
+  <button id="submit-iterate-btn" class="primary submit-btn">
+    Zur nächsten Iteration
+  </button>
+  <p class="hint">
+    Deine Auswahl geht an Claude für die nächste Iteration. Es wird kein Code geschrieben.
+  </p>
 
-// Highlight the current section in the TOC as the user scrolls
-function installScrollSpy() {
-  const items = document.querySelectorAll('.section-nav-item');
-  if (!items.length) return;
-  const byId = new Map();
-  items.forEach(i => byId.set(i.dataset.sectionId, i));
-  const io = new IntersectionObserver(entries => {
-    entries.forEach(en => {
-      const item = byId.get(en.target.id);
-      if (!item) return;
-      if (en.isIntersecting) {
-        items.forEach(i => i.classList.remove('is-active'));
-        item.classList.add('is-active');
-      }
-    });
-  }, { rootMargin: '-30% 0px -60% 0px', threshold: 0 });
-  byId.forEach((_, id) => {
-    const sec = document.getElementById(id);
-    if (sec) io.observe(sec);
-  });
-}
+  <!-- Mandatory gap so the user does not misclick -->
+  <div class="submit-gap" aria-hidden="true"></div>
 
-// Keep nav state in sync
-document.addEventListener('change', updateSectionNavState);
-document.addEventListener('DOMContentLoaded', () => {
-  buildSectionNav();
-  installScrollSpy();
-});
+  <!-- Secondary: explicit implementation commit -->
+  <button id="submit-implement-btn" class="implement-btn">
+    <span class="warn-icon" aria-hidden="true">⚠</span>
+    Mit Feedback implementieren
+  </button>
+  <p class="hint hint-warn">
+    Claude setzt die Auswahl jetzt in echte Änderungen um.
+  </p>
+</div>
 ```
 
-**Important:**
-- Every navigable `<section>` needs `id` AND `data-nav-label`.
-- If a section has a tri-state radio group, its `name` MUST be `eval-{section-id}`
-  so the TOC can mirror the current state.
-- `buildSectionNav()` must run again after every iteration switch — call it
-  from the `showIteration()` handler so the TOC reflects the active round.
+### CSS
 
-### Submit Handler
+```css
+.submit-btn, .implement-btn {
+  width: 100%;
+  padding: 0.8rem 1rem;
+  border-radius: 10px;
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: pointer;
+  margin-top: 0.5rem;
+}
+.submit-btn {
+  border: none;
+  background: var(--accent-color, #58a6ff);
+  color: white;
+}
+.submit-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.submit-gap { height: 2rem; }
+
+.implement-btn {
+  background: transparent;
+  color: var(--warning-color, #d29922);
+  border: 1px solid var(--warning-color, #d29922);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+}
+.implement-btn:hover {
+  background: color-mix(in srgb, var(--warning-color, #d29922) 15%, transparent);
+}
+.implement-btn .warn-icon { font-size: 1rem; }
+.hint-warn { color: var(--warning-color, #d29922); }
+```
+
+### JS
+
 ```javascript
-// Timestamp of the most recent submit click. Compared against the server's
-// `_processed_at` in the heartbeat poll to detect "Claude finished processing"
-// and auto-restore the ready panel without a JS eval round-trip.
 let _submittedAt = 0;
 
-document.getElementById('submit-btn').addEventListener('click', async () => {
-  const data = collectDecisions();
+function wireSubmit(btnId, action) {
+  const btn = document.getElementById(btnId);
+  if (!btn) return;
+  btn.addEventListener('click', () => submitWithAction(action));
+}
+
+async function submitWithAction(action) {
+  const data = collectDecisions(action);
   const container = document.getElementById('concept-decisions');
   container.textContent = JSON.stringify(data);
   document.body.classList.add('concept-submitted');
   _submittedAt = Date.now();
 
-  // Switch panel to "submitted" state immediately (optimistic UI)
   document.getElementById('panel-ready').style.display = 'none';
   document.getElementById('panel-submitted').style.display = 'block';
 
-  // POST decisions to bridge server — Claude reads via GET /decisions
   try {
     await fetch('/decisions', {
       method: 'POST',
@@ -1154,16 +1748,15 @@ document.getElementById('submit-btn').addEventListener('click', async () => {
       body: JSON.stringify(data)
     });
   } catch (e) {
-    // Bridge server unreachable — cache decisions for retry
     localStorage.setItem(STORAGE_KEY + '-pending', JSON.stringify(data));
   }
-
   saveState();
-});
+}
+
+wireSubmit('submit-iterate-btn', 'iterate');
+wireSubmit('submit-implement-btn', 'implement');
 
 // --- Offline Submit Queue ---
-// If the user submitted while disconnected, retry delivery when the bridge
-// server comes back. Checked after each successful heartbeat poll.
 async function retryPendingSubmission() {
   const pendingKey = STORAGE_KEY + '-pending';
   const pending = localStorage.getItem(pendingKey);
@@ -1175,43 +1768,38 @@ async function retryPendingSubmission() {
       body: pending
     });
     if (res.ok) localStorage.removeItem(pendingKey);
-  } catch (e) { /* still offline — will retry next heartbeat cycle */ }
+  } catch (e) { /* still offline */ }
 }
 ```
 
-### Panel State Reset
+Claude-side: on receiving the payload, branch on `action`:
+- `iterate` → Step 5b iterate branch: summarize + append next iteration only
+- `implement` → Step 5b implement branch: actually write code/files, then
+  still append a new iteration as a frozen "implementiert" record
 
-When Claude finishes processing, it calls `POST /reset` on the bridge server.
-The server stamps `_processed_at` with the current time. The page's heartbeat
-poll (see § Claude Connection Heartbeat) reads that timestamp on the next
-tick and — if it's newer than `_submittedAt` — runs `restorePanelToReady()`
-locally. No browser eval injection from Claude needed; the page self-heals.
+## Panel State Reset
+
+When Claude finishes processing, it POSTs `/reset` on the bridge server.
+The server stamps `_processed_at`; the page's heartbeat poll sees the
+updated timestamp and restores the ready panel. No browser eval injection.
 
 ```javascript
-// Called by the heartbeat poll when the server's processed_at has advanced
-// past our last submit. Also safe to call manually for legacy eval paths.
 function restorePanelToReady() {
   document.getElementById('panel-submitted').style.display = 'none';
   document.getElementById('panel-ready').style.display = 'block';
-  const btn = document.getElementById('submit-btn');
-  btn.disabled = false;
-  btn.textContent = 'Entscheidungen abschicken';
+  ['submit-iterate-btn', 'submit-implement-btn'].forEach(id => {
+    const btn = document.getElementById(id);
+    if (btn) btn.disabled = false;
+  });
   document.body.classList.remove('concept-submitted');
   _submittedAt = 0;
-  // Clear cached decisions so reload doesn't resurrect stale selections
   const slug = location.pathname.split('/').pop().replace('.html', '');
   localStorage.removeItem('concept-state-' + slug);
 }
 ```
 
-This is the visual cycle:
-```
-[Ready: button active] → User clicks Submit → [Submitted: waiting indicator]
-    → Claude processes → POST /reset → heartbeat poll sees processed_at >
-    submittedAt → restorePanelToReady() → [Ready: button active, new round]
-```
+## Theme Toggle
 
-### Theme Toggle
 ```javascript
 document.getElementById('theme-toggle').addEventListener('click', () => {
   const html = document.documentElement;
@@ -1220,29 +1808,11 @@ document.getElementById('theme-toggle').addEventListener('click', () => {
 });
 ```
 
-### Claude Connection Heartbeat (HTTP Bridge)
-
-The heartbeat uses the **HTTP Bridge** — the concept bridge server
-(`scripts/concept-server.py`) exposes `/heartbeat` endpoints that both Claude
-and the page communicate through.
-
-**How it works:**
-- The bridge server self-pulses `_heartbeat_ts` every 30s from a daemon
-  thread. As long as the process is alive, the timestamp stays fresh —
-  even while Claude's REPL is busy and cron jobs can't fire.
-- Claude additionally POSTs `/heartbeat` via cron and on each monitoring
-  poll (~15s when active). Redundant with the self-pulse, kept for
-  belt-and-suspenders in case the server thread stalls.
-- The page polls `GET /heartbeat` every 5 seconds via `fetch()`.
-- If the heartbeat is older than 90 seconds → warning is shown (90s
-  comfortably covers a 30s self-pulse interval; a stale reading means
-  the server process itself is gone).
-- If the heartbeat is fresh → warning hidden.
+## Claude Connection Heartbeat (HTTP Bridge)
 
 ```javascript
-// --- Claude Connection Heartbeat (HTTP Bridge) ---
-const HEARTBEAT_STALE_MS = 90000; // 90s — 3× the server's 30s self-pulse; stale means the server process is gone
-const HEARTBEAT_GRACE_MS = 30000; // 30s — Claude needs time to start bridge + cron
+const HEARTBEAT_STALE_MS = 90000;
+const HEARTBEAT_GRACE_MS = 30000;
 const _pageLoadedAt = Date.now();
 let _lastHeartbeatTs = 0;
 
@@ -1251,17 +1821,11 @@ async function pollHeartbeat() {
     const res = await fetch('/heartbeat', { cache: 'no-store' });
     const data = await res.json();
     _lastHeartbeatTs = data.ts || 0;
-  } catch (e) {
-    // Server unreachable — heartbeat stays stale
-  }
+  } catch (e) { /* server unreachable */ }
 }
 
-// Poll /decisions for the server's `_processed_at` timestamp. When the
-// server stamp is newer than our last submit we know Claude ran POST /reset
-// and we should flip the panel back to ready — fully client-driven, no
-// browser-eval injection from Claude needed.
 async function pollProcessedState() {
-  if (!_submittedAt) return; // nothing pending locally
+  if (!_submittedAt) return;
   try {
     const res = await fetch('/decisions', { cache: 'no-store' });
     const data = await res.json();
@@ -1271,41 +1835,39 @@ async function pollProcessedState() {
     if (Number.isFinite(processedMs) && processedMs > _submittedAt) {
       restorePanelToReady();
     }
-  } catch (e) {
-    // Server unreachable — will retry next tick
-  }
+  } catch (e) { /* retry next tick */ }
 }
 
 function checkClaudeConnection() {
-  // Suppress warning during grace period — Claude needs time to start the
-  // bridge server, set up the heartbeat cron, and send the first POST.
-  if (Date.now() - _pageLoadedAt < HEARTBEAT_GRACE_MS) return;
-
   const isConnected = _lastHeartbeatTs && (Date.now() - _lastHeartbeatTs) < HEARTBEAT_STALE_MS;
+  const inGrace = Date.now() - _pageLoadedAt < HEARTBEAT_GRACE_MS;
+  const connecting = document.getElementById('connection-connecting');
   const warning = document.getElementById('connection-warning');
-  const btn = document.getElementById('submit-btn');
+  const btns = ['submit-iterate-btn', 'submit-implement-btn']
+    .map(id => document.getElementById(id)).filter(Boolean);
   const panelSubmitted = document.getElementById('panel-submitted');
 
-  // Don't interfere with the "submitted" state
   if (panelSubmitted && panelSubmitted.style.display !== 'none') return;
 
   if (isConnected) {
+    if (connecting) connecting.style.display = 'none';
     if (warning) warning.style.display = 'none';
-    if (btn) btn.disabled = false;
-    // Retry any pending offline submission now that we're connected
+    btns.forEach(b => b.disabled = false);
     retryPendingSubmission();
+  } else if (inGrace) {
+    // Still in grace period — show "connecting" overlay, no warning yet
+    if (connecting) connecting.style.display = 'flex';
+    if (warning) warning.style.display = 'none';
+    btns.forEach(b => b.disabled = false);
   } else {
+    // Past grace AND heartbeat stale → disconnected warning
+    if (connecting) connecting.style.display = 'none';
     if (warning) warning.style.display = 'flex';
-    // Submit button stays ENABLED even when disconnected — decisions are
-    // cached in localStorage and auto-delivered when Claude reconnects.
-    // The warning banner is enough to inform the user.
-    if (btn) btn.disabled = false;
+    // Buttons stay enabled: offline submissions are cached & retried
+    btns.forEach(b => b.disabled = false);
   }
 }
 
-// Poll heartbeat every 5 seconds — starts immediately so data arrives ASAP.
-// checkClaudeConnection() is a no-op during grace period, so the warning
-// won't flash before Claude has had time to set up.
 setInterval(async () => {
   await pollHeartbeat();
   checkClaudeConnection();
@@ -1318,37 +1880,24 @@ setInterval(async () => {
 curl -s -X POST http://localhost:{port}/heartbeat
 ```
 
-No browser JS injection needed. See `monitoring.md` § HTTP Bridge Monitoring
-for integration into the monitoring protocol.
-
-**Legacy fallback:** If the bridge server is not available (e.g., someone opens
-a concept HTML file directly), the heartbeat check gracefully degrades — the
-`fetch('/heartbeat')` call fails silently, the heartbeat stays stale, and the
-submit button remains disabled. The user can still use the page for read-only
-review.
-
 ## Iteration Tabs
 
 Iterations of a concept page are appended as `<section data-iteration="N">`
 blocks inside the same HTML file. The tab bar lives **at the top of the
 right-side decision panel** (a compact vertical chip list, rendered above
-the section TOC and submit block). It must NEVER appear inside the
-left-hand content area — the content area is reserved for the concept.
+the section TOC and submit block). All three templates support iterations —
+prototype and free include them identically.
 
 ### Tab Bar HTML
 
 ```html
 <nav class="iteration-tabs" role="tablist" aria-label="Iterationen">
   <button class="iteration-tab" role="tab"
-          data-iteration="1"
-          aria-selected="false"
-          aria-controls="iter-1">
+          data-iteration="1" aria-selected="false" aria-controls="iter-1">
     Iteration 1
   </button>
   <button class="iteration-tab" role="tab"
-          data-iteration="2"
-          aria-selected="true"
-          aria-controls="iter-2">
+          data-iteration="2" aria-selected="true" aria-controls="iter-2">
     Iteration 2
   </button>
 </nav>
@@ -1363,16 +1912,11 @@ Rules:
 - Exactly one section carries `data-active`. The matching tab has
   `aria-selected="true"`.
 - Non-active sections get the `hidden` attribute AND are frozen
-  (see "Freezing Past Iterations" below).
+  (see "Freezing Past Iterations").
 - Tabs stay clickable — switching tab reveals the chosen section and
-  hides all others. Tabs never disappear.
+  hides all others.
 
 ### Tab Bar CSS
-
-The tab bar lives at the TOP of the right-side decision panel — not inside
-the content area. Render as a compact vertical chip list (one chip per
-iteration). Falls back to horizontal scroll only when the panel is very
-narrow.
 
 ```css
 .iteration-tabs {
@@ -1409,7 +1953,6 @@ narrow.
   content: "● ";
   color: var(--accent-color, #58a6ff);
 }
-/* Frozen (non-active) iteration: slightly dimmed, no pointer events on inputs */
 section[data-iteration]:not([data-active]) {
   opacity: 0.85;
 }
@@ -1424,21 +1967,18 @@ section[data-iteration]:not([data-active]) select {
 
 ### Freezing Past Iterations
 
-When appending iteration N+1, Claude must freeze the previous section so
-the user sees exactly what they submitted:
+When appending iteration N+1, Claude must freeze the previous section:
 
 1. Remove `data-active`, add `hidden` to the previous `<section>`.
 2. On every `input`, `textarea`, `select`, `button` inside it: set `disabled`.
 3. On every `textarea`, `input[type="text"]`: set `readonly`.
 4. For tri-state buttons: keep the `aria-pressed`/selected class exactly as
    the user submitted it — do NOT clear selections.
-5. Add a small "Eingefroren — Iteration N" banner at the top of the section
-   (optional but strongly recommended) so the user knows why it is read-only.
+5. Add a small "Eingefroren — Iteration N" banner at the top (optional).
 
 ### Tab Switch JS
 
 ```javascript
-// --- Iteration Tabs ---
 function showIteration(n) {
   document.querySelectorAll('section[data-iteration]').forEach(sec => {
     const match = String(sec.dataset.iteration) === String(n);
@@ -1448,55 +1988,35 @@ function showIteration(n) {
     const match = String(tab.dataset.iteration) === String(n);
     tab.setAttribute('aria-selected', match ? 'true' : 'false');
   });
-  // Heartbeat/submit "music" only runs for the active iteration. Older
-  // iterations are frozen snapshots — no re-submit, no new decisions.
   const activeSec = document.querySelector('section[data-iteration][data-active]');
   const isLive = activeSec && String(activeSec.dataset.iteration) === String(n);
   document.body.classList.toggle('viewing-frozen', !isLive);
-  // Hide ALL live panel states when viewing a frozen iteration — otherwise
-  // a mid-processing spinner (panel-submitted) or the ready panel can bleed
-  // through and misrepresent the frozen snapshot as interactive.
   const panelReady = document.getElementById('panel-ready');
   const panelSubmitted = document.getElementById('panel-submitted');
   const panelFrozen = document.getElementById('panel-frozen');
   if (panelReady) panelReady.style.display = isLive ? 'block' : 'none';
   if (panelSubmitted) {
-    // Only show panel-submitted when live AND concept-submitted is set
     const submitted = document.body.classList.contains('concept-submitted');
     panelSubmitted.style.display = (isLive && submitted) ? 'block' : 'none';
   }
-  // Optional passive hint while viewing history
   if (panelFrozen) panelFrozen.style.display = isLive ? 'none' : 'block';
-  // Rebuild the section TOC so it reflects the currently-visible iteration.
-  // (Only the active iteration is navigable; frozen tabs reuse their own
-  // sections but should still be browsable.)
   if (typeof buildSectionNav === 'function') buildSectionNav();
-  if (typeof syncFreeformFlag === 'function') syncFreeformFlag();
+  document.dispatchEvent(new CustomEvent('iteration:changed'));
 }
 
 document.querySelectorAll('.iteration-tab').forEach(tab => {
   tab.addEventListener('click', () => showIteration(tab.dataset.iteration));
 });
 
-// On load, show whichever iteration is marked data-active.
 document.addEventListener('DOMContentLoaded', () => {
   const active = document.querySelector('section[data-iteration][data-active]');
   if (active) showIteration(active.dataset.iteration);
 });
 ```
 
-### Reload Polling (pick up file rewrites)
-
-Every iteration append rewrites the HTML file on disk, then Claude POSTs
-`/reload` on the bridge server. The browser polls `/reload` and reloads
-when the counter advances — guaranteeing the tab matches disk without any
-browser MCP injection.
+### Reload Polling
 
 ```javascript
-// --- Reload Poller ---
-// The bridge server exposes /reload with a monotonic counter. Claude POSTs
-// to bump it after rewriting the HTML file. The page polls and reloads
-// when it sees a newer counter than the one it booted with.
 let _bootReloadCounter = null;
 async function pollReload() {
   try {
@@ -1505,17 +2025,39 @@ async function pollReload() {
     const { counter } = await res.json();
     if (_bootReloadCounter === null) { _bootReloadCounter = counter; return; }
     if (counter > _bootReloadCounter) {
-      // New iteration landed on disk — reload so the tab bar and new
-      // section appear. localStorage preserves frozen-tab state.
       location.reload();
     }
-  } catch (e) { /* bridge offline — ignore, retry next tick */ }
+  } catch (e) { /* bridge offline */ }
 }
 setInterval(pollReload, 3000);
 document.addEventListener('DOMContentLoaded', pollReload);
 ```
 
-**Why 3 s?** Fast enough that the new iteration appears within a blink
-after Claude finishes writing, slow enough that idle pages do not hammer
-the server. The cron tick for heartbeat runs every 60 s — those two loops
-are independent.
+## Design System
+
+### Colors
+- Dark mode: `#0d1117` background, `#c9d1d9` text, `#58a6ff` accent
+- Light mode: `#ffffff` background, `#24292f` text, `#0969da` accent
+- Success: `#3fb950` / `#1a7f37`
+- Warning: `#d29922` / `#9a6700`
+- Danger: `#f85149` / `#cf222e`
+
+### Typography
+- System font stack: `-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif`
+- Headings: 600 weight, tight letter-spacing
+- Body: 400 weight, 1.6 line-height
+- Code: `'Cascadia Code', 'Fira Code', monospace`
+
+### Spacing
+- Section gap: `2rem`
+- Card padding: `1.5rem`
+- Element gap: `0.75rem`
+
+### Interactive Elements
+- Toggle switches: 44px wide, smooth transition, clear on/off state
+- Checkboxes: custom styled, visible check mark
+- Comment fields: `width: 100%` within their container, `min-height: 80px`,
+  auto-expanding textarea
+- Text inputs: `width: 100%` within container, generous padding (`0.75rem`)
+- Submit button: in decision panel, full-width within panel
+- Sliders: labeled endpoints, current value display, full container width

--- a/plugins/devops/skills/devops-concept/deep-knowledge/validation-gate.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/validation-gate.md
@@ -1,13 +1,20 @@
 # Post-Generation Validation Gate
 
 After writing the HTML file, validate that all mandatory interactive patterns
-are present. **Grep the generated file** for each required pattern:
+are present. **Grep the generated file** for each required pattern. The check
+runs in two phases: first the shared patterns (all templates), then the
+template-specific extras selected by `<html data-template="...">`.
+
+## Phase 1 — Shared patterns (ALL templates)
+
+Every concept page must contain these 20 patterns, regardless of template:
 
 | # | Pattern to grep | Purpose |
 |---|----------------|---------|
 | 1 | `concept-decisions` | Decision data JSON container |
 | 2 | `concept-submitted` | CSS class for monitoring detection signal |
-| 3 | `connection-warning` | Disconnection warning element |
+| 3 | `connection-warning` | Disconnection warning element (overlay on #panel-ready) |
+| 3b | `connection-connecting` | Grace-period "Claude is connecting" overlay (shown by default) |
 | 4 | `checkClaudeConnection` | Heartbeat checker function |
 | 5 | `HEARTBEAT_STALE_MS` | Heartbeat staleness threshold |
 | 6 | `HEARTBEAT_GRACE_MS` | Grace period — suppresses warning during startup |
@@ -19,21 +26,79 @@ are present. **Grep the generated file** for each required pattern:
 | 12 | `data-iteration` | Iteration section marker |
 | 13 | `iteration-tabs` | Tab bar container in the decision panel |
 | 14 | `pollReload` | Reload-signal poller (picks up file rewrites) |
-| 15 | `sec.hidden` | Tab-switch JS toggles the `hidden` attribute — prevents all iterations rendering at once |
-| 16 | `pollProcessedState` | Auto-reset poll handler — restores the ready panel when the server's `_processed_at` advances past the local `_submittedAt` |
-| 17 | `section-nav` | Generalised panel TOC — every `data-nav-label` section (variants AND plain sections) gets a scroll anchor |
-| 18 | `data-nav-label` | Marker on nav-eligible sections — required so `buildSectionNav()` can populate the TOC |
+| 15 | `sec.hidden` | Tab-switch JS toggles the `hidden` attribute |
+| 16 | `pollProcessedState` | Auto-reset poll handler |
+| 17 | `section-nav` OR `screen-nav` | Panel navigation (TOC for decision/free, screen list for prototype) |
+| 18 | `data-nav-label` | Marker on nav-eligible sections |
+| 19 | `submit-iterate-btn` | Primary submit: iterate action (no code changes) |
+| 20 | `submit-implement-btn` | Secondary submit: implement action (real changes) |
 
-**If ANY pattern is missing → DO NOT open the page.** Fix the HTML first,
-then re-validate. This is a **blocking gate** — no exceptions, no "this
-page doesn't need it". Every concept page needs monitoring, every monitored
-page needs the heartbeat guard.
+Additionally, the `<html>` element MUST carry `data-template="decision"` (or
+`prototype`, or `free`) so `collectDecisions()` dispatches to the correct
+branch. The submit payload MUST include an `action` field with value
+`"iterate"` or `"implement"`.
+
+## Phase 2 — Template-specific patterns
+
+Run the subset matching the template picked in Step 1a of `SKILL.md`.
+
+### Template: decision
+
+| # | Pattern | Purpose |
+|---|---------|---------|
+| D1 | `eval-group` OR `tri-state-group` | Bi-state evaluation container (tri-state-* is legacy alias) |
+| D2 | `eval-` (as input name prefix) | Bi-state radio name convention (`eval-{variant-id}`) |
+| D3 | `data-decision` | Variant card marker for `collectDecisionDecisions()` |
+| D4 | `value="include"` | One of exactly two allowed radio values |
+| D5 | `value="discard"` | The other allowed value |
+
+The selector MUST have exactly two radio inputs per variant (no `value="only"`).
+If the page contains no variants (unusual for the decision template), D1–D5
+may be skipped — but in that case the content likely belongs in the `free`
+template instead. Reconsider the template pick before suppressing these.
+
+### Template: prototype
+
+| # | Pattern | Purpose |
+|---|---------|---------|
+| P1 | `feedback-dock` | Collapsible bottom dock container |
+| P2 | `feedback-toggle` | FAB that opens the dock |
+| P3 | `feedback-screen-list` | Auto-populated per-screen comment list |
+| P4 | `data-screen` | Marker on screen sections that feed the dock |
+| P5 | `proto-general-feedback` | General-notes textarea |
+| P6 | `panel-fab` | FAB that opens the decision overlay |
+| P7 | `panel-backdrop` | Overlay backdrop element |
+| P8 | `collectPrototypeDecisions` | Prototype branch of `collectDecisions` |
+
+At least one `<section data-screen id="…" data-nav-label="…">` MUST exist
+inside the active iteration. A prototype with zero screens can't collect
+per-screen feedback.
+
+### Template: free
+
+| # | Pattern | Purpose |
+|---|---------|---------|
+| F1 | `collectFreeDecisions` | Free branch of `collectDecisions` |
+
+The free template has no mandatory body structure. Tri-state (`tri-state-group`,
+`eval-` radio names) is opt-in — include it only where a section needs
+user evaluation. The decision panel (sticky sidebar) is reused from the
+decision template with no changes.
+
+## Failure handling
+
+**If ANY shared pattern is missing, or any template-specific mandatory pattern
+is missing → DO NOT open the page.** Fix the HTML first, then re-validate.
+This is a **blocking gate** — no exceptions, no "this page doesn't need it".
 
 **Common failures this gate catches:**
 - Heartbeat system omitted → submit button stays clickable without monitoring
 - Connection warning missing → user gets no feedback when Claude disconnects
 - Panel states missing → no visual transition on submit/reset cycle
 - localStorage missing → user selections lost on reload or tab close
+- `data-template` missing → `collectDecisions` can't pick the right branch
+- Prototype without `data-screen` → feedback dock renders empty
 
-The patterns in `templates.md` (§ Claude Connection Heartbeat,
-§ Submit Handler, § State Persistence) provide the reference implementations.
+The patterns in `templates.md` (§ Claude Connection Heartbeat, § Submit
+Handler, § State Persistence, § Template: prototype, § Template: free)
+provide the reference implementations.

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.56.1",
+  "version": "0.57.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

Reorganise `devops-concept` around three explicit page templates with strict
ordered auto-selection (prototype → decision → free), bi-state evaluation,
and a two-button submit that separates feedback-only iteration from actual
implementation.

### Templates

- **decision** — sidebar layout, multi-variant cards, bi-state (Verwerfen /
  Miteinbeziehen) per variant. Content sub-variants (analysis, plan, concept,
  comparison, dashboard, creative) are scoped here.
- **prototype** — fullscreen single-screen click-dummy, overlay decision
  panel (☰, FAB right) + collapsible feedback dock (💬, bottom) with
  context-sensitive per-screen textarea + persistent general-notes. Buttons
  in the mockup navigate via `data-screen-link="next|prev|{id}"`.
- **free** — Claude-authored freeform body with opt-in bi-state per section.

### Submit semantics

`collectDecisions()` now emits `action: "iterate" | "implement"` driven by
two separate buttons. **"Zur nächsten Iteration"** never touches code —
only loops the feedback. **"Mit Feedback implementieren"** (warning-styled,
2rem gap, confirm dialog) is the only path that writes real changes.

### Connection overlay

Two-state overlay on top of the submit area: accent-pulsing "Claude
verbindet sich" during grace period, warning-colored "Claude ist nicht
verbunden" once heartbeat stays stale. `pointer-events: none` keeps the
buttons clickable — clicks queue in `localStorage` and auto-deliver on
reconnect.

### Localisation

Step 2 now mandates reading `[ui-locale: xx]` and pulling every
user-facing string from the expanded locale table. New locales are
translated inline and cached back into templates.md.

### Examples

Three reference pages in `docs/concepts/2026-04-21-template-example-*.html`
exercise the full stack end-to-end.

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` — 103 tests pass
- [x] Codex review addressed (tri-state legacy cleanup, iteration-switch
      nav rebuild, overlay text/behaviour alignment)
- [ ] Manual: open all three example HTMLs, verify click-dummy nav,
      bi-state eval, dual submit, connecting → disconnected overlay cycle