### PR TITLE
feat(learn): prune feedback memory + harness workaround (0.72.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.71.0"
+    "version": "0.72.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.71.0",
+      "version": "0.72.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.71.0",
+      "version": "0.72.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.72.0] — 2026-05-13
+
+### Changed
+
+- **plugins/devops/skills/devops-learn/SKILL.md** — `/devops-learn` now prunes duplicate `feedback_*.md` entries from auto-memory after persisting the canonical rule to its proper file (skill / extension / deep-knowledge / CLAUDE.md). New Step 6 resolves the project memory dir at `~/.claude/projects/<encoded-cwd>/memory/` (using the **main** worktree path derived from `git worktree list --porcelain` — not `git-common-dir` trimming, which breaks for `core.worktree`/`core.bare`/separate-git-dir/submodule layouts; encoded path is realpath-resolved with native drive-letter casing, UNC paths skip silently), globs `feedback_*.md`, matches semantically against the just-persisted learning (same intent + trigger condition + non-trivial overlap, conservative), and offers deletion via AskUserQuestion per match (Löschen recommended, Behalten, Anzeigen) including removal of the bullet from `MEMORY.md`. Skipped for cross-project routing (5d) — feedback memory belongs to *this* session, not the target. Only `feedback_*.md` ever touched; `user_*`/`project_*`/`reference_*` have different lifecycles. Rules section narrowed: "never create or update content" with explicit carve-out for Step 6 cleanup writes
+- **plugins/devops/skills/devops-learn/SKILL.md** — frontmatter `disable-model-invocation: true` removed as workaround for a Claude Code harness bug where the flag was being applied to user-typed `/devops-learn` slash commands too broadly, blocking BOTH the slash dispatcher AND the model's Skill-tool fallback. With the flag set, a user-typed `/devops-learn` would silently fail and the model — having no working path to the skill — fell back to writing personal `feedback_*.md` memory directly, which is the exact behavior the skill exists to prevent. The description's existing "Triggers ONLY on explicit invocation" language plus the explicit trigger-phrase list (`/devops-learn`, "lerne das", "merk dir das fürs Projekt", "remember this for the project", "capture learning") replaces the flag's defense-in-depth role with prose-level discipline. Trade-off: model can now in principle auto-trigger the skill on conversational matches, but the trigger phrases are deliberately narrow and explicit. Upstream harness bug should still be filed against anthropics/claude-code so the flag's semantics get fixed at the dispatcher layer
+
 ## [0.71.0] — 2026-05-13
 
 ### Removed
@@ -19,7 +26,7 @@
 
 - **plugins/devops/.claude-plugin/plugin.json** — version `0.70.0 → 0.71.0`
 
-
+## [0.70.0] — 2026-05-13
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.71.0**
+**Version: 0.72.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.71.0",
+  "version": "0.72.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/skills/devops-learn/SKILL.md
+++ b/plugins/devops/skills/devops-learn/SKILL.md
@@ -225,11 +225,19 @@ to *this* session, not the target project — leave it alone.
 
 1. **Resolve the project memory dir.** The path is
    `~/.claude/projects/<encoded-cwd>/memory/` where `<encoded-cwd>` replaces
-   each `:`, `\`, and `/` in the path with `-`. If the current repo is a
-   worktree, use the **main** project path, not the worktree path (per the
-   existing `feedback_memory_in_main_project` convention) — derive it from
-   `git rev-parse --git-common-dir` (strip the trailing `/.git*` segments).
-   Use Glob to confirm the dir exists; skip silently if not.
+   each `:`, `\`, and `/` in the **canonical absolute path** with `-`. Before
+   encoding: resolve symlinks (`realpath` semantics) and preserve the OS's
+   native drive-letter case (Windows: as reported by `git rev-parse`).
+   If the current repo is a worktree, use the **main** project path, not the
+   worktree path (per the existing `feedback_memory_in_main_project`
+   convention). Derive the main path robustly via
+   `git worktree list --porcelain` and take the first `worktree` entry — that
+   is always the primary checkout. Do NOT trim `git-common-dir`: it fails for
+   `core.worktree`, `core.bare`, separate-git-dir, and submodule layouts.
+   Use Glob to confirm the resulting `~/.claude/projects/<encoded>/memory/`
+   exists; if not, skip Step 6 silently. For non-standard paths (UNC,
+   network shares): if encoding looks ambiguous (e.g. leading `\\server`),
+   skip silently rather than guess.
 
 2. **List candidates.** Glob `feedback_*.md` in that dir AND read `MEMORY.md`
    (which is the index). Skip silently if no `feedback_*` files.
@@ -296,9 +304,10 @@ write this skill performs.
 
 ## Rules
 
-- **Never write** to user feedback memory from this skill — auto-memory owns
-  that channel. The skill **may delete** duplicate `feedback_*.md` entries
-  (Step 6) once the canonical rule is in place, with user confirmation.
+- **Never create or update content in** user feedback memory from this skill
+  — auto-memory owns that channel. The **only** permitted writes are Step 6
+  duplicate-cleanup: deleting matched `feedback_*.md` files and removing
+  their bullets from `MEMORY.md`, both requiring user confirmation per match.
 - **Always** prefer deep-knowledge > skill/extension > CLAUDE.md.
 - **Respect the soft caps** above; re-route to the next-larger container
   before busting CLAUDE.md or SKILL.md targets.

--- a/plugins/devops/skills/devops-learn/SKILL.md
+++ b/plugins/devops/skills/devops-learn/SKILL.md
@@ -4,7 +4,9 @@ version: 0.1.0
 description: >-
   Capture a long-term learning/correction and route it to the correct project-
   specific instructions (skill, skill-extension, deep-knowledge, or as a last
-  resort CLAUDE.md) — NOT to personal feedback memory. Handles four targets:
+  resort CLAUDE.md) — NOT to personal feedback memory. After persisting, prunes
+  any now-duplicate `feedback_*.md` auto-memory entries with confirmation.
+  Handles four targets:
   (1) the devops plugin source itself when invoked from dotclaude, (2) a project-
   specific skill-extension when invoked from a consumer project and the learning
   fits an existing plugin skill, (3) a new project-specific skill or deep-knowledge
@@ -15,7 +17,6 @@ description: >-
   fürs Projekt", "remember this for the project", "capture learning". Do NOT
   trigger for one-off conversational corrections or for personal feedback memory.
 argument-hint: "<learning text>"
-disable-model-invocation: true
 allowed-tools: Bash(git *), AskUserQuestion, Read, Write, Edit, Glob, Grep, Skill, mcp__plugin_devops_dotclaude-completion__render_completion_card
 ---
 
@@ -212,7 +213,53 @@ anywhere outside any single project — **stop and ask first** via AskUserQuesti
 
 Never write to `~/.claude/CLAUDE.md` without explicit confirmation.
 
-## Step 6 — Confirm and report
+## Step 6 — Clean up duplicate feedback memory
+
+The canonical rule now lives in its proper file. Any pre-existing entry in
+**auto-memory feedback** that covers the same ground is now a stale duplicate
+— auto-memory is for personal style/tone preferences, not project rules, so
+the duplicate should be removed once the sorted Claude instructions own it.
+
+Skip this step entirely for 5d (cross-project): the feedback memory belongs
+to *this* session, not the target project — leave it alone.
+
+1. **Resolve the project memory dir.** The path is
+   `~/.claude/projects/<encoded-cwd>/memory/` where `<encoded-cwd>` replaces
+   each `:`, `\`, and `/` in the path with `-`. If the current repo is a
+   worktree, use the **main** project path, not the worktree path (per the
+   existing `feedback_memory_in_main_project` convention) — derive it from
+   `git rev-parse --git-common-dir` (strip the trailing `/.git*` segments).
+   Use Glob to confirm the dir exists; skip silently if not.
+
+2. **List candidates.** Glob `feedback_*.md` in that dir AND read `MEMORY.md`
+   (which is the index). Skip silently if no `feedback_*` files.
+
+3. **Match semantically against the just-persisted learning.** For each
+   feedback file, read its frontmatter `description` and the first ~10 body
+   lines. Same rule = same intent + same trigger condition + non-trivial
+   overlap with the rule we just wrote (not merely "same broad topic").
+   Be conservative — if in doubt, treat as non-match and skip.
+
+4. If 0 matches: produce no output, continue to Step 7.
+
+5. If 1+ matches: list them via AskUserQuestion (one question per match if
+   multiple, or `multiSelect` if the user wants to handle them in bulk). For
+   each, show the file name + description + which new file now owns the rule.
+   Options per match:
+   - **Löschen** (Recommended) — Regel lebt jetzt in `<new file>`
+   - **Behalten** — bleibt als persönliche Präferenz relevant
+   - **Erst vollständig anzeigen**
+
+6. For each chosen deletion:
+   - Delete the `feedback_*.md` file
+   - Remove its bullet line from `MEMORY.md` (Edit, not Write)
+   - Add the path to the Step 7 report
+
+Only target `feedback_*.md` files. **Never** touch `user_*`, `project_*`, or
+`reference_*` memories — those have different lifecycles and are not what
+the learn skill replaces.
+
+## Step 7 — Confirm and report
 
 After persisting, show the user:
 
@@ -220,11 +267,12 @@ After persisting, show the user:
 - The verbatim rule that was added
 - If a CLAUDE.md was touched: the `/devops-claude-md-lint` result for that file
   (don't re-count lines manually — relay the lint output)
+- If Step 6 deleted any feedback memories: list the removed file names
 
 For 5d issue creation: show the issue URL.
 For 5d prompt: show the copy-pastable block.
 
-## Step 7 — Completion Card
+## Step 8 — Completion Card
 
 Call `mcp__plugin_devops_dotclaude-completion__render_completion_card`:
 
@@ -248,8 +296,9 @@ write this skill performs.
 
 ## Rules
 
-- **Never** write to user feedback memory from this skill — that is a separate
-  channel handled by auto-memory.
+- **Never write** to user feedback memory from this skill — auto-memory owns
+  that channel. The skill **may delete** duplicate `feedback_*.md` entries
+  (Step 6) once the canonical rule is in place, with user confirmation.
 - **Always** prefer deep-knowledge > skill/extension > CLAUDE.md.
 - **Respect the soft caps** above; re-route to the next-larger container
   before busting CLAUDE.md or SKILL.md targets.

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.71.0",
+  "version": "0.72.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

- `/devops-learn` Step 6 prunes now-duplicate `feedback_*.md` auto-memory entries after persisting the canonical rule to its proper file (with `MEMORY.md` bullet removal, per-match user confirmation, conservative semantic matching)
- Step 6 resolves the main worktree path via `git worktree list --porcelain` (robust against core.worktree/bare/separate-git-dir/submodule layouts), encodes the canonical realpath, skips UNC silently
- Frontmatter `disable-model-invocation: true` removed as workaround for a Claude Code harness bug where the flag was applied too broadly, blocking user-typed slash commands AND the model's Skill-tool fallback — leaving only personal-memory writes as exit, exactly what the skill exists to prevent
- Rules section narrowed: "never create or update content" with explicit Step 6 carve-out

## Test plan
- [x] `npm run lint`
- [x] `npm test` (103 tests passing)
- [x] Codex review: 4 findings → 3 fixed inline (path resolution via `git worktree list --porcelain`, realpath/drive-case normalization, Rules wording), 1 acknowledged trade-off (`disable-model-invocation` removal — user-decided)
- [ ] Real-world: trigger `/devops-learn` on a learning that has an existing `feedback_*.md` duplicate; confirm AskUserQuestion offers deletion and `MEMORY.md` bullet is removed
- [ ] Upstream: file harness bug at anthropics/claude-code (slash-command dispatcher honoring `disable-model-invocation` too broadly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)