### PR TITLE
refactor(refresh-usage): isolated Edge scraper profile

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.57.0"
+    "version": "0.58.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.57.0",
+      "version": "0.58.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.57.0",
+      "version": "0.58.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.58.0] — 2026-04-22
+
+### Changed
+
+- **plugins/devops/scripts/refresh-usage-headless.js** + **plugins/devops/skills/devops-refresh-usage/SKILL.md** + **plugins/devops/mcp-server/index.js** + **plugins/devops/skills/devops-burn/SKILL.md** — usage scraper no longer restarts the user's Edge browser. Previous flow (`taskkill /IM msedge.exe` + `--restore-last-session`) killed every Edge window to gain CDP access, then rebuilt the session. Replaced with a dedicated, isolated Edge instance under `~/.claude/edge-usage-profile` with its own `user-data-dir` and CDP port — spawned headless on demand, persisted between invocations for silent CDP reuse, killed only by its own PID tree. The user's main Edge (windows, tabs, cookies) is never touched. First run requires a one-time visible login to claude.ai in the scraper profile; cookies then persist and all subsequent scrapes run invisibly in the background. `mcp-server/index.js::refreshUsage` collapsed from a ~130-line CDP escalation chain to a single `execSync` call now that the script manages its own lifecycle. Removed obsolete `--auto-start` / `--activate-cdp` flags and exit codes `6`/`7`; new exit code `2` (not logged in) opens a visible login window and is surfaced inline to the user
+
 ## [0.57.0] — 2026-04-22
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.57.0**
+**Version: 0.58.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.57.0",
+  "version": "0.58.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/mcp-server/index.js
+++ b/plugins/devops/mcp-server/index.js
@@ -469,14 +469,12 @@ function renderCard(input, meterText, buildId) {
 // CDP scrape orchestration (calls existing refresh-usage-headless.js)
 // ---------------------------------------------------------------------------
 
-// Track whether we auto-started Edge so we can document cleanup.
-// NOTE: Edge started via --auto-start persists beyond this process.
-// The scraper script manages Edge lifecycle — if Edge was already running,
-// --auto-start is a no-op. If it was started fresh, it remains running
-// for future scrapes. This is intentional: killing Edge on MCP exit would
-// disrupt the user's browser. The user can close Edge manually or it will
-// be reused by subsequent sessions.
-// See: scripts/devops-refresh-usage-headless.js --auto-start for details.
+// The scraper runs a DEDICATED, isolated Edge instance (own user-data-dir
+// under ~/.claude/edge-usage-profile, own CDP port). The user's main Edge
+// is never touched. The script handles launch + scrape + kill internally;
+// we just invoke it once and check the exit code.
+// First run requires a one-time visible login (exit code 2).
+// See: scripts/refresh-usage-headless.js
 
 function readUsageJson() {
   try {
@@ -499,89 +497,17 @@ function refreshUsage() {
     }
   }
 
-  // --- CDP escalation chain with proper timeouts ---
-  // Scraper worst-case: 20s restart + 24s page-poll = 44s.
-  // Timeouts must exceed that or execSync kills the scraper mid-operation.
+  // Single invocation — the script manages the dedicated scraper instance
+  // lifecycle internally (launch, scrape, kill). Worst case: 20s launch +
+  // 24s page-poll = 44s; keep timeout above that.
   let lastExitCode = null;
-
   try {
-    let cdpReady = false;
-    try {
-      execSync(`node "${SCRAPER_SCRIPT}" --check-only`, {
-        timeout: 5000,
-        stdio: ['pipe', 'pipe', 'pipe'],
-      });
-      cdpReady = true;
-    } catch (checkErr) {
-      lastExitCode = checkErr.status;
-    }
-
-    if (!cdpReady) {
-      // Escalation: auto-start → activate-cdp (stepwise)
-      let escalated = false;
-      if (lastExitCode === 7) {
-        // Edge not running — try non-destructive auto-start first
-        try {
-          execSync(`node "${SCRAPER_SCRIPT}" --auto-start --quiet`, {
-            timeout: 60000,
-            stdio: ['pipe', 'pipe', 'pipe'],
-          });
-          escalated = true;
-        } catch (autoErr) {
-          console.error('[dotclaude-completion-mcp] auto-start failed:', autoErr.message);
-          // auto-start failed (Edge may have started without CDP) → try activate-cdp
-          try {
-            execSync(`node "${SCRAPER_SCRIPT}" --activate-cdp --quiet`, {
-              timeout: 60000,
-              stdio: ['pipe', 'pipe', 'pipe'],
-            });
-            escalated = true;
-          } catch (actErr) {
-            console.error('[dotclaude-completion-mcp] activate-cdp after auto-start failed:', actErr.message);
-            lastExitCode = actErr.status || 6;
-          }
-        }
-      } else if (lastExitCode === 5) {
-        // Edge running without CDP — activate directly
-        try {
-          execSync(`node "${SCRAPER_SCRIPT}" --activate-cdp --quiet`, {
-            timeout: 60000,
-            stdio: ['pipe', 'pipe', 'pipe'],
-          });
-          escalated = true;
-        } catch (actErr) {
-          console.error('[dotclaude-completion-mcp] activate-cdp failed:', actErr.message);
-          lastExitCode = actErr.status || 6;
-        }
-      }
-
-      // If escalation wrote data, we can skip the final scrape
-      if (escalated) {
-        const escalatedData = readUsageJson();
-        if (escalatedData?.session) {
-          const ageMs = Date.now() - new Date(escalatedData.timestamp).getTime();
-          if (ageMs < 30_000) {
-            // Fresh data from escalation — use directly
-            let delta5h = null;
-            let deltaWk = null;
-            if (previous?.session) {
-              delta5h = computeDelta(escalatedData.session?.pct, previous.session?.pct);
-              deltaWk = computeDelta(escalatedData.weekly?.pct, previous.weekly?.pct);
-            }
-            return { success: true, data: escalatedData, delta5h, deltaWk };
-          }
-        }
-      }
-    }
-
-    // Final scrape attempt (CDP should be available now)
     execSync(`node "${SCRAPER_SCRIPT}" --quiet`, {
-      timeout: 45000,
+      timeout: 60000,
       stdio: ['pipe', 'pipe', 'pipe'],
     });
-
     const freshData = readUsageJson();
-    if (freshData) {
+    if (freshData?.session) {
       let delta5h = null;
       let deltaWk = null;
       if (previous?.session) {
@@ -591,32 +517,8 @@ function refreshUsage() {
       return { success: true, data: freshData, delta5h, deltaWk };
     }
   } catch (err) {
-    console.error('[dotclaude-completion-mcp] Scrape failed:', err.message);
-    lastExitCode = err.status || lastExitCode;
-
-    // Retry once after 3s — Edge may need a moment after restart
-    try {
-      execSync('timeout /t 3 /nobreak > NUL 2>&1 || sleep 3', {
-        timeout: 5000, shell: true, stdio: 'ignore',
-      });
-      execSync(`node "${SCRAPER_SCRIPT}" --quiet`, {
-        timeout: 45000,
-        stdio: ['pipe', 'pipe', 'pipe'],
-      });
-      const retryData = readUsageJson();
-      if (retryData?.session) {
-        let delta5h = null;
-        let deltaWk = null;
-        if (previous?.session) {
-          delta5h = computeDelta(retryData.session?.pct, previous.session?.pct);
-          deltaWk = computeDelta(retryData.weekly?.pct, previous.weekly?.pct);
-        }
-        return { success: true, data: retryData, delta5h, deltaWk };
-      }
-    } catch (retryErr) {
-      console.error('[dotclaude-completion-mcp] Retry also failed:', retryErr.message);
-      lastExitCode = retryErr.status || lastExitCode;
-    }
+    lastExitCode = err.status;
+    console.error('[dotclaude-completion-mcp] Scrape failed (exit', lastExitCode, '):', err.message);
   }
 
   // Last resort: use any existing data (even stale) with age indicator
@@ -629,14 +531,11 @@ function refreshUsage() {
     return { success: true, data: cached, delta5h: null, deltaWk: null };
   }
 
-  // Map exit codes to human-readable reasons
   const reasons = {
-    2: 'not logged in to claude.ai',
+    2: 'scraper profile not logged in — visible login window was opened, log in once and retry',
     3: 'usage page parse error',
     4: 'CDP WebSocket failed',
-    5: 'Edge running without CDP — restart failed',
-    6: 'Edge restart failed',
-    7: 'Edge not installed or not startable',
+    5: 'scraper instance could not launch (Edge not installed?)',
   };
   const reason = reasons[lastExitCode] || `scrape exit code ${lastExitCode}`;
   return { success: false, data: null, reason };
@@ -661,7 +560,7 @@ server.registerTool(
       "Fetch live token usage data from claude.ai. Always scrapes fresh data. " +
       "Returns structured usage percentages, reset times, deltas against " +
       "the previous scrape, and a pre-rendered ASCII usage meter. " +
-      "Handles CDP fallback chain (auto-start Edge, activate CDP).",
+      "Uses a dedicated, isolated Edge scraper profile — user's main Edge is untouched.",
     inputSchema: z.object({}),
   },
   async () => {

--- a/plugins/devops/scripts/refresh-usage-headless.js
+++ b/plugins/devops/scripts/refresh-usage-headless.js
@@ -1,30 +1,32 @@
 #!/usr/bin/env node
 /**
  * @script refresh-usage-headless
- * @version 0.1.0
+ * @version 0.2.0
  * @plugin devops
  *
  * Headless Usage Scraper for claude.ai
  *
- * Connects to the user's running Edge browser via Chrome DevTools Protocol (CDP).
- * Opens a background tab, scrapes usage data, closes the tab — invisible to the user.
- * Uses raw WebSocket CDP protocol (no Playwright for scraping) to avoid Edge focus stealing.
+ * Spawns a dedicated, isolated Edge instance with its own user-data-dir under
+ * ~/.claude/edge-usage-profile — completely independent of the user's main
+ * Edge windows/tabs. Scrapes usage via raw CDP WebSocket, then kills only
+ * that dedicated instance (by PID tree). The user's main Edge is never
+ * touched.
+ *
+ * Login: the scraper profile starts empty. On first run it needs a one-time
+ * visible login to claude.ai; cookies then persist in the scraper profile
+ * and subsequent runs are fully headless/invisible.
  *
  * Exit codes:
  *   0 = success
- *   1 = no browser context
- *   2 = not logged in
+ *   2 = not logged in (visible login window was opened)
  *   3 = parse error
  *   4 = scrape failed
- *   5 = CDP not available (Edge not running with --remote-debugging-port)
- *   6 = Edge restart requested but failed
+ *   5 = scraper instance could not be launched
  *
  * Flags:
- *   --quiet           suppress output (debug logs only; --summary still prints)
- *   --summary         after successful scrape, print formatted usage box to stdout
- *   --activate-cdp    restart Edge with CDP flag (visible, one-time)
- *   --auto-start      start Edge with CDP only if no Edge process is running (non-destructive)
- *   --check-only      only check if CDP is available, exit 0 or 5
+ *   --quiet           suppress debug logs (--summary still prints)
+ *   --summary         after success, print formatted usage box
+ *   --check-only      report whether the scraper CDP is currently alive (0/5)
  */
 
 const { execSync, spawn } = require('child_process');
@@ -35,7 +37,10 @@ const os = require('os');
 // Store usage data in ~/.claude — same location regardless of CWD or worktree
 const SCRIPTS_DIR = path.join(os.homedir(), '.claude');
 const USAGE_LIVE_PATH = path.join(SCRIPTS_DIR, 'usage-live.json');
+const SCRAPER_PROFILE_DIR = path.join(SCRIPTS_DIR, 'edge-usage-profile');
+const SCRAPER_PID_FILE = path.join(SCRIPTS_DIR, 'edge-usage-scraper.pid');
 const USAGE_URL = 'https://claude.ai/settings/usage';
+const LOGIN_URL = 'https://claude.ai/login';
 const CDP_PORT = 9223;
 const CDP_URL = `http://127.0.0.1:${CDP_PORT}`;
 const EDGE_EXE = findEdgeExecutable();
@@ -76,8 +81,6 @@ if (process.platform !== 'win32') {
 
 const isQuiet = process.argv.includes('--quiet');
 const printSummary = process.argv.includes('--summary');
-const activateCDP = process.argv.includes('--activate-cdp');
-const autoStart = process.argv.includes('--auto-start');
 const checkOnly = process.argv.includes('--check-only');
 
 function log(...args) {
@@ -179,68 +182,56 @@ async function isCDPAvailable() {
   } catch { return false; }
 }
 
-/** Check if any Edge process is currently running. */
-function isEdgeRunning() {
+/** Kill the previously-spawned scraper instance (PID tree). Never touches the user's main Edge. */
+function killScraperInstance() {
   try {
-    const out = execSync('tasklist /FI "IMAGENAME eq msedge.exe" /NH', { encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'] });
-    return out.includes('msedge.exe');
-  } catch { return false; }
+    const pid = parseInt(fs.readFileSync(SCRAPER_PID_FILE, 'utf8').trim(), 10);
+    if (pid > 0) {
+      try { execSync(`taskkill /F /PID ${pid} /T`, { stdio: 'ignore' }); } catch {}
+    }
+  } catch {}
+  try { fs.unlinkSync(SCRAPER_PID_FILE); } catch {}
 }
 
-/** Start Edge with CDP — only when no Edge process is running. Non-destructive. */
-async function autoStartEdgeWithCDP() {
-  if (isEdgeRunning()) {
-    log('Edge is running without CDP — auto-start skipped (would need restart)');
-    return false;
-  }
+/**
+ * Launch a dedicated Edge instance with its own user-data-dir and CDP port.
+ * Runs fully isolated from the user's main Edge — separate cookies, separate
+ * processes, separate tabs. Main Edge is never touched.
+ *
+ * @param {{ visible?: boolean, url?: string }} opts
+ *   visible: true opens a window (needed for first-time login); false runs headless.
+ *   url: initial URL to load.
+ * @returns {Promise<number|null>} child PID on success, null on timeout
+ */
+async function launchScraperInstance({ visible = false, url = USAGE_URL } = {}) {
+  try { fs.mkdirSync(SCRAPER_PROFILE_DIR, { recursive: true }); } catch {}
 
-  log('Edge not running — starting with CDP on port', CDP_PORT, '...');
-  const child = spawn(EDGE_EXE, [
+  const args = [
+    `--user-data-dir=${SCRAPER_PROFILE_DIR}`,
     `--remote-debugging-port=${CDP_PORT}`,
     '--no-first-run',
-    '--no-default-browser-check'
-  ], { detached: true, stdio: 'ignore' });
-  child.unref();
-
-  for (let i = 0; i < 15; i++) {
-    await new Promise(r => setTimeout(r, 1000));
-    if (await isCDPAvailable()) {
-      log('Edge auto-started with CDP on port', CDP_PORT);
-      return true;
-    }
+    '--no-default-browser-check',
+    '--disable-features=msEdgeFeatureOverrides',
+  ];
+  if (!visible) {
+    args.push('--headless=new', '--disable-gpu');
   }
+  args.push(url);
 
-  log('Edge auto-start failed within 15 seconds');
-  return false;
-}
-
-/** Restart Edge with CDP flag. Visible to user — use only with explicit consent. */
-async function restartEdgeWithCDP() {
-  log('Restarting Edge with CDP on port', CDP_PORT, '...');
-
-  // Graceful shutdown first — gives Edge time to save session state for --restore-last-session
-  try { execSync('taskkill /IM msedge.exe', { stdio: 'ignore' }); } catch {}
-  await new Promise(r => setTimeout(r, 4000));
-  // Force-kill any remaining processes
-  try { execSync('taskkill /F /IM msedge.exe', { stdio: 'ignore' }); } catch {}
-  await new Promise(r => setTimeout(r, 1000));
-
-  const child = spawn(EDGE_EXE, [
-    `--remote-debugging-port=${CDP_PORT}`,
-    '--restore-last-session'
-  ], { detached: true, stdio: 'ignore' });
+  log(`Launching dedicated scraper instance (${visible ? 'visible' : 'headless'})...`);
+  const child = spawn(EDGE_EXE, args, { detached: true, stdio: 'ignore' });
   child.unref();
+  try { fs.writeFileSync(SCRAPER_PID_FILE, String(child.pid)); } catch {}
 
   for (let i = 0; i < 20; i++) {
     await new Promise(r => setTimeout(r, 1000));
     if (await isCDPAvailable()) {
-      log('Edge started with CDP on port', CDP_PORT);
-      return true;
+      log('Scraper CDP ready on port', CDP_PORT);
+      return child.pid;
     }
   }
-
-  log('Edge did not start with CDP within 20 seconds');
-  return false;
+  log('Scraper instance did not become ready within 20 seconds');
+  return null;
 }
 
 /**
@@ -455,51 +446,60 @@ function markCached(ageMin) {
   } catch {}
 }
 
-(async () => {
-  const cdpReady = await isCDPAvailable();
-
-  if (checkOnly) {
-    // Extended check: also report whether Edge is running (exit 7 = not running at all)
-    if (cdpReady) process.exit(0);
-    process.exit(isEdgeRunning() ? 5 : 7);
-  }
-
-  if (!cdpReady) {
-    if (autoStart) {
-      // Non-destructive: only start Edge if it's not running at all
-      if (!(await autoStartEdgeWithCDP())) {
-        // Auto-start failed or Edge is running without CDP — fall back to cache
-        const cacheAge = getCacheAge();
-        if (cacheAge >= 0) {
-          log(`Using cached data (${cacheAge}m old) — Edge auto-start not possible`);
-          markCached(cacheAge);
-          if (printSummary) printUsageSummary();
-          process.exit(0);
-        }
-        process.exit(5);
-      }
-    } else if (activateCDP) {
-      // Destructive: restart Edge (requires user consent)
-      if (!(await restartEdgeWithCDP())) process.exit(6);
-    } else {
-      log('CDP not available on port', CDP_PORT);
-      process.exit(5);
-    }
-  }
-
-  const code = await scrapeViaCDP();
-  if (code === 0) {
-    if (printSummary) printUsageSummary();
-    process.exit(0);
-  }
-
-  // Scrape failed — try cache as last resort
+function useCacheOrExit(code) {
   const cacheAge = getCacheAge();
   if (cacheAge >= 0) {
-    log(`Scrape failed (code ${code}), using cached data (${cacheAge}m old)`);
+    log(`Falling back to cached data (${cacheAge}m old)`);
     markCached(cacheAge);
     if (printSummary) printUsageSummary();
     process.exit(0);
   }
   process.exit(code);
+}
+
+(async () => {
+  if (checkOnly) {
+    process.exit((await isCDPAvailable()) ? 0 : 5);
+  }
+
+  // If CDP is already up, a scraper instance from a previous run is still
+  // alive — reuse it silently, no relaunch. Otherwise spawn a fresh
+  // dedicated instance (main Edge is never touched either way).
+  const cdpAlreadyUp = await isCDPAvailable();
+  if (!cdpAlreadyUp) {
+    killScraperInstance(); // clear any stale PID file
+    const pid = await launchScraperInstance({ visible: false, url: USAGE_URL });
+    if (!pid) {
+      log('Could not launch scraper instance');
+      useCacheOrExit(5);
+      return;
+    }
+  }
+
+  const code = await scrapeViaCDP();
+
+  if (code === 0) {
+    // Leave the headless scraper alive for fast reuse on the next invocation.
+    // It's a single background msedge.exe with its own isolated profile —
+    // no visible window, no interference with the user's main Edge.
+    if (printSummary) printUsageSummary();
+    process.exit(0);
+  }
+
+  if (code === 2) {
+    // Not logged in — kill the headless instance, open a VISIBLE window
+    // for one-time login. Caller (SKILL.md) tells the user inline.
+    killScraperInstance();
+    log('LOGIN_REQUIRED: scraper profile is not logged in to claude.ai');
+    await launchScraperInstance({ visible: true, url: LOGIN_URL });
+    // Leave the visible window alive — the user will interact with it.
+    // Drop the PID file so the next scrape run can't kill this login window.
+    try { fs.unlinkSync(SCRAPER_PID_FILE); } catch {}
+    process.exit(2);
+  }
+
+  // Scrape failed (parse/CDP error) — kill so next run relaunches fresh,
+  // then fall back to cached data.
+  killScraperInstance();
+  useCacheOrExit(code);
 })();

--- a/plugins/devops/skills/devops-burn/SKILL.md
+++ b/plugins/devops/skills/devops-burn/SKILL.md
@@ -60,7 +60,7 @@ Options: `["Ja, burn starten", "Nein, abbrechen"]`
 Fetch current usage data to understand how much budget remains:
 
 ```bash
-node "${CLAUDE_PLUGIN_ROOT}/scripts/devops-refresh-usage-headless.js" --auto-start --quiet --summary
+node "${CLAUDE_PLUGIN_ROOT}/scripts/refresh-usage-headless.js" --quiet --summary
 ```
 
 Read `~/.claude/usage-live.json` and compute:

--- a/plugins/devops/skills/devops-refresh-usage/SKILL.md
+++ b/plugins/devops/skills/devops-refresh-usage/SKILL.md
@@ -21,59 +21,44 @@ Do NOT call Read on files that may not exist — skip missing files silently (no
 2. Project: `{project}/.claude/skills/refresh-usage/SKILL.md` + `reference.md`
 3. Merge: project > global > plugin defaults
 
-## Step 1 — Fetch data (aggressive fallback chain)
+## Step 1 — Fetch data
 
-**NEVER show `[no data]` without exhausting ALL fallbacks first.**
-Run this chain top-to-bottom. Stop at first success.
+The script spawns a **dedicated, isolated Edge instance** with its own
+`user-data-dir` under `~/.claude/edge-usage-profile`. It is completely
+independent from the user's main Edge — separate cookies, separate
+processes, no tabs touched. Scrapes headless, then kills only that
+instance by PID tree.
 
 The script path is `${CLAUDE_PLUGIN_ROOT}/scripts/refresh-usage-headless.js` (use the plugin root, NOT a relative path).
 
-### 1a. Try Edge CDP directly
+### 1a. Run the scraper
 
 ```bash
-node "${CLAUDE_PLUGIN_ROOT}/scripts/refresh-usage-headless.js" --quiet --check-only
+node "${CLAUDE_PLUGIN_ROOT}/scripts/refresh-usage-headless.js" --quiet --summary
 ```
-- Exit 0 → CDP ready → scrape:
-  ```bash
-  node "${CLAUDE_PLUGIN_ROOT}/scripts/refresh-usage-headless.js" --quiet --summary
-  ```
-  → Done. Read `~/.claude/usage-live.json`.
 
-### 1b. Edge not running (exit 7) → auto-start
+Exit codes:
+- `0` → success. Usage written to `~/.claude/usage-live.json`.
+- `2` → **scraper profile is not logged in**. A visible Edge window has been opened at `https://claude.ai/login`. **Tell the user inline**, e.g.:
+  > ⚠️ Der Usage-Scraper hat ein eigenes Edge-Profil unter `~/.claude/edge-usage-profile`. Dieses ist noch nicht bei Claude eingeloggt — ein Edge-Fenster wurde gerade geöffnet. Bitte einmal einloggen (Cookies bleiben danach im Scraper-Profil persistent). Danach funktioniert der Scraper dauerhaft headless im Hintergrund.
+  After the message, use cached data for this turn (see 1c).
+- `3` / `4` / `5` → scrape/launch failure. Fall through to 1b.
 
-```bash
-node "${CLAUDE_PLUGIN_ROOT}/scripts/refresh-usage-headless.js" --auto-start --quiet --summary
-```
-- Starts Edge with CDP in background, scrapes, done.
-- No user interaction needed.
+### 1b. Browser fallback (optional)
 
-### 1c. Edge running without CDP (exit 5) → activate CDP
-
-```bash
-node "${CLAUDE_PLUGIN_ROOT}/scripts/refresh-usage-headless.js" --activate-cdp --quiet
-```
-- Restarts Edge with CDP flag (restores tabs via `--restore-last-session`).
-- Then scrape:
-  ```bash
-  node "${CLAUDE_PLUGIN_ROOT}/scripts/refresh-usage-headless.js" --quiet --summary
-  ```
-- This is autonomous — do NOT ask the user for permission. Edge restart is fast and restores all tabs.
-
-### 1d. CDP still failed → open browser tab as fallback
-
-If all CDP attempts fail, use the Playwright browser tools:
+If the scraper fails repeatedly, use the Playwright tools:
 ```
 browser_navigate → https://claude.ai/settings/usage
 ```
-Wait for page load, read the usage text from the page, parse it manually using the same percentage/reset patterns from Step 2.
+Parse the page text using the same percentage/reset patterns from Step 2.
 
-### 1e. Last resort — cached data
+### 1c. Cached data (automatic)
 
-Read `~/.claude/usage-live.json`. If it exists and is less than 30 minutes old, use it with `[cached Xm ago]` label.
+The script already falls back to `~/.claude/usage-live.json` with a `[cached Xm ago]` label when scraping fails and a cache exists. You don't need to do anything extra — just read the file.
 
-### 1f. No data
+### 1d. No data
 
-Only after ALL of 1a–1e fail: show `[no data]` with the specific reason (e.g., "Edge not installed", "not logged in to claude.ai").
+Only after 1a–1c all fail: show `[no data]` with the specific reason.
 
 ## Step 2 — Parse and store
 
@@ -105,9 +90,9 @@ ratio > 1.3  → 🪫 + "Hoher Verbrauch — neue Session oder Haiku empfohlen"
 
 ## Rules
 
-- **NEVER give up early** — exhaust the full fallback chain (1a→1b→1c→1d→1e) before showing `[no data]`.
-- **Always attempt fresh data** — cached data only as automatic fallback after all live methods fail.
-- **Silent execution** — CDP operations are invisible. Edge restart is autonomous (restores tabs).
-- **Playwright fallback is acceptable** — if CDP fails, opening a browser tab to scrape is fine.
+- **Never touch the user's main Edge.** The scraper always spawns a dedicated, isolated Edge instance with its own user-data-dir (`~/.claude/edge-usage-profile`) and kills only that instance by PID tree when done.
+- **One-time login is expected.** On first run (or after a profile wipe) the scraper profile has no cookies. The script opens a visible login window and exits with code `2`. Tell the user inline — do NOT retry silently.
+- **Silent after first login.** Once the user has logged in once, the scraper profile's cookies persist and all subsequent runs are invisible.
+- **Playwright fallback is acceptable** — if the scraper fails, opening a browser tab via Playwright to scrape is fine.
 - **Delta computation**: Read `usage-live.json` before and after refresh. Delta = new_pct - old_pct.
 - **Script path**: Always use `${CLAUDE_PLUGIN_ROOT}/scripts/refresh-usage-headless.js`, never a relative path.

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.57.0",
+  "version": "0.58.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

Usage scraper no longer nukes the user's Edge browser. Dedicated, isolated
Edge instance under `~/.claude/edge-usage-profile` with its own `user-data-dir`
and CDP port — main Edge (tabs, cookies, windows) is never touched.

## Changes

- `scripts/refresh-usage-headless.js` — spawn headless Edge with dedicated
  `user-data-dir` + CDP port; kill only by stored PID tree. Persist scraper
  between invocations for silent CDP reuse; visible login window on first run
  (exit code `2`).
- `mcp-server/index.js::refreshUsage` — collapsed from ~130 lines of CDP
  escalation to a single `execSync` call now that the script owns its
  own lifecycle.
- `skills/devops-refresh-usage/SKILL.md` — single-invocation flow, inline
  user hint for the one-time login.
- `skills/devops-burn/SKILL.md` — fix stale filename + removed flag.

## Test plan

- [x] `npm run lint` — passes
- [x] `npm test` — 103 tests green
- [ ] Manual: first invocation opens visible login window, second runs silently
- [ ] Manual: main Edge windows stay untouched during scrape

🤖 Generated with [Claude Code](https://claude.com/claude-code)