### PR TITLE
feat(autonomous): wait for active sessions before shutdown (0.60.4)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.60.3"
+    "version": "0.60.4"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.60.3",
+      "version": "0.60.4",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.60.3",
+      "version": "0.60.4",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.60.4] — 2026-04-25
+
+### Changed
+
+- **plugins/devops/skills/devops-autonomous/SKILL.md** — `/devops-autonomous` shutdown option now waits for other active Claude sessions before powering off the PC, instead of cutting them off mid-thought. New Step 8a polls `~/.claude/projects/**/*.jsonl` mtimes: a file modified within the last 2 minutes signals that another session (any project, any worktree, including subagents) is still in a tool-call or thinking phase. Loop sleeps in 30 s intervals up to 30 min hard cap, then proceeds regardless to avoid indefinite hangs. Self-detection reconstructs the encoded project-dir name from `cygpath -w "$PWD"` with `[\:.] → -` substitution to match the exact directory under `~/.claude/projects/`, so the entire own session tree (main session + spawned subagents) is excluded — not just a single jsonl picked by an unreliable "freshest globally" heuristic. A sentinel value (`@@NO_SELF_MATCH@@`) replaces an empty `SELF_DIR` so `grep -vF '/'` cannot collapse to "filter all absolute paths" and trigger an immediate shutdown when self-detection fails (codex review caught this). Step 2 Q3 + Step 0.5 resume question option descriptions mention the wait so the user understands the new behaviour at decision time
+
 ## [0.60.3] — 2026-04-25
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.60.3**
+**Version: 0.60.4**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.60.3",
+  "version": "0.60.4",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/skills/devops-autonomous/SKILL.md
+++ b/plugins/devops/skills/devops-autonomous/SKILL.md
@@ -72,7 +72,7 @@ If found:
    > multiSelect: false
    > Options (fixed order):
    > 1. label: "Nur Bericht (empfohlen)" — description: "Ergebnisse als Report, PC bleibt an."
-   > 2. label: "Herunterfahren" — description: "PC fährt nach Abschluss automatisch herunter."
+   > 2. label: "Herunterfahren" — description: "PC fährt nach Abschluss herunter. Wartet vorher, falls andere Claude-Sessions (egal welches Projekt) noch arbeiten."
 - Delete the resume file
 - Skip Steps 1-4, jump directly to Step 5 with the resumed context
 - On completion, proceed normally through Steps 7-8
@@ -124,7 +124,7 @@ In `analyze` mode, desktop is only used for visual inspection (screenshots), nev
 > multiSelect: false
 > Options (fixed order):
 > 1. label: "Nein, nur Bericht (empfohlen)" — description: "Ergebnisse als Report, PC bleibt an."
-> 2. label: "Ja, herunterfahren" — description: "PC fährt 60s nach Abschluss automatisch herunter."
+> 2. label: "Ja, herunterfahren" — description: "PC fährt 60s nach Abschluss herunter. Wartet vorher, falls andere Claude-Sessions (egal welches Projekt) noch arbeiten."
 
 ## Step 3 — Permission Priming (ALL permissions BEFORE confirmation)
 
@@ -362,14 +362,44 @@ the CLI card is the quick confirmation.
 
 ## Step 8 — Shutdown
 
-Execute if user chose "Ja, herunterfahren" AND status is COMPLETED or INTERRUPTED:
+Execute if user chose "Ja, herunterfahren" AND status is COMPLETED or INTERRUPTED.
+
+### 8a — Wait for Other Active Claude Sessions
+
+Never cut off another running Claude session — any project, any worktree. Before
+the shutdown command, poll `~/.claude/projects/**/*.jsonl` mtimes. A jsonl modified
+within the last 2 minutes means that session is mid-thought or mid-tool-call.
+Exclude our own project tree entirely (our main session + any subagents we spawned).
+
+Self-detection: env vars like `CLAUDE_SESSION_ID` are not exposed to Bash. Use
+`basename($PWD)` — Claude encodes the project path as a directory under
+`~/.claude/projects/` whose name ends with the worktree/project basename
+(e.g. `…-eager-rubin-98f8d6`).
+
+Loop max 30 minutes, then proceed regardless (avoid indefinite hang):
+
+```bash
+PROJECTS="$HOME/.claude/projects"
+BASE=$(basename "$PWD")
+SELF_DIR=$(find "$PROJECTS" -maxdepth 1 -type d -name "*-${BASE}" 2>/dev/null | head -1)
+for i in $(seq 1 60); do
+  active=$(find "$PROJECTS" -name '*.jsonl' -newermt '2 minutes ago' 2>/dev/null \
+            | grep -vF -- "${SELF_DIR}/" | head -1)
+  [ -z "$active" ] && break
+  sleep 30
+done
+```
+
+### 8b — Execute Shutdown
+
 ```bash
 shutdown /s /t 60 /c "Autonomous task completed. Shutting down in 60s. Run 'shutdown /a' to abort."
 ```
+
 **INTERRUPTED:** Shutdown is safe because progress is saved in `AUTONOMOUS-RESUME.json`
 and committed locally. The user can resume on next boot via Step 0.5.
 
 **BLOCKED:** Skip shutdown — user must intervene immediately, data integrity may be at risk.
 
 **Never ask about shutdown inline.** The decision was made in Step 2 (or Step 0.5 on
-resume). Just execute it.
+resume). Just execute it (after the 8a wait).

--- a/plugins/devops/skills/devops-autonomous/SKILL.md
+++ b/plugins/devops/skills/devops-autonomous/SKILL.md
@@ -371,24 +371,34 @@ the shutdown command, poll `~/.claude/projects/**/*.jsonl` mtimes. A jsonl modif
 within the last 2 minutes means that session is mid-thought or mid-tool-call.
 Exclude our own project tree entirely (our main session + any subagents we spawned).
 
-Self-detection: env vars like `CLAUDE_SESSION_ID` are not exposed to Bash. Use
-`basename($PWD)` — Claude encodes the project path as a directory under
-`~/.claude/projects/` whose name ends with the worktree/project basename
-(e.g. `…-eager-rubin-98f8d6`).
+Self-detection: env vars like `CLAUDE_SESSION_ID` are not exposed to Bash.
+Reconstruct the encoded project-dir name from `$PWD` — Claude encodes the
+Windows path under `~/.claude/projects/` by replacing `\`, `:`, `.` with `-`
+(e.g. `C:\…\eager-rubin-98f8d6` → `C--…--claude-worktrees-eager-rubin-98f8d6`).
 
 Loop max 30 minutes, then proceed regardless (avoid indefinite hang):
 
 ```bash
 PROJECTS="$HOME/.claude/projects"
-BASE=$(basename "$PWD")
-SELF_DIR=$(find "$PROJECTS" -maxdepth 1 -type d -name "*-${BASE}" 2>/dev/null | head -1)
+ENCODED=$(cygpath -w "$PWD" 2>/dev/null | sed 's/[\\:.]/-/g')
+[ -z "$ENCODED" ] && ENCODED=$(basename "$PWD")  # non-Windows fallback
+SELF_DIR="$PROJECTS/$ENCODED"
+[ -d "$SELF_DIR" ] || SELF_DIR=""
+# Sentinel prevents grep -vF '/' from filtering ALL absolute paths when SELF_DIR is empty
+SELF_PATTERN="${SELF_DIR:+${SELF_DIR}/}"
+[ -z "$SELF_PATTERN" ] && SELF_PATTERN="@@NO_SELF_MATCH@@"
 for i in $(seq 1 60); do
   active=$(find "$PROJECTS" -name '*.jsonl' -newermt '2 minutes ago' 2>/dev/null \
-            | grep -vF -- "${SELF_DIR}/" | head -1)
+            | grep -vF -- "$SELF_PATTERN" | head -1)
   [ -z "$active" ] && break
   sleep 30
 done
 ```
+
+Failure mode: if encoding doesn't match (unexpected path layout), `SELF_DIR`
+stays empty and the sentinel falls through. The loop then waits on its own
+session too — burns the full 30 min cap before shutdown. Safer than cutting
+off other sessions by accident.
 
 ### 8b — Execute Shutdown
 

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.60.3",
+  "version": "0.60.4",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

`/devops-autonomous` shutdown option now waits for other active Claude sessions before powering off the PC. New Step 8a polls `~/.claude/projects/**/*.jsonl` mtimes — files modified within the last 2 minutes signal active tool-calls or thinking. Loop sleeps in 30 s intervals up to 30 min hard cap.

Self-detection reconstructs the encoded project-dir name from `cygpath -w "$PWD"` with `[\:.] → -` substitution. The entire own session tree (main + subagents) is excluded — not a single jsonl picked by an unreliable heuristic.

## Why

Before: shutdown cut off other Claude sessions mid-thought (other projects, parallel worktrees, multi-agent runs).
After: waits up to 30 min of silence across all sessions, then shuts down.

## Codex Review Findings (fixed in 2nd commit)

- **High** — empty `SELF_DIR` made `grep -vF '/'` filter all absolute paths → immediate shutdown despite active sessions. Fixed via sentinel `@@NO_SELF_MATCH@@`.
- **Medium** — `basename`-only match was ambiguous on suffix collisions. Fixed by reconstructing the full encoded path via `cygpath`.

## Test plan

- [x] Lint + 103 tests green
- [x] Codex review gate ran (rc=0, 2 findings addressed)
- [x] Live-tested self-detection: 6 jsonls active, 1 (own) correctly excluded → 5 foreign
- [x] Live-tested empty SELF_DIR fallback: 6 jsonls remain unfiltered → safe wait

🤖 Generated with [Claude Code](https://claude.com/claude-code)