### PR TITLE
refactor(completion-card): functional Changes bullets (0.61.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.61.1"
+    "version": "0.61.2"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.61.1",
+      "version": "0.61.2",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.61.1",
+      "version": "0.61.2",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.61.2] — 2026-04-27
+
+### Changed
+
+- **plugins/devops/templates/completion-card.md** + **plugins/devops/mcp-server/index.js** + **plugins/devops/skills/devops-commit/SKILL.md** + **plugins/devops/skills/devops-ship/SKILL.md** — completion-card `Changes` section is now functional-by-default. Both halves of the `area → description` bullet must describe what the user perceives or what behaves differently, not which files were edited. The `area → description` shape stays — it's the strength of the section — but `area` is now the functional surface (`Completion card`, `Ship pipeline`, `Skill devops-flow`), never a file path or internal module name. File names are allowed only when the file IS the deliverable: a skill, `keybindings.json`, `settings.json`, `CLAUDE.md`, a hook script. Internal helpers/renderers/libs (`mcp-server/index.js`, `lib/card-guard.js`) never appear. Technical wording stays legitimate when the topic itself is genuinely technical (parser, build flag, protocol). Producer skills (`devops-commit`, `devops-ship`) now point at this rule explicitly so callers don't bias their summaries back toward staged-diff / ship-result file lists. Schema `describe()` text on `changes.area` and `changes.description` carries do/don't examples so any caller that only reads the tool schema gets the same constraint. Codex review flagged producer-skill drift as a real risk; both producer skills updated in the same commit
+
 ## [0.61.1] — 2026-04-27
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.61.1**
+**Version: 0.61.2**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.61.1",
+  "version": "0.61.2",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/mcp-server/index.js
+++ b/plugins/devops/mcp-server/index.js
@@ -668,10 +668,10 @@ server.registerTool(
       changes: z.preprocess(
         v => typeof v === 'string' ? tryParse(v) : v,
         z.array(z.object({
-          area: z.string(),
-          description: z.string(),
+          area: z.string().describe("Functional surface the user perceives or the change is about (e.g. 'Completion card', 'Ship pipeline', 'Branch cleanup', 'Skill devops-flow'). NOT a file path or internal module name. Technical wording only when the topic itself is purely technical (parser, flag, protocol)."),
+          description: z.string().describe("What behaves differently now, in user-domain language. Describe the functional/user-visible effect — same rule as `area`: technical phrasing only when the topic is genuinely technical."),
         })).max(3).optional(),
-      ).describe("What changed (max 3)"),
+      ).describe("Top 3 FUNCTIONAL changes — both `area` AND description should describe what the user perceives or what behaves differently, not which files were edited. Keep the 'area → description' shape. Files/paths only when the file IS the deliverable (skill, keybindings.json, settings.json, CLAUDE.md, hook script). Internal helpers/renderers/libs never appear. Good: 'Completion card → Changes-Bullets jetzt funktional formuliert'. Good (purely technical topic): 'JSON parser → akzeptiert trailing commas'. Bad: 'mcp-server/index.js → renderChanges() angepasst'."),
       tests: z.preprocess(
         v => typeof v === 'string' ? tryParse(v) : v,
         z.array(z.object({

--- a/plugins/devops/skills/devops-commit/SKILL.md
+++ b/plugins/devops/skills/devops-commit/SKILL.md
@@ -137,7 +137,7 @@ render_completion_card({
   summary: "<~10 words, user's language>",
   lang: "<de|en>",
   session_id: "<from hook input>",
-  changes: [{ area, description }, ...],   // from the staged diff
+  changes: [{ area, description }, ...],   // top 3 FUNCTIONAL changes (user-perceived effect), derived from the staged diff but phrased as behavior — not file lists. See completion-card template § Changes.
   state: { branch, commit: "<short sha>", pushed: <bool>, merged: null }
 })
 ```

--- a/plugins/devops/skills/devops-ship/SKILL.md
+++ b/plugins/devops/skills/devops-ship/SKILL.md
@@ -272,7 +272,7 @@ render_completion_card({
   lang: "de",
   cwd: "<current working directory — same as ship_release>",
   buildId: <from ship_build.buildId>,
-  changes: [<from ship_build/devops-ship_version_bump results>],
+  changes: [<top 3 FUNCTIONAL changes — user-perceived effect, phrased as behavior. Derive from ship_build/version_bump results but do NOT list files/modules. See completion-card template § Changes.>],
   tests: [<from ship_build results>],
   state: {
     branch: "main",

--- a/plugins/devops/templates/completion-card.md
+++ b/plugins/devops/templates/completion-card.md
@@ -199,6 +199,38 @@ Warn          var.    "  ⚠ Pace!" or empty
 Bullet list (`*`), each bullet: `area → what happened`.
 **Max 3 bullets.** Summarize if more than 3 changes. No nested bullets.
 
+**Both `area` AND description must be functional.** Keep the `area → description`
+pattern — it's the strength of this section. But both halves describe what the
+user perceives or what behaves differently, not how the code is structured.
+Use technical wording only when the topic itself is genuinely technical (a
+build flag, a parser bug, a protocol detail) — never as a default.
+
+- ✅ `Completion card → Changes-Bullets sind jetzt funktional formuliert`
+- ✅ `Branch cleanup → fragt vor dem Entfernen eines Worktrees nach`
+- ✅ `Ship pipeline → versionsbump überspringt unveränderte Plugins`
+- ❌ `mcp-server/index.js → renderChanges() angepasst`
+- ❌ `templates, schema → Beschreibung erweitert`
+
+**File names only when the file is the artifact itself.** A skill, a keybindings
+file, a settings.json entry, a CLAUDE.md, a hook script — these *are* the
+deliverable, so naming them is the functional description. Implementation files
+(renderers, helpers, internal modules) are not.
+
+- ✅ `keybindings.json → Ctrl+S auf Submit umgemappt` (file = deliverable)
+- ✅ `Skill devops-ship → Pre-flight prüft jetzt branch protection` (skill = deliverable)
+- ❌ `lib/card-guard.js → neue Validierung hinzugefügt` (internal module)
+
+**Purely technical topic = technical wording is fine.** If the change really is
+about a parser, a flag, a protocol, a perf fix — describe it as such. The rule
+is "default to functional", not "forbid technical".
+
+- ✅ `JSON parser → akzeptiert jetzt trailing commas`
+- ✅ `Build cache → invalidiert bei plugin.json-Änderung`
+
+**`area`** is the functional surface (what the user perceives or what the change
+is *about*), e.g. `Completion card`, `Ship pipeline`, `Branch cleanup`,
+`Skill devops-flow`. Not a file path, not an internal module name.
+
 | Variants | Behavior |
 |----------|----------|
 | ship-successful, ready, test, ship-blocked | **Required** |

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.61.1",
+  "version": "0.61.2",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

Completion-card `Changes` section now defaults to functional, user-perceived descriptions. Both `area` and `description` describe behavior, not files — the `area → description` shape stays. File names appear only when the file IS the deliverable (skill, keybindings, settings.json, CLAUDE.md, hook). Technical wording remains legitimate when the topic itself is purely technical.

Producer skills (`devops-commit`, `devops-ship`) updated to point at the new rule so callers don't bias summaries toward staged-diff / ship-result file lists. Schema `describe()` text carries do/don't examples for callers that only read the schema.

## Test plan

- [x] `npm run lint`
- [x] `npm test` (103 tests passed)
- [x] Codex review (judgment finding on producer-skill drift addressed in same commit)
