### PR TITLE
feat(ship): document deferred MCP tool loading (0.60.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.60.1"
+    "version": "0.60.2"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.60.1",
+      "version": "0.60.2",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.60.1",
+      "version": "0.60.2",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.60.2] — 2026-04-24
+
+### Added
+
+- **plugins/devops/deep-knowledge/mcp-deferred-tools.md** — new cross-cutting reference documenting the deferred-tools pattern. In sessions with a large tool inventory, MCP tool schemas land deferred: their names appear in the SessionStart `<system-reminder>` deferred list, but their JSONSchema is NOT loaded until `ToolSearch` is explicitly invoked with `select:<tool-name>`. A previous ship attempt misdiagnosed this as a missing MCP server, then deadlocked on the guard hook blocking the manual PR-creation fallback. Doc explains the detection heuristic (presence in deferred list = registered), the single-roundtrip bulk-load pattern (`select:name1,name2,...` in one ToolSearch call), and anti-patterns (do not conclude "server missing" from a deferred entry, do not fall back to manual PR-creation when the guard fires)
+
+### Changed
+
+- **plugins/devops/skills/devops-ship/SKILL.md** — new `Step 0.5 — Load Deferred MCP Schemas` between `Step 0` (extensions) and `Step 1` (preflight). Mandatory bulk-load of all five `ship_*` tool schemas via a single `ToolSearch({ query: "select:...", max_results: 5 })` call before Step 1 runs. Step also defines the failure contract: if any of the five schemas are missing from the returned `<functions>` block, the MCP server is genuinely unregistered — STOP and report, do NOT fall back to `gh pr create` (the guard blocks it anyway). Prevents the previous-session deadlock where the pipeline was never entered because Claude assumed the tools were absent
+- **plugins/devops/hooks/pre-tool-use/pre.ship.guard.js** bumped to 0.3.0 — block message for manual PR creation/merge now includes the exact `ToolSearch` recovery query with all five `ship_*` tool names pre-filled, plus a pointer to `deep-knowledge/mcp-deferred-tools.md`. Hook behaviour (Bash-only, regex patterns) unchanged; only the stderr message grew more helpful
+
 ## [0.60.1] — 2026-04-24
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.60.1**
+**Version: 0.60.2**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.60.1",
+  "version": "0.60.2",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/deep-knowledge/INDEX.md
+++ b/plugins/devops/deep-knowledge/INDEX.md
@@ -20,6 +20,7 @@ Quick-reference for all deep-knowledge topics. Read this FIRST to find the right
 | [fact-verification.md](fact-verification.md) | Fact Verification | Cross-cutting rule for all web research, claims, and statistics. |
 | [git-hygiene.md](git-hygiene.md) | Git Hygiene | Cross-cutting git rules referenced by `/devops-commit`, `/devops-ship`, and h... |
 | [local-llm-delegation.md](local-llm-delegation.md) | Local LLM Delegation | Cross-cutting rule for all implementation agents (core, frontend, feature, ai) |
+| [mcp-deferred-tools.md](mcp-deferred-tools.md) | MCP Deferred Tools | Cross-cutting rule: in sessions with a large tool inventory (Computer Use, Ch... |
 | [merge-safety.md](merge-safety.md) | Merge Safety — Parallel Development | Cross-cutting reference for preventing silent overwrites when multiple develo... |
 | [plugin-behavior.md](plugin-behavior.md) | Plugin Behavior Rules | Core behavioral rules enforced by the devops plugin. |
 | [pre-mortem.md](pre-mortem.md) | Pre-Mortem / Red-Team Self-Critique | Cross-cutting rule for reducing blind spots before non-trivial changes. |

--- a/plugins/devops/deep-knowledge/mcp-deferred-tools.md
+++ b/plugins/devops/deep-knowledge/mcp-deferred-tools.md
@@ -1,0 +1,63 @@
+# MCP Deferred Tools
+
+Cross-cutting rule: in sessions with a large tool inventory (Computer Use, Chrome MCP, many third-party MCPs), Claude Code **defers** most MCP tool schemas. The tools appear in the SessionStart `<system-reminder>` deferred-tools list, but their JSONSchema is NOT loaded — calling them directly fails with `InputValidationError`.
+
+Relevant for devops: all `dotclaude-ship` and `dotclaude-issues` tools land deferred. Only `dotclaude-completion` tools are usually auto-loaded because the completion card hook fires on every Stop.
+
+## The trap
+
+A past session reached this failure mode:
+
+1. Claude saw `gh pr create` blocked by `pre.ship.guard.js`.
+2. Claude searched via ToolSearch with wrong queries, got no results, concluded "ship MCP server is missing".
+3. Claude reported the plugin as broken — but the server was running correctly; the tool schemas were simply deferred.
+4. Deadlock: guard blocks the manual fallback, Claude thinks the proper path is unavailable.
+
+The server was not broken. The tools were one `ToolSearch` call away.
+
+## How to detect deferred tools
+
+The SessionStart `<system-reminder>` lists deferred tool names verbatim. Example for this plugin:
+
+```
+mcp__plugin_devops_dotclaude-ship__ship_preflight
+mcp__plugin_devops_dotclaude-ship__ship_build
+mcp__plugin_devops_dotclaude-ship__ship_version_bump
+mcp__plugin_devops_dotclaude-ship__ship_release
+mcp__plugin_devops_dotclaude-ship__ship_cleanup
+mcp__plugin_devops_dotclaude-issues__match_issues
+```
+
+Presence in that list = registered + available. Absence = the MCP server genuinely failed to start (check `/mcp` status or server stderr).
+
+## How to load a schema
+
+Use `ToolSearch` with the `select:` prefix. Load ALL tools needed for the current pipeline in ONE call — not one per round-trip:
+
+```
+ToolSearch({
+  query: "select:mcp__plugin_devops_dotclaude-ship__ship_preflight,mcp__plugin_devops_dotclaude-ship__ship_build,mcp__plugin_devops_dotclaude-ship__ship_version_bump,mcp__plugin_devops_dotclaude-ship__ship_release,mcp__plugin_devops_dotclaude-ship__ship_cleanup",
+  max_results: 5
+})
+```
+
+The result contains a `<functions>` block with one `<function>{...}</function>` line per loaded tool. After that block appears, the tools are callable exactly like any other tool.
+
+## When to do this
+
+- `/devops-ship` skill: mandatory, see `SKILL.md` Step 0.5.
+- Any skill that calls MCP tools from a non-completion server: load schemas upfront in the Step 0 / setup phase.
+- Guard-hook recovery: if `pre.ship.guard.js` fires and you cannot see ship tools, ToolSearch first — do NOT retry the blocked Bash command.
+
+## Anti-patterns
+
+- **Do NOT** conclude "server missing" from a deferred list entry. Deferred = lazy-loaded schema, not absent.
+- **Do NOT** fall back to manual `gh pr create` / `gh pr merge` when ship tools appear unavailable — the guard hook blocks it intentionally.
+- **Do NOT** load tools one at a time. One ToolSearch call can load the whole pipeline in a single round-trip.
+- **Do NOT** re-load a tool whose schema is already visible in the conversation. Once loaded, it persists for the session.
+
+## Related
+
+- `pre.ship.guard.js` — block message explicitly points here.
+- `skills/devops-ship/SKILL.md` Step 0.5 — enforces this pattern for the ship pipeline.
+- `plugin-behavior.md` — general MCP-server expectations.

--- a/plugins/devops/hooks/pre-tool-use/pre.ship.guard.js
+++ b/plugins/devops/hooks/pre-tool-use/pre.ship.guard.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * @hook pre.ship.guard
- * @version 0.2.0
+ * @version 0.3.0
  * @event PreToolUse
  * @plugin devops
  * @description Block manual PR creation/merging via Bash.
@@ -42,7 +42,16 @@ process.stdin.on('end', () => {
   process.stderr.write(
     'BLOCKED: Manual PR creation/merging detected. ' +
     'Use /devops-ship for shipping. ' +
-    'The ship pipeline ensures build-ID, safety checks, version bumps, and proper completion cards.\n'
+    'The ship pipeline ensures build-ID, safety checks, version bumps, and proper completion cards.\n' +
+    '\n' +
+    'If ship_* MCP tools appear missing: they are likely DEFERRED, not unregistered. ' +
+    'Load their schemas via ToolSearch before calling:\n' +
+    '  ToolSearch({ query: "select:mcp__plugin_devops_dotclaude-ship__ship_preflight,' +
+    'mcp__plugin_devops_dotclaude-ship__ship_build,' +
+    'mcp__plugin_devops_dotclaude-ship__ship_version_bump,' +
+    'mcp__plugin_devops_dotclaude-ship__ship_release,' +
+    'mcp__plugin_devops_dotclaude-ship__ship_cleanup", max_results: 5 })\n' +
+    'See {PLUGIN_ROOT}/deep-knowledge/mcp-deferred-tools.md for details.\n'
   );
   process.exit(2);
 });

--- a/plugins/devops/skills/devops-ship/SKILL.md
+++ b/plugins/devops/skills/devops-ship/SKILL.md
@@ -54,6 +54,25 @@ Project extensions define: quality gate commands, deploy targets, version files,
 
 4. Codex context: Read `{PLUGIN_ROOT}/deep-knowledge/codex-integration.md` — this skill has a **mandatory** Codex review gate (§1 in that doc), which MUST be called via `{PLUGIN_ROOT}/scripts/codex-safe.sh` (5-min hard timeout, see "Hard Timeout & Failure-Tolerance" section), NEVER via the `/codex:rescue` Agent tool. Detect Codex availability now so Step 2 can act on it.
 
+## Step 0.5 — Load Deferred MCP Schemas
+
+Ship tools from the `dotclaude-ship` MCP server are often **deferred** in large-tool-inventory sessions (their names appear in the SessionStart deferred-tools list, but their schemas are NOT loaded yet). Calling them directly before the schema is loaded fails with `InputValidationError`.
+
+See `{PLUGIN_ROOT}/deep-knowledge/mcp-deferred-tools.md` for the full pattern.
+
+**Before Step 1**, load all ship tool schemas in ONE `ToolSearch` call:
+
+```
+ToolSearch({
+  query: "select:mcp__plugin_devops_dotclaude-ship__ship_preflight,mcp__plugin_devops_dotclaude-ship__ship_build,mcp__plugin_devops_dotclaude-ship__ship_version_bump,mcp__plugin_devops_dotclaude-ship__ship_release,mcp__plugin_devops_dotclaude-ship__ship_cleanup",
+  max_results: 5
+})
+```
+
+If the `ToolSearch` result contains all five `<function>` entries, proceed. If ANY are missing from the returned block, the server is genuinely not registered — STOP and report to the user (do NOT fall back to `gh pr create`; the guard hook will block it).
+
+Do NOT skip this step even if you "think" the tools are available. `analysis` / `ready` / `test` cards have no ship-tool dependency and won't hit this — only the full pipeline does.
+
 ## Step 1 — Pre-Flight & Rebase Loop
 
 Run preflight, resolve any merge-safety issues autonomously, and re-check — repeat until the branch is clean.

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.60.1",
+  "version": "0.60.2",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary
Prevent the "missing MCP server" misdiagnosis that deadlocked a previous ship attempt. Deferred tools from `dotclaude-ship` / `dotclaude-issues` are registered but lazy-loaded — their JSONSchema needs an explicit `ToolSearch` call before use.

## Changes
- `skills/devops-ship/SKILL.md` — new `Step 0.5 — Load Deferred MCP Schemas` before preflight, mandatory bulk-load via one `ToolSearch` call.
- `hooks/pre-tool-use/pre.ship.guard.js` → 0.3.0 — block message now includes the exact `ToolSearch` recovery query + pointer to the new deep-knowledge doc.
- `deep-knowledge/mcp-deferred-tools.md` — full pattern, detection heuristic, bulk-load example, anti-patterns (don't conclude "server missing"; don't fall back to manual PR creation when the guard fires).

## Test plan
- [x] `npm run lint` clean
- [x] `npm test` — 103/103 pass
- [x] `ship_preflight` — ready, no overlap, version consistent
- [x] `ship_build` — buildId `compassionate-ptolemy-0df06f-e8f9159`