### PR TITLE
fix(concept): state-aware step 3 label (0.72.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.72.0"
+    "version": "0.72.1"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.72.0",
+      "version": "0.72.1",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.72.0",
+      "version": "0.72.1",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.72.1] — 2026-05-13
+
+### Fixed
+
+- **plugins/devops/skills/devops-concept/deep-knowledge/templates.md** — submitted-panel progress step 3 no longer shows the contradictory "Implementierung abgeschlossen" / ⏳ pairing while still mid-implementation. The `<li data-step="implemented">` now carries three sibling `<span class="step-label" data-state-label="…">` elements (`pending` / `active` / `done`) and the matching CSS rule `.status-steps li[data-state="X"] .step-label[data-state-label="X"] { display: inline; }` swaps the visible copy based on the li's `data-state`. Pending shows the existing `panel.step_waiting` ("Warten…" / "Waiting…"), active shows the new `panel.step_implemented_active` ("Implementierung läuft" / "Implementation in progress"), done keeps `panel.step_implemented` ("Implementierung abgeschlossen" / "Implementation complete"). `_setStep` stays icon-only — no JS change. Steps without `data-state-label` spans (the `submitted` and `received` rows) are unaffected because the visibility rule is scoped to `.step-label[data-state-label]`. Bug only surfaces in regenerated concept pages — existing HTML files retain the old static label
+
+### Changed
+
+- **plugins/devops/.claude-plugin/plugin.json** — version `0.72.0 → 0.72.1`
+
 ## [0.72.0] — 2026-05-13
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.72.0**
+**Version: 0.72.1**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.72.0",
+  "version": "0.72.1",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/skills/devops-concept/deep-knowledge/templates.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/templates.md
@@ -56,6 +56,7 @@ must see their own language. The locale hint is authoritative.
 | `panel.step_submitted`         | Submitted                      | Übermittelt |
 | `panel.step_received`          | Claude is processing           | Claude verarbeitet |
 | `panel.step_implemented`       | Implementation complete        | Implementierung abgeschlossen |
+| `panel.step_implemented_active`| Implementation in progress     | Implementierung läuft |
 | `panel.step_waiting`           | Waiting…                       | Warten… |
 | `panel.disconnected_title`     | Claude is not connected        | Claude ist nicht verbunden |
 | `panel.disconnected_hint`      | You can still submit — your click is queued and delivered as soon as Claude is back. | Du kannst trotzdem absenden — der Klick wird gespeichert und gesendet, sobald Claude wieder da ist. |
@@ -226,7 +227,8 @@ the `[ui-locale: ...]` hint produced.
           </li>
           <li data-step="implemented" data-state="pending" hidden>
             <span class="step-icon" aria-hidden="true">○</span>
-            <span class="step-label">{{panel.step_implemented}}</span>
+            <span class="step-label" data-state-label="active">{{panel.step_implemented_active}}</span>
+            <span class="step-label" data-state-label="done">{{panel.step_implemented}}</span>
           </li>
         </ol>
         <p class="submitted-hint">{{panel.submitted_hint}}</p>
@@ -783,7 +785,8 @@ The wiring is a single delegated click handler installed alongside
           </li>
           <li data-step="implemented" data-state="pending" hidden>
             <span class="step-icon" aria-hidden="true">○</span>
-            <span class="step-label">{{panel.step_implemented}}</span>
+            <span class="step-label" data-state-label="active">{{panel.step_implemented_active}}</span>
+            <span class="step-label" data-state-label="done">{{panel.step_implemented}}</span>
           </li>
         </ol>
         <p class="submitted-hint">{{panel.submitted_hint}}</p>
@@ -1671,6 +1674,20 @@ document.addEventListener('DOMContentLoaded', () => {
 @keyframes step-pulse {
   0%, 100% { opacity: 0.5; }
   50% { opacity: 1; }
+}
+/* State-dependent step labels. When an <li> carries multiple
+   .step-label[data-state-label] spans, only the one matching the li's
+   current data-state is visible. Used by the "implemented" step where
+   "Implementierung läuft" (active) reads differently than "Implementierung
+   abgeschlossen" (done). Steps without data-state-label spans are
+   unaffected — their plain .step-label stays visible always. */
+.status-steps li .step-label[data-state-label] {
+  display: none;
+}
+.status-steps li[data-state="pending"] .step-label[data-state-label="active"],
+.status-steps li[data-state="active"] .step-label[data-state-label="active"],
+.status-steps li[data-state="done"] .step-label[data-state-label="done"] {
+  display: inline;
 }
 
 /* Waiting dots animation */

--- a/plugins/devops/skills/devops-concept/deep-knowledge/templates.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/templates.md
@@ -227,6 +227,7 @@ the `[ui-locale: ...]` hint produced.
           </li>
           <li data-step="implemented" data-state="pending" hidden>
             <span class="step-icon" aria-hidden="true">○</span>
+            <span class="step-label" data-state-label="pending">{{panel.step_waiting}}</span>
             <span class="step-label" data-state-label="active">{{panel.step_implemented_active}}</span>
             <span class="step-label" data-state-label="done">{{panel.step_implemented}}</span>
           </li>
@@ -785,6 +786,7 @@ The wiring is a single delegated click handler installed alongside
           </li>
           <li data-step="implemented" data-state="pending" hidden>
             <span class="step-icon" aria-hidden="true">○</span>
+            <span class="step-label" data-state-label="pending">{{panel.step_waiting}}</span>
             <span class="step-label" data-state-label="active">{{panel.step_implemented_active}}</span>
             <span class="step-label" data-state-label="done">{{panel.step_implemented}}</span>
           </li>
@@ -1684,7 +1686,7 @@ document.addEventListener('DOMContentLoaded', () => {
 .status-steps li .step-label[data-state-label] {
   display: none;
 }
-.status-steps li[data-state="pending"] .step-label[data-state-label="active"],
+.status-steps li[data-state="pending"] .step-label[data-state-label="pending"],
 .status-steps li[data-state="active"] .step-label[data-state-label="active"],
 .status-steps li[data-state="done"] .step-label[data-state-label="done"] {
   display: inline;

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.72.0",
+  "version": "0.72.1",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary
Submitted-panel progress step 3 no longer shows "Implementierung abgeschlossen" together with the active (⏳) icon. The label is now state-bound:

- **pending** (○) → `panel.step_waiting` ("Warten…" / "Waiting…")
- **active** (⏳) → new `panel.step_implemented_active` ("Implementierung läuft" / "Implementation in progress")
- **done** (✓) → `panel.step_implemented` ("Implementierung abgeschlossen" / "Implementation complete")

Three sibling `<span data-state-label="…">` elements per li; CSS scopes visibility to the li's `data-state`. `_setStep` stays icon-only — no JS change. Other steps without `[data-state-label]` spans are unaffected.

## Test plan
- [x] `npm run lint` clean
- [x] `npm test` — 103/103 pass
- [x] Codex review — initial pending-state finding addressed in follow-up commit
- [ ] Next generated concept page in implement-action flow shows correct label per state

## Notes
Existing concept HTML files keep the old static label — regeneration required for the fix to surface there.