### PR TITLE
feat(concept): generic form-collection coverage gate (0.60.3)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.60.2"
+    "version": "0.60.3"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.60.2",
+      "version": "0.60.3",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.60.2",
+      "version": "0.60.3",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.60.3] — 2026-04-25
+
+### Changed
+
+- **plugins/devops/skills/devops-concept/SKILL.md** + **deep-knowledge/validation-gate.md** + **deep-knowledge/templates.md** + **deep-knowledge/iteration-rules.md** — generic form-collection coverage gate. Concept pages must now implement `collectDecisions()` via a generic catch-all (`querySelectorAll('input, select, textarea')` scoped to `section[data-iteration][data-active]`) that ships every named control as `allFields` in the submit payload, not via hand-listed selectors per field. Hand-listed selectors written for iteration N silently miss new fields added in iteration N+1: the user sees the panel turn green, but Claude receives a truncated payload and can only act on the iteration-N keys. Validation gate grows from 20 to 22 mandatory shared patterns (#21 catch-all selector, #22 `[data-active]` scope); reference `collectAllFormFields()` lives in templates.md and is wired into the dispatcher so typed sub-objects (`decisions[]`, `comments[]`) coexist with the catch-all rather than replacing it. SKILL.md Step 5 grows a coverage check that compares submitted `allFields` against the DOM of the just-frozen iteration; new Step 5c.2.5 is a verify-collection gate that reads existing `collectDecisions()` JS and forces a fix BEFORE appending iteration N+1 if the catch-all is missing. iteration-rules.md gains the matching append-checklist + procedure entry
+
 ## [0.60.2] — 2026-04-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.60.2**
+**Version: 0.60.3**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.60.2",
+  "version": "0.60.3",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/skills/devops-concept/SKILL.md
+++ b/plugins/devops/skills/devops-concept/SKILL.md
@@ -357,9 +357,10 @@ and `deep-knowledge/templates.md` § Iteration Tabs for the reference HTML.
 
 ### Post-Generation Validation (mandatory gate)
 
-After writing the HTML file, grep it for the 18 mandatory interactive
+After writing the HTML file, grep it for the 22 mandatory interactive
 patterns (heartbeat, panel states, iteration tabs, section TOC, reload
-polling, etc.).
+polling, generic form-collection catch-all scoped to the active
+iteration, etc.).
 **If ANY pattern is missing → DO NOT open the page.** Fix the HTML first,
 then re-validate. See `deep-knowledge/validation-gate.md` for the full
 pattern list and common failure modes.
@@ -441,6 +442,14 @@ User submits → Claude reads → Claude processes → Claude updates page → U
 1. Read the JSON from `#concept-decisions`
 2. Parse into structured decisions and comments
 
+**Coverage check:** before processing decisions, verify every named form
+field that exists in the just-frozen iteration HTML appears in the
+`decisions` payload (specifically the `allFields` catch-all). If a field
+is in the DOM but missing in the payload, flag it to the user immediately
+("the JS missed these fields, please re-submit after I fix the collection
+function"). See `deep-knowledge/validation-gate.md` § Generic Form
+Collection for the required pattern.
+
 ### 5b. Process & Act — branch by `action`
 
 The submit payload carries an `action` field (`"iterate"` or `"implement"`).
@@ -490,6 +499,15 @@ for the polling contract.
    `input`/`textarea`/`select`/`button` inside the section, set `readonly`
    on text inputs and textareas, preserve the submitted values exactly
    (read them from the just-processed decisions JSON).
+2.5. **Verify form collection coverage.** Read the existing JS for
+   `collectDecisions()` (or its template-specific variant). Confirm it
+   uses a generic `querySelectorAll('input, select, textarea')` scoped
+   to `[data-active]`. If it uses hand-listed selectors instead, fix it
+   NOW before appending the new iteration — otherwise the new section's
+   fields will silently fail to upload at submit time. See
+   `deep-knowledge/iteration-rules.md` § Procedure on every iteration —
+   coverage gate and `deep-knowledge/validation-gate.md` § Generic Form
+   Collection for the required pattern.
 3. Append a new `<section data-iteration="{N+1}" data-active>` with the
    updated / next-round content (new variants, refined options, whatever
    the feedback produced). Set `submitted: false` in `#concept-decisions`,

--- a/plugins/devops/skills/devops-concept/deep-knowledge/iteration-rules.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/iteration-rules.md
@@ -30,3 +30,38 @@ selections, read-only comments).
   bottom on narrow screens.
 
 See `templates.md` § Iteration Tabs for the reference HTML/CSS/JS.
+
+## Iteration append checklist
+
+When appending a new iteration section (Step 5c of `SKILL.md`), verify
+**before** posting `/reload`:
+
+1. ☐ All new form elements live inside the new
+      `<section data-iteration="N">`.
+2. ☐ Each form element has either a `name`, `id`, or `data-*` attribute
+      that `collectAllFormFields()` can use as a key.
+3. ☐ No new `data-*` attributes are introduced without checking the
+      collection function picks them up (the catch-all should, but
+      verify — see `validation-gate.md` § Generic Form Collection).
+4. ☐ Locally test: open the page, submit, inspect `#concept-decisions`.
+      Every input/select/textarea in the active iteration MUST appear in
+      the JSON. If any is missing → the catch-all is broken, fix BEFORE
+      reload.
+
+## Procedure on every iteration — coverage gate (Step 5c, Step 2.5)
+
+Before appending the new iteration section, insert this verification step
+between "freeze previous" (step 2 of the SKILL.md procedure) and "append
+new section" (step 3):
+
+**2.5. Verify form collection coverage.** Read the existing JS for
+`collectDecisions()` (or its template-specific variant). Confirm it uses
+a generic `querySelectorAll('input, select, textarea')` scoped to
+`[data-active]`. If it uses hand-listed selectors instead, fix it NOW
+before appending the new iteration — otherwise the new section's fields
+will silently fail to upload at submit time.
+
+This gate exists because hand-listed selectors written for iteration N
+will not pick up new fields introduced in iteration N+1, and the failure
+is silent: the user sees the panel turn green, but Claude receives a
+truncated payload.

--- a/plugins/devops/skills/devops-concept/deep-knowledge/templates.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/templates.md
@@ -1615,14 +1615,52 @@ The submit handler picks the branch based on `data-template` on `<html>`.
 An `action` (`iterate` | `implement`) is passed in from the button that was
 clicked and merged into the payload.
 
+The dispatcher ALSO runs a generic catch-all scoped to the active
+iteration (`section[data-iteration][data-active]`) so every named form
+element ships in `allFields`, regardless of whether the template-specific
+branch was updated for new fields. This is the safety net mandated by
+`validation-gate.md` § Generic Form Collection — never remove it, never
+replace it with hand-listed selectors. The typed sub-objects (`decisions`,
+`comments`) live alongside `allFields` for ergonomics; they do not
+substitute for it.
+
 ```javascript
+function collectAllFormFields(scope) {
+  const fields = {};
+  // Catch-all: every named input, select, textarea inside scope.
+  scope.querySelectorAll('input, select, textarea').forEach(el => {
+    const key = el.dataset.field
+             || el.dataset.v4
+             || el.dataset.confirm
+             || el.dataset.rename
+             || el.dataset.entities
+             || el.dataset.comment
+             || el.name
+             || el.id;
+    if (!key) return;  // unnamed control — skip
+    if (el.type === 'checkbox') {
+      fields[key] = el.checked;
+    } else if (el.type === 'radio') {
+      if (el.checked) fields[el.name] = el.value;
+    } else {
+      fields[key] = el.value;
+    }
+  });
+  return fields;
+}
+
 function collectDecisions(action = 'iterate') {
+  const active = document.querySelector('section[data-iteration][data-active]')
+              || document.body;
+  const allFields = collectAllFormFields(active);
+
   const template = document.documentElement.dataset.template || 'decision';
   let payload;
   if (template === 'prototype') payload = collectPrototypeDecisions();
   else if (template === 'free') payload = collectFreeDecisions();
   else payload = collectDecisionDecisions();
   payload.action = action;
+  payload.allFields = allFields;
   return payload;
 }
 

--- a/plugins/devops/skills/devops-concept/deep-knowledge/validation-gate.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/validation-gate.md
@@ -7,7 +7,7 @@ template-specific extras selected by `<html data-template="...">`.
 
 ## Phase 1 — Shared patterns (ALL templates)
 
-Every concept page must contain these 20 patterns, regardless of template:
+Every concept page must contain these 22 patterns, regardless of template:
 
 | # | Pattern to grep | Purpose |
 |---|----------------|---------|
@@ -32,6 +32,65 @@ Every concept page must contain these 20 patterns, regardless of template:
 | 18 | `data-nav-label` | Marker on nav-eligible sections |
 | 19 | `submit-iterate-btn` | Primary submit: iterate action (no code changes) |
 | 20 | `submit-implement-btn` | Secondary submit: implement action (real changes) |
+| 21 | `querySelectorAll('input, select, textarea')` inside `collectDecisions` | Generic form catch-all (no hand-listed selectors per field) |
+| 22 | `data-active]` selector inside `collectDecisions` | Catch-all is scoped to the active iteration only |
+
+**Failure for 21 / 22:** if either pattern is missing, the page is rejected
+at the post-generation gate. See § Generic Form Collection below for the
+required pattern.
+
+## Generic Form Collection (mandatory for all templates)
+
+**Problem:** When iterations are appended, custom `collectDecisions()` code
+written for an earlier iteration silently misses new fields added in later
+iterations. The user submits, sees the panel turn green, but Claude
+receives incomplete data.
+
+**Rule:** `collectDecisions()` MUST collect every form element inside the
+active iteration via a generic selector — NOT via hand-listed selectors
+per field. Specific selectors (for grouped sub-objects like `decisions[]`,
+`comments[]`) are allowed *in addition* but must never replace the
+catch-all.
+
+### Required pattern (free, decision, and prototype branches)
+
+```javascript
+function collectAllFormFields(scope) {
+  const fields = {};
+  // Catch-all: every named input, select, textarea inside scope
+  scope.querySelectorAll('input, select, textarea').forEach(el => {
+    const key = el.dataset.field
+             || el.dataset.v4
+             || el.dataset.confirm
+             || el.dataset.rename
+             || el.dataset.entities
+             || el.dataset.comment
+             || el.name
+             || el.id;
+    if (!key) return;  // unnamed control — skip
+    if (el.type === 'checkbox') {
+      fields[key] = el.checked;
+    } else if (el.type === 'radio') {
+      if (el.checked) fields[el.name] = el.value;
+    } else {
+      fields[key] = el.value;
+    }
+  });
+  return fields;
+}
+
+function collectDecisions(action) {
+  const active = document.querySelector('section[data-iteration][data-active]')
+              || document.body;
+  const allFields = collectAllFormFields(active);
+  // Optional: also build typed sub-objects (decisions[], comments[], …)
+  // for ergonomics — but NEVER as a replacement for allFields.
+  return { submitted: true, action, allFields, /* …typed objects… */ };
+}
+```
+
+See `templates.md` § collectDecisions (dispatcher) for the live reference
+implementation that wires this into the per-template branches.
 
 Additionally, the `<html>` element MUST carry `data-template="decision"` (or
 `prototype`, or `free`) so `collectDecisions()` dispatches to the correct

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.60.2",
+  "version": "0.60.3",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary
- New mandatory rule: every concept page's `collectDecisions()` must use a generic `querySelectorAll('input, select, textarea')` scoped to `section[data-iteration][data-active]` and ship results as `allFields`.
- Hand-listed selectors silently miss new fields when iterations are appended — user sees the panel turn green but Claude receives a truncated payload.
- Validation gate: 20 → 22 mandatory shared patterns (#21 catch-all selector, #22 `[data-active]` scope).
- New Step 5c.2.5 verify-collection gate forces a fix BEFORE appending iteration N+1 if the catch-all is missing.

## Test plan
- [ ] Generate a fresh concept page (each template: decision / prototype / free) and confirm patterns 21-22 are present
- [ ] Add a new field to iteration N+1 without touching `collectDecisions()` and verify it shows up in `allFields` on submit
- [ ] Verify the post-generation grep gate flags missing patterns 21 or 22