### PR TITLE
refactor(skill)!: rename self-update → plugin-update (0.69.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.68.0"
+    "version": "0.69.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.68.0",
+      "version": "0.69.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.68.0",
+      "version": "0.69.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+<<<<<<< HEAD
+## [0.69.0] — 2026-05-13
+
+### Changed
+
+- **BREAKING** — **plugins/devops/skills/devops-plugin-update/SKILL.md** (renamed from `devops-self-update`) + **README.md** + **INSTALL.md** + **CLAUDE.md** + **plugins/devops/hooks/session-start/ss.plugin.update.js** — slash-command renamed `/devops-self-update` → `/devops-plugin-update` for clarity: the old name was ambiguous about *what* updates (the session? the user? the plugin?), the new name explicitly states the plugin is the target. Skill `name:` field, directory, heading, README Features bullet + skills table, INSTALL alternative-install paragraph, CLAUDE.md test-instruction, and the hook header comment all updated. Trigger phrases in the description (`"self update"`, `"plugin updaten"`, `"update plugin"`, `"neue version"`) unchanged for backward compatibility — so the model still matches old phrasings even though the literal slash-command is gone. CHANGELOG history references to the old name are preserved verbatim as historical record. Migration: any external automation or muscle-memory invoking `/devops-self-update` must switch to `/devops-plugin-update`
+
+### Fixed
+
+- **README.md** — skill count corrected from 15 to 17 (added missing `devops-burn` and `devops-learn` to both the Features bullet and the slash-command table). Stale-count miss was surfaced during the rename refactor and fixed inline since the same lines were already being touched
+
 ## [0.68.0] — 2026-05-13
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ See @.claude/project-map.md for directory structure.
 
 ## Context: This is the plugin SOURCE repo
 - Changes here affect the plugin itself — not a consumer project
-- Test changes by running `/devops-self-update` from a consumer project
+- Test changes by running `/devops-plugin-update` from a consumer project
 - The `.claude/plugins/cache/` on a consumer machine is the installed copy
 
 ## Release

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -28,10 +28,10 @@ claude plugin update devops@Jerry0022
 
 Or enable auto-update via **Settings** → **Plugins** → **Marketplaces**.
 
-Alternatively, use the built-in self-update skill:
+Alternatively, use the built-in plugin-update skill:
 
 ```
-/devops-self-update
+/devops-plugin-update
 ```
 
 ## Project-specific extensions (optional)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.68.0**
+**Version: 0.69.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 
@@ -168,7 +168,7 @@ For the full extension guide with examples per skill, see `deep-knowledge/skill-
 ## Features
 
 - **13 Hooks** — automated guards and triggers across the full session lifecycle
-- **15 Skills** — devops-ship, devops-commit, devops-flow, devops-deep-research, devops-new-issue, devops-project-setup, devops-readme, devops-refresh-usage, devops-extend-skill, devops-repo-health, devops-claude-md-lint, devops-concept, devops-agents, devops-plugin-update, devops-autonomous
+- **17 Skills** — devops-ship, devops-commit, devops-flow, devops-deep-research, devops-new-issue, devops-project-setup, devops-readme, devops-refresh-usage, devops-extend-skill, devops-repo-health, devops-claude-md-lint, devops-concept, devops-agents, devops-plugin-update, devops-autonomous, devops-burn, devops-learn
 - **10 Agents** — AI, Core, Designer, Feature, Frontend, Gamer, PO, QA, Research, Windows
 - **Completion Flow** — mandatory card after every task (8 variants), visual verification, ship recommendation
 - **Ship Enforcement** — intent detection, PR command blocking, automatic /devops-ship skill routing
@@ -275,6 +275,8 @@ SessionStart  ──>  PreToolUse  ──>  PostToolUse  ──>  UserPromptSubm
 | `/devops-concept` | Explicit | Interactive HTML page for analysis, plans, concepts, and prototypes |
 | `/devops-agents` | Explicit | Evaluate agents and orchestrate parallel execution |
 | `/devops-autonomous` | Explicit | Fully autonomous agent orchestration while user is AFK |
+| `/devops-burn` | Explicit | High-throughput autonomous task runner with aggressive parallelization |
+| `/devops-learn` | Explicit | Capture long-term learnings and route to project-specific instructions |
 
 ### Agents (spawned for parallel work)
 

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ For the full extension guide with examples per skill, see `deep-knowledge/skill-
 ## Features
 
 - **13 Hooks** — automated guards and triggers across the full session lifecycle
-- **15 Skills** — devops-ship, devops-commit, devops-flow, devops-deep-research, devops-new-issue, devops-project-setup, devops-readme, devops-refresh-usage, devops-extend-skill, devops-repo-health, devops-claude-md-lint, devops-concept, devops-agents, devops-self-update, devops-autonomous
+- **15 Skills** — devops-ship, devops-commit, devops-flow, devops-deep-research, devops-new-issue, devops-project-setup, devops-readme, devops-refresh-usage, devops-extend-skill, devops-repo-health, devops-claude-md-lint, devops-concept, devops-agents, devops-plugin-update, devops-autonomous
 - **10 Agents** — AI, Core, Designer, Feature, Frontend, Gamer, PO, QA, Research, Windows
 - **Completion Flow** — mandatory card after every task (8 variants), visual verification, ship recommendation
 - **Ship Enforcement** — intent detection, PR command blocking, automatic /devops-ship skill routing
@@ -270,7 +270,7 @@ SessionStart  ──>  PreToolUse  ──>  PostToolUse  ──>  UserPromptSubm
 | `/devops-refresh-usage` | Explicit + Hook | Token usage tracking (CLI + CDP) |
 | `/devops-extend-skill` | Explicit | Scaffold or adapt project-level skill extensions |
 | `/devops-repo-health` | Explicit | Repository branch hygiene analysis and cleanup |
-| `/devops-self-update` | Explicit | Update the plugin to the latest version from GitHub |
+| `/devops-plugin-update` | Explicit | Update the plugin to the latest version from GitHub |
 | `/devops-claude-md-lint` | Explicit | Audit CLAUDE.md files for size, structure, and token efficiency |
 | `/devops-concept` | Explicit | Interactive HTML page for analysis, plans, concepts, and prototypes |
 | `/devops-agents` | Explicit | Evaluate agents and orchestrate parallel execution |

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.68.0",
+  "version": "0.69.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/hooks/session-start/ss.plugin.update.js
+++ b/plugins/devops/hooks/session-start/ss.plugin.update.js
@@ -7,7 +7,7 @@
  * @description Auto-update plugin marketplace clones, rebuild cache, and update registry.
  *   Workaround for anthropics/claude-code#14061 — Desktop never runs git pull
  *   on marketplace clones and never rebuilds the plugin cache.
- *   Shares the same update logic as /devops-self-update (see SKILL.md).
+ *   Shares the same update logic as /devops-plugin-update (see SKILL.md).
  *
  *   When a plugin with an MCP server is upgraded mid-session, the running
  *   MCP processes point at the now-deleted old installPath. A sentinel file

--- a/plugins/devops/skills/devops-plugin-update/SKILL.md
+++ b/plugins/devops/skills/devops-plugin-update/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: devops-self-update
-version: 0.4.0
+name: devops-plugin-update
+version: 0.5.0
 description: >-
   Manually update the devops plugin to latest from GitHub. Delegates to
   ss.plugin.update hook (pull + cache + registry), then adds changelog and
@@ -9,7 +9,7 @@ description: >-
 allowed-tools: Bash(git *), Bash(node *), Read, Glob
 ---
 
-# Self-Update Plugin
+# Plugin Update
 
 Manually trigger a plugin update with user-facing reporting.
 

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.68.0",
+  "version": "0.69.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

- Slash-command `/devops-self-update` renamed to `/devops-plugin-update` for clarity — the new name explicitly states that the **plugin** is what gets updated.
- README skill count fixed from 15 → 17 (added missing `devops-burn` + `devops-learn` to Features bullet and skills table).
- **BREAKING:** any external automation or muscle-memory invoking `/devops-self-update` must switch to `/devops-plugin-update`. Trigger phrases in the description (`"self update"`, `"plugin updaten"`, `"update plugin"`, `"neue version"`) kept for backward compatibility.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run test` — 103 tests pass
- [x] Codex review gate — 2 findings, both addressed (breaking-change note in CHANGELOG + skill-count fix)
- [x] No remaining `devops-self` / `Self-Update` / `self-update` references outside CHANGELOG history