### PR TITLE
fix(concept): submit/reset race, buttons re-enabled mid-write (0.61.4)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.61.3"
+    "version": "0.61.4"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.61.3",
+      "version": "0.61.4",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.61.3",
+      "version": "0.61.4",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.61.4] — 2026-05-04
+
+### Fixed
+
+- **plugins/devops/skills/devops-concept/SKILL.md** + **deep-knowledge/bridge-server.md** + **deep-knowledge/monitoring.md** + **deep-knowledge/templates.md** — fixed a UI race in the concept skill where the submit panel flipped back to "ready" while Claude was still mid-write, letting the user fire duplicate submissions on the still-active old iteration. Step 5c instructed Claude to POST `/reset` BEFORE the file rewrite and `/reload`, which stamped `_processed_at` on the server immediately. The browser's `pollProcessedState` (5s tick) saw the fresh stamp, called `restorePanelToReady()`, and re-enabled the submit buttons — even though the new iteration was not yet on disk and the old one was still the active section. The bug window stretched across the seconds Claude spent reading + generating + writing the new iteration. Fix reorders the protocol so `/reset` is the LAST step (after `/reload`), and the visible panel reset now happens via the `/reload`-triggered `location.reload()` (fresh page, no `concept-submitted` class — naturally in ready state). `pollProcessedState` is now a true safety-net: it only flips the panel locally when a reload-counter advance has been observed (= new iteration is imminent) OR a 5-minute stale timeout elapses (recovery for closed tabs / JS errors where reload never fired). Defense-in-depth at the submit handler too — `_submitInFlight` lock + non-zero `_submittedAt` guard at function entry blocks duplicate clicks even if the UI ever flickers back to ready prematurely. `_submittedReloadCounter` is captured at submit time as the gate variable. Existing concept pages already in user tabs benefit from the protocol reorder (server-side change); newly generated pages additionally get the browser-side hardening
+
 ## [0.61.3] — 2026-04-28
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.61.3**
+**Version: 0.61.4**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.61.3",
+  "version": "0.61.4",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/skills/devops-concept/SKILL.md
+++ b/plugins/devops/skills/devops-concept/SKILL.md
@@ -484,13 +484,13 @@ signal the browser to reload. This is the ONLY update path — there is no
 separate "in-place edit" vs. "new file" distinction anymore.
 
 Procedure on every iteration (including the very first response to feedback).
-Before the steps below, POST `/reset` with the captured `_version` (see cron
-prompt in Step 3). This stamps `_processed_at` on the server so the
-browser's `pollProcessedState` can restore the panel to the ready state
-automatically — Claude does NOT send a browser-eval reset. The subsequent
-`pollReload` tick picks up the file rewrite and the tab reloads onto the
-new active iteration. See `deep-knowledge/templates.md` § Panel State Reset
-for the polling contract.
+
+**Order matters — `/reset` is the LAST step, NOT the first.** Posting `/reset`
+early stamps `_processed_at` on the server, which makes the browser's
+`pollProcessedState` flip the panel back to "ready" before the new iteration
+is on disk. The user then sees the still-active OLD iteration with
+re-enabled submit buttons and can fire a duplicate submission. The new
+iteration must be live in the browser BEFORE the server signals "processed".
 
 1. Read the existing HTML file (same path, always).
 2. Freeze the currently-active iteration section per the rules in
@@ -520,6 +520,12 @@ for the polling contract.
    The browser's `pollReload` loop sees the counter bump and calls
    `location.reload()`. The reload lands on the new active iteration
    because the HTML declares it via `data-active`.
+6. **Only now** POST `/reset` with the captured `_version` (see cron
+   prompt in Step 3). This stamps `_processed_at` on the server as the
+   final step. The browser's `pollProcessedState` is a safety-net —
+   it will only restore the panel state when a reload counter advance
+   has been observed OR a long stale timeout elapses. See
+   `deep-knowledge/templates.md` § Panel State Reset for the polling contract.
 
 The tab bar is anchored at the top of the right-side decision panel —
 above the section TOC and the submit block. It must never appear inside

--- a/plugins/devops/skills/devops-concept/deep-knowledge/bridge-server.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/bridge-server.md
@@ -39,7 +39,10 @@ AND provides HTTP endpoints for heartbeat and decision exchange.
            before treating the rest as decision data.
          • Process per Step 5 (Live Feedback Loop) — act on the user's choices
            (approve/tweak/reject, included options, comment-driven tweaks).
-         • After processing, reset conditionally — pass the noted version:
+           Step 5c writes the new iteration to the HTML file and POSTs
+           `/reload` BEFORE the reset below. Reset is the LAST action.
+         • After the file rewrite AND the `/reload` POST have completed,
+           reset conditionally — pass the noted version:
            Bash: curl -s -o /dev/null -w "%{http_code}" -X POST \
                        -H "Content-Type: application/json" \
                        -d '{"version": <noted>}' http://localhost:{port}/reset
@@ -47,9 +50,10 @@ AND provides HTTP endpoints for heartbeat and decision exchange.
            again while you were processing. Re-fetch /decisions, process the
            new payload (which supersedes what you just finished), then retry
            the conditional reset with the new `_version`.
-         • Report the outcome to the user. The browser's panel auto-resets
-           within 5s via the `_processed_at` heartbeat poll — no browser-eval
-           injection required.
+         • Report the outcome to the user. The visible panel reset happens
+           via the `/reload`-triggered `location.reload()` in the browser —
+           the page reloads onto the new iteration with a fresh ready panel.
+           The `_processed_at` poll is only a safety-net for stuck states.
    EOF)
    ```
 

--- a/plugins/devops/skills/devops-concept/deep-knowledge/monitoring.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/monitoring.md
@@ -146,7 +146,9 @@ No browser eval needed. The bridge server handles everything.
 
 **Reset after processing** — tell the bridge server to clear decisions.
 Always pass the captured `_version` so a submission that races with your
-reset is not silently dropped (409 = retry):
+reset is not silently dropped (409 = retry). **`/reset` is the LAST step
+of every processing cycle, after the file rewrite and `/reload`** — see
+§ Live Page Update below.
 ```bash
 curl -s -o /dev/null -w "%{http_code}" -X POST \
      -H "Content-Type: application/json" \
@@ -154,11 +156,11 @@ curl -s -o /dev/null -w "%{http_code}" -X POST \
 ```
 
 On success the server stamps `_processed_at` with the current UTC time.
-The browser polls `/decisions` every 5 s, compares `_processed_at` against
-its local `_submittedAt`, and — when the server stamp is newer — flips the
-panel back to the ready state by itself. **No JS eval injection from
-Claude required.** See `templates.md` § Panel State Reset for the client
-contract.
+The visible panel reset already happened via `location.reload()` (triggered
+by `/reload` in the previous step). The browser's `pollProcessedState` only
+flips the panel locally as a safety-net — when a reload counter advance
+has been observed OR a long stale timeout elapses. See `templates.md`
+§ Panel State Reset for the client contract.
 
 ### Legacy Fallback: JS Eval (for page updates)
 
@@ -316,10 +318,24 @@ Map decisions back to the original context:
 
 ### Live Page Update (after each round)
 
-After processing a submission, Claude MUST reset the bridge server and
-update the browser page:
+After processing a submission, Claude MUST update the browser page and
+THEN reset the bridge server. **Order is mandatory** — resetting before
+the new iteration is on disk causes a phantom "ready" panel on the still
+active old iteration, allowing duplicate submissions before the reload
+lands.
 
-1. **Reset bridge server state (conditional on `_version`):**
+1. **Rewrite the HTML file** with the new iteration appended (Step 5c
+   in `SKILL.md`).
+
+2. **Trigger reload** — bump the reload counter:
+   ```bash
+   curl -s -X POST http://localhost:$PORT/reload
+   ```
+   The browser's `pollReload` (every 3 s) sees the counter advance and
+   calls `location.reload()`. The freshly loaded page is in ready state
+   automatically (`concept-submitted` is not persisted).
+
+3. **Reset bridge server state (conditional on `_version`)** — LAST step:
    ```bash
    curl -s -o /dev/null -w "%{http_code}" -X POST \
         -H "Content-Type: application/json" \
@@ -328,19 +344,19 @@ update the browser page:
    A 200 stamps `_processed_at`; a 409 means a newer submission arrived —
    re-fetch `/decisions` and process that instead.
 
-2. **Page UI auto-resets** — the browser's 5 s heartbeat tick sees the
-   new `_processed_at` and calls `restorePanelToReady()` locally. No
-   browser eval needed from Claude. If the page is disconnected (closed
-   tab / crashed tool), the reset still applies server-side and will take
-   effect the next time the page loads.
+4. **Page UI** — the visual reset already happened via `location.reload()`
+   in step 2. The `_processed_at` stamp from step 3 is a safety-net read
+   by the browser's `pollProcessedState` only when a reload counter
+   advance has been observed OR a long stale timeout elapses (recovery
+   for the rare case where reload didn't fire — closed tab, JS error).
 
-3. **Update content to reflect processed state** (via browser eval if available):
+5. **Update content to reflect processed state** (via browser eval if available):
    - Mark processed items visually (checkmark, "Verarbeitet" badge)
    - Show results of the processing (e.g., generated code, updated plan)
    - Add new decision points if the processing revealed further choices
    - Gray out discarded variants
 
-4. **Resume monitoring** — return to the polling loop for the next round
+6. **Resume monitoring** — return to the polling loop for the next round
 
 ### Persistence
 

--- a/plugins/devops/skills/devops-concept/deep-knowledge/templates.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/templates.md
@@ -1768,6 +1768,13 @@ deliberately to reach the implement button.
 
 ```javascript
 let _submittedAt = 0;
+// Reload counter captured at submit time. The panel only flips back to
+// "ready" via _processed_at when the server's reload counter has advanced
+// past this — i.e. Claude has actually written the new iteration. Without
+// this gate, /reset stamps _processed_at while Claude is still mid-write
+// and the user sees re-enabled buttons on the still-active old iteration.
+let _submittedReloadCounter = null;
+let _submitInFlight = false;
 
 function wireSubmit(btnId, action) {
   const btn = document.getElementById(btnId);
@@ -1776,11 +1783,18 @@ function wireSubmit(btnId, action) {
 }
 
 async function submitWithAction(action) {
+  // Belt-and-suspenders guard: if a submission is already in flight (panel
+  // shows "submitted"), ignore further clicks. restorePanelToReady() resets
+  // _submittedAt to 0, so this only blocks while we're actually waiting.
+  if (_submitInFlight || _submittedAt) return;
+  _submitInFlight = true;
+
   const data = collectDecisions(action);
   const container = document.getElementById('concept-decisions');
   container.textContent = JSON.stringify(data);
   document.body.classList.add('concept-submitted');
   _submittedAt = Date.now();
+  _submittedReloadCounter = _bootReloadCounter;
 
   document.getElementById('panel-ready').style.display = 'none';
   document.getElementById('panel-submitted').style.display = 'block';
@@ -1795,6 +1809,7 @@ async function submitWithAction(action) {
     localStorage.setItem(STORAGE_KEY + '-pending', JSON.stringify(data));
   }
   saveState();
+  _submitInFlight = false;
 }
 
 wireSubmit('submit-iterate-btn', 'iterate');
@@ -1823,9 +1838,15 @@ Claude-side: on receiving the payload, branch on `action`:
 
 ## Panel State Reset
 
-When Claude finishes processing, it POSTs `/reset` on the bridge server.
-The server stamps `_processed_at`; the page's heartbeat poll sees the
-updated timestamp and restores the ready panel. No browser eval injection.
+The primary reset is the page reload itself: Claude POSTs `/reload` after
+writing the new iteration, the browser's `pollReload` calls
+`location.reload()`, and the freshly loaded page is in ready state because
+the `concept-submitted` class is not persisted.
+
+`restorePanelToReady()` is a safety-net — only called when `_processed_at`
+indicates Claude finished AND a reload counter advance has been observed
+(i.e. a reload is imminent / about to happen) OR a long stale timeout has
+elapsed (recovery for closed tabs / JS errors where reload never fired).
 
 ```javascript
 function restorePanelToReady() {
@@ -1837,6 +1858,8 @@ function restorePanelToReady() {
   });
   document.body.classList.remove('concept-submitted');
   _submittedAt = 0;
+  _submittedReloadCounter = null;
+  _submitInFlight = false;
   const slug = location.pathname.split('/').pop().replace('.html', '');
   localStorage.removeItem('concept-state-' + slug);
 }
@@ -1868,6 +1891,15 @@ async function pollHeartbeat() {
   } catch (e) { /* server unreachable */ }
 }
 
+// Safety-net timeout — if Claude /reset stamped _processed_at but no
+// reload counter advance ever followed (closed tab, JS error, server
+// went down between /reload and /reset), we still want to recover the
+// panel rather than leaving the user stuck staring at "submitted".
+// 5 minutes is long enough that any well-behaved iteration will have
+// reloaded the page first, and short enough that a real stuck state
+// recovers without manual intervention.
+const PROCESSED_SAFETY_MS = 5 * 60 * 1000;
+
 async function pollProcessedState() {
   if (!_submittedAt) return;
   try {
@@ -1876,7 +1908,33 @@ async function pollProcessedState() {
     const processedIso = data && data._processed_at;
     if (!processedIso) return;
     const processedMs = Date.parse(processedIso);
-    if (Number.isFinite(processedMs) && processedMs > _submittedAt) {
+    if (!Number.isFinite(processedMs) || processedMs <= _submittedAt) return;
+
+    // _processed_at IS newer than submission. Two paths to actually
+    // restore the panel:
+    //   (a) The reload counter has advanced past submit-time → Claude
+    //       wrote a new iteration; pollReload will trigger location.reload()
+    //       within 3s. Restoring eagerly here is a no-op visually but
+    //       cleans local state.
+    //   (b) A long safety timeout elapsed → reload never fired (closed
+    //       tab, JS error, network blip); recover so the user is not
+    //       stuck on a frozen "submitted" panel.
+    // Otherwise: Claude is mid-processing (e.g. /reset arrived but file
+    // write + /reload is still pending, or the protocol order was wrong).
+    // Keep the panel in "submitted" state so the user cannot duplicate-
+    // submit on the still-active old iteration.
+    let reloadAdvanced = false;
+    try {
+      const r2 = await fetch('/reload', { cache: 'no-store' });
+      if (r2.ok) {
+        const { counter } = await r2.json();
+        reloadAdvanced = (_submittedReloadCounter !== null) &&
+                         (counter > _submittedReloadCounter);
+      }
+    } catch (_) { /* ignore — fall back to safety timer */ }
+
+    const longStale = (Date.now() - _submittedAt) > PROCESSED_SAFETY_MS;
+    if (reloadAdvanced || longStale) {
       restorePanelToReady();
     }
   } catch (e) { /* retry next tick */ }

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.61.3",
+  "version": "0.61.4",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

Fixes a UI race in the `devops-concept` skill: after submitting decisions, the panel briefly flipped back to "ready" while Claude was still mid-write, letting the user fire a duplicate submission on the still-active old iteration.

## Root cause

Step 5c instructed Claude to POST `/reset` **before** the file rewrite + `/reload`. That stamped `_processed_at` on the bridge server immediately. The browser's `pollProcessedState` (5s tick) saw the fresh stamp, called `restorePanelToReady()`, and re-enabled the submit buttons — even though the new iteration was not yet on disk. The window covered the full read → generate → write time.

## Fix

- **Protocol reorder** — `/reset` is now the LAST step of Step 5c, after `/reload`. The visible panel reset happens via the `/reload`-triggered `location.reload()` (fresh page, no `concept-submitted` class).
- **`pollProcessedState` is a true safety-net** — only flips the panel when a reload-counter advance has been observed OR a 5-minute stale timeout elapses (recovery for closed tabs / JS errors).
- **Submit-handler guard** — `_submitInFlight` lock + non-zero `_submittedAt` check at function entry blocks duplicate clicks even if the UI ever flickers.
- `_submittedReloadCounter` captured at submit time as the gate variable.

## Files

- `plugins/devops/skills/devops-concept/SKILL.md`
- `plugins/devops/skills/devops-concept/deep-knowledge/bridge-server.md`
- `plugins/devops/skills/devops-concept/deep-knowledge/monitoring.md`
- `plugins/devops/skills/devops-concept/deep-knowledge/templates.md`

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 103 passed
- [x] Codex review — no findings
- [ ] Manual: open a concept page, submit, confirm buttons stay locked until the actual `location.reload()` fires