### PR TITLE
fix(refresh-usage): off-screen window + 15s cache + login PID tracking

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.60.0"
+    "version": "0.60.1"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.60.0",
+      "version": "0.60.1",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.60.0",
+      "version": "0.60.1",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.60.1] — 2026-04-24
+
+### Fixed
+
+- **plugins/devops/scripts/refresh-usage-headless.js** — three issues with the dedicated Edge usage scraper that caused visible windows to keep popping over the user's other windows. (1) `--headless=new` is detected by claude.ai which serves the login page despite valid cookies, so each scrape returned `notLoggedIn` and spawned yet another visible login window. Replaced with a real (non-headless) Edge instance positioned off-screen at `--window-position=-32000,-32000` with `--window-size=1,1` and `--silent-launch` — same auth/cookie behaviour as the visible login session, but invisible. (2) Rapid back-to-back invocations (e.g. multiple completion cards in a turn) re-launched Edge each time even when the previous result was seconds old. New `FRESH_CACHE_MAX_AGE_SECONDS = 15` short-circuit reads the cached `usage-live.json` and exits before any Edge spawn when data is fresh enough. (3) When a visible login window was spawned but the user had not yet logged in, the next scrape would spawn another login window because the PID file had been intentionally deleted. New `LOGIN_PID_FILE` tracks the visible login window's PID separately from the scraper PID; `loginWindowAlive()` checks via `tasklist` and short-circuits with cached data instead of duplicating windows. PID file is cleared on the next successful scrape
+
 ## [0.60.0] — 2026-04-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.60.0**
+**Version: 0.60.1**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.60.0",
+  "version": "0.60.1",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/scripts/refresh-usage-headless.js
+++ b/plugins/devops/scripts/refresh-usage-headless.js
@@ -39,6 +39,11 @@ const SCRIPTS_DIR = path.join(os.homedir(), '.claude');
 const USAGE_LIVE_PATH = path.join(SCRIPTS_DIR, 'usage-live.json');
 const SCRAPER_PROFILE_DIR = path.join(SCRIPTS_DIR, 'edge-usage-profile');
 const SCRAPER_PID_FILE = path.join(SCRIPTS_DIR, 'edge-usage-scraper.pid');
+const LOGIN_PID_FILE = path.join(SCRIPTS_DIR, 'edge-usage-login.pid');
+// If the cached usage-live.json is fresher than this, skip the Edge launch
+// entirely and just print the cached summary. Prevents window-spam when the
+// card is rendered in rapid succession.
+const FRESH_CACHE_MAX_AGE_SECONDS = 15;
 const USAGE_URL = 'https://claude.ai/settings/usage';
 const LOGIN_URL = 'https://claude.ai/login';
 const CDP_PORT = 9223;
@@ -214,7 +219,16 @@ async function launchScraperInstance({ visible = false, url = USAGE_URL } = {}) 
     '--disable-features=msEdgeFeatureOverrides',
   ];
   if (!visible) {
-    args.push('--headless=new', '--disable-gpu');
+    // Don't use --headless=new: claude.ai detects it and serves the login page
+    // even with valid cookies. Run a real Edge window but off-screen + tiny so
+    // it stays invisible. Auth/cookies behave identically to the visible login
+    // session.
+    args.push(
+      '--window-position=-32000,-32000',
+      '--window-size=1,1',
+      '--disable-gpu',
+      '--silent-launch'
+    );
   }
   args.push(url);
 
@@ -475,9 +489,34 @@ function useCacheOrExit(code) {
   process.exit(code);
 }
 
+/** Is the visible login window (from a previous run) still alive? */
+function loginWindowAlive() {
+  try {
+    const pid = parseInt(fs.readFileSync(LOGIN_PID_FILE, 'utf8').trim(), 10);
+    if (!(pid > 0)) return false;
+    // tasklist exits 0 if process exists
+    const out = execSync(`tasklist /FI "PID eq ${pid}" /NH`, {
+      encoding: 'utf8', timeout: 3000, stdio: ['pipe', 'pipe', 'ignore']
+    });
+    return /msedge\.exe/i.test(out);
+  } catch { return false; }
+}
+
 (async () => {
   if (checkOnly) {
     process.exit((await isCDPAvailable()) ? 0 : 5);
+  }
+
+  // 15s short-circuit: if cached data is fresh enough, skip Edge entirely.
+  // Eliminates window-spam from rapid back-to-back invocations.
+  const cacheAgeMin = getCacheAge();
+  if (cacheAgeMin >= 0) {
+    const ageSec = Math.round((Date.now() - new Date(JSON.parse(fs.readFileSync(USAGE_LIVE_PATH, 'utf8')).timestamp).getTime()) / 1000);
+    if (ageSec < FRESH_CACHE_MAX_AGE_SECONDS) {
+      log(`Using fresh cache (${ageSec}s old, < ${FRESH_CACHE_MAX_AGE_SECONDS}s threshold)`);
+      if (printSummary) printUsageSummary();
+      process.exit(0);
+    }
   }
 
   // If CDP is already up, a scraper instance from a previous run is still
@@ -497,22 +536,35 @@ function useCacheOrExit(code) {
   const code = await scrapeViaCDP();
 
   if (code === 0) {
-    // Leave the headless scraper alive for fast reuse on the next invocation.
-    // It's a single background msedge.exe with its own isolated profile —
+    // Successful scrape means we're logged in — clear any stale login-PID
+    // marker so future failures can spawn a fresh login window if needed.
+    try { fs.unlinkSync(LOGIN_PID_FILE); } catch {}
+    // Leave the hidden scraper alive for fast reuse on the next invocation.
+    // It's a single off-screen msedge.exe with its own isolated profile —
     // no visible window, no interference with the user's main Edge.
     if (printSummary) printUsageSummary();
     process.exit(0);
   }
 
   if (code === 2) {
-    // Not logged in — kill the headless instance, open a VISIBLE window
-    // for one-time login. Caller (SKILL.md) tells the user inline.
+    // Not logged in. If a previous login window is still open, do NOT spawn
+    // another one — user is presumably still working on it.
+    if (loginWindowAlive()) {
+      log('LOGIN_REQUIRED: visible login window from previous run still open — not spawning another');
+      useCacheOrExit(2);
+      return;
+    }
+    // Kill the hidden scraper instance, open a VISIBLE window for one-time
+    // login. Caller (SKILL.md) tells the user inline.
     killScraperInstance();
     log('LOGIN_REQUIRED: scraper profile is not logged in to claude.ai');
-    await launchScraperInstance({ visible: true, url: LOGIN_URL });
-    // Leave the visible window alive — the user will interact with it.
-    // Drop the PID file so the next scrape run can't kill this login window.
+    const loginPid = await launchScraperInstance({ visible: true, url: LOGIN_URL });
+    // Move the PID into a separate login-pid file so the next scrape run
+    // (a) can't kill this login window, and (b) can detect it's still open.
     try { fs.unlinkSync(SCRAPER_PID_FILE); } catch {}
+    if (loginPid) {
+      try { fs.writeFileSync(LOGIN_PID_FILE, String(loginPid)); } catch {}
+    }
     process.exit(2);
   }
 

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.60.0",
+  "version": "0.60.1",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary
- Replace `--headless=new` with off-screen real Edge window — claude.ai blocked headless mode and served the login page even with valid cookies, causing repeated visible login spawns
- Short-circuit Edge launch when cached usage data is < 15s old (eliminates window spam from rapid completion-card renders)
- Track visible login window PID separately so a stuck login flow does not spawn duplicate windows on every subsequent scrape

## Test plan
- [x] `npm run lint` passes
- [x] `npm test` passes (103/103)
- [ ] After merge: kill old `msedge.exe` scraper instance, then trigger several completion cards in succession — verify no visible Edge windows appear and cache is reused under 15s