### PR TITLE
feat(non-vcs): repo-mode + guards + delivery docs (0.73.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.72.1"
+    "version": "0.73.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.72.1",
+      "version": "0.73.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.72.1",
+      "version": "0.73.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [0.73.0] — 2026-05-13
+
+### Added
+
+- **plugins/devops/mcp-server/ship/lib/repo-mode.js** — new lib exporting `detectRepoMode(cwd)` returning `"git" | "git-no-remote" | "none"` and `isGitRepo(cwd)`. Foundation for non-VCS / non-remote project support. No module-level cache: the MCP server is long-lived and stale repo-mode readings would silently break ship pipelines after `git init` / `git remote add`. Each call costs <5 ms (two `git rev-parse` invocations max)
+- **plugins/devops/mcp-server/ship/tools/preflight.js** — `repoMode === "none"` short-circuit returns a synthetic preflight result with `mode: "file-only"`, pseudo-branch `<file-only>`, and a cosmetic pseudo-commit derived from `floor(latestMtime/1000)` (SHA-1 short, depth-2 directory scan, ignores `.git`/`node_modules`). `git-no-remote` mode skips fetch / unpushed-count / base-ahead / file-overlap checks (all require `origin/` refs) and surfaces a warning instead of errors. New top-level `mode` field on the result so downstream tools can branch
+- **plugins/devops/mcp-server/ship/tools/release.js** — early-return for `repoMode === "none"` (`{ success: true, skipped: true, reason: "file-only-mode", delivered: "none" }`) and `"git-no-remote"` (`delivered: "local-commit-only"`). No `git push` / `gh pr create` attempted when there's nothing to push to. Result carries `mode` field
+- **plugins/devops/mcp-server/index.js** — new completion-card variant `ready-files` and a `state.mode === "file-only"` rendering branch in `renderState()` that emits `📂 files: N modified · delivered: <target>` instead of the branch/commit/pushed/merged segments. Misleading `state.branch || 'main'` fallback removed — empty branch now omits the branch segment entirely instead of fabricating `main`
+- **plugins/devops/hooks/user-prompt-submit/prompt.ship.detect.js** — `isGitRepo(cwd)` guard wraps the ship-instruction injection block (placed AFTER throttle / session-id detection so the cheap exits still happen first). In non-git directories the hook silently exits 0 instead of injecting a `MANDATORY Skill("devops-ship")` directive that would crash preflight downstream
+- **plugins/devops/hooks/user-prompt-submit/prompt.git.sync.js** — `isGitRepo(cwd)` guard wraps the `scripts/git-sync.js` spawn so non-git dirs no longer produce stderr noise on every user prompt. Both hooks duplicate the `isGitRepo()` helper inline (CommonJS) rather than importing the ESM `repo-mode.js` lib — intentional to avoid ESM/CJS interop in the hook path
+- **plugins/devops/skills/devops-commit/SKILL.md** — new **Step 0.5 — Repo-mode check** between the existing `disable-model-invocation` note and Step 1 intent detection. `git rev-parse --is-inside-work-tree` runs first; on non-zero exit the skill emits a structured abort message pointing to either `git init` or the new delivery-target extension in `.claude/skills/ship/reference.md`. Replaces the previous hard-crash on `git status` in non-git dirs
+- **plugins/devops/skills/devops-repo-health/SKILL.md** — new **Step 0 — Repo-mode check** before the SAFETY block. Same `git rev-parse --is-inside-work-tree` guard with a tailored abort message ("Repo health analysiert git-Branches/PRs/Worktrees — in einer Nicht-Git-Dir gibt es nichts zu prüfen")
+- **plugins/devops/deep-knowledge/skill-extension-guide.md** — new top-level `## Delivery targets` section with four worked examples for `{project}/.claude/skills/ship/reference.md`: `git+gh` (default, no extension), `ssh-rsync` (marked *future work* — schema stable but handler not yet implemented), `ha-rest` (marked *future work* — Home Assistant REST + `reload_core_config` planned), `none` (skip delivery entirely). Aligns terminology with `devops-ship/SKILL.md` Step 4a so consumers see consistent "future work" status across both files
+- **plugins/devops/skills/devops-ship/SKILL.md** — new **Step 4a — Delivery extension hook** after the squash-merge traceability section. Documents that `/devops-ship` reads `{project}/.claude/skills/ship/reference.md` for a `deliver:` field, dispatches to `git+gh` (default), `ssh-rsync` (future), `ha-rest` (future), or `none`. Explicit note that the two future handlers fall through to `none` in this release — the extension point is documented for forward compatibility so consumer reference.md files written today remain valid
+
+### Changed
+
+- **plugins/devops/mcp-server/ship/tools/version-bump.js** — "no manifest found" path changed from hard error (`{ success: false, error: ... }`) to soft skip (`{ success: true, skipped: true, reason: "no-manifest" }` for normal git repos, `reason: "no-manifest-in-file-only-mode"` for `repoMode === "none"`). Allows shipping docs-only / config-only repos without forcing a synthetic version manifest. Trade-off acknowledged: previously the hard error gated bad-state ships; consumers shipping git repos without manifests now get through silently — relying on the surrounding pipeline (preflight, build, release) to catch missing essentials
+- **plugins/devops/.claude-plugin/plugin.json** — version `0.72.1 → 0.73.0`
+
 ## [0.72.1] — 2026-05-13
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.72.1**
+**Version: 0.73.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.72.1",
+  "version": "0.73.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/deep-knowledge/skill-extension-guide.md
+++ b/plugins/devops/deep-knowledge/skill-extension-guide.md
@@ -128,9 +128,11 @@ Configure how `/devops-ship` delivers the release by setting a `deliver:` field 
 No extension needed. `/devops-ship` creates a PR via `gh`, merges it, and pushes the
 tag. This is the built-in behavior when no `deliver:` field is present.
 
-### 2. `ssh-rsync`
+### 2. `ssh-rsync` *(future work)*
 
-Copies build output to a remote server after the PR merges.
+Planned extension that will copy build output to a remote server after the PR merges.
+Currently the value is accepted but falls through to `none` — the documented schema is
+stable so consumer reference.md files can be authored now.
 
 ```yaml
 # .claude/skills/ship/reference.md
@@ -139,11 +141,12 @@ target: user@host:/var/www/app
 rsync_args: ["-az", "--delete"]
 ```
 
-Prerequisites: SSH key in `~/.ssh/` and host in `known_hosts`.
+Prerequisites (when implemented): SSH key in `~/.ssh/` and host in `known_hosts`.
 
-### 3. `ha-rest`
+### 3. `ha-rest` *(future work)*
 
-Pushes config to a Home Assistant instance after ship.
+Planned extension that will push config to a Home Assistant instance after ship.
+Currently the value is accepted but falls through to `none`.
 
 ```yaml
 # .claude/skills/ship/reference.md
@@ -152,8 +155,8 @@ base_url: http://homeassistant.local:8123
 token_env: HA_TOKEN
 ```
 
-After delivering, the consumer calls `POST /api/services/homeassistant/reload_core_config`.
-Canonical use case: shipping HA YAML configs managed in git.
+When implemented, the handler will `POST /api/services/homeassistant/reload_core_config`
+after upload. Canonical use case: shipping HA YAML configs managed in git.
 
 ### 4. `none`
 

--- a/plugins/devops/deep-knowledge/skill-extension-guide.md
+++ b/plugins/devops/deep-knowledge/skill-extension-guide.md
@@ -118,6 +118,48 @@ Every plugin skill starts with Step 0:
 - module:auth, module:dashboard, module:api
 ```
 
+## Delivery targets
+
+Configure how `/devops-ship` delivers the release by setting a `deliver:` field in
+`{project}/.claude/skills/ship/reference.md`.
+
+### 1. `git+gh` (default)
+
+No extension needed. `/devops-ship` creates a PR via `gh`, merges it, and pushes the
+tag. This is the built-in behavior when no `deliver:` field is present.
+
+### 2. `ssh-rsync`
+
+Copies build output to a remote server after the PR merges.
+
+```yaml
+# .claude/skills/ship/reference.md
+deliver: ssh-rsync
+target: user@host:/var/www/app
+rsync_args: ["-az", "--delete"]
+```
+
+Prerequisites: SSH key in `~/.ssh/` and host in `known_hosts`.
+
+### 3. `ha-rest`
+
+Pushes config to a Home Assistant instance after ship.
+
+```yaml
+# .claude/skills/ship/reference.md
+deliver: ha-rest
+base_url: http://homeassistant.local:8123
+token_env: HA_TOKEN
+```
+
+After delivering, the consumer calls `POST /api/services/homeassistant/reload_core_config`.
+Canonical use case: shipping HA YAML configs managed in git.
+
+### 4. `none`
+
+For projects that only edit files in-place with no delivery step. `deliver: none` makes
+`/devops-ship` skip Step 4a entirely.
+
 ## Agent extensions
 
 Same pattern applies to agents:

--- a/plugins/devops/hooks/user-prompt-submit/prompt.git.sync.js
+++ b/plugins/devops/hooks/user-prompt-submit/prompt.git.sync.js
@@ -11,10 +11,26 @@
 
 require('../lib/plugin-guard');
 
-const { execSync } = require('child_process');
+const { execSync, execFileSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
+
+/**
+ * Returns true if cwd is inside a git work tree.
+ * @param {string} cwd
+ * @returns {boolean}
+ */
+function isGitRepo(cwd) {
+  try {
+    execFileSync('git', ['rev-parse', '--is-inside-work-tree'], {
+      cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 const THROTTLE_FILE = path.join(os.tmpdir(), `dotclaude-devops-git-sync-${process.ppid}`);
 const THROTTLE_MS = 15 * 60 * 1000; // 15 minutes
@@ -31,6 +47,11 @@ try {
 
 // Update throttle timestamp immediately
 try { fs.writeFileSync(THROTTLE_FILE, Date.now().toString()); } catch {}
+
+// Guard: skip in non-git directories
+if (!isGitRepo(process.cwd())) {
+  process.exit(0);
+}
 
 // Delegate to shared sync script
 const scriptPath = path.resolve(__dirname, '../../scripts/git-sync.js');

--- a/plugins/devops/hooks/user-prompt-submit/prompt.ship.detect.js
+++ b/plugins/devops/hooks/user-prompt-submit/prompt.ship.detect.js
@@ -12,7 +12,24 @@
 
 require('../lib/plugin-guard');
 
+const { execFileSync } = require('child_process');
 const { readSessionFile } = require('../lib/session-id');
+
+/**
+ * Returns true if cwd is inside a git work tree.
+ * @param {string} cwd
+ * @returns {boolean}
+ */
+function isGitRepo(cwd) {
+  try {
+    execFileSync('git', ['rev-parse', '--is-inside-work-tree'], {
+      cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 let inputData = '';
 process.stdin.setEncoding('utf8');
@@ -90,6 +107,11 @@ process.stdin.on('end', () => {
     if (cacheWarning) {
       process.stdout.write(cacheWarning + '\n');
     }
+    process.exit(0);
+  }
+
+  // --- Guard: skip injection in non-git directories ---
+  if (!isGitRepo(process.cwd())) {
     process.exit(0);
   }
 

--- a/plugins/devops/mcp-server/index.js
+++ b/plugins/devops/mcp-server/index.js
@@ -175,6 +175,7 @@ function renderUsageMeterForCard(usageData, delta5h, deltaWk, healthLine) {
 const VARIANTS = {
   'ship-successful': { usage: true,  changes: true,  tests: true,  state: true,  userTest: false, userFinalTest: true  },
   ready:             { usage: true,  changes: true,  tests: true,  state: true,  userTest: false, userFinalTest: true  },
+  'ready-files':     { usage: true,  changes: true,  tests: true,  state: true,  userTest: false, userFinalTest: true  },
   'ship-blocked':    { usage: true,  changes: true,  tests: true,  state: true,  userTest: false, userFinalTest: true  },
   test:              { usage: true,  changes: true,  tests: true,  state: true,  userTest: true,  userFinalTest: true  },
   'test-minimal':    { usage: false, changes: false, tests: false, state: false, userTest: false, userFinalTest: false },
@@ -284,6 +285,12 @@ function renderState(state, variant, repoUrl) {
     return '';
   }
 
+  if (state.mode === 'file-only') {
+    const filesModified = state.filesModified || 0;
+    const delivered = state.delivered || 'none';
+    return '\ud83d\udcc2 files: ' + filesModified + ' modified \u00b7 delivered: ' + delivered;
+  }
+
   let icon;
   if (state.merged)                            icon = '\u2705';
   else if (state.appStatus === 'running')      icon = '\ud83d\udfe2';
@@ -292,7 +299,7 @@ function renderState(state, variant, repoUrl) {
   else if (state.pushed)                       icon = '\u2705';
   else                                         icon = '\u2796';
 
-  const branch = state.branch || 'main';
+  const branch = state.branch || '';
   const branchLabel = branch + (state.worktree ? ' (worktree)' : '');
   const branchStr = repoUrl
     ? '[`' + branchLabel + '`](' + repoUrl + '/tree/' + branch + ')'
@@ -331,7 +338,7 @@ function renderState(state, variant, repoUrl) {
   const segments = [mergeStr, prStr];
   if (!state.merged) segments.push(pushStr);
   segments.push(commitStr);
-  if (!(state.merged && rawBranch && state.merged === rawBranch)) segments.push(branchStr);
+  if (branch && !(state.merged && rawBranch && state.merged === rawBranch)) segments.push(branchStr);
   let line = icon + ' ' + segments.join(' \u00b7 ');
 
   if (state.appStatus === 'running')     line += ' \u00b7 app running';

--- a/plugins/devops/mcp-server/ship/lib/repo-mode.js
+++ b/plugins/devops/mcp-server/ship/lib/repo-mode.js
@@ -1,32 +1,25 @@
 import { execFileSync } from "node:child_process"
 
-const cache = new Map()
+// No cache: long-lived MCP server could see git init / remote changes
+// between calls. Each detectRepoMode runs <5ms; staleness is the bigger risk.
 
 export function detectRepoMode(cwd) {
-  if (cache.has(cwd)) return cache.get(cwd)
-
-  let mode
   try {
     execFileSync("git", ["rev-parse", "--is-inside-work-tree"], {
       cwd, encoding: "utf8", stdio: "ignore",
     })
   } catch {
-    mode = "none"
-    cache.set(cwd, mode)
-    return mode
+    return "none"
   }
 
   try {
     execFileSync("git", ["remote", "get-url", "origin"], {
       cwd, encoding: "utf8", stdio: "ignore",
     })
-    mode = "git"
+    return "git"
   } catch {
-    mode = "git-no-remote"
+    return "git-no-remote"
   }
-
-  cache.set(cwd, mode)
-  return mode
 }
 
 export function isGitRepo(cwd) {

--- a/plugins/devops/mcp-server/ship/lib/repo-mode.js
+++ b/plugins/devops/mcp-server/ship/lib/repo-mode.js
@@ -1,0 +1,35 @@
+import { execFileSync } from "node:child_process"
+
+const cache = new Map()
+
+export function detectRepoMode(cwd) {
+  if (cache.has(cwd)) return cache.get(cwd)
+
+  let mode
+  try {
+    execFileSync("git", ["rev-parse", "--is-inside-work-tree"], {
+      cwd, encoding: "utf8", stdio: "ignore",
+    })
+  } catch {
+    mode = "none"
+    cache.set(cwd, mode)
+    return mode
+  }
+
+  try {
+    execFileSync("git", ["remote", "get-url", "origin"], {
+      cwd, encoding: "utf8", stdio: "ignore",
+    })
+    mode = "git"
+  } catch {
+    mode = "git-no-remote"
+  }
+
+  cache.set(cwd, mode)
+  return mode
+}
+
+export function isGitRepo(cwd) {
+  const mode = detectRepoMode(cwd)
+  return mode === "git" || mode === "git-no-remote"
+}

--- a/plugins/devops/mcp-server/ship/tools/preflight.js
+++ b/plugins/devops/mcp-server/ship/tools/preflight.js
@@ -4,14 +4,41 @@
  */
 
 import { z } from "zod";
+import { createHash } from "node:crypto";
+import { readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
 import { git, currentBranch, dirtyState, commitsAhead, unpushedCommits, isWorktree, detectParentBranch, detectDefaultBranch, branchExists, fileOverlap, getConfig } from "../lib/git.js";
 import { readVersion, verifyVersionFiles } from "../lib/version.js";
 import { writeSentinel } from "../lib/sentinel.js";
+import { detectRepoMode } from "../lib/repo-mode.js";
 
 export const schema = z.object({
   base: z.string().optional().describe("Base branch to ship into. Omit to auto-detect: parent branch (from sub-branch naming) or the repository's default branch (origin/HEAD, typically 'main' or 'master')."),
   cwd: z.string().describe("Working directory of the target repo (required — must be passed by the caller)"),
 });
+
+function latestMtime(dir, depth) {
+  let max = 0
+  let entries
+  try { entries = readdirSync(dir) } catch { return max }
+  for (const name of entries) {
+    if (name === ".git" || name === "node_modules") continue
+    const full = join(dir, name)
+    let st
+    try { st = statSync(full) } catch { continue }
+    if (st.mtimeMs > max) max = st.mtimeMs
+    if (depth > 0 && st.isDirectory()) {
+      const child = latestMtime(full, depth - 1)
+      if (child > max) max = child
+    }
+  }
+  return max
+}
+
+function pseudoCommit(mtimeMs) {
+  const ts = Math.floor(mtimeMs / 1000)
+  return createHash("sha1").update("mtime-" + ts).digest("hex").slice(0, 7)
+}
 
 export async function handler(params) {
   let { base } = params;
@@ -20,6 +47,34 @@ export async function handler(params) {
   const opts = { cwd };
   const checks = [];
   const errors = [];
+
+  const repoMode = detectRepoMode(cwd)
+
+  // file-only: not a git repo — return synthetic preflight result immediately
+  if (repoMode === "none") {
+    const mtime = latestMtime(cwd, 2)
+    const commit = pseudoCommit(mtime)
+    return {
+      ready: true,
+      mode: "file-only",
+      branch: "<file-only>",
+      base: null,
+      autoDetectedBase: null,
+      intermediate: false,
+      ahead: null,
+      unpushed: null,
+      inWorktree: false,
+      needsRebase: false,
+      version: null,
+      projectType: null,
+      checks: [{ name: "repo-mode", value: "none", ok: true }],
+      warnings: [],
+      errors: [],
+      commit,
+    }
+  }
+
+  const noRemote = repoMode === "git-no-remote"
 
   // 1. Current branch
   const branch = currentBranch(opts);
@@ -78,51 +133,60 @@ export async function handler(params) {
   }
   checks.push({ name: "clean-tree", ok: !state.dirty, modified: state.modified.length, untracked: state.untracked.length });
 
-  // 5. Fetch base from origin to ensure accurate commit count
-  git(`fetch origin ${base}`, opts);
+  // 5. Fetch base from origin to ensure accurate commit count (skip when no remote)
+  if (!noRemote) git(`fetch origin ${base}`, opts);
 
   // 6. Commits ahead (compare against origin/ ref for accuracy)
   const originBase = `origin/${base}`;
-  const ahead = commitsAhead(baseExists === "remote" || baseExists === "local" ? originBase : base, opts);
+  const aheadRef = !noRemote && (baseExists === "remote" || baseExists === "local") ? originBase : base;
+  const ahead = commitsAhead(aheadRef, opts);
   if (ahead === 0) {
     errors.push(`No commits ahead of ${base} — nothing to ship`);
   }
   checks.push({ name: "commits-ahead", value: ahead, ok: ahead > 0 });
 
-  // 7. Unpushed commits (hard gate — must be 0 before shipping)
-  const unpushed = unpushedCommits(opts);
-  if (unpushed !== null && unpushed > 0) {
+  // 7. Unpushed commits (hard gate — must be 0 before shipping; skip when no remote)
+  const unpushed = noRemote ? null : unpushedCommits(opts);
+  if (!noRemote && unpushed !== null && unpushed > 0) {
     errors.push(`${unpushed} unpushed commit(s) — push before shipping`);
   }
-  checks.push({ name: "all-pushed", value: unpushed, ok: unpushed === 0 || unpushed === null });
+  checks.push({ name: "all-pushed", value: unpushed, ok: unpushed === 0 || unpushed === null, ...(noRemote && { skipped: true, reason: "no-remote" }) });
 
-  // 8. Base branch ahead check (warning — resolved autonomously by ship skill)
-  const baseBehindCount = (() => {
-    const count = git(`rev-list --count HEAD..${originBase}`, opts);
-    return count ? parseInt(count, 10) : 0;
-  })();
-  checks.push({
-    name: "base-ahead",
-    value: baseBehindCount,
-    ok: baseBehindCount === 0,
-    ...(baseBehindCount > 0 && { warning: `Base branch '${base}' is ${baseBehindCount} commit(s) ahead — rebase will be handled automatically` }),
-  });
-
-  // 9. File overlap detection (warning — resolved autonomously by ship skill)
-  const overlap = fileOverlap(originBase, opts);
-  if (overlap.overlap.length > 0) {
+  // 8. Base branch ahead check (skip when no remote — nothing to compare against)
+  if (!noRemote) {
+    const baseBehindCount = (() => {
+      const count = git(`rev-list --count HEAD..${originBase}`, opts);
+      return count ? parseInt(count, 10) : 0;
+    })();
     checks.push({
-      name: "file-overlap",
-      ok: false,
-      count: overlap.overlap.length,
-      files: overlap.overlap.slice(0, 20),
-      totalBranchFiles: overlap.branchFiles.length,
-      totalBaseFiles: overlap.baseFiles.length,
-      mergeBase: overlap.mergeBase?.slice(0, 8),
-      warning: `${overlap.overlap.length} file(s) modified in both branches — will be resolved during rebase`,
+      name: "base-ahead",
+      value: baseBehindCount,
+      ok: baseBehindCount === 0,
+      ...(baseBehindCount > 0 && { warning: `Base branch '${base}' is ${baseBehindCount} commit(s) ahead — rebase will be handled automatically` }),
     });
   } else {
-    checks.push({ name: "file-overlap", ok: true, count: 0 });
+    checks.push({ name: "base-ahead", value: 0, ok: true, skipped: true, reason: "no-remote" });
+  }
+
+  // 9. File overlap detection (skip when no remote — no origin ref to compare)
+  if (!noRemote) {
+    const overlap = fileOverlap(originBase, opts);
+    if (overlap.overlap.length > 0) {
+      checks.push({
+        name: "file-overlap",
+        ok: false,
+        count: overlap.overlap.length,
+        files: overlap.overlap.slice(0, 20),
+        totalBranchFiles: overlap.branchFiles.length,
+        totalBaseFiles: overlap.baseFiles.length,
+        mergeBase: overlap.mergeBase?.slice(0, 8),
+        warning: `${overlap.overlap.length} file(s) modified in both branches — will be resolved during rebase`,
+      });
+    } else {
+      checks.push({ name: "file-overlap", ok: true, count: 0 });
+    }
+  } else {
+    checks.push({ name: "file-overlap", ok: true, count: 0, skipped: true, reason: "no-remote" });
   }
 
   // 10. Git config check (warning — auto-fixed by ship skill)
@@ -158,6 +222,7 @@ export async function handler(params) {
 
   // Collect warnings from checks (non-blocking issues resolved autonomously)
   const warnings = checks.filter(c => c.warning).map(c => c.warning);
+  if (noRemote) warnings.push("No origin remote — push, PR creation, and merge will be skipped");
 
   // Determine if rebase is needed (any merge-safety warnings present)
   const needsRebase = checks.some(c =>
@@ -173,6 +238,7 @@ export async function handler(params) {
 
   return {
     ready,
+    mode: repoMode,
     branch,
     base,
     autoDetectedBase,

--- a/plugins/devops/mcp-server/ship/tools/preflight.js
+++ b/plugins/devops/mcp-server/ship/tools/preflight.js
@@ -35,6 +35,8 @@ function latestMtime(dir, depth) {
   return max
 }
 
+// Cosmetic-only: used in completion-card display for file-only mode.
+// NOT a stable identity token — collisions within 1s, depth limited to 2.
 function pseudoCommit(mtimeMs) {
   const ts = Math.floor(mtimeMs / 1000)
   return createHash("sha1").update("mtime-" + ts).digest("hex").slice(0, 7)

--- a/plugins/devops/mcp-server/ship/tools/release.js
+++ b/plugins/devops/mcp-server/ship/tools/release.js
@@ -7,6 +7,7 @@ import { z } from "zod";
 import { execFileSync } from "node:child_process";
 import { git, gitStrict, currentBranch, headShort, dirtyState, isWorktree, isRebasedOnto, fileOverlap } from "../lib/git.js";
 import { createPR, mergePR, createRelease, findExistingPR } from "../lib/github.js";
+import { detectRepoMode } from "../lib/repo-mode.js";
 
 export const schema = z.object({
   base: z.string().default("main").describe("Base branch for PR (may be a feature branch for intermediate merges)"),
@@ -25,9 +26,18 @@ export async function handler(params) {
   const cwd = params.cwd;
   if (!cwd) throw new Error("cwd is required — MCP server runs in the plugin directory, not the target repo");
   const opts = { cwd };
+
+  const repoMode = detectRepoMode(cwd)
+  if (repoMode === "none") {
+    return { success: true, skipped: true, reason: "file-only-mode", delivered: "none" }
+  }
+  if (repoMode === "git-no-remote") {
+    return { success: true, skipped: true, reason: "no-remote", delivered: "local-commit-only" }
+  }
+
   const branch = currentBranch(opts);
   const intermediate = base !== "main";
-  const result = { branch, base, intermediate };
+  const result = { branch, base, intermediate, mode: repoMode };
 
   try {
     // Optional: commit version-bumped files

--- a/plugins/devops/mcp-server/ship/tools/version-bump.js
+++ b/plugins/devops/mcp-server/ship/tools/version-bump.js
@@ -5,6 +5,7 @@
 
 import { z } from "zod";
 import { readVersion, bumpVersion, updateVersionFiles, verifyVersionFiles } from "../lib/version.js";
+import { detectRepoMode } from "../lib/repo-mode.js";
 
 export const schema = z.object({
   bump: z.enum(["patch", "minor", "major", "none"]).describe("Semantic version bump type"),
@@ -19,10 +20,10 @@ export async function handler(params) {
   // Read current version
   const { version: vOld, type: projectType, file: sourceFile } = readVersion(cwd);
   if (!vOld) {
-    return {
-      success: false,
-      error: "No version file found (no plugin.json or package.json)",
-    };
+    if (detectRepoMode(cwd) === "none") {
+      return { success: true, skipped: true, reason: "no-manifest-in-file-only-mode", version: null };
+    }
+    return { success: true, skipped: true, reason: "no-manifest" };
   }
 
   // Skip if no bump

--- a/plugins/devops/skills/devops-commit/SKILL.md
+++ b/plugins/devops/skills/devops-commit/SKILL.md
@@ -27,6 +27,23 @@ explicit user commands (`/devops-commit`), never by model initiative. Extensions
 still loaded and merged normally — `disable-model-invocation` only controls
 trigger behavior, not extension resolution.
 
+## Step 0.5 — Repo-mode check
+
+Before any git command, verify this directory is a git repository:
+
+```bash
+git rev-parse --is-inside-work-tree
+```
+
+If this fails (exit != 0), abort with a structured message:
+
+> Dieses Verzeichnis ist nicht versioniert. `/devops-commit` requires git.
+> Options:
+> - `git init` to start version control here
+> - Or configure a non-git delivery target in `.claude/skills/ship/reference.md` (see skill-extension-guide.md -> Delivery targets)
+
+Do NOT proceed with any git command. End the skill.
+
 ## Step 1 — Detect intent
 
 - **Amend**: user says "amend", "update last commit", "fix last commit" → amend flow in Step 8

--- a/plugins/devops/skills/devops-repo-health/SKILL.md
+++ b/plugins/devops/skills/devops-repo-health/SKILL.md
@@ -16,6 +16,20 @@ allowed-tools: Bash(git *), Bash(gh *), Bash(start *), Bash(cmd *), Read, Write,
 Analyze the repository for branch hygiene, unmerged work, and cleanup opportunities.
 Present results as an interactive concept page with filters and decision controls.
 
+## Step 0 — Repo-mode check
+
+Before any git command, verify this directory is a git repository:
+
+```bash
+git rev-parse --is-inside-work-tree
+```
+
+If this fails (exit != 0), abort:
+
+> Repo health analysiert git-Branches/PRs/Worktrees — in einer Nicht-Git-Dir gibt es nichts zu pruefen. Aborting.
+
+Do NOT proceed. End the skill.
+
 ## SAFETY: Worktree Branch Protection
 
 **HARD RULE — no exceptions:**

--- a/plugins/devops/skills/devops-ship/SKILL.md
+++ b/plugins/devops/skills/devops-ship/SKILL.md
@@ -233,6 +233,23 @@ Feature: Video filters (end-to-end)
 
 This preserves the audit trail through squash-merges. Without these references, `git log` on main only shows one commit with no link back to the sub-branch work.
 
+### Step 4a — Delivery extension hook
+
+After `ship_release` succeeds, check `{project}/.claude/skills/ship/reference.md` for a
+`deliver:` field:
+
+- **Default (`git+gh` or field absent):** existing behavior — PR + merge already done in Step 4.
+- **`ssh-rsync`:** rsync build output to the configured `target`. (Future work — currently falls through to `none`.)
+- **`ha-rest`:** POST to Home Assistant REST API at `base_url`. (Future work — currently falls through to `none`.)
+- **`none`:** skip delivery entirely.
+
+When `deliver` is set, the MCP `ship_release` tool dispatches to the corresponding
+handler. Handlers `ssh-rsync` and `ha-rest` are extension points documented for
+consumer configuration — not yet implemented in this release (they fall through to
+`none` intentionally).
+
+See `deep-knowledge/skill-extension-guide.md -> Delivery targets` for reference.md examples.
+
 ## Step 5 — Cleanup
 
 **If in a worktree**: call `ExitWorktree(action: "remove")` FIRST to release the CWD lock.

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.72.1",
+  "version": "0.73.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

Adds non-VCS / non-remote support across the ship pipeline so the plugin works in projects that are not git repos (e.g. Home Assistant config dirs) or git repos without an `origin` remote.

## Changes

- **New `repo-mode.js` lib** — `detectRepoMode(cwd)` returns `"git" | "git-no-remote" | "none"`; `isGitRepo(cwd)` derived from it. No cache (long-lived MCP server staleness risk).
- **Ship pipeline degrades gracefully** — `preflight` short-circuits to a synthetic `mode: "file-only"` result for non-git dirs; `git-no-remote` skips fetch/unpushed/base-ahead/file-overlap checks. `release` early-returns with `skipped: true` for both non-git and no-remote. `version-bump` soft-skips missing manifests instead of hard-erroring.
- **Hook guards** — `prompt.ship.detect.js` and `prompt.git.sync.js` exit silently in non-git dirs (no MANDATORY-ship injection, no stderr noise on every prompt).
- **Skill guards** — `/devops-commit` and `/devops-repo-health` gain a Step-0 `git rev-parse --is-inside-work-tree` check with a structured abort message instead of crashing on the first `git` call.
- **Completion-card `file-only` variant** — `mcp-server/index.js` renders `📂 files: N modified · delivered: <target>` when `state.mode === "file-only"`. Removed the misleading `branch || 'main'` fallback.
- **Delivery extension docs** — new `## Delivery targets` section in `skill-extension-guide.md` and a `Step 4a` in `devops-ship/SKILL.md` documenting the `deliver:` extension hook (`git+gh` default · `ssh-rsync` future · `ha-rest` future · `none`). Schema stable, handlers `ssh-rsync` / `ha-rest` fall through to `none` in this release.

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` 103/103 passed
- [x] `repo-mode.js` smoke: `detectRepoMode(repoRoot) === "git"`, `detectRepoMode(os.tmpdir()) === "none"`
- [x] Hook guards smoke: both hooks exit 0 in tmpdir, normal path still triggers in git repo
- [x] Codex review addressed (cache removal, doc alignment, pseudo-commit caveat)
