### PR TITLE
feat(testing): web-tech-always rule + Electron/3rd-party user-final-test flag

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.58.1"
+    "version": "0.59.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.58.1",
+      "version": "0.59.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.58.1",
+      "version": "0.59.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.59.0] — 2026-04-23
+
+### Added
+
+- **plugins/devops/deep-knowledge/test-strategy.md** — three new SSOT sections covering previously ambiguous testing territory. (1) *Web Tech → Always Browser-Test (Mocks OK)* makes browser verification mandatory for any change that touches browser-renderable code (HTML/CSS/JS framework files, UI deps, static `index.html`) — mocks for missing backends are expected, no "browser not needed" exit. Closes the gap where an Electron app was classified as "no web tech" and skipped verification. (2) *Electron / Native UI — Dev-Browser + User-Final-Test* splits testing: renderer-level via mounted HTML in Edge with mocks during dev, packaged-app final test only via computer-use when the user chose "Desktop übernehmen", otherwise flagged in the completion card. (3) *Third-Party Integrations — Mock-First + User-Final-Test* requires automated mock tests (MSW/nock/fixtures) for integration shape, then always flags the real-world validation as user-final-test-required-after-deployment. Mock step is never a substitute for the real step
+- **plugins/devops/mcp-server/index.js** + **plugins/devops/templates/completion-card.md** — new `userFinalTest` input for `render_completion_card` (array of strings or `{ action, afterDeployment }` objects). Renders a unified `🧑 TESTE bitte noch:` (DE) / `🧑 Please TEST:` (EN) block in Block A of all variants except `test-minimal`, with a per-bullet `— nach Deployment` / `— after deployment` suffix for 3rd-party items. Wording matches the existing CTA style (imperative CAPS verb + casual tone)
+- **plugins/devops/deep-knowledge/test-strategy.md** *Completion-Card Handoff* section — explicit contract that any caller of `render_completion_card` (inline Claude, agents, `/devops-autonomous`) must populate `userFinalTest` when Electron-packaged or 3rd-party rules apply. This is the only signal the user sees about work automation could not cover
+
+### Changed
+
+- **plugins/devops/deep-knowledge/agent-orchestration.md** QA-Wave testing protocol — expanded from 4 to 6 rules. Rule 3 references test-strategy's Web-Tech-Always rule instead of duplicating it. New rule 4 (Electron/Native UI) and rule 5 (3rd-party integrations) map directly to the new test-strategy sections. Rule 6 (computer-use restriction) unchanged in spirit but now carves a clean exception for packaged-Electron final tests under desktop takeover. QA agent prompt template now instructs QA to emit `userFinalTest` items for forward-propagation to the completion card
+- **plugins/devops/skills/devops-autonomous/SKILL.md** Step 3b — browser probing is now **mandatory** when any web-tech gate signal is true, including Electron/Tauri renderers. Removes the previous `[--] Browser nicht benötigt (Electron-App)` misclassification. Step 5 Live Testing and Step 7a Gather Completion Data both instruct forwarding `userFinalTest` items from QA to the completion card
+- **plugins/devops/agents/qa.md** + **plugins/devops/agents/frontend.md** — responsibilities updated to reference the new Web-Tech-Always rule; QA output schema gains a structured `userFinalTest` field that is forwarded 1:1 to `render_completion_card` (orchestrator must not rename or drop it)
+
 ## [0.58.1] — 2026-04-23
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.58.1**
+**Version: 0.59.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.58.1",
+  "version": "0.59.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/agents/frontend.md
+++ b/plugins/devops/agents/frontend.md
@@ -42,7 +42,10 @@ Your worktree starts on HEAD (main). You MUST rebase immediately:
 
 - Read `{PLUGIN_ROOT}/deep-knowledge/pre-mortem.md` before non-trivial implementation.
 - For mechanical UI boilerplate (prop-typed components, form scaffolds, barrel exports, repeated variants, >20 lines): read `{PLUGIN_ROOT}/deep-knowledge/local-llm-delegation.md` and delegate to `local_generate` when the gate is green.
-- Always verify visual output with screenshots
+- Always verify visual output in a real browser (follow
+  `{PLUGIN_ROOT}/deep-knowledge/test-strategy.md` § Web Tech → Always Browser-Test).
+  Mocks for missing backends/APIs are expected. For Electron/Tauri renderers,
+  mount the renderer HTML in Edge with main-process calls mocked.
 - Follow existing component patterns in the project
 - CSS changes need responsive verification
 - Prefer HTML rendering for design, Mermaid for flows

--- a/plugins/devops/agents/qa.md
+++ b/plugins/devops/agents/qa.md
@@ -23,9 +23,17 @@ Before starting, read `{PLUGIN_ROOT}/deep-knowledge/codex-integration.md` §4 (Q
 
 - Run unit tests and report results
 - Build the project and verify success
+- **Browser-verify web tech changes** (see `{PLUGIN_ROOT}/deep-knowledge/test-strategy.md`
+  § Web Tech → Always Browser-Test). Mandatory when HTML/CSS/JS framework files
+  changed — mocks for missing backends are expected. No "browser not needed" exit.
 - Take screenshots of UI changes
 - Check console logs for errors
 - Generate build-ID after successful build
+- **Flag User-Final-Tests** in output when automation cannot cover the final step:
+  - Packaged Electron/Tauri without desktop takeover → `🧑 TESTE bitte noch:`
+  - Third-party integrations (OAuth, payments, webhooks, external APIs) →
+    `🧑 TESTE bitte noch:` + bullet with `— nach Deployment` suffix
+  - Always include concrete action (what to open, what to click, what to verify).
 - **Automatically run** Codex review via Bash: `bash "${CLAUDE_PLUGIN_ROOT}/scripts/codex-safe.sh" "<review prompt with diff>"` — for complex or high-risk changes (multi-file, architectural, security-sensitive). Skip for trivial single-file fixes. Handle exit codes per codex-integration.md: rc=124 → log timeout and continue without findings; rc=126/127 → skip silently; other non-zero → note and continue. **Never** invoke `/codex:rescue` via the Agent tool.
 - Report findings in structured format
 
@@ -39,8 +47,13 @@ QA_RESULT:
   console_errors: [list or "none"]
   build_id: <hash> | "not generated"
   findings: [list of issues or "clean"]
+  userFinalTest: [] | [{ action: "...", afterDeployment?: true }]
   codex_review: "not requested" | "advised" | "findings: [...]"
 ```
+
+`userFinalTest` is forwarded 1:1 to `render_completion_card` — the orchestrator
+must not rename or drop the field. Omit or pass `[]` when everything was
+automatable.
 
 ## Rules
 

--- a/plugins/devops/deep-knowledge/agent-orchestration.md
+++ b/plugins/devops/deep-knowledge/agent-orchestration.md
@@ -112,23 +112,52 @@ Target specific test files for changed modules — see `deep-knowledge/test-stra
 **2. Build Verification**
 Run the build command (`npm run build` or equivalent) to verify compilation succeeds.
 
-**3. Browser-Based Visual Verification (UI projects)**
-For projects with a UI (web apps, Electron, etc.):
+**3. Browser-Based Visual Verification — MANDATORY for Web Tech**
+
+See `deep-knowledge/test-strategy.md` § Web Tech → Always Browser-Test.
+If any web-tech gate signal is true (HTML/CSS/JS framework files changed, UI dep
+in `package.json`, static `index.html` present) → browser verification is
+**required**, mocks are expected. No "browser not needed" exit for web tech.
+
 - **Orchestrator** (before spawning QA): probe the browser tool waterfall from
   `deep-knowledge/browser-tool-strategy.md` (Chrome MCP → Playwright → Preview).
   Set `$BROWSER_TOOL` to the first responder. If Preview is selected, start a
-  server via `preview_start` and capture `$SERVER_ID`.
+  server via `preview_start` and capture `$SERVER_ID`. If no dev server exists,
+  fall back to opening static HTML via `file:///`.
 - **QA agent** uses whichever tool the orchestrator selected:
   - Chrome MCP: `computer` (screenshot), `read_page`
   - Playwright: `browser_take_screenshot`, `browser_snapshot`
   - Preview: `preview_screenshot`, `preview_snapshot` (pass `serverId`)
 - All three are DOM/protocol-based — no desktop takeover, no user interruption.
-- Skip visual verification for non-UI changes (config, scripts, docs).
+- Skip only for genuinely non-UI changes (pure config, scripts, docs, backend-only).
 
-**4. Computer-Use Restriction — HARD RULE**
+**4. Electron / Native UI — Dev-Browser + User-Final-Test**
+
+See `deep-knowledge/test-strategy.md` § Electron / Native UI.
+Renderer-level verification happens via rule 3 (mount renderer HTML in Edge, mock
+main-process calls). Final integration test on the packaged app requires
+`computer-use` — **only** if the user chose "Desktop übernehmen", otherwise QA
+flags the completion card with `🧑 TESTE bitte noch:` plus concrete
+steps. Never claim an Electron/Tauri change "verified" based on dev-browser mocks
+alone.
+
+**5. Third-Party Integrations — Mock-First + User-Final-Test**
+
+See `deep-knowledge/test-strategy.md` § Third-Party Integrations.
+Any code calling external services (OAuth, payments, social APIs, webhooks,
+analytics, LLM APIs) follows two mandatory steps:
+1. Automated mock test (MSW/nock/fixtures) — verifies integration shape.
+2. Real test — flagged in completion card as
+   `🧑 TESTE bitte noch:` + bullet with `— nach Deployment` suffix.
+
+The mock step is **not** a substitute for step 2. Both are required.
+
+**6. Computer-Use Restriction — HARD RULE**
+
 **NEVER** use computer-use (`mcp__computer-use__*`) for testing unless the user
 **explicitly** requested desktop takeover (e.g., "Desktop übernehmen", "use
-computer-use", "nimm den Desktop", "desktop testing").
+computer-use", "nimm den Desktop", "desktop testing") — with the single exception
+of the packaged-Electron final test (rule 4) when desktop mode is active.
 
 Browser-based testing via the waterfall tools is always allowed and runs in the
 background. Computer-use is the **only** testing method that requires explicit
@@ -136,14 +165,26 @@ user opt-in.
 
 **QA Agent Prompt — Append These Instructions:**
 ```
-Test the changes:
+Test the changes (follow deep-knowledge/test-strategy.md):
 1. Run unit/integration tests for changed modules
 2. Run the build to verify it succeeds
-3. [If UI project] Use {$BROWSER_TOOL} to visually verify changed views —
-   take screenshots of key flows. Tool: {tool-specific instructions from waterfall}.
-4. Do NOT use computer-use or desktop takeover for testing
-5. Report results as: { method: "...", result: "pass" | "fail — reason" }
+3. [If web tech] Use {$BROWSER_TOOL} to verify changed views — snapshots preferred,
+   screenshots for layout/styling. Mocks for missing backends are expected.
+4. [If 3rd-party integration] Mock the external calls in automated tests, THEN
+   add a userFinalTest item with afterDeployment: true and a concrete action.
+5. [If packaged Electron/Tauri without desktop takeover] Renderer tests via step 3;
+   add a userFinalTest item (afterDeployment: false) with a concrete action.
+6. Do NOT use computer-use unless desktop takeover is explicitly active.
+7. Report results as:
+   - tests: [{ method, result: "pass" | "fail — reason" }]
+   - userFinalTest: [{ action, afterDeployment? }]  // forwarded to render_completion_card
 ```
+
+**Orchestrator handoff:** When the QA agent returns `userFinalTest` items, pass
+them through to `render_completion_card` as the `userFinalTest` input so the
+completion card displays the unified `🧑 TESTE bitte noch:` block.
+Never drop this field — it's the only signal the user sees about work that
+automation couldn't cover.
 
 ## Branch Strategy
 

--- a/plugins/devops/deep-knowledge/test-strategy.md
+++ b/plugins/devops/deep-knowledge/test-strategy.md
@@ -11,6 +11,102 @@ Skip visual preview when changes are **not visible in the running dev server**:
 - **Build/installer assets**: icon files, installer code, static design assets
 - **CI/CD**: workflow files, release scripts, Dockerfile
 
+## Web Tech → Always Browser-Test (Mocks OK) — HARD RULE
+
+If the change touches **any browser-renderable code** (HTML, CSS, JS/TS framework
+components — React, Vue, Angular, Svelte, Solid, Astro, vanilla DOM, Electron
+renderer, Tauri webview), a browser-based verification is **mandatory**. There is
+no "browser not needed" exit for web tech.
+
+**Gate signals (any one triggers the rule):**
+- Files changed match: `*.html`, `*.css`, `*.scss`, `*.vue`, `*.svelte`,
+  `*.tsx`, `*.jsx`, `*.astro`, or `.ts/.js` under `src/`/`app/`/`components/`/`pages/`/`views/`/`renderer/`
+- `package.json` contains UI deps (react, vue, angular, next, nuxt, vite, svelte,
+  solid, astro, electron, tauri, remix, gatsby, lit, qwik)
+- Static `index.html` or equivalent entry exists
+
+**Testing path (first that applies):**
+1. Dev server already running → navigate + snapshot
+2. Dev server startable via `npm run dev` / `preview_start` → start, then snapshot
+3. Static HTML → open via `file:///` in Edge (Claude-in-Chrome extension)
+4. Packaged Electron/Tauri renderer → see "Electron/Native UI" rule below
+
+**Mocks are expected.** Missing backends, disabled auth, stubbed API responses,
+fixture data, MSW/nock interceptors — all acceptable. The goal is to exercise the
+changed view in a real browser engine, not to hit production services.
+
+**Never skip browser verification for web tech with justifications like "no
+preview server configured" or "Electron app, no web server".** If the project is
+pure web tech, configure a dev preview or mount the HTML directly.
+
+## Electron / Native UI — Dev-Browser + User-Final-Test
+
+Packaged Electron, Tauri, native-UI hybrid apps cannot be reached by Chrome-MCP /
+Playwright / Preview once bundled — those tools operate on Edge or on a spawned
+browser instance, not inside the app's own webview. Testing therefore splits:
+
+**During development (automated):**
+- Component/renderer-level verification via the "Web Tech → Always Browser-Test"
+  rule above. Mount the renderer HTML (or a storybook-style harness) directly in
+  Edge and exercise it there, with main-process calls mocked.
+- This is **always required** when renderer code changed — no exceptions.
+
+**Final integration test (cannot be automated without takeover):**
+- Only `computer-use` can click on a packaged Electron window. It is used **only**
+  when the user explicitly chose "Desktop übernehmen" (see
+  `desktop-testing.md`).
+- If desktop-takeover was not chosen → flag in completion card:
+  `🧑 TESTE bitte noch:` with concrete steps (what to open, what to verify).
+
+Never claim an Electron/Tauri change is "verified" based on dev-browser mocks alone
+— the mocked renderer is not the production runtime.
+
+## Third-Party Integrations — Mock-First + User-Final-Test
+
+Any code that calls external services (OAuth providers, Stripe, SendGrid, social
+APIs, webhooks, analytics, SaaS backends, LLM APIs) follows a mandatory two-step
+protocol:
+
+**Step 1 — Automated mock test (required):**
+- Intercept / stub the 3rd-party calls (MSW, nock, recorded fixtures, in-memory mock).
+- Verify the **integration shape**: request payload, response handling, error paths,
+  retry logic, state transitions.
+- Never send real requests to production 3rd-party endpoints during automated tests.
+
+**Step 2 — Real integration test (cannot be automated):**
+- Flag in completion card: `🧑 TESTE bitte noch:` + bullet with `— nach Deployment` suffix
+  with the concrete action (e.g. "Login mit Google in Prod-Umgebung testen",
+  "Test-Zahlung mit Stripe Live-Key durchführen").
+- Never declare the integration "verified" based on the mock step alone — credentials,
+  quotas, DNS, CORS, real-world timing issues only surface against real endpoints.
+
+**Applies equally to:** local/dev environments where the 3rd-party is unreachable,
+CI runs without live credentials, autonomous/background sessions. The mock step is
+**not** a substitute for the user/deployment step — both are required.
+
+## Completion-Card Handoff (for any caller)
+
+When work is done and `render_completion_card` is called — **whether inline, via
+agents, or from `/devops-autonomous`** — the caller MUST populate `userFinalTest`
+whenever one of the rules above applies:
+
+- Packaged Electron/Tauri + no desktop takeover → one item per flow, `afterDeployment: false`
+- 3rd-party integration → one item per integration, `afterDeployment: true`
+
+Input shape (see `mcp-server/index.js` `userFinalTest` zod schema):
+
+```js
+userFinalTest: [
+  "Electron-App öffnen → Settings-Dialog testen",          // string shorthand
+  { action: "Login mit Google in Prod-Umgebung testen",   // object form
+    afterDeployment: true },
+]
+```
+
+The card renders a unified `🧑 TESTE bitte noch:` (DE) / `🧑 Please TEST:` (EN)
+block with the bullets. Never summarize away — this is the only signal the user
+sees about work automation could not cover.
+
 ## Task-specific tests (run immediately after changes)
 
 Run only tests directly related to the current task:

--- a/plugins/devops/mcp-server/index.js
+++ b/plugins/devops/mcp-server/index.js
@@ -173,14 +173,14 @@ function renderUsageMeterForCard(usageData, delta5h, deltaWk, healthLine) {
 // ---------------------------------------------------------------------------
 
 const VARIANTS = {
-  'ship-successful': { usage: true,  changes: true,  tests: true,  state: true,  userTest: false },
-  ready:             { usage: true,  changes: true,  tests: true,  state: true,  userTest: false },
-  'ship-blocked':    { usage: true,  changes: true,  tests: true,  state: true,  userTest: false },
-  test:              { usage: true,  changes: true,  tests: true,  state: true,  userTest: true  },
-  'test-minimal':    { usage: false, changes: false, tests: false, state: false, userTest: false },
-  analysis:          { usage: true,  changes: true,  tests: false, state: true,  userTest: false },
-  aborted:           { usage: true,  changes: true,  tests: false, state: true,  userTest: false },
-  fallback:          { usage: true,  changes: true,  tests: false, state: true,  userTest: false },
+  'ship-successful': { usage: true,  changes: true,  tests: true,  state: true,  userTest: false, userFinalTest: true  },
+  ready:             { usage: true,  changes: true,  tests: true,  state: true,  userTest: false, userFinalTest: true  },
+  'ship-blocked':    { usage: true,  changes: true,  tests: true,  state: true,  userTest: false, userFinalTest: true  },
+  test:              { usage: true,  changes: true,  tests: true,  state: true,  userTest: true,  userFinalTest: true  },
+  'test-minimal':    { usage: false, changes: false, tests: false, state: false, userTest: false, userFinalTest: false },
+  analysis:          { usage: true,  changes: true,  tests: false, state: true,  userTest: false, userFinalTest: true  },
+  aborted:           { usage: true,  changes: true,  tests: false, state: true,  userTest: false, userFinalTest: true  },
+  fallback:          { usage: true,  changes: true,  tests: false, state: true,  userTest: false, userFinalTest: true  },
 };
 
 const CTA = {
@@ -346,6 +346,22 @@ function renderUserTest(steps) {
   return '**Please test**\n' + items.join('\n');
 }
 
+const USER_FINAL_TEST_LABEL = {
+  de: { header: '\uD83E\uDDD1 **TESTE bitte noch:**', suffix: ' \u2014 nach Deployment' },
+  en: { header: '\uD83E\uDDD1 **Please TEST:**',      suffix: ' \u2014 after deployment' },
+};
+
+function renderUserFinalTest(items, lang) {
+  if (!items || items.length === 0) return '';
+  const labels = USER_FINAL_TEST_LABEL[lang] || USER_FINAL_TEST_LABEL.de;
+  const bullets = items.map(it => {
+    const action = typeof it === 'string' ? it : (it && it.action) || '';
+    const afterDeployment = typeof it === 'object' && it && it.afterDeployment;
+    return '* ' + action + (afterDeployment ? labels.suffix : '');
+  });
+  return labels.header + '\n' + bullets.join('\n');
+}
+
 function renderCTA(variant, cta, lang, state) {
   const templates = CTA[lang] || CTA.de;
   cta = cta || {};
@@ -443,6 +459,17 @@ function renderCard(input, meterText, buildId) {
     const testBlock = renderUserTest(input.userTest);
     if (testBlock) {
       parts.push(testBlock);
+      parts.push('');
+    }
+  }
+
+  // User-final-test flag (Electron without takeover, 3rd-party integrations)
+  // Available in all variants except test-minimal — so e.g. a ship-successful
+  // card can still flag "test the real Stripe integration in prod".
+  if (config.userFinalTest) {
+    const finalBlock = renderUserFinalTest(input.userFinalTest, lang);
+    if (finalBlock) {
+      parts.push(finalBlock);
       parts.push('');
     }
   }
@@ -683,6 +710,16 @@ server.registerTool(
         v => typeof v === 'string' ? tryParse(v) : v,
         z.array(z.string()).optional(),
       ).describe("Manual test steps (test variant only)"),
+      userFinalTest: z.preprocess(
+        v => typeof v === 'string' ? tryParse(v) : v,
+        z.array(z.union([
+          z.string(),
+          z.object({
+            action: z.string(),
+            afterDeployment: z.boolean().optional(),
+          }),
+        ])).optional(),
+      ).describe("User-final-test items — for changes where automation cannot cover the last step (packaged Electron/Tauri without desktop takeover, 3rd-party integrations). Pass strings for local final tests; pass { action, afterDeployment: true } for 3rd-party items that require deployment first. Available in all variants except test-minimal."),
     }),
   },
   async (params) => {

--- a/plugins/devops/skills/devops-autonomous/SKILL.md
+++ b/plugins/devops/skills/devops-autonomous/SKILL.md
@@ -148,9 +148,20 @@ including the **Edge Credo** (§ Edge Credo — Hard Rules):
 - New tab in existing Edge window — never a new Edge window
 - These rules apply in BOTH foreground and background/autonomous mode
 
+**Browser probing is MANDATORY when any web-tech gate signal is true** (see
+`deep-knowledge/test-strategy.md` § Web Tech → Always Browser-Test). This includes
+Electron/Tauri: their renderer is web tech and must be verified in a browser with
+mocks, even though the packaged app itself cannot be driven via Chrome-MCP. Never
+skip browser probing with "Electron app, no preview server" — the renderer still
+needs browser-based component verification.
+
 Run the waterfall probe (Chrome MCP → Playwright → Preview), set `$BROWSER_TOOL`
 to the first responder. If none respond → show the error block from the strategy
 doc and abort browser-dependent work. Never use computer-use for browser tasks.
+
+Mark `[--] Browser nicht benötigt` ONLY for pure non-UI work (CLI tool without
+web frontend, backend-only service, config/docs/scripts). If ANY web-tech gate
+signal applies, `$BROWSER_TOOL` must be active before proceeding.
 
 ### 3c — File & Shell Tools
 Run a harmless `Bash` command (e.g., `echo "permission primed"`), `Read` a file,
@@ -279,8 +290,16 @@ Follow the **QA Testing Protocol** from `deep-knowledge/agent-orchestration.md` 
 Use `$BROWSER_TOOL` (from Step 3b) for all browser-based visual verification.
 
 **Autonomous-specific additions:**
-- **Native desktop apps**: use computer-use **only** if user chose "Desktop
-  übernehmen" in Step 2. Otherwise skip native-app visual testing.
+- **Web tech**: browser verification is MANDATORY (rule 3). Mocks are expected.
+  Never skip because "no preview server".
+- **Packaged Electron/Tauri**: renderer tested via `$BROWSER_TOOL` with mocks
+  (rule 4). If user chose "Desktop übernehmen", run the packaged-app final test
+  via computer-use. Otherwise add a `userFinalTest` item (string form) for the
+  completion card — renders as `🧑 TESTE bitte noch:`.
+- **3rd-party integrations**: mock automated tests (rule 5). Always add a
+  `userFinalTest` item with `afterDeployment: true` — renders under the same
+  `🧑 TESTE bitte noch:` block with `— nach Deployment` suffix. Never mark the
+  integration "verified" on mocks alone.
 - Track progress via TodoWrite.
 
 ## Step 6 — Error Handling
@@ -308,6 +327,12 @@ Call `render_completion_card` (variant per status: "ship-successful" for COMPLET
 "ship-blocked" for BLOCKED, "ready" for INTERRUPTED,
 "analysis" for analyze-mode COMPLETED; pushed: false, pr: null).
 **Capture the full card output** — it will be embedded in the HTML report.
+
+**Always forward `userFinalTest` items** collected during Step 5 Live Testing
+(packaged Electron/Tauri without takeover, 3rd-party integrations). The card
+renders a unified `🧑 TESTE bitte noch:` block — this is the only signal the
+user sees about work that automation couldn't cover, so never drop or summarize
+these items away.
 
 ### 7b — Build HTML Report
 

--- a/plugins/devops/templates/completion-card.md
+++ b/plugins/devops/templates/completion-card.md
@@ -58,6 +58,11 @@ All variables in `{{...}}`. Sections wrapped in `{{#if}}` are conditional per va
 1. {{each: test-step}}
 {{/if}}
 
+{{#if user-final-test}}
+🧑 **TESTE bitte noch:**
+* {{each: action}}{{#if afterDeployment}} — nach Deployment{{/if}}
+{{/if}}
+
 {{#if usage}}
 {{context-health-line}}
 
@@ -292,6 +297,44 @@ Numbered steps the user must perform manually.
 | test | **Required** |
 | all others | **Omit** |
 
+### User-final-test
+
+Flags work that **cannot be automated** — even when automated tests pass. Two
+sources (see `deep-knowledge/test-strategy.md` § Electron / Native UI and
+§ Third-Party Integrations):
+
+- **Packaged Electron/Tauri without desktop takeover** → a final check on the
+  real app that only the user can click through.
+- **Third-party integrations** (OAuth, payments, webhooks, external APIs) → mocks
+  covered the shape, but real endpoints need real credentials in a deployed env.
+
+Wording is identical across both cases — only the `— nach Deployment` / `— after
+deployment` suffix distinguishes the 3rd-party case:
+
+```
+🧑 **TESTE bitte noch:**
+* Electron-App öffnen → Settings-Dialog testen
+* Login mit Google in Prod-Umgebung testen — nach Deployment
+```
+
+```
+🧑 **Please TEST:**
+* Open Electron app → test Settings dialog
+* Test Google login in prod environment — after deployment
+```
+
+**Input contract:** `userFinalTest` is an array; each item is either a plain
+string (no deployment suffix) or `{ action: string, afterDeployment: true }`.
+The header is always rendered once; the suffix is attached per bullet.
+
+| Variants | Behavior |
+|----------|----------|
+| ship-successful, ready, ship-blocked, test, analysis, aborted, fallback | **If QA flagged one** — otherwise omit |
+| test-minimal | **Omit** (session greeting, no QA context) |
+
+Rendered between state/user-test and the usage meter so it sits in Block A's
+"what you still need to do" region, not buried in CTA.
+
 ### CTA (Call to Action)
 
 One-liner as `##` heading.
@@ -350,16 +393,16 @@ The footer line sits between the separator and the CTA. It contains:
 
 ## Variant Table
 
-| # | Variant | CTA-Icon | Changes | Tests | User-Test | State | Usage |
-|---|---------|---------|---------|-------|-----------|-------|-------|
-| 1 | ship-successful | 🚀 | yes | yes | — | final | yes |
-| 2 | ready | 📦 | yes | if ran | — | branch | yes |
-| 3 | ship-blocked | ⛔ | yes | if ran | — | branch | yes |
-| 4 | test | 🧪 | yes | if ran | yes | app-status | yes |
-| 5 | test-minimal | ▶️ | — | — | — | — | — |
-| 6 | analysis | 📋 | yes | — | — | none | yes |
-| 7 | aborted | 🚫 | opt. | — | — | dep. | yes |
-| 8 | **fallback** | 🔧 | yes | — | — | dep. | yes |
+| # | Variant | CTA-Icon | Changes | Tests | User-Test | User-Final-Test | State | Usage |
+|---|---------|---------|---------|-------|-----------|-----------------|-------|-------|
+| 1 | ship-successful | 🚀 | yes | yes | — | if flagged | final | yes |
+| 2 | ready | 📦 | yes | if ran | — | if flagged | branch | yes |
+| 3 | ship-blocked | ⛔ | yes | if ran | — | if flagged | branch | yes |
+| 4 | test | 🧪 | yes | if ran | yes | if flagged | app-status | yes |
+| 5 | test-minimal | ▶️ | — | — | — | — | — | — |
+| 6 | analysis | 📋 | yes | — | — | if flagged | none | yes |
+| 7 | aborted | 🚫 | opt. | — | — | if flagged | dep. | yes |
+| 8 | **fallback** | 🔧 | yes | — | — | if flagged | dep. | yes |
 
 - **ship-successful (1)**: ONLY after /devops-ship + successfully merged to origin/main. PR vs. direct push → state line shows the difference.
 - **ship-blocked (3)**: ONLY after /devops-ship + NOT merged (PR open, build fail, etc.).

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.58.1",
+  "version": "0.59.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

Three gaps in the testing strategy are closed by one SSOT in test-strategy.md plus a unified completion-card flag that works inline, via agents, and in autonomous mode.

- New userFinalTest input on render_completion_card renders the unified block in all variants except test-minimal
- QA-Wave protocol expanded from 4 to 6 rules, referencing the new SSOT
- devops-autonomous no longer marks Electron apps as Browser nicht benoetigt

## Test plan

- [ ] Trigger a completion card with userFinalTest items
- [ ] Run /devops-autonomous on an Electron project - Step 3b must NOT skip browser probe
- [ ] Run /devops-agents QA wave on a web project with 3rd-party calls