### PR TITLE
feat(local-llm): think-stripper + instructions param + 300s timeout

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.59.0"
+    "version": "0.60.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.59.0",
+      "version": "0.60.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.59.0",
+      "version": "0.60.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.60.0] — 2026-04-23
+
+### Added
+
+- **plugins/local-llm/mcp-server/index.js** — `local_generate` gains an optional `instructions` parameter so Claude can attach task-specific guidance (style, library choice, output shape, naming conventions, "no thinking output", etc.) without the plugin needing to re-bake a static base prompt. Instructions are appended to the existing base system prompt under a clearly delimited `Additional task-specific instructions:` section; the base prompt itself stays the SSOT for output discipline (no fences, no commentary)
+
+### Fixed
+
+- **plugins/local-llm/mcp-server/index.js** — reasoning models (qwen3-vl, deepseek-r1, etc.) inline a `<think>…</think>` block at the start of `content` when reached via AnythingLLM's OpenAI-compat endpoint (the API does not split the block into a separate `reasoning` field). Generated code returned to Claude was therefore prefixed with the model's chain-of-thought, which broke direct use of the output in `Write` calls. New `stripThinkingBlock()` removes all `<think>` and `<thinking>` blocks (case-insensitive, multiple occurrences), composed via `sanitizeOutput()` together with the existing `stripOuterFence()`. Base prompt now also explicitly forbids `<think>` blocks as a belt-and-braces hint to compliant models
+- **plugins/local-llm/hooks/lib/anythingllm-http.js** — `COMPLETION_TIMEOUT_MS` raised from 120s to 300s. Reasoning-heavy 8B models with thinking overhead routinely take 90–180s for outputs above ~300 tokens even when AnythingLLM correctly forwards to Ollama, hitting the previous timeout for tasks that perfectly fit the delegation criteria (e.g. a 25-test Vitest file). 300s leaves headroom for cold-start model load (~10s) plus thinking + answer generation at the typical 6–8 tok/s of qwen3-vl:8b
+
 ## [0.59.0] — 2026-04-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.59.0**
+**Version: 0.60.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.59.0",
+  "version": "0.60.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.59.0",
+  "version": "0.60.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/local-llm/hooks/lib/anythingllm-http.js
+++ b/plugins/local-llm/hooks/lib/anythingllm-http.js
@@ -22,7 +22,7 @@ const { URL } = require('node:url');
 
 const HEALTH_TIMEOUT_MS = 2000;
 const REQUEST_TIMEOUT_MS = 60_000;
-const COMPLETION_TIMEOUT_MS = 120_000;
+const COMPLETION_TIMEOUT_MS = 300_000;
 
 function requestJson({ baseUrl, path, method = 'GET', apiKey, body, timeoutMs = REQUEST_TIMEOUT_MS }) {
   return new Promise((resolve) => {

--- a/plugins/local-llm/mcp-server/index.js
+++ b/plugins/local-llm/mcp-server/index.js
@@ -56,6 +56,19 @@ function stripOuterFence(text) {
   return match ? match[1] : trimmed;
 }
 
+// Reasoning models (qwen3, deepseek-r1, etc.) inline a <think>…</think> or
+// <thinking>…</thinking> block before the actual answer. The OpenAI-compat
+// endpoint does NOT split it into a separate field — it lands in `content`.
+// Strip ALL such blocks (not just the first) and return only the answer.
+function stripThinkingBlock(text) {
+  if (typeof text !== "string") return text;
+  return text.replace(/<think(?:ing)?>[\s\S]*?<\/think(?:ing)?>/gi, "").trim();
+}
+
+function sanitizeOutput(text) {
+  return stripOuterFence(stripThinkingBlock(text));
+}
+
 // ---------------------------------------------------------------------------
 // Status
 // ---------------------------------------------------------------------------
@@ -170,9 +183,16 @@ server.registerTool(
       temperature: z.number().min(0).max(1).optional().describe(
         "Generation temperature. Default 0.2 (deterministic). Never above 0.5 for code."
       ),
+      instructions: z.string().optional().describe(
+        "Optional task-specific guidance appended to the base system prompt. " +
+        "Use this to enforce style, library choices, output shape, naming, or " +
+        "to suppress reasoning output (e.g. 'no thinking, output code only', " +
+        "'use vitest', 'prefer arrow functions', 'no type assertions'). " +
+        "Keep it short — system context counts against the model's window."
+      ),
     }),
   },
-  async ({ task, context, language, temperature }) => {
+  async ({ task, context, language, temperature, instructions }) => {
     const phase = await getPhase();
     if (!phase.ready) {
       return {
@@ -184,11 +204,14 @@ server.registerTool(
     }
 
     const lang = language || "the appropriate language";
-    const systemPrompt =
+    const baseSystemPrompt =
       "You are a code generation assistant. Output ONLY the requested code — " +
-      "no explanations, no markdown fences, no commentary. " +
+      "no explanations, no markdown fences, no commentary, no <think> blocks. " +
       "If the task specifies a function signature, match it exactly. " +
       "Follow the coding style shown in the context if provided.";
+    const systemPrompt = instructions
+      ? `${baseSystemPrompt}\n\nAdditional task-specific instructions:\n${instructions}`
+      : baseSystemPrompt;
 
     let userPrompt = `Language: ${lang}\n\nTask: ${task}`;
     if (context) userPrompt += `\n\nContext (existing code to follow):\n${context}`;
@@ -222,7 +245,7 @@ server.registerTool(
       content: [{
         type: "text",
         text: JSON.stringify({
-          code: stripOuterFence(result.content),
+          code: sanitizeOutput(result.content),
           tokensUsed: result.tokensUsed,
           finishReason: result.finishReason,
           workspace: WORKSPACE_SLUG,


### PR DESCRIPTION
## Summary

Three local-llm fixes that together unblock real-world use of `local_generate` with reasoning-heavy 8B models (qwen3-vl, deepseek-r1, etc.):

1. **`<think>` block stripping** — reasoning models inline their chain-of-thought into `content` via the OpenAI-compat endpoint. New `stripThinkingBlock()` removes them so generated code is directly usable in `Write` calls.
2. **`instructions` parameter** — Claude can now attach task-specific guidance (style, library, naming) without baking changes into the static base prompt.
3. **Timeout 120s → 300s** — reasoning + answer generation at ~6–8 tok/s for qwen3-vl:8b routinely exceeded the previous 120s ceiling for outputs above ~300 tokens, even when AnythingLLM forwarded correctly to Ollama. 300s gives headroom for cold-start + thinking + answer.

CHANGELOG bumped to 0.60.0 (minor — new MCP parameter).

## Test plan
- [x] `npm run lint` — passes
- [x] `npm run test` — 103/103 passes
- [x] live verification: `local_generate` clamp() task succeeded after timeout bump (380 tokens, finishReason `stop`)
- [ ] post-merge `/devops-self-update` on a consumer — re-test with `instructions` param to confirm `<think>` blocks no longer leak into output

🤖 Generated with [Claude Code](https://claude.com/claude-code)