### PR TITLE
fix(usage): equal-length bars + surface scraper login state

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.58.0"
+    "version": "0.58.1"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.58.0",
+      "version": "0.58.1",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.58.0",
+      "version": "0.58.1",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.58.1] — 2026-04-23
+
+### Fixed
+
+- **plugins/devops/mcp-server/index.js** + **plugins/devops/scripts/refresh-usage-headless.js** — usage card now surfaces scraper login status instead of silently serving stale data. The MCP server's `refreshUsage` catch-block propagates the scraper exit code: on `2` (not logged in) the cached usage JSON is tagged with `_loginRequired: true` and `renderUsageMeterForCard` renders a prominent `⚠ Scraper not logged in — Edge login window opened, log in once` warning. Previously the failure path fell through silently and consumers saw day-old "cached" data with no indication that a one-time login was needed. The scraper itself now detects logged-out state even when claude.ai does not redirect away from `/settings/usage`: checks for email input fields and login-button text in the page body, and after the 24s poll window treats any "no `<main>` element" result as logged-out (the most common cause) rather than as a generic parse error
+- **plugins/devops/mcp-server/index.js** `renderUsageLine` — both usage bars are now the same total length regardless of reset-time width. `resetStr` is padded to a fixed 7 chars (matches `23h 59m`, the widest possible value), and the trailing ` left` label is removed — redundant given the `Xh Ym` / `Xd Yh` format already implies duration. Previously a `5h` reset like `30m` and a `Wk` reset like `1d 17h` produced visibly different line lengths
+
 ## [0.58.0] — 2026-04-22
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.58.0**
+**Version: 0.58.1**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.58.0",
+  "version": "0.58.1",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/mcp-server/index.js
+++ b/plugins/devops/mcp-server/index.js
@@ -91,12 +91,14 @@ function renderUsageLine(label, pct, elapsedPct, delta, resetMinutes) {
   const bar = renderBar(pct, elapsedPct);
   const pctStr = String(pct).padStart(3, ' ') + '%';
   const deltaStr = formatDelta(delta);
-  const resetStr = formatResetShort(resetMinutes);
+  // Fixed-width reset column (max '23h 59m' = 7 chars) so both lines align
+  // regardless of whether one shows '30m' and the other '1d 17h'.
+  const resetStr = formatResetShort(resetMinutes).padEnd(7, ' ');
   const pace = pct - elapsedPct;
   const warn = pace > 10 ? '  \u26a0 Pace!' : '';
   // Fixed-width delta column so · reset always aligns
   const deltaPart = deltaStr ? (' ' + deltaStr).padEnd(5, ' ') : '     ';
-  return label + '  ' + bar + '  ' + pctStr + deltaPart + '  \u00b7 ' + resetStr + ' left' + warn;
+  return label + '  ' + bar + '  ' + pctStr + deltaPart + '  \u00b7 ' + resetStr + warn;
 }
 
 function renderUsageMeter(usageData, delta5h, deltaWk) {
@@ -140,13 +142,18 @@ function renderUsageMeterForCard(usageData, delta5h, deltaWk, healthLine) {
     lines.push(renderUsageLine('Wk', w.pct, elapsedWkPct, deltaWk, w.resetInMinutes));
   }
 
-  // Stale/cached data indicator — only show when data is notably old (>30min)
-  if (usageData._cached && usageData._ageMinutes > 30) {
+  // Failure indicator — login required is always shown prominently regardless
+  // of cache age (the scraper can't refresh until the user logs in once).
+  if (usageData._loginRequired) {
+    lines.push('');
+    lines.push('\u26a0 Scraper not logged in \u2014 Edge login window opened, log in once (then fresh data on every card)');
+  } else if (usageData._cached && usageData._ageMinutes > 30) {
     const ageLabel = usageData._ageMinutes >= 60
       ? `~${Math.round(usageData._ageMinutes / 60)}h old`
       : `~${usageData._ageMinutes}m old`;
+    const suffix = usageData._failureReason ? ` (${usageData._failureReason})` : '';
     lines.push('');
-    lines.push(`cached \u00b7 ${ageLabel}`);
+    lines.push(`cached \u00b7 ${ageLabel}${suffix}`);
   }
 
   lines.push('```');
@@ -521,6 +528,14 @@ function refreshUsage() {
     console.error('[dotclaude-completion-mcp] Scrape failed (exit', lastExitCode, '):', err.message);
   }
 
+  const reasons = {
+    2: 'scraper profile not logged in — visible login window was opened, log in once and retry',
+    3: 'usage page parse error',
+    4: 'CDP WebSocket failed',
+    5: 'scraper instance could not launch (Edge not installed?)',
+  };
+  const reason = reasons[lastExitCode] || (lastExitCode ? `scrape exit code ${lastExitCode}` : null);
+
   // Last resort: use any existing data (even stale) with age indicator
   const cached = readUsageJson();
   if (cached?.session) {
@@ -528,17 +543,12 @@ function refreshUsage() {
     cached._ageMinutes = Math.round(
       (Date.now() - new Date(cached.timestamp).getTime()) / 60_000
     );
+    if (reason) cached._failureReason = reason;
+    if (lastExitCode === 2) cached._loginRequired = true;
     return { success: true, data: cached, delta5h: null, deltaWk: null };
   }
 
-  const reasons = {
-    2: 'scraper profile not logged in — visible login window was opened, log in once and retry',
-    3: 'usage page parse error',
-    4: 'CDP WebSocket failed',
-    5: 'scraper instance could not launch (Edge not installed?)',
-  };
-  const reason = reasons[lastExitCode] || `scrape exit code ${lastExitCode}`;
-  return { success: false, data: null, reason };
+  return { success: false, data: null, reason: reason || 'no usage data available' };
 }
 
 // ---------------------------------------------------------------------------

--- a/plugins/devops/scripts/refresh-usage-headless.js
+++ b/plugins/devops/scripts/refresh-usage-headless.js
@@ -313,6 +313,9 @@ async function scrapeViaCDP() {
     log('Attached to target, sessionId:', sessionId);
 
     // Wait for page to load — poll until content appears or timeout
+    // Detect logged-out state via URL redirect, OR by the presence of a
+    // login button / email input (claude.ai sometimes renders the login UI
+    // at /settings/usage without changing the URL).
     let evalData = null;
     for (let attempt = 0; attempt < 12; attempt++) {
       await new Promise(r => setTimeout(r, 2000));
@@ -320,6 +323,12 @@ async function scrapeViaCDP() {
         expression: `(() => {
           const url = window.location.href;
           if (url.includes('/login') || url.includes('/logout')) return JSON.stringify({ notLoggedIn: true });
+          // Login UI heuristics — these appear on the public login page
+          if (document.querySelector('input[type="email"], input[name="email"]')) return JSON.stringify({ notLoggedIn: true });
+          const bodyText = (document.body && document.body.innerText) || '';
+          if (/Continue with Google|Mit Google fortfahren|Log in to Claude|Bei Claude anmelden/i.test(bodyText)) {
+            return JSON.stringify({ notLoggedIn: true });
+          }
           const main = document.querySelector('main');
           if (!main) return JSON.stringify({ noMain: true });
           const text = main.innerText;
@@ -332,6 +341,15 @@ async function scrapeViaCDP() {
       evalData = JSON.parse(evalResult.result?.value || '{}');
       if (evalData.notLoggedIn || evalData.text) break;
       log(`Page not ready yet (attempt ${attempt + 1}/12)...`);
+    }
+
+    // If we never got usage text AND never found a login signal, the page
+    // probably failed to render. Assume logged-out (most common cause) so
+    // the caller opens a visible login window instead of serving silently
+    // stale cached data forever.
+    if (evalData && !evalData.text && !evalData.notLoggedIn) {
+      log('Page did not render usage content — treating as not-logged-in');
+      evalData = { notLoggedIn: true };
     }
 
     // Close the background target

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.58.0",
+  "version": "0.58.1",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary
- Both usage bars now render the same total length regardless of reset-time width (`30m` vs `1d 17h`). `resetStr` padded to 7 chars; redundant ` left` label removed.
- Scraper login state is now surfaced in the card: exit code 2 from the scraper tags the cached JSON with `_loginRequired: true`, and the renderer shows a prominent `⚠ Scraper not logged in — Edge login window opened` warning instead of silently serving stale data.
- Scraper detects logged-out state even when claude.ai keeps the URL at `/settings/usage` — checks for email inputs and login-button text, and treats a persistent missing `<main>` element as logged-out rather than a generic parse error.

## Test plan
- [x] `npm run lint` clean
- [x] `npm test` — 103/103 passing
- [x] `renderUsageLine` manual smoke: lines equal length for matched and disparate reset widths
- [x] Manual scraper run exits with code 2 and opens visible login window when profile is logged out

🤖 Generated with [Claude Code](https://claude.com/claude-code)