### PR TITLE
feat(self-calibration): Step 4 cycle math in Stop hook (0.61.3)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.61.2"
+    "version": "0.61.3"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.61.2",
+      "version": "0.61.3",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.61.2",
+      "version": "0.61.3",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.61.3] — 2026-04-28
+
+### Changed
+
+- **plugins/devops/hooks/stop/stop.flow.selfcalibration.js** + **plugins/devops/scheduled-tasks/self-calibration/SKILL.md** — Step 4 (Skill Internalization) cycle math now lives in the Stop hook itself, not in SKILL.md prose. The hook discovers `{PLUGIN_ROOT}/deep-knowledge/*.md` and `{PLUGIN_ROOT}/skills/*/deep-knowledge/*.md`, computes `batchSize = ceil(total * 0.25)` and `startIndex = (cycle * batchSize) % total`, reads + advances + persists the cycle index to `$TMPDIR/dotclaude-devops-calibration-cycle.json`, and emits the current batch's file paths directly in its prompt — Claude only reads. Previously the cycle file was never created in practice because the hook prompt asked for "Step 0" only and the SKILL.md batch math was LLM-discretionary; later deep-knowledge files were systematically underread. Persistence uses atomic write-temp-then-rename (same pattern as `hooks/lib/session-id.js#writeSessionFile`) so concurrent Stop hooks from parallel worktrees cannot observe a half-written cycle file. There is intentionally no inter-process lock around the read-modify-write sequence — interleaved reads can lose one increment (worst case: one batch repeats, no crash, no data loss). SKILL.md now describes coverage as "best-effort eventual" instead of claiming guarantees, including the unwritable-tmpdir degradation. Empty-discovery status line fixed (was misleading "files 0..-1 of 0"). Codex review flagged the persistence robustness as the main correctness concern; atomic-write fix landed in the same ship
+
 ## [0.61.2] — 2026-04-27
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.61.2**
+**Version: 0.61.3**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.61.2",
+  "version": "0.61.3",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/hooks/stop/stop.flow.selfcalibration.js
+++ b/plugins/devops/hooks/stop/stop.flow.selfcalibration.js
@@ -1,16 +1,21 @@
 #!/usr/bin/env node
 /**
  * @hook stop.flow.selfcalibration
- * @version 1.0.0
+ * @version 1.1.0
  * @event Stop
  * @plugin devops
  * @description Run self-calibration when Claude finishes a response turn.
  *   Only fires if >10 minutes have passed since the last calibration in
- *   the current worktree. Replaces the cron-based approach (v0.7.0) to
- *   ensure calibration only runs after real user interaction, never idle.
+ *   the current worktree.
  *
- *   Worktree-specific: timestamp is keyed to process.cwd(), so parallel
- *   worktrees have independent cooldowns.
+ *   Step 4 (Skill Internalization) batch math runs in the hook itself —
+ *   discovery, cycle rotation, and persistence are deterministic JS, so
+ *   they no longer depend on the LLM following SKILL.md prose. The hook
+ *   emits the current batch's file paths in its prompt; Claude just reads
+ *   them silently.
+ *
+ *   Worktree-specific cooldown: timestamp is keyed to process.cwd(), so
+ *   parallel worktrees have independent cooldowns.
  */
 
 require('../lib/plugin-guard');
@@ -21,7 +26,8 @@ const crypto = require('crypto');
 const os = require('os');
 
 const PLUGIN_DIR = path.resolve(__dirname, '..', '..');
-const COOLDOWN_MS = 10 * 60 * 1000; // 10 minutes
+const COOLDOWN_MS = 10 * 60 * 1000;
+const CYCLE_FILE = path.join(os.tmpdir(), 'dotclaude-devops-calibration-cycle.json');
 
 function worktreeKey() {
   const cwd = process.cwd().replace(/\\/g, '/');
@@ -32,37 +38,101 @@ function lastRunFile() {
   return path.join(os.tmpdir(), `dotclaude-devops-calibration-wt-${worktreeKey()}`);
 }
 
+function discoverDeepKnowledge() {
+  const files = [];
+
+  const pluginDk = path.join(PLUGIN_DIR, 'deep-knowledge');
+  try {
+    for (const f of fs.readdirSync(pluginDk)) {
+      if (f.endsWith('.md') && f !== 'INDEX.md') {
+        files.push(path.join(pluginDk, f));
+      }
+    }
+  } catch {}
+
+  const skillsDir = path.join(PLUGIN_DIR, 'skills');
+  try {
+    for (const skill of fs.readdirSync(skillsDir)) {
+      const skillDk = path.join(skillsDir, skill, 'deep-knowledge');
+      try {
+        for (const f of fs.readdirSync(skillDk)) {
+          if (f.endsWith('.md')) {
+            files.push(path.join(skillDk, f));
+          }
+        }
+      } catch {}
+    }
+  } catch {}
+
+  return files.sort();
+}
+
+function readCycle() {
+  try {
+    const raw = fs.readFileSync(CYCLE_FILE, 'utf8');
+    const data = JSON.parse(raw);
+    if (Number.isInteger(data.cycle) && data.cycle >= 0) return data.cycle;
+  } catch {}
+  return 0;
+}
+
+function writeCycle(cycle) {
+  try {
+    fs.writeFileSync(CYCLE_FILE, JSON.stringify({ cycle }), 'utf8');
+  } catch {}
+}
+
+function pickBatch(files, cycle) {
+  const total = files.length;
+  if (total === 0) return { batch: [], total: 0, batchSize: 0, startIndex: 0 };
+  const batchSize = Math.ceil(total * 0.25);
+  const startIndex = (cycle * batchSize) % total;
+  const batch = [];
+  for (let i = 0; i < batchSize; i++) {
+    batch.push(files[(startIndex + i) % total]);
+  }
+  return { batch, total, batchSize, startIndex };
+}
+
 process.stdin.setEncoding('utf8');
 process.stdin.on('data', () => {});
 process.stdin.on('end', () => {
   const file = lastRunFile();
 
-  // Check worktree-specific cooldown
   try {
     const stat = fs.statSync(file);
     if (Date.now() - stat.mtimeMs < COOLDOWN_MS) {
-      process.exit(0); // Cooldown active
+      process.exit(0);
     }
-  } catch {
-    // File doesn't exist — first run in this worktree
-  }
+  } catch {}
 
-  // Find SKILL.md
   const skillPath = path.join(PLUGIN_DIR, 'scheduled-tasks', 'self-calibration', 'SKILL.md');
   try {
     fs.readFileSync(skillPath, 'utf8');
   } catch {
-    process.exit(0); // No skill file
+    process.exit(0);
   }
 
-  // Update timestamp before emitting (prevents double-fire)
   try {
     fs.writeFileSync(file, String(Date.now()), 'utf8');
   } catch {}
 
-  const resolvedPath = skillPath.replace(/\\/g, '/');
+  const allFiles = discoverDeepKnowledge();
+  const cycle = readCycle();
+  const { batch, total, batchSize, startIndex } = pickBatch(allFiles, cycle);
+  writeCycle(cycle + 1);
+
+  const skillPathFwd = skillPath.replace(/\\/g, '/');
+  const batchList = batch.length
+    ? batch.map(f => `  - ${f.replace(/\\/g, '/')}`).join('\n')
+    : '  (no deep-knowledge files discovered — skip Step 4)';
+
   process.stdout.write(
-    `Execute self-calibration: Read ${resolvedPath} and run Step 0 (Completion Flow Internalization). ` +
-    `Use the file's parent of scheduled-tasks/ as the plugin root.\n`
+    `Execute self-calibration: Read ${skillPathFwd} and run ALL steps (0 through 5).\n` +
+    `Use the file's parent of scheduled-tasks/ as the plugin root.\n\n` +
+    `Step 4 batch — cycle ${cycle}, files ${startIndex}..${startIndex + batchSize - 1} of ${total}:\n` +
+    `${batchList}\n\n` +
+    `The hook has already advanced the cycle index and persisted it to ` +
+    `${CYCLE_FILE.replace(/\\/g, '/')} — just silently read the listed files for Step 4.\n`
   );
 });

--- a/plugins/devops/hooks/stop/stop.flow.selfcalibration.js
+++ b/plugins/devops/hooks/stop/stop.flow.selfcalibration.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * @hook stop.flow.selfcalibration
- * @version 1.1.0
+ * @version 1.2.0
  * @event Stop
  * @plugin devops
  * @description Run self-calibration when Claude finishes a response turn.
@@ -16,6 +16,13 @@
  *
  *   Worktree-specific cooldown: timestamp is keyed to process.cwd(), so
  *   parallel worktrees have independent cooldowns.
+ *
+ *   Persistence is best-effort with atomic write-temp-then-rename. There is
+ *   no inter-process lock, so two Stop events that interleave their
+ *   read-modify-write of the cycle file can lose one increment (worst case:
+ *   one batch repeats — no crash, no data loss). On unwritable tmpdir the
+ *   cooldown silently degrades to "fire every turn" — acceptable for a
+ *   calibration loop, surfaced in SKILL.md.
  */
 
 require('../lib/plugin-guard');
@@ -36,6 +43,19 @@ function worktreeKey() {
 
 function lastRunFile() {
   return path.join(os.tmpdir(), `dotclaude-devops-calibration-wt-${worktreeKey()}`);
+}
+
+// Atomic write: write to .tmp then rename. Prevents partial reads from
+// concurrent Stop hooks observing a half-written file. Same pattern as
+// hooks/lib/session-id.js#writeSessionFile.
+function atomicWrite(filePath, content) {
+  const tmp = `${filePath}.tmp.${process.pid}`;
+  try {
+    fs.writeFileSync(tmp, content, 'utf8');
+    fs.renameSync(tmp, filePath);
+  } catch {
+    try { fs.unlinkSync(tmp); } catch {}
+  }
 }
 
 function discoverDeepKnowledge() {
@@ -77,9 +97,7 @@ function readCycle() {
 }
 
 function writeCycle(cycle) {
-  try {
-    fs.writeFileSync(CYCLE_FILE, JSON.stringify({ cycle }), 'utf8');
-  } catch {}
+  atomicWrite(CYCLE_FILE, JSON.stringify({ cycle }));
 }
 
 function pickBatch(files, cycle) {
@@ -113,9 +131,7 @@ process.stdin.on('end', () => {
     process.exit(0);
   }
 
-  try {
-    fs.writeFileSync(file, String(Date.now()), 'utf8');
-  } catch {}
+  atomicWrite(file, String(Date.now()));
 
   const allFiles = discoverDeepKnowledge();
   const cycle = readCycle();
@@ -123,14 +139,17 @@ process.stdin.on('end', () => {
   writeCycle(cycle + 1);
 
   const skillPathFwd = skillPath.replace(/\\/g, '/');
+  const batchHeader = total === 0
+    ? `Step 4 batch — no deep-knowledge files discovered, skip Step 4:`
+    : `Step 4 batch — cycle ${cycle}, files ${startIndex}..${startIndex + batchSize - 1} of ${total}:`;
   const batchList = batch.length
     ? batch.map(f => `  - ${f.replace(/\\/g, '/')}`).join('\n')
-    : '  (no deep-knowledge files discovered — skip Step 4)';
+    : '  (none)';
 
   process.stdout.write(
     `Execute self-calibration: Read ${skillPathFwd} and run ALL steps (0 through 5).\n` +
     `Use the file's parent of scheduled-tasks/ as the plugin root.\n\n` +
-    `Step 4 batch — cycle ${cycle}, files ${startIndex}..${startIndex + batchSize - 1} of ${total}:\n` +
+    `${batchHeader}\n` +
     `${batchList}\n\n` +
     `The hook has already advanced the cycle index and persisted it to ` +
     `${CYCLE_FILE.replace(/\\/g, '/')} — just silently read the listed files for Step 4.\n`

--- a/plugins/devops/scheduled-tasks/self-calibration/SKILL.md
+++ b/plugins/devops/scheduled-tasks/self-calibration/SKILL.md
@@ -92,26 +92,28 @@ If found → take preparatory action.
 
 ## Step 4 — Skill Internalization
 
-Silently read and internalize plugin knowledge:
+Silently read and internalize plugin knowledge.
 
+**Discovery, batch math, and cycle persistence run in the Stop hook itself**
+(`hooks/stop/stop.flow.selfcalibration.js`). The hook emits the current batch's
+file paths directly in its prompt — just read them silently.
+
+What the hook handles deterministically:
+- Discovers `{PLUGIN_ROOT}/deep-knowledge/*.md` and
+  `{PLUGIN_ROOT}/skills/*/deep-knowledge/*.md`, sorted alphabetically
+- Computes `batchSize = ceil(total * 0.25)` and
+  `startIndex = (cycle * batchSize) % total` (wraps around)
+- Reads + advances + persists the cycle index in
+  `$TMPDIR/dotclaude-devops-calibration-cycle.json`
+
+What you do:
 1. Read the project's CLAUDE.md (if exists)
-2. Discover all deep-knowledge files in the plugin (use `{PLUGIN_ROOT}` from hook):
-   - `{PLUGIN_ROOT}/deep-knowledge/*.md` (plugin-level)
-   - `{PLUGIN_ROOT}/skills/*/deep-knowledge/*.md` (skill-level)
-3. Sort alphabetically by path
-4. Calculate batch: `ceil(total * 0.25)`
-5. **Load cycle index** from `$TMPDIR/dotclaude-devops-calibration-cycle.json`
-   - If file exists: read `{ cycle: N }` and use N as current cycle
-   - If file missing or corrupt: start at cycle 0
-6. Compute: `startIndex = (cycle * batchSize) % total`
-7. Read the current batch (wrap around at end of list)
-8. **Persist cycle index**: write `{ cycle: N + 1 }` back to the same file
-9. Silent self-calibration — no output needed
+2. Read each file the hook listed under "Step 4 batch" — silently, no output
 
 This ensures Claude stays familiar with all plugin rules, even those
-not directly triggered in the current session. Persisting the cycle index
-across sessions guarantees even coverage — without it, every new session
-starts at batch 0 and later files are systematically underread.
+not directly triggered in the current session. The hook-driven cycle
+index guarantees even coverage across sessions — every file gets read
+in rotation regardless of which session triggers calibration.
 
 ## Step 5 — Baseline Review
 
@@ -134,8 +136,12 @@ Example extensions:
 ## Rules
 
 - All paths use `~` or relative references — never hardcoded
-- Deep-knowledge files are discovered dynamically via Glob
-- Batch rotation uses explicit index math: `startIndex = (cycle * batchSize) % total`
-- Cycle index persisted to `$TMPDIR/dotclaude-devops-calibration-cycle.json` for cross-session continuity
-- This task is **opt-in** — users enable it via scheduled task configuration
+- Deep-knowledge discovery + batch rotation are owned by the Stop hook
+  (`hooks/stop/stop.flow.selfcalibration.js`), not Claude
+- Batch math: `batchSize = ceil(total * 0.25)`,
+  `startIndex = (cycle * batchSize) % total`
+- Cycle index persisted to `$TMPDIR/dotclaude-devops-calibration-cycle.json`
+  for cross-session continuity (written by the hook)
+- This task fires automatically on the Stop event with a 10-minute
+  worktree-specific cooldown
 - Token budget: ~5K-15K per cycle (mostly reads, minimal writes)

--- a/plugins/devops/scheduled-tasks/self-calibration/SKILL.md
+++ b/plugins/devops/scheduled-tasks/self-calibration/SKILL.md
@@ -110,10 +110,13 @@ What you do:
 1. Read the project's CLAUDE.md (if exists)
 2. Read each file the hook listed under "Step 4 batch" — silently, no output
 
-This ensures Claude stays familiar with all plugin rules, even those
-not directly triggered in the current session. The hook-driven cycle
-index guarantees even coverage across sessions — every file gets read
-in rotation regardless of which session triggers calibration.
+This keeps Claude familiar with plugin rules that aren't directly
+triggered in the current session. Coverage is **best-effort eventual**,
+not guaranteed: persistence uses atomic write-temp-then-rename but no
+inter-process lock, so two Stop events that interleave their cycle
+read+write can lose one increment (worst case: one batch repeats — no
+crash, no data loss). Over many cycles, every file still gets read in
+rotation.
 
 ## Step 5 — Baseline Review
 
@@ -141,7 +144,11 @@ Example extensions:
 - Batch math: `batchSize = ceil(total * 0.25)`,
   `startIndex = (cycle * batchSize) % total`
 - Cycle index persisted to `$TMPDIR/dotclaude-devops-calibration-cycle.json`
-  for cross-session continuity (written by the hook)
+  via atomic write-temp+rename. No inter-process lock — concurrent Stop
+  events from different worktrees may lose one increment (acceptable
+  best-effort behavior; one repeated batch, no crash)
+- Cooldown marker uses the same atomic-write pattern. If `$TMPDIR` is
+  unwritable, the cooldown silently degrades to "fire every turn"
 - This task fires automatically on the Stop event with a 10-minute
   worktree-specific cooldown
 - Token budget: ~5K-15K per cycle (mostly reads, minimal writes)

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.61.2",
+  "version": "0.61.3",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

Step 4 (Skill Internalization) cycle math moves from SKILL.md prose into the Stop hook itself. The hook discovers all `deep-knowledge/*.md` files plus `skills/*/deep-knowledge/*.md`, computes `batchSize = ceil(total * 0.25)` and `startIndex = (cycle * batchSize) % total`, reads + advances + persists the cycle index to `$TMPDIR/dotclaude-devops-calibration-cycle.json`, and emits the current batch's file paths directly in its prompt — Claude only reads.

Before this, the cycle file was never created in practice: the hook prompt asked for "Step 0" only and the SKILL.md batch math was LLM-discretionary, so later deep-knowledge files were systematically underread.

## Robustness

- Persistence uses atomic write-temp-then-rename (same pattern as `hooks/lib/session-id.js#writeSessionFile`) — concurrent Stop hooks from parallel worktrees cannot observe a half-written cycle file
- No inter-process lock around the read-modify-write sequence; interleaved reads can lose one increment (worst case: one batch repeats — no crash, no data loss)
- SKILL.md now describes coverage as "best-effort eventual" instead of claiming guarantees, including the unwritable-tmpdir degradation
- Empty-discovery status line fixed (was misleading "files 0..-1 of 0")

## Test plan

- [x] `node -c` syntax check
- [x] Dry-run cycle 0 → files 0..11 of 46, cycle.json = `{cycle:1}`
- [x] Dry-run cycle 1 → files 12..23 of 46, cycle.json = `{cycle:2}`
- [x] `npm test` — 103 tests pass
- [x] Codex review — flagged race conditions; atomic-write fix landed in same ship