### PR TITLE
refactor(learn): delegate CLAUDE.md checks to lint (0.69.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.69.0"
+    "version": "0.69.1"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.69.0",
+      "version": "0.69.1",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.69.0",
+      "version": "0.69.1",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
-<<<<<<< HEAD
+## [0.69.1] — 2026-05-13
+
+### Changed
+
+- **plugins/devops/skills/devops-learn/SKILL.md** + **plugins/devops/skills/devops-claude-md-lint/SKILL.md** — `/devops-learn` now delegates CLAUDE.md size and structure checks to `/devops-claude-md-lint` instead of "mental line counts". Step 5a (plugin repo) and Step 5c (consumer project) both invoke the lint skill via the Skill tool after any CLAUDE.md edit; Step 6 relays the lint output instead of re-counting lines. Inline duplication of the ~20-line soft cap removed — single source of truth is `deep-knowledge/content-conventions.md`, referenced explicitly with the canonical "target ~20 lines, re-route above ~25" note kept inline as a bias reminder so the soft cap does not collapse into the lint's hard `>25` warning threshold. `/devops-claude-md-lint` description clarified to distinguish auto-trigger filtering (still off for CLAUDE.md content edits) from explicit invocation by other skills (now allowed and documented). Closes the only "inline duplication" gap surfaced by an audit of plugin-wide CLAUDE.md handling — `/devops-ship` (Step 7) still says "Never touch CLAUDE.md" and stays correct as-is
+
 ## [0.69.0] — 2026-05-13
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.69.0**
+**Version: 0.69.1**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.69.0",
+  "version": "0.69.1",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/skills/devops-claude-md-lint/SKILL.md
+++ b/plugins/devops/skills/devops-claude-md-lint/SKILL.md
@@ -7,7 +7,9 @@ description: >-
   recommended maximum for index-style CLAUDE.md). Suggests creating one if
   missing. Triggers on: "lint claude md", "claude md check", "check claude md",
   "CLAUDE.md zu lang", "audit claude md", "claude md audit".
-  Do NOT trigger for editing CLAUDE.md content or for /devops-project-setup.
+  Do NOT auto-trigger from user phrasing for editing CLAUDE.md content or
+  for /devops-project-setup. MAY be invoked explicitly via the Skill tool
+  by other skills (devops-learn, devops-project-setup) as a post-edit gate.
 argument-hint: "[--fix]"
 allowed-tools: Read, Glob, Bash, Write, Edit, mcp__plugin_devops_dotclaude-completion__render_completion_card
 ---

--- a/plugins/devops/skills/devops-learn/SKILL.md
+++ b/plugins/devops/skills/devops-learn/SKILL.md
@@ -96,7 +96,9 @@ Store as `{topic}` ∈ {`plugin`, `project`}.
 
 Use this decision table. **In every branch: prefer deep-knowledge over skill
 over CLAUDE.md** — see the Conventions section below for soft caps, re-route
-triggers, and the self-reference rule. Single source: `content-conventions.md`.
+triggers, and the self-reference rule. Single source:
+`deep-knowledge/content-conventions.md` (CLAUDE.md target ~20 lines, re-route
+above ~25).
 
 | `{target_project}`     | `{topic}`  | Action                                           |
 |------------------------|------------|--------------------------------------------------|
@@ -121,9 +123,9 @@ The user is editing the plugin source. Choose target file:
 4. **Hook behavior** → edit `plugins/devops/hooks/<phase>/<hook>.js`.
 
 Only touch `plugins/devops/CLAUDE.md` or root `CLAUDE.md` if neither skill nor
-deep-knowledge fits and the rule is a one-liner. After any CLAUDE.md edit,
-invoke `/devops-claude-md-lint` via the **Skill** tool to verify size and
-structure — do not eyeball line counts.
+deep-knowledge fits and the rule is a one-liner. Bias: keep CLAUDE.md at
+~20 lines (target). After any CLAUDE.md edit, invoke `/devops-claude-md-lint`
+via the **Skill** tool to verify size and structure — do not eyeball line counts.
 
 ### 5b — Consumer project, plugin topic, fits a skill
 
@@ -158,9 +160,9 @@ Decide between project-skill and project-deep-knowledge:
     (b) fall back to deep-knowledge
 
 Only as last resort append a one-line pointer to `{project}/CLAUDE.md` so the
-new file gets discovered. After any CLAUDE.md edit, invoke
-`/devops-claude-md-lint` via the **Skill** tool — single source of truth for
-size/structure checks.
+new file gets discovered. Bias: keep CLAUDE.md at ~20 lines (target). After
+any CLAUDE.md edit, invoke `/devops-claude-md-lint` via the **Skill** tool —
+single source of truth for size/structure checks.
 
 ### 5d — Different project (cross-project)
 

--- a/plugins/devops/skills/devops-learn/SKILL.md
+++ b/plugins/devops/skills/devops-learn/SKILL.md
@@ -95,9 +95,8 @@ Store as `{topic}` ∈ {`plugin`, `project`}.
 ## Step 5 — Route by target × topic
 
 Use this decision table. **In every branch: prefer deep-knowledge over skill
-over CLAUDE.md** — see the Conventions section below for soft caps and the
-self-reference rule. CLAUDE.md target is ~20 lines (soft); skill files ~200
-lines (soft); deep-knowledge unbounded.
+over CLAUDE.md** — see the Conventions section below for soft caps, re-route
+triggers, and the self-reference rule. Single source: `content-conventions.md`.
 
 | `{target_project}`     | `{topic}`  | Action                                           |
 |------------------------|------------|--------------------------------------------------|
@@ -122,8 +121,9 @@ The user is editing the plugin source. Choose target file:
 4. **Hook behavior** → edit `plugins/devops/hooks/<phase>/<hook>.js`.
 
 Only touch `plugins/devops/CLAUDE.md` or root `CLAUDE.md` if neither skill nor
-deep-knowledge fits and the rule is a one-liner. Re-run the lint mental check:
-~20 lines after the edit (soft cap — see Conventions).
+deep-knowledge fits and the rule is a one-liner. After any CLAUDE.md edit,
+invoke `/devops-claude-md-lint` via the **Skill** tool to verify size and
+structure — do not eyeball line counts.
 
 ### 5b — Consumer project, plugin topic, fits a skill
 
@@ -158,7 +158,9 @@ Decide between project-skill and project-deep-knowledge:
     (b) fall back to deep-knowledge
 
 Only as last resort append a one-line pointer to `{project}/CLAUDE.md` so the
-new file gets discovered. CLAUDE.md target ~20 lines (soft cap, see Conventions).
+new file gets discovered. After any CLAUDE.md edit, invoke
+`/devops-claude-md-lint` via the **Skill** tool — single source of truth for
+size/structure checks.
 
 ### 5d — Different project (cross-project)
 
@@ -214,7 +216,8 @@ After persisting, show the user:
 
 - Which file(s) changed (path + line count delta)
 - The verbatim rule that was added
-- Any pointer line added to CLAUDE.md (with reminder of current line count)
+- If a CLAUDE.md was touched: the `/devops-claude-md-lint` result for that file
+  (don't re-count lines manually — relay the lint output)
 
 For 5d issue creation: show the issue URL.
 For 5d prompt: show the copy-pastable block.

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.69.0",
+  "version": "0.69.1",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

- `/devops-learn` now invokes `/devops-claude-md-lint` via the Skill tool after every CLAUDE.md edit instead of doing a "mental line count" — single source of truth for size and structure checks.
- Inline duplication of the `~20-line` soft cap removed from devops-learn. Canonical rule lives in `deep-knowledge/content-conventions.md`; a one-line `target ~20 / re-route >25` bias reminder is kept inline so the soft cap does not collapse into the lint's hard `>25` warning threshold.
- `/devops-claude-md-lint` description clarified to distinguish auto-trigger filtering (still off for CLAUDE.md content edits) from explicit invocation by other skills (now allowed and documented as the post-edit gate for `/devops-learn` and `/devops-project-setup`).

## Test plan

- [x] `npm run lint` clean
- [x] `npm run test` — 103/103 passing
- [x] Codex review pass — 2 findings + 1 nitpick all addressed inline before ship