### PR TITLE
feat(concept): heartbeat split + SessionStart resume hook (0.63.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.62.0"
+    "version": "0.63.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.62.0",
+      "version": "0.63.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.62.0",
+      "version": "0.63.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ node_modules/
 .claude/scheduled_tasks.lock
 .claude/usage-live.json
 .claude/.ship-in-progress
+.claude/concept-active.json
 # Plugin-managed runtime dirs
 .claude/.plugin-version
 .claude/hooks/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.63.0] — 2026-05-04
+
+### Added
+
+- **plugins/devops/hooks/session-start/ss.concept.resume.js** + **plugins/devops/hooks/hooks.json** — new SessionStart hook recovers an open `/devops-concept` session after Claude restarts. Reads `.claude/concept-active.json` (port, html_path, slug, server_pid, cron_id, started_at), probes the bridge with `GET /heartbeat`, and instructs Claude to re-arm the polling cron — and to immediately process any submission already sitting in `/pending` rather than waiting for the next 60s tick. The polling cron is session-only and dies with the previous session; before this hook, a Claude restart left the bridge running but unmonitored, so submissions silently rotted until the user noticed manually. Stale state (24h+, server gone) is auto-pruned. State file is gitignored and `html_path` is validated to a `docs/concepts/*.html` shape so a forged or committed state file cannot steer Claude at arbitrary paths (codex review finding). `/pending` probe failures are reported as `unknown` instead of falsely collapsing to `idle`, so an inconclusive probe makes Claude fetch `/decisions` once authoritatively. Both the SKILL.md Step 3 (write the file before opening Edge) and Step 6 (delete the file with `kill $SERVER_PID + rm -f` before the completion card) document the lifecycle so the resume signal cannot misfire on a closed concept
+
+### Fixed
+
+- **plugins/devops/scripts/concept-server.py** + **plugins/devops/skills/devops-concept/deep-knowledge/templates.md** + **deep-knowledge/bridge-server.md** — split the bridge heartbeat into two distinct timestamps so the page connection indicator can no longer lie about Claude's reachability. The single `_heartbeat_ts` was driven by both the daemon-thread self-pulse (every 30s, proves the server is alive) AND Claude's `POST /heartbeat` from the cron — collapsing those into one field meant the indicator stayed green forever from the self-pulse alone, even after Claude's session restarted and the polling cron died. Submissions then sat unprocessed in the bridge with the page falsely reporting "Claude verbunden". Server now exposes `server_ts` (self-pulse, server alive) and `claude_ts` (last Claude POST, polling cron alive) separately; `GET /heartbeat` returns both plus `ts` as a legacy alias of `claude_ts` for back-compat with older page JS. The browser-side `pollHeartbeat` reads `data.claude_ts || data.ts`, never `server_ts`, so a dead Claude polling cron now correctly flips the indicator to "nicht verbunden" within the existing 90s stale window — surfacing the real problem instead of hiding it. Old pages still in user tabs continue to work via the `ts`-alias path; new pages get the explicit `claude_ts` field
+
 ## [0.62.0] — 2026-05-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.62.0**
+**Version: 0.63.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.62.0",
+  "version": "0.63.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/hooks/hooks.json
+++ b/plugins/devops/hooks/hooks.json
@@ -11,6 +11,7 @@
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-start/ss.tokens.scan.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-start/ss.git.check.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-start/ss.git.sync.js" },
+          { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-start/ss.concept.resume.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-start/ss.team.changelog.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-start/ss.flow.selfcalibration.js", "_deprecated": "moved to UserPromptSubmit — kept as fallback for older runtimes" }
         ]

--- a/plugins/devops/hooks/session-start/ss.concept.resume.js
+++ b/plugins/devops/hooks/session-start/ss.concept.resume.js
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+/**
+ * @hook ss.concept.resume
+ * @version 0.1.0
+ * @event SessionStart
+ * @plugin devops
+ * @description Recover an open concept session after a Claude restart.
+ *   Reads `.claude/concept-active.json` (written by /devops-concept Step 3),
+ *   probes the bridge server to confirm it is still running, and instructs
+ *   Claude to re-arm the polling cron — and pick up any unprocessed
+ *   submission immediately. Without this hook the polling cron (which is
+ *   session-only) dies with the prior session and any pending submission
+ *   silently rots in the bridge server until the user notices.
+ */
+
+require('../lib/plugin-guard');
+
+const fs = require('fs');
+const path = require('path');
+const http = require('http');
+
+const cwd = process.cwd();
+const STATE_PATH = path.join(cwd, '.claude', 'concept-active.json');
+
+// Age-out: if a state file is older than 24h and the server is gone,
+// we just delete the orphan. Real concept sessions almost never run that long.
+const STALE_AFTER_MS = 24 * 60 * 60 * 1000;
+
+function readState() {
+  try {
+    const raw = fs.readFileSync(STATE_PATH, 'utf8');
+    const obj = JSON.parse(raw);
+    if (!obj || typeof obj.port !== 'number') return null;
+    return obj;
+  } catch {
+    return null;
+  }
+}
+
+function deleteState() {
+  try { fs.unlinkSync(STATE_PATH); } catch { /* already gone */ }
+}
+
+function isStale(state) {
+  if (!state.started_at) return false;
+  const t = Date.parse(state.started_at);
+  if (!Number.isFinite(t)) return false;
+  return (Date.now() - t) > STALE_AFTER_MS;
+}
+
+/**
+ * GET http://localhost:{port}{pathname}, returns parsed JSON or null.
+ * Short timeout — if the server is dead the connect should fail fast on
+ * localhost and we don't want to block SessionStart on a slow probe.
+ */
+function probe(port, pathname, timeoutMs = 1500) {
+  return new Promise((resolve) => {
+    const req = http.get(
+      { host: '127.0.0.1', port, path: pathname, timeout: timeoutMs },
+      (res) => {
+        if (res.statusCode !== 200) {
+          res.resume();
+          return resolve(null);
+        }
+        const chunks = [];
+        res.on('data', (c) => chunks.push(c));
+        res.on('end', () => {
+          try {
+            resolve(JSON.parse(Buffer.concat(chunks).toString('utf8')));
+          } catch {
+            resolve(null);
+          }
+        });
+      }
+    );
+    req.on('timeout', () => { req.destroy(); resolve(null); });
+    req.on('error', () => resolve(null));
+  });
+}
+
+(async () => {
+  const state = readState();
+  if (!state) process.exit(0);
+
+  const heartbeat = await probe(state.port, '/heartbeat');
+  if (!heartbeat) {
+    // Server gone. If the file is also stale, prune it; otherwise leave it
+    // alone — the user might be restarting the server in another terminal.
+    if (isStale(state)) deleteState();
+    process.exit(0);
+  }
+
+  // Server is alive. Check whether a submission is sitting unprocessed.
+  const pending = await probe(state.port, '/pending');
+  const hasPending = !!(pending && pending.pending);
+
+  const cronBody =
+    `Silently run both steps for the concept bridge on port ${state.port}: ` +
+    `(1) Heartbeat POST: Bash: curl -s -X POST http://localhost:${state.port}/heartbeat > /dev/null. ` +
+    `(2) Pending check via /pending: Bash: curl -s http://localhost:${state.port}/pending | python -c "import sys,json; d=json.load(sys.stdin); print(\\'true\\' if d.get(\\'pending\\') else \\'false\\')". ` +
+    `If exactly "false" → produce NO output (silent tick). ` +
+    `If exactly "true" → curl -s http://localhost:${state.port}/decisions, parse JSON, note _version, process per devops-concept SKILL.md Step 5 (rewrite HTML, POST /reload, then conditionally POST /reset with the noted version). On 409 retry with the new version. Report the outcome to the user.`;
+
+  const lines = [];
+  lines.push(
+    `An open /devops-concept session was found in this project ` +
+    `(port ${state.port}, html_path ${state.html_path}, slug ${state.slug || '?'}). ` +
+    `The bridge server is alive but the polling cron from the previous Claude session is gone (crons are session-only). ` +
+    `Re-arm it now: call CronCreate with cron "* * * * *" (recurring: true) and prompt: '${cronBody}'.`
+  );
+
+  if (hasPending) {
+    lines.push(
+      `IMMEDIATELY ALSO process the pending submission BEFORE waiting for the first cron tick: ` +
+      `curl -s http://localhost:${state.port}/decisions, parse, then run devops-concept SKILL.md Step 5 ` +
+      `(rewrite HTML at ${state.html_path}, POST /reload, conditional /reset with the captured _version). ` +
+      `The user already submitted and is waiting — do not delay this on the cron schedule.`
+    );
+  } else {
+    lines.push(
+      `No submission is pending right now — just keeping the cron alive is enough. ` +
+      `When the user submits, the next cron tick (≤60s) will pick it up automatically.`
+    );
+  }
+
+  process.stdout.write(lines.join(' ') + '\n');
+})();

--- a/plugins/devops/hooks/session-start/ss.concept.resume.js
+++ b/plugins/devops/hooks/session-start/ss.concept.resume.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * @hook ss.concept.resume
- * @version 0.1.0
+ * @version 0.2.0
  * @event SessionStart
  * @plugin devops
  * @description Recover an open concept session after a Claude restart.
@@ -11,6 +11,21 @@
  *   submission immediately. Without this hook the polling cron (which is
  *   session-only) dies with the prior session and any pending submission
  *   silently rots in the bridge server until the user notices.
+ *
+ *   Trust model: `.claude/concept-active.json` is treated as a per-project
+ *   state file, NOT as authenticated control input. We accept that anyone
+ *   with write access to the project tree can author it, but we do NOT let
+ *   `html_path` steer Claude at arbitrary paths — it must be a clean
+ *   relative path under `docs/concepts/` and end in `.html`. The file is
+ *   also gitignored so a malicious branch cannot smuggle one in via PR.
+ *
+ *   Multi-session caveat: this hook does not coordinate ownership across
+ *   parallel Claude sessions on the same project. If two sessions are open,
+ *   both will arm a polling cron and both may process the same submission;
+ *   the bridge's optimistic /reset (409 on version mismatch) prevents data
+ *   loss but cannot prevent duplicate Step 5 work. This is a known limit —
+ *   the realistic case (one user, one active session per worktree) is
+ *   the only one we optimize for.
  */
 
 require('../lib/plugin-guard');
@@ -26,11 +41,36 @@ const STATE_PATH = path.join(cwd, '.claude', 'concept-active.json');
 // we just delete the orphan. Real concept sessions almost never run that long.
 const STALE_AFTER_MS = 24 * 60 * 60 * 1000;
 
+/**
+ * Validate the html_path field. Constraints:
+ *   - relative (no drive letter, no leading / or \)
+ *   - no traversal segments (`..`)
+ *   - lives under `docs/concepts/`
+ *   - ends in `.html`
+ * The hook injects this string into stdout instructions that Claude will
+ * act on, so we tighten the allowed shape to make sure a forged state
+ * file cannot point Claude at arbitrary repository files.
+ */
+function isValidHtmlPath(p) {
+  if (typeof p !== 'string' || p.length === 0 || p.length > 256) return false;
+  if (/^[a-zA-Z]:[\\/]/.test(p)) return false; // windows drive
+  if (p.startsWith('/') || p.startsWith('\\')) return false; // absolute posix
+  const norm = p.replace(/\\/g, '/');
+  if (norm.split('/').includes('..')) return false; // traversal
+  if (!norm.startsWith('docs/concepts/')) return false;
+  if (!norm.endsWith('.html')) return false;
+  return true;
+}
+
 function readState() {
   try {
     const raw = fs.readFileSync(STATE_PATH, 'utf8');
     const obj = JSON.parse(raw);
     if (!obj || typeof obj.port !== 'number') return null;
+    if (!Number.isInteger(obj.port) || obj.port < 1 || obj.port > 65535) return null;
+    if (!isValidHtmlPath(obj.html_path)) return null;
+    if (obj.slug !== undefined && typeof obj.slug !== 'string') return null;
+    if (obj.slug && !/^[a-zA-Z0-9._-]{1,80}$/.test(obj.slug)) return null;
     return obj;
   } catch {
     return null;
@@ -91,8 +131,20 @@ function probe(port, pathname, timeoutMs = 1500) {
   }
 
   // Server is alive. Check whether a submission is sitting unprocessed.
+  // We must distinguish three states explicitly:
+  //   - probe ok, pending: false → safe to wait on cron schedule
+  //   - probe ok, pending: true  → process immediately
+  //   - probe failed              → AMBIGUOUS, do NOT pretend it's false.
+  //     Hiding "I don't know" as "no submission pending" is the worst
+  //     failure mode for a waiting user. Tell Claude to fetch /decisions
+  //     once now so the answer is resolved authoritatively.
   const pending = await probe(state.port, '/pending');
-  const hasPending = !!(pending && pending.pending);
+  let pendingState; // 'pending' | 'idle' | 'unknown'
+  if (pending && typeof pending.pending === 'boolean') {
+    pendingState = pending.pending ? 'pending' : 'idle';
+  } else {
+    pendingState = 'unknown';
+  }
 
   const cronBody =
     `Silently run both steps for the concept bridge on port ${state.port}: ` +
@@ -109,12 +161,19 @@ function probe(port, pathname, timeoutMs = 1500) {
     `Re-arm it now: call CronCreate with cron "* * * * *" (recurring: true) and prompt: '${cronBody}'.`
   );
 
-  if (hasPending) {
+  if (pendingState === 'pending') {
     lines.push(
       `IMMEDIATELY ALSO process the pending submission BEFORE waiting for the first cron tick: ` +
       `curl -s http://localhost:${state.port}/decisions, parse, then run devops-concept SKILL.md Step 5 ` +
       `(rewrite HTML at ${state.html_path}, POST /reload, conditional /reset with the captured _version). ` +
       `The user already submitted and is waiting — do not delay this on the cron schedule.`
+    );
+  } else if (pendingState === 'unknown') {
+    lines.push(
+      `The /pending probe was inconclusive (timeout, non-200, or malformed JSON). ` +
+      `Do NOT assume idle. Fetch /decisions once now: curl -s http://localhost:${state.port}/decisions. ` +
+      `If submitted=true, run Step 5 immediately (rewrite ${state.html_path}, /reload, conditional /reset). ` +
+      `If submitted=false, just continue with the cron — the next tick will catch any later submission.`
     );
   } else {
     lines.push(

--- a/plugins/devops/scripts/concept-server.py
+++ b/plugins/devops/scripts/concept-server.py
@@ -2,7 +2,15 @@
 Concept Bridge Server — HTTP-based heartbeat and decision bridge.
 
 Replaces `python -m http.server` with a custom server that adds:
-- GET/POST /heartbeat — Claude signals presence via curl, page polls via fetch
+- GET/POST /heartbeat — Claude signals presence via POST, page polls via GET.
+  GET response is `{ server_ts, claude_ts, ts }`:
+    * `server_ts` — daemon-thread self-pulse (server alive, Claude state unknown).
+    * `claude_ts` — last POST /heartbeat from Claude (Claude is actively polling).
+    * `ts` — legacy alias = `claude_ts` for backwards compat with older page JS.
+  The browser MUST gate the connection indicator on `claude_ts`, not `server_ts`.
+  Otherwise the server's own self-pulse falsely shows "Claude connected" even
+  when Claude's polling cron is dead (e.g. after a session restart) and
+  submissions silently rot in the bridge until the user notices manually.
 - GET/POST /decisions — Page submits decisions via POST, Claude reads via GET.
   GET response includes `_version` (for optimistic /reset concurrency) and
   `_processed_at` (ISO timestamp of the last successful /reset — the browser
@@ -19,12 +27,13 @@ This bypasses Chrome MCP JS injection limitations entirely. The page
 communicates with Claude through HTTP endpoints instead of requiring
 JavaScript eval injection into the browser tab.
 
-A daemon thread self-pulses `_heartbeat_ts` every 30s so the browser's
-connection indicator reflects "bridge server alive" rather than "Claude's
-REPL is currently idle". Session-based crons only fire while the REPL is
-idle, which is exactly not the case while Claude actively builds the page
-or processes submissions — the self-pulse closes that false-negative gap.
-POST /heartbeat still works for belt-and-suspenders signaling.
+A daemon thread self-pulses `_server_ts` every 30s so the browser can tell
+"bridge server is alive" from "Claude is actively polling". The split
+heartbeat replaces the older single `_heartbeat_ts` which conflated both
+signals — a server-only pulse used to render as "Claude connected", which
+hid the case where Claude's polling cron had died (session restart, busy
+REPL) while the server kept ticking. POST /heartbeat now updates ONLY
+`_claude_ts`, and the browser gates the indicator on that.
 
 Usage:
     python concept-server.py <port> [directory]
@@ -41,7 +50,8 @@ import time
 import threading
 from datetime import datetime, timezone
 
-_heartbeat_ts = 0
+_server_ts = 0
+_claude_ts = 0
 _decisions = '{"submitted": false, "decisions": [], "comments": []}'
 # Monotonic counter — incremented on every POST /decisions. Used by /reset
 # for optimistic concurrency: Claude reads version via GET, processes, then
@@ -82,8 +92,17 @@ class ConceptBridgeHandler(http.server.SimpleHTTPRequestHandler):
     def do_GET(self):
         if self.path == '/heartbeat':
             with _lock:
-                ts = _heartbeat_ts
-            self._json_response({"ts": ts})
+                server_ts = _server_ts
+                claude_ts = _claude_ts
+            # `ts` is a legacy alias of `claude_ts` for older page JS that
+            # only knows the single-field response. Gating on `ts` then
+            # transparently means "gating on Claude's heartbeat" — which is
+            # exactly what we want even before the page is regenerated.
+            self._json_response({
+                "server_ts": server_ts,
+                "claude_ts": claude_ts,
+                "ts": claude_ts,
+            })
         elif self.path == '/decisions':
             # Return the stored decisions payload with the current server
             # version appended as `_version`. Claude must pass this value back
@@ -126,12 +145,16 @@ class ConceptBridgeHandler(http.server.SimpleHTTPRequestHandler):
             super().do_GET()
 
     def do_POST(self):
-        global _heartbeat_ts, _decisions, _version, _processed_at, _reload_counter
+        global _server_ts, _claude_ts, _decisions, _version, _processed_at, _reload_counter
         if self.path == '/heartbeat':
+            # POST /heartbeat is reserved for Claude (curl from cron). Updates
+            # ONLY `_claude_ts` — the server's own self-pulse touches `_server_ts`
+            # and must not be conflated with "Claude is reachable". See module
+            # docstring for the full rationale.
             with _lock:
-                _heartbeat_ts = int(time.time() * 1000)
-                ts = _heartbeat_ts
-            self._json_response({"ok": True, "ts": ts})
+                _claude_ts = int(time.time() * 1000)
+                ts = _claude_ts
+            self._json_response({"ok": True, "ts": ts, "claude_ts": ts})
         elif self.path == '/decisions':
             length = int(self.headers.get('Content-Length', 0))
             body = self.rfile.read(length).decode()
@@ -229,11 +252,14 @@ class ConceptBridgeHandler(http.server.SimpleHTTPRequestHandler):
         pass  # suppress per-request logging
 
 
-def _heartbeat_self_pulse(interval_s: int = 30):
-    global _heartbeat_ts
+def _server_self_pulse(interval_s: int = 30):
+    """Updates ONLY `_server_ts` — proves the server process and its event
+    loop are alive. Has nothing to do with whether Claude is reachable; the
+    browser must gate the connection indicator on `_claude_ts`."""
+    global _server_ts
     while True:
         with _lock:
-            _heartbeat_ts = int(time.time() * 1000)
+            _server_ts = int(time.time() * 1000)
         time.sleep(interval_s)
 
 
@@ -243,10 +269,11 @@ if __name__ == '__main__':
     os.chdir(directory)
 
     # Prime + self-pulse: the browser checks the heartbeat within 5s of page
-    # load, so set it once before serving and then refresh every 30s from a
-    # daemon thread that dies with the server process.
-    _heartbeat_ts = int(time.time() * 1000)
-    threading.Thread(target=_heartbeat_self_pulse, daemon=True).start()
+    # load, so set `_server_ts` once before serving and then refresh every 30s
+    # from a daemon thread that dies with the server process. `_claude_ts`
+    # stays 0 until Claude actually POSTs — that's the whole point of the split.
+    _server_ts = int(time.time() * 1000)
+    threading.Thread(target=_server_self_pulse, daemon=True).start()
 
     with http.server.HTTPServer(('', port), ConceptBridgeHandler) as httpd:
         print(f"Concept bridge server on http://localhost:{port}/")

--- a/plugins/devops/skills/devops-concept/SKILL.md
+++ b/plugins/devops/skills/devops-concept/SKILL.md
@@ -374,12 +374,22 @@ open a separate browser window.
 
 Start the bridge server (`scripts/concept-server.py`) on a random port
 (8700-8999), arm the combined heartbeat + auto-poll cron (fires every
-minute, handles heartbeat + decision pickup + conditional reset), send
-the first heartbeat, and open the page in the user's existing Edge window.
+minute, handles heartbeat + decision pickup + conditional reset), write
+`.claude/concept-active.json` so a future SessionStart can rediscover this
+concept, send the first heartbeat, and open the page in the user's
+existing Edge window.
+
+The state file (`port`, `html_path`, `slug`, `server_pid`, `cron_id`,
+`started_at`) is what makes the concept survivable across Claude restarts:
+the `ss.concept.resume` SessionStart hook reads it, verifies the bridge
+is still running via `GET /heartbeat`, and tells the new session whether
+to re-arm the polling cron or pick up an unprocessed submission. Without
+the state file the new session has no way to know a concept was ever
+opened — the polling cron is session-only and dies with the old session.
 
 See `deep-knowledge/bridge-server.md` for the full setup — script lookup,
-launch command, cron body, rationale for `/pending` over substring checks,
-and cleanup.
+launch command, cron body, state-file schema, rationale for `/pending`
+over substring checks, and cleanup ordering.
 
 ### After opening, inform the user:
 
@@ -549,7 +559,27 @@ previous rounds; each entry records its `iteration` number).
 ## Step 6 — Completion Card
 
 The feedback loop ends when the user is satisfied (user says "fertig"/"done",
-closes the page, or all items are processed). Then render a completion card.
+closes the page, or all items are processed). Then **clean up the
+bridge-server state** and render a completion card.
+
+### 6a. Clean up the active-concept state
+
+Before rendering the completion card, dispose of the bridge server and
+its state file in this exact order (per `deep-knowledge/bridge-server.md`
+§ Step 7):
+
+```bash
+kill $SERVER_PID 2>/dev/null
+rm -f .claude/concept-active.json
+```
+
+Then `CronDelete <cron_id>`. Removing `concept-active.json` is mandatory
+— if the file lingers, the next SessionStart's `ss.concept.resume` hook
+will surface a phantom resume hint pointing at a server that no longer
+exists. The `kill` is best-effort: if the user already closed the
+terminal that spawned the server, the PID may be gone, which is fine.
+
+### 6b. Render the completion card
 
 Call `mcp__plugin_devops_dotclaude-completion__render_completion_card`:
 

--- a/plugins/devops/skills/devops-concept/deep-knowledge/bridge-server.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/bridge-server.md
@@ -12,7 +12,11 @@ AND provides HTTP endpoints for heartbeat and decision exchange.
    ```bash
    python "$PLUGIN_ROOT" {random-port} "{concept-dir}" &
    ```
-   Use a random port (8700-8999) to avoid conflicts. Store the port as `$PORT`.
+   Use a random port (8700-8999) to avoid conflicts. Store the port as `$PORT`
+   and the spawned background PID as `$SERVER_PID` (`echo $!` immediately
+   after the `&`-launch). Both are written to `.claude/concept-active.json`
+   in step 6 so the SessionStart resume hook can find this server again
+   after a Claude restart.
 
 3. Set up the **combined heartbeat + auto-poll cron**. This single cron keeps
    the connection indicator green AND automatically picks up user submissions
@@ -68,12 +72,47 @@ AND provides HTTP endpoints for heartbeat and decision exchange.
    the contract explicit: every tick does both. Minimum cron resolution is 1 min,
    so the max submit-to-process lag is ~60 s — acceptable for interactive flows.
 
-4. Send the first heartbeat immediately:
+4. **Persist active-concept state.** Write `.claude/concept-active.json` in
+   the project root with the metadata the SessionStart resume hook
+   (`ss.concept.resume`) needs to recover this concept after a Claude
+   restart. Do this BEFORE the first heartbeat — once the file exists, any
+   subsequent SessionStart can rediscover the running server.
+
+   ```json
+   {
+     "port": 8742,
+     "html_path": "docs/concepts/2026-04-12-auth-middleware-redesign.html",
+     "slug": "auth-middleware-redesign",
+     "server_pid": 12345,
+     "cron_id": "ab12cd34",
+     "started_at": "2026-04-12T14:30:00.000Z"
+   }
+   ```
+
+   - `port` — the bridge port chosen in step 2.
+   - `html_path` — relative path inside the project; the hook uses it to
+     verify the concept file still exists.
+   - `slug` — kebab-case topic from the filename, used in resume messaging.
+   - `server_pid` — captured via `echo $!` after the `python … &` launch.
+   - `cron_id` — the ID `CronCreate` returned in step 3. A new session
+     refreshes the polling cron, the old ID is just informational (the old
+     session-only cron died with the prior session and cannot be reaped).
+   - `started_at` — ISO-8601 UTC. Lets the hook age-out stale state after
+     ~24 h even if cleanup did not run.
+
+   Path: ALWAYS `<project-cwd>/.claude/concept-active.json` (NOT a worktree
+   subpath, NOT under `docs/`). The hook reads this exact path and silently
+   exits when missing. Create `.claude/` if needed; do not commit the file
+   (add `concept-active.json` to `.gitignore` if not already covered by
+   `.claude/`).
+
+5. Send the first heartbeat immediately (POST = Claude pulse, not the
+   server self-pulse — see `templates.md` § Claude Connection Heartbeat):
    ```bash
    curl -s -X POST http://localhost:{port}/heartbeat
    ```
 
-5. Open in Edge (reuses the running instance, adds a tab):
+6. Open in Edge (reuses the running instance, adds a tab):
    ```bash
    # Windows
    start "" msedge "http://localhost:{port}/{filename}"
@@ -83,8 +122,13 @@ AND provides HTTP endpoints for heartbeat and decision exchange.
    The empty `""` is required on Windows — without it, `cmd.exe` interprets
    the first quoted argument as a window title.
 
-6. After monitoring ends, clean up:
+7. After monitoring ends (user says "fertig"/"done", aborts, or Step 6 of
+   SKILL.md fires the completion card), clean up in this order:
    ```bash
-   kill %1  # or track the PID
+   kill $SERVER_PID 2>/dev/null  # or `kill %1` if still in shell scope
+   rm -f .claude/concept-active.json
    ```
-   Also delete the heartbeat cron via `CronDelete`.
+   Also delete the polling cron via `CronDelete <cron_id>`. The state file
+   MUST be removed when the concept session is intentionally ended,
+   otherwise the next SessionStart will surface a phantom resume hint for a
+   server that no longer exists.

--- a/plugins/devops/skills/devops-concept/deep-knowledge/templates.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/templates.md
@@ -1877,6 +1877,24 @@ document.getElementById('theme-toggle').addEventListener('click', () => {
 
 ## Claude Connection Heartbeat (HTTP Bridge)
 
+The server response splits the heartbeat into TWO timestamps:
+
+- `claude_ts` — last `POST /heartbeat` from Claude (the polling cron is alive
+  and Claude will pick up submissions). This is the field the indicator must
+  gate on.
+- `server_ts` — daemon-thread self-pulse (the bridge process is alive). Used
+  only to distinguish "server crashed" from "Claude not polling" in error
+  messaging — never to decide whether the indicator goes green.
+- `ts` — legacy alias of `claude_ts` for back-compat with older pages that
+  pre-date the split. Always equal to `claude_ts` on a current server.
+
+Gating on `server_ts` would keep the indicator green even after Claude's
+session restarts (cron is session-only and dies with the session) — silently
+hiding the case where submissions fall into a black hole. The bug that
+motivated the split: `_heartbeat_ts` used to be a single field that the
+self-pulse refreshed every 30s, so the page showed "Claude verbunden"
+indefinitely no matter what Claude was actually doing.
+
 ```javascript
 const HEARTBEAT_STALE_MS = 90000;
 const HEARTBEAT_GRACE_MS = 30000;
@@ -1887,7 +1905,11 @@ async function pollHeartbeat() {
   try {
     const res = await fetch('/heartbeat', { cache: 'no-store' });
     const data = await res.json();
-    _lastHeartbeatTs = data.ts || 0;
+    // Prefer `claude_ts` (post-split server); fall back to `ts` for
+    // back-compat with legacy server builds that only expose the merged field.
+    // NEVER use `server_ts` here — the daemon self-pulse would falsely
+    // light up the indicator while Claude's polling cron is dead.
+    _lastHeartbeatTs = data.claude_ts || data.ts || 0;
   } catch (e) { /* server unreachable */ }
 }
 

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.62.0",
+  "version": "0.63.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

- Splits the concept bridge heartbeat into `server_ts` (daemon self-pulse) vs `claude_ts` (Claude's POST), so the page connection indicator can no longer falsely show "Claude verbunden" when only the server is pulsing and the polling cron is dead.
- Adds a SessionStart hook (`ss.concept.resume`) that reads `.claude/concept-active.json`, probes the live bridge, and tells Claude to re-arm the per-minute polling cron — and to immediately fetch `/decisions` for any pending submission instead of waiting for the next tick.
- Hardens the hook against the Codex review findings: gitignored state file, `html_path` validated to `docs/concepts/*.html`, `/pending` probe failures surface as `unknown` (not silently treated as idle).

## Background

A real failure showed up while shipping this branch: a concept page (port 8847 in another worktree) showed "Claude verbunden" but the submission had been sitting unprocessed for hours. The single `_heartbeat_ts` was getting refreshed by the server's own daemon thread, so the indicator lied about Claude's reachability. The session-only polling cron had died with a prior Claude session and nothing rearmed it on restart.

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` 103/103 green
- [x] Hook smoke-tested against live bridge (idle, pending, probe-failed branches)
- [x] Hook silent-exits on missing state, traversal `..`, absolute path, malformed port
- [x] Codex review (gpt-5.4): findings addressed inline; multi-session caveat documented in JSDoc