### PR TITLE
feat: crash hardening — concept panel + MCP envcheck (0.64.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.63.0"
+    "version": "0.64.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.63.0",
+      "version": "0.64.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.63.0",
+      "version": "0.64.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.64.0] — 2026-05-10
+
+### Added
+
+- **plugins/devops/hooks/session-start/ss.mcp.envcheck.js** + **plugins/devops/hooks/hooks.json** — new SessionStart hook scans every globally-enabled plugin's `.mcp.json` for `${VAR_NAME}` placeholders and surfaces any that are unset before they can crash a tool call. Without it, an enabled plugin with a missing env (e.g. `github@claude-plugins-official` without `GITHUB_PERSONAL_ACCESS_TOKEN`) produced a cryptic mid-session `Plugin MCP server error - mcp-config-invalid: Missing environment variables: …` and corrupted the conversation tool_use/tool_result pairing as a side effect. The hook prints a structured action block — list of affected plugins, missing variables, and two concrete fix options (set the variable user-globally, or flip the plugin to `false` in `enabledPlugins`) — so Claude can ask the user which path applies per plugin instead of crashing later. Walks `~/.claude/plugins/cache/<marketplace>/<plugin>/[<version>/].mcp.json`, accepts both the legacy `enabledPlugins[key] === true` shorthand and the `{ enabled, config }` object form (same lenient contract ss.tokens.scan.js already uses), exits silently when nothing is missing. Never `exit(2)` — env-var setup is a user choice, not a hard block
+
+### Fixed
+
+- **plugins/devops/skills/devops-concept/deep-knowledge/templates.md** — two UX flaws in the concept-page decision panel that let accidental clicks burn a Claude iteration. (1) Empty-submit guard: every `Next iteration` / `Implement with feedback` click is now gated on `_userInteracted` (driven only by `event.isTrusted` so `restoreState()`-fired events don't count) and asks for confirmation if nothing was modified in the active iteration. The flag persists across reloads via localStorage so a user who entered feedback before reload isn't asked to confirm work he already authored. (2) Connection overlay: the `connecting` and `disconnected` overlays previously had `pointer-events: none` so clicks fell through to the submit buttons below — the user couldn't tell which button he was firing. Both overlays now carry an explicit `Verstanden` button (the only interactive element), the submit buttons stay `disabled` until the user acknowledges, and a small per-button cache hint (`gecached — wird beim Verbinden gesendet`) replaces the click-through behaviour. Ack state resets unconditionally on reconnect — including while `panel-submitted` is visible — so a subsequent disconnect always re-shows the overlay rather than silently inheriting the prior acknowledgement. Both flows added to decision and prototype templates so behaviour is identical across layouts. Codex review flagged the panel-submitted ack-leak and the unsaved-flag-after-reload bug as real state leaks; both fixes landed in the same ship
+
 ## [0.63.0] — 2026-05-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.63.0**
+**Version: 0.64.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.63.0",
+  "version": "0.64.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/hooks/hooks.json
+++ b/plugins/devops/hooks/hooks.json
@@ -8,6 +8,7 @@
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-start/ss.permissions.ensure.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-start/ss.knowledge.index.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-start/ss.mcp.deps.js" },
+          { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-start/ss.mcp.envcheck.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-start/ss.tokens.scan.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-start/ss.git.check.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-start/ss.git.sync.js" },

--- a/plugins/devops/hooks/session-start/ss.mcp.envcheck.js
+++ b/plugins/devops/hooks/session-start/ss.mcp.envcheck.js
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+/**
+ * @hook ss.mcp.envcheck
+ * @version 0.1.0
+ * @event SessionStart
+ * @plugin devops
+ * @description Detect enabled plugins whose .mcp.json references env vars
+ *   that are not set. Prevents cryptic mid-session crashes like
+ *   "Plugin MCP server error - mcp-config-invalid: MCP server X invalid:
+ *   Missing environment variables: FOO" by surfacing the issue at session
+ *   start with concrete fix options for the user.
+ *
+ *   Scope: globally-enabled plugins in ~/.claude/settings.json. Project-
+ *   level enabledPlugins (project/.claude/settings.json) and local
+ *   overrides are not inspected here — they'd require knowing CWD at hook
+ *   time, and the global level catches the common "I enabled it once and
+ *   forgot" footgun the user actually hit.
+ *
+ *   Output: stdout text block (additionalContext) so Claude relays it to
+ *   the user verbatim. Never exit(2) — env-var setup is a user choice, not
+ *   a hard error we should block on.
+ */
+
+require('../lib/plugin-guard');
+
+const fs = require('fs');
+const path = require('path');
+
+const home = process.env.HOME || process.env.USERPROFILE || '';
+if (!home) process.exit(0);
+
+const PLUGINS_CACHE = path.join(home, '.claude', 'plugins', 'cache');
+const SETTINGS = path.join(home, '.claude', 'settings.json');
+
+if (!fs.existsSync(PLUGINS_CACHE) || !fs.existsSync(SETTINGS)) process.exit(0);
+
+let settings;
+try {
+  settings = JSON.parse(fs.readFileSync(SETTINGS, 'utf8'));
+} catch {
+  process.exit(0);
+}
+
+const enabledPlugins = settings.enabledPlugins || {};
+const ENV_VAR_RE = /\$\{([A-Z_][A-Z0-9_]*)\}/g;
+
+function findMcpJson(marketplace, pluginName) {
+  const baseDir = path.join(PLUGINS_CACHE, marketplace, pluginName);
+  if (!fs.existsSync(baseDir)) return null;
+
+  // .mcp.json may sit directly under the plugin dir, or one level down
+  // under a version-hash subfolder (e.g. github/61c0597779bd/.mcp.json).
+  const direct = path.join(baseDir, '.mcp.json');
+  if (fs.existsSync(direct)) return direct;
+
+  let entries;
+  try {
+    entries = fs.readdirSync(baseDir, { withFileTypes: true });
+  } catch {
+    return null;
+  }
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const nested = path.join(baseDir, entry.name, '.mcp.json');
+    if (fs.existsSync(nested)) return nested;
+  }
+  return null;
+}
+
+function collectEnvRefs(configStr) {
+  const refs = new Set();
+  let m;
+  ENV_VAR_RE.lastIndex = 0;
+  while ((m = ENV_VAR_RE.exec(configStr)) !== null) refs.add(m[1]);
+  return refs;
+}
+
+const issues = [];
+
+for (const [key, enabled] of Object.entries(enabledPlugins)) {
+  if (enabled !== true) continue;
+  const at = key.lastIndexOf('@');
+  if (at < 1) continue;
+  const pluginName = key.slice(0, at);
+  const marketplace = key.slice(at + 1);
+
+  const mcpJsonPath = findMcpJson(marketplace, pluginName);
+  if (!mcpJsonPath) continue;
+
+  let raw;
+  try {
+    raw = fs.readFileSync(mcpJsonPath, 'utf8');
+  } catch {
+    continue;
+  }
+  // Validate JSON parses, but scan the raw text so we catch refs in any
+  // position (URL, header value, args, env block — wherever the plugin
+  // author put them).
+  try {
+    JSON.parse(raw);
+  } catch {
+    continue;
+  }
+
+  const refs = collectEnvRefs(raw);
+  if (refs.size === 0) continue;
+
+  const missing = [...refs].filter((v) => !process.env[v]);
+  if (missing.length > 0) {
+    issues.push({ plugin: pluginName, marketplace, missing, configPath: mcpJsonPath });
+  }
+}
+
+if (issues.length === 0) process.exit(0);
+
+const out = [];
+out.push('MCP env-var check at session start. Show the user this block verbatim:');
+out.push('');
+out.push('⚠️  **MCP-Server-Konfiguration unvollständig**');
+out.push('');
+out.push('Diese aktivierten Plugins erwarten Environment-Variablen, die nicht gesetzt sind. Sobald Claude den jeweiligen Server kontaktiert, crasht der Tool-Call mit `mcp-config-invalid` (genau wie in deinen letzten Errors):');
+out.push('');
+for (const issue of issues) {
+  const vars = issue.missing.map((v) => `\`${v}\``).join(', ');
+  out.push(`- **${issue.plugin}** (\`${issue.marketplace}\`) → fehlt: ${vars}`);
+}
+out.push('');
+out.push('**Was tun — eine Option pro Plugin wählen:**');
+out.push('');
+out.push('1. **Variable setzen** — den Token/Wert in eine User-Env oder in `~/.claude/settings.json` unter `env: { ... }` eintragen, dann neue Session starten.');
+out.push('2. **Plugin deaktivieren** — in `~/.claude/settings.json` unter `enabledPlugins` den Eintrag auf `false` setzen. Spart den Crash, wenn du das Plugin gerade nicht brauchst.');
+out.push('');
+out.push('Frag den Nutzer welche Option für jedes betroffene Plugin gelten soll, bevor du Änderungen machst.');
+
+process.stdout.write(out.join('\n'));

--- a/plugins/devops/hooks/session-start/ss.mcp.envcheck.js
+++ b/plugins/devops/hooks/session-start/ss.mcp.envcheck.js
@@ -78,7 +78,12 @@ function collectEnvRefs(configStr) {
 const issues = [];
 
 for (const [key, enabled] of Object.entries(enabledPlugins)) {
-  if (enabled !== true) continue;
+  // enabledPlugins values can be either `true` (legacy boolean shorthand) or
+  // an object like `{ enabled: true, config: { ... } }`. Treat anything other
+  // than an explicit `false` / `{enabled:false}` as enabled — same lenient
+  // contract ss.tokens.scan.js already relies on.
+  if (enabled === false) continue;
+  if (enabled && typeof enabled === 'object' && enabled.enabled === false) continue;
   const at = key.lastIndexOf('@');
   if (at < 1) continue;
   const pluginName = key.slice(0, at);

--- a/plugins/devops/skills/devops-concept/deep-knowledge/templates.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/templates.md
@@ -57,6 +57,10 @@ must see their own language. The locale hint is authoritative.
 | `panel.disconnected_hint`      | You can still submit — your click is queued and delivered as soon as Claude is back. | Du kannst trotzdem absenden — der Klick wird gespeichert und gesendet, sobald Claude wieder da ist. |
 | `panel.connecting_title`       | Claude is connecting           | Claude verbindet sich |
 | `panel.connecting_hint`        | One moment — establishing the connection. | Einen Moment — die Verbindung wird aufgebaut. |
+| `panel.acknowledge`            | Got it                         | Verstanden |
+| `panel.btn_cache_hint`         | cached — sent on reconnect     | gecached — wird beim Verbinden gesendet |
+| `panel.empty_iterate_confirm`  | Nothing was changed. Submit "Next iteration" anyway? | Du hast nichts geändert. Trotzdem "Zur nächsten Iteration" absenden? |
+| `panel.empty_implement_confirm`| Nothing was changed. Implement with feedback anyway? Claude will still write code. | Du hast nichts geändert. Trotzdem mit Feedback implementieren? Claude schreibt dann Code. |
 | `panel.toggle_open`            | Open decisions                 | Entscheidungen öffnen |
 | `panel.close`                  | Close                          | Schliessen |
 | `variant.include`              | Include                        | Miteinbeziehen |
@@ -160,26 +164,39 @@ the `[ui-locale: ...]` hint produced.
              2. Heartbeat confirmed fresh → both hidden.
              3. Past grace period AND heartbeat stale → #connection-warning
                 visible, connecting hidden.
-             Both are absolute overlays on top of #panel-ready. -->
+             Both are absolute overlays on top of #panel-ready. The "Got it"
+             button is the ONLY clickable element while the overlay is visible
+             (panel-warning has pointer-events: auto). The submit buttons stay
+             disabled with a small cache-hint label until the user
+             acknowledges, at which point the overlay slides away and the
+             submit buttons become clickable (still cached if disconnected). -->
         <div id="connection-connecting" class="panel-warning panel-warning--connecting" style="display: flex;">
           <span class="warning-icon" aria-hidden="true">⋯</span>
           <strong>{{panel.connecting_title}}</strong>
           <p class="warning-message">{{panel.connecting_hint}}</p>
+          <button type="button" class="panel-warning__ack-btn" data-ack="connecting">{{panel.acknowledge}}</button>
         </div>
         <div id="connection-warning" class="panel-warning" style="display: none;">
           <span class="warning-icon" aria-hidden="true">⚠</span>
           <strong>{{panel.disconnected_title}}</strong>
           <p class="warning-message">{{panel.disconnected_hint}}</p>
+          <button type="button" class="panel-warning__ack-btn" data-ack="warning">{{panel.acknowledge}}</button>
         </div>
 
         <button id="submit-iterate-btn" class="primary submit-btn">{{panel.submit_iterate}}</button>
         <p class="hint">{{panel.submit_iterate_hint}}</p>
+        <p class="hint hint-cache" data-cache-hint="iterate" hidden>
+          <span aria-hidden="true">⚠</span> {{panel.btn_cache_hint}}
+        </p>
         <div class="submit-gap" aria-hidden="true"></div>
         <button id="submit-implement-btn" class="implement-btn">
           <span class="warn-icon" aria-hidden="true">⚠</span>
           {{panel.submit_implement}}
         </button>
         <p class="hint hint-warn">{{panel.submit_implement_hint}}</p>
+        <p class="hint hint-cache" data-cache-hint="implement" hidden>
+          <span aria-hidden="true">⚠</span> {{panel.btn_cache_hint}}
+        </p>
       </div>
 
       <!-- Post-submit state: waiting for Claude -->
@@ -691,14 +708,38 @@ The wiring is a single delegated click handler installed alongside
              AND closes the panel. -->
       </nav>
       <div id="panel-ready">
+        <!-- Connection overlays — same contract as the sidebar templates.
+             Show "connecting" / "disconnected" with a "Got it" button; the
+             submit buttons stay disabled until the user acknowledges, then
+             unlock with a small cache-hint label (offline submissions are
+             auto-queued by retryPendingSubmission). -->
+        <div id="connection-connecting" class="panel-warning panel-warning--connecting" style="display: flex;">
+          <span class="warning-icon" aria-hidden="true">⋯</span>
+          <strong>{{panel.connecting_title}}</strong>
+          <p class="warning-message">{{panel.connecting_hint}}</p>
+          <button type="button" class="panel-warning__ack-btn" data-ack="connecting">{{panel.acknowledge}}</button>
+        </div>
+        <div id="connection-warning" class="panel-warning" style="display: none;">
+          <span class="warning-icon" aria-hidden="true">⚠</span>
+          <strong>{{panel.disconnected_title}}</strong>
+          <p class="warning-message">{{panel.disconnected_hint}}</p>
+          <button type="button" class="panel-warning__ack-btn" data-ack="warning">{{panel.acknowledge}}</button>
+        </div>
+
         <button id="submit-iterate-btn" class="primary submit-btn">{{panel.submit_iterate}}</button>
         <p class="hint">{{panel.submit_iterate_hint}}</p>
+        <p class="hint hint-cache" data-cache-hint="iterate" hidden>
+          <span aria-hidden="true">⚠</span> {{panel.btn_cache_hint}}
+        </p>
         <div class="submit-gap" aria-hidden="true"></div>
         <button id="submit-implement-btn" class="implement-btn">
           <span class="warn-icon" aria-hidden="true">⚠</span>
           {{panel.submit_implement}}
         </button>
         <p class="hint hint-warn">{{panel.submit_implement_hint}}</p>
+        <p class="hint hint-cache" data-cache-hint="implement" hidden>
+          <span aria-hidden="true">⚠</span> {{panel.btn_cache_hint}}
+        </p>
       </div>
       <div id="panel-submitted" style="display: none;"><!-- waiting state --></div>
     </aside>
@@ -1438,21 +1479,23 @@ document.addEventListener('DOMContentLoaded', () => {
 ## Decision Panel State CSS
 
 ```css
-/* Connection warning — overlays the submit area when Claude is offline.
-   Requires #panel-ready to be position: relative.
-   pointer-events: none so the user can still click the submit buttons
-   through the overlay — clicks land in the offline queue and are
-   auto-delivered on reconnect. */
+/* Connection warning — overlays the submit area while Claude is connecting
+   or unreachable. Requires #panel-ready to be position: relative.
+   pointer-events: auto so the only clickable element while the overlay is
+   visible is its "Got it" button — the underlying submit buttons stay
+   blocked. After the user acknowledges, the overlay is hidden via JS, the
+   submit buttons are enabled, and a small cache-hint stays under each
+   button so the user knows offline submissions are queued. */
 #panel-ready { position: relative; }
 .panel-warning {
   position: absolute; inset: 0; z-index: 5;
-  pointer-events: none;
+  pointer-events: auto;
   display: flex; flex-direction: column;
   align-items: center; justify-content: center;
   gap: 0.75rem; text-align: center; padding: 1.5rem;
   border-radius: 10px;
   border: 1px solid var(--warning-color, #d29922);
-  background: color-mix(in srgb, var(--panel-bg, #161b22) 70%, transparent);
+  background: color-mix(in srgb, var(--panel-bg, #161b22) 88%, transparent);
   backdrop-filter: blur(2px);
   -webkit-backdrop-filter: blur(2px);
   color: var(--text-color, #c9d1d9);
@@ -1463,6 +1506,25 @@ document.addEventListener('DOMContentLoaded', () => {
   font-size: 0.88rem; color: var(--text-secondary, #8b949e);
   line-height: 1.5; max-width: 280px; margin: 0;
 }
+.panel-warning__ack-btn {
+  margin-top: 0.5rem;
+  padding: 0.45rem 1.1rem;
+  border-radius: 8px;
+  border: 1px solid var(--warning-color, #d29922);
+  background: color-mix(in srgb, var(--warning-color, #d29922) 15%, transparent);
+  color: var(--warning-color, #d29922);
+  font-weight: 600; font-size: 0.88rem;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+.panel-warning__ack-btn:hover {
+  background: var(--warning-color, #d29922);
+  color: var(--panel-bg, #161b22);
+}
+.panel-warning__ack-btn:focus-visible {
+  outline: 2px solid var(--warning-color, #d29922);
+  outline-offset: 2px;
+}
 /* Connecting variant — same overlay, accent color + pulsing icon */
 .panel-warning--connecting { border-color: var(--accent-color, #58a6ff); }
 .panel-warning--connecting .warning-icon {
@@ -1470,10 +1532,33 @@ document.addEventListener('DOMContentLoaded', () => {
   animation: pulse-connect 1.4s ease-in-out infinite;
 }
 .panel-warning--connecting strong { color: var(--accent-color, #58a6ff); }
+.panel-warning--connecting .panel-warning__ack-btn {
+  border-color: var(--accent-color, #58a6ff);
+  background: color-mix(in srgb, var(--accent-color, #58a6ff) 15%, transparent);
+  color: var(--accent-color, #58a6ff);
+}
+.panel-warning--connecting .panel-warning__ack-btn:hover {
+  background: var(--accent-color, #58a6ff);
+  color: var(--panel-bg, #161b22);
+}
+.panel-warning--connecting .panel-warning__ack-btn:focus-visible {
+  outline-color: var(--accent-color, #58a6ff);
+}
 @keyframes pulse-connect {
   0%, 100% { opacity: 0.45; }
   50% { opacity: 1; }
 }
+
+/* Per-button cache hint — shown only when overlay was acknowledged but
+   Claude is still connecting / disconnected. Toggled via [hidden]. */
+.hint-cache {
+  font-size: 0.78rem;
+  line-height: 1.35;
+  margin: 0.25rem 0 0;
+  color: var(--warning-color, #d29922);
+  display: flex; align-items: center; gap: 0.35rem;
+}
+.hint-cache[hidden] { display: none; }
 
 /* Submitted state */
 .submitted-indicator {
@@ -1775,6 +1860,24 @@ let _submittedAt = 0;
 // and the user sees re-enabled buttons on the still-active old iteration.
 let _submittedReloadCounter = null;
 let _submitInFlight = false;
+// Tracks whether the user has actually changed any field in the active
+// iteration. restoreState() and DOMContentLoaded fire change/input events
+// that are NOT user-driven, so we gate on event.isTrusted to ignore them.
+// Reset to false on iteration-switch / reload — collectDecisions still
+// ships the full payload, but submitWithAction asks for confirmation if
+// the user clicks submit without having touched anything.
+let _userInteracted = false;
+function _markUserInteracted(e) {
+  if (e && e.isTrusted) _userInteracted = true;
+}
+document.addEventListener('change', _markUserInteracted, true);
+document.addEventListener('input', _markUserInteracted, true);
+document.addEventListener('iteration:changed', () => { _userInteracted = false; });
+
+const _emptyConfirmKey = {
+  iterate: 'panel.empty_iterate_confirm',
+  implement: 'panel.empty_implement_confirm'
+};
 
 function wireSubmit(btnId, action) {
   const btn = document.getElementById(btnId);
@@ -1787,6 +1890,17 @@ async function submitWithAction(action) {
   // shows "submitted"), ignore further clicks. restorePanelToReady() resets
   // _submittedAt to 0, so this only blocks while we're actually waiting.
   if (_submitInFlight || _submittedAt) return;
+
+  // Empty-submit guard: if the user clicks submit without having modified
+  // any field in the active iteration, ask before sending. Avoids burning
+  // a Claude turn on accidental clicks.
+  if (!_userInteracted) {
+    const msg = (action === 'implement')
+      ? '{{panel.empty_implement_confirm}}'
+      : '{{panel.empty_iterate_confirm}}';
+    if (!window.confirm(msg)) return;
+  }
+
   _submitInFlight = true;
 
   const data = collectDecisions(action);
@@ -1962,6 +2076,28 @@ async function pollProcessedState() {
   } catch (e) { /* retry next tick */ }
 }
 
+// Acknowledged-overlay state. Each overlay (connecting / warning) is
+// independent: acknowledging "connecting" should NOT silently dismiss the
+// stronger "warning" overlay if the connection actually went stale later.
+// Cleared automatically when isConnected becomes true.
+const _overlayAck = { connecting: false, warning: false };
+
+document.addEventListener('click', (e) => {
+  const btn = e.target && e.target.closest && e.target.closest('.panel-warning__ack-btn');
+  if (!btn) return;
+  const which = btn.dataset.ack;
+  if (which === 'connecting' || which === 'warning') {
+    _overlayAck[which] = true;
+    checkClaudeConnection();
+  }
+});
+
+function _setCacheHints(visible) {
+  document.querySelectorAll('[data-cache-hint]').forEach(el => {
+    el.hidden = !visible;
+  });
+}
+
 function checkClaudeConnection() {
   const isConnected = _lastHeartbeatTs && (Date.now() - _lastHeartbeatTs) < HEARTBEAT_STALE_MS;
   const inGrace = Date.now() - _pageLoadedAt < HEARTBEAT_GRACE_MS;
@@ -1974,21 +2110,32 @@ function checkClaudeConnection() {
   if (panelSubmitted && panelSubmitted.style.display !== 'none') return;
 
   if (isConnected) {
+    // Reset ack state so a future drop re-shows the overlay rather than
+    // silently leaving the user in offline-cache mode.
+    _overlayAck.connecting = false;
+    _overlayAck.warning = false;
     if (connecting) connecting.style.display = 'none';
     if (warning) warning.style.display = 'none';
+    _setCacheHints(false);
     btns.forEach(b => b.disabled = false);
     retryPendingSubmission();
   } else if (inGrace) {
-    // Still in grace period — show "connecting" overlay, no warning yet
-    if (connecting) connecting.style.display = 'flex';
+    // Grace period: heartbeat not yet confirmed. Show "connecting" overlay
+    // with a "Got it" button. Submit buttons are disabled until the user
+    // acknowledges, then they unlock with a small cache-hint label so the
+    // user knows the submission will be queued.
+    if (connecting) connecting.style.display = _overlayAck.connecting ? 'none' : 'flex';
     if (warning) warning.style.display = 'none';
-    btns.forEach(b => b.disabled = false);
+    _setCacheHints(_overlayAck.connecting);
+    btns.forEach(b => b.disabled = !_overlayAck.connecting);
   } else {
-    // Past grace AND heartbeat stale → disconnected warning
+    // Past grace AND heartbeat stale → disconnected warning. Same ack flow:
+    // overlay until "Got it", then buttons unlock and offline submissions
+    // are cached + auto-retried by retryPendingSubmission().
     if (connecting) connecting.style.display = 'none';
-    if (warning) warning.style.display = 'flex';
-    // Buttons stay enabled: offline submissions are cached & retried
-    btns.forEach(b => b.disabled = false);
+    if (warning) warning.style.display = _overlayAck.warning ? 'none' : 'flex';
+    _setCacheHints(_overlayAck.warning);
+    btns.forEach(b => b.disabled = !_overlayAck.warning);
   }
 }
 

--- a/plugins/devops/skills/devops-concept/deep-knowledge/templates.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/templates.md
@@ -1640,6 +1640,13 @@ function saveState() {
     if (el.id || el.name) state['select:' + (el.id || el.name)] = el.value;
   });
   state['theme'] = document.documentElement.getAttribute('data-theme');
+  // Persist the user-interacted flag so a reload while the user has unsaved
+  // edits does not re-arm the empty-submit confirm dialog. Restored values
+  // would otherwise look like "untouched defaults" because change/input
+  // events fire from restoreState() (isTrusted=false) and are ignored.
+  if (typeof _userInteracted !== 'undefined' && _userInteracted) {
+    state['_userInteracted'] = true;
+  }
   localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
 }
 
@@ -1658,6 +1665,10 @@ function restoreState() {
       return;
     }
     if (state.theme) document.documentElement.setAttribute('data-theme', state.theme);
+    // Preserve the user's prior interaction flag across reloads — see saveState().
+    if (state._userInteracted && typeof _userInteracted !== 'undefined') {
+      _userInteracted = true;
+    }
     Object.entries(state).forEach(([key, value]) => {
       if (key.startsWith('_')) return;
       const [type, ...rest] = key.split(':');
@@ -2107,13 +2118,20 @@ function checkClaudeConnection() {
     .map(id => document.getElementById(id)).filter(Boolean);
   const panelSubmitted = document.getElementById('panel-submitted');
 
+  // Always clear ack state on reconnect — even while the submitted-state
+  // early-return below is active. Otherwise: user acks `warning`, reconnects
+  // while `panel-submitted` is showing, drops again before reload → the
+  // next outage would silently inherit the prior ack and skip the warning.
+  if (isConnected) {
+    _overlayAck.connecting = false;
+    _overlayAck.warning = false;
+  }
+
   if (panelSubmitted && panelSubmitted.style.display !== 'none') return;
 
   if (isConnected) {
-    // Reset ack state so a future drop re-shows the overlay rather than
-    // silently leaving the user in offline-cache mode.
-    _overlayAck.connecting = false;
-    _overlayAck.warning = false;
+    // Ack state already cleared above so a future drop re-shows the overlay
+    // rather than silently leaving the user in offline-cache mode.
     if (connecting) connecting.style.display = 'none';
     if (warning) warning.style.display = 'none';
     _setCacheHints(false);

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.63.0",
+  "version": "0.64.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

Hardens two failure modes that surfaced in real use:

- **`/devops-concept` panel** — accidental submits and click-through overlays could burn Claude turns or silently fire the wrong button while the connection was still establishing.
- **MCP envcheck** — an enabled plugin with a missing env var (e.g. `github@claude-plugins-official` without `GITHUB_PERSONAL_ACCESS_TOKEN`) used to crash mid-session with `mcp-config-invalid` and a corrupted `tool_use`/`tool_result` pairing as fallout.

## Changes

- **concept**: empty-submit confirm gate driven by `_userInteracted` (gated on `event.isTrusted`, persisted across reload)
- **concept**: connection overlays now carry a "Verstanden" button; submit buttons disabled until acknowledged; small per-button cache-hint replaces click-through behaviour
- **concept**: ack state resets unconditionally on reconnect — including while `panel-submitted` is visible — so a subsequent drop always re-shows the overlay
- **hooks**: new `ss.mcp.envcheck.js` scans enabled-plugins' `.mcp.json` for unset `${VAR}` placeholders and prints a structured action block (set var OR disable plugin) — never `exit(2)`, never blocks
- **lenient `enabledPlugins` contract**: accepts both `true` shorthand and `{ enabled, config }` object form, matching `ss.tokens.scan.js`

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 103/103 passed
- [x] Smoke test envcheck hook → detects `github@claude-plugins-official` without `GITHUB_PERSONAL_ACCESS_TOKEN`
- [x] Codex review gate — 3 findings, all auto-fixed in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)