### PR TITLE
fix(card): unify battery marker glyph to ╏ (0.64.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.64.0"
+    "version": "0.64.1"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.64.0",
+      "version": "0.64.1",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.64.0",
+      "version": "0.64.1",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.64.1] — 2026-05-11
+
+### Fixed
+
+- **plugins/devops/mcp-server/index.js** + **plugins/devops/templates/completion-card.md** — completion-card battery line now uses a single marker glyph (`╏`, light dashed vertical) for the elapsed-time position regardless of whether the marker falls inside the heavy-filled used zone or the light free zone. Previously the marker switched to `╇` (heavy horizontal + light up vertical) when it landed inside the filled zone, producing a `+`-shaped cross between two heavy dashes that read like a corrupted underscore in monospace fonts — visible in the Wk row whenever weekly usage was ahead of elapsed time. The 5h row almost always rendered the marker in the free zone, so its `╏` looked clean; the inconsistency between the two rows was the actual UX complaint. Branch in `renderBar()` simplified to an unconditional `╏`; template doc updated (example bar, glyph legend, column reference). No behavior change beyond the glyph swap — marker position, bar width, and pace warning logic untouched
+
 ## [0.64.0] — 2026-05-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.64.0**
+**Version: 0.64.1**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.64.0",
+  "version": "0.64.1",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/mcp-server/index.js
+++ b/plugins/devops/mcp-server/index.js
@@ -50,7 +50,7 @@ function renderBar(pct, elapsedPct) {
   let bar = '';
   for (let i = 0; i < total; i++) {
     if (i === elapsedPos) {
-      bar += i < filled ? '\u2547' : '\u254f'; // ╇ heavy+marker / ╏ light+marker
+      bar += '\u254f'; // ╏ light dashed vertical — consistent marker glyph in both filled and free zones
     } else if (i < filled) {
       bar += '\u2501'; // ━ heavy horizontal — used
     } else {

--- a/plugins/devops/templates/completion-card.md
+++ b/plugins/devops/templates/completion-card.md
@@ -108,7 +108,7 @@ If `usage-live.json` is missing: show error message instead of bars.
 
 ```
 5h  ━━━━━━━━━╏────   67%  +1%  · 1h 42m left
-Wk  ━━━━╇━━━──────   60%  +8% !!  · 4d 11h left  ⚠ Pace!
+Wk  ━━━━╏━━━──────   60%  +8% !!  · 4d 11h left  ⚠ Pace!
 ```
 
 **Error rendering (no data):**
@@ -128,8 +128,7 @@ elapsed_pos  = round(elapsed_pct / 100 * total_blocks)
 Each position in the 14-character bar is one of:
 - `━` (heavy horizontal) — used area
 - `─` (light horizontal) — free area
-- `╇` (heavy + marker) — elapsed position within the used (filled) area
-- `╏` (light + marker) — elapsed position within the free (empty) area
+- `╏` (light dashed vertical) — elapsed-time marker, same glyph regardless of fill zone
 
 The elapsed marker replaces the character at `elapsed_pos` regardless of fill. No separate arrow line is used.
 
@@ -175,7 +174,7 @@ Column       Width    Content
 ──────────   ──────   ──────────────────────────
 Label         2 chr   "5h" / "Wk"
 Gap           2 chr   "  "
-Bar          14 chr   ━━━╇── (always 14)
+Bar          14 chr   ━━━╏── (always 14)
 Gap           2 chr   "  "
 Pct           3 chr   right-aligned, space-padded
 Pct-suffix    1 chr   "%"

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.64.0",
+  "version": "0.64.1",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

Completion-card battery line now renders the elapsed-time marker as `╏` (light dashed vertical) in both the heavy-filled used zone and the light free zone. Previously the marker switched to `╇` inside the filled zone, producing a `+`-shaped cross between two heavy dashes that read like a corrupted underscore — most visible in the Wk row whenever weekly usage was ahead of elapsed time, while the 5h row stayed clean because its marker almost always fell in the free zone.

## Changes

- `plugins/devops/mcp-server/index.js` — `renderBar()` always emits `╏` at the elapsed position; removed the `i < filled ? ╇ : ╏` branch.
- `plugins/devops/templates/completion-card.md` — example bar, glyph legend, and column reference updated to the single-marker convention.
- `CHANGELOG.md` — 0.64.1 entry.

## Tests

- `npm run lint` → clean.
- `npm test` → 103/103 passing.
- Manual `renderBar()` probe — Wk(21%, 17% elapsed) now renders `━━╏───────────`, 5h(23%, 88% elapsed) renders `━━━─────────╏─`. Same glyph both rows.

## Review

- Codex review (mandatory gate): **No findings** — change classified as cosmetic, no behavior or correctness regression.