### PR TITLE
feat(concept): speech-bubble feedback dock (0.75.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.74.0"
+    "version": "0.75.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.74.0",
+      "version": "0.75.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.74.0",
+      "version": "0.75.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.75.0] — 2026-05-14
+
+### Changed
+
+- **plugins/devops/skills/devops-concept/deep-knowledge/templates.md** — prototype-template feedback dock redesigned from a full-width bottom bar into a speech-bubble overlay anchored to the 💬 FAB. Geometry: `left: 2rem` (FAB-aligned), `right: calc(2rem + 56px + 1rem)` (reserves the ☰ Menü-FAB area), `bottom: calc(2rem + 56px - 6px)` (sits directly above the FAB with a hair of overlap so the bubble reads as growing out of the FAB), `padding-left: 80px` (content starts beside the FAB, never behind it), `border-radius: 18px`, soft pop-in animation with `transform-origin` anchored at the FAB centre. Mobile breakpoint (≤560px) lifts the bubble fully above the FAB instead of overlapping, so phones don't squeeze the inner content column. The 💬 FAB itself gets `z-index: 220` so it stays visible AND clickable while the dock is open — clicking it toggles open↔close.
+- **plugins/devops/skills/devops-concept/deep-knowledge/templates.md** — close button changed from `✕` to `−` (minimise) with `aria-label="{{panel.minimize}}"`. The button is a *minimise*, not a destroy: dock textarea content is preserved in localStorage across close/reopen cycles. Locale table gains new key `panel.minimize` (Minimize / Minimieren).
+- **plugins/devops/skills/devops-concept/deep-knowledge/templates.md** — accessibility polish on the 💬 FAB toggle: `aria-expanded` reflects open/closed state, and `aria-label` swaps between two strings via new `data-label-open` / `data-label-close` data attributes (so screen-reader users hear "Feedback öffnen" when closed and "Minimieren" when open). `closeDock()` restores focus to the FAB when the close originated from inside the dock (previously the dock disappeared via `display: none` and left focus orphaned on a detached element)
+- **plugins/devops/skills/devops-concept/SKILL.md** — "Prototype Feedback Dock" section rewritten to describe the speech-bubble + minimise semantics
+- **plugins/devops/.claude-plugin/plugin.json** — version `0.74.0 → 0.75.0`
+
 ## [0.74.0] — 2026-05-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.74.0**
+**Version: 0.75.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.74.0",
+  "version": "0.75.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/skills/devops-concept/SKILL.md
+++ b/plugins/devops/skills/devops-concept/SKILL.md
@@ -251,14 +251,18 @@ findings I marked Miteinbeziehen").
 
 ### Prototype Feedback Dock
 
-The prototype template has no tri-state. Instead, a collapsible **feedback
-dock** at the bottom of the viewport holds structured feedback:
+The prototype template has no tri-state. Instead, a **speech-bubble feedback
+dock** anchored to the 💬 FAB (bottom-left) holds structured feedback:
 
 - A top-level textarea for general notes on the prototype
 - One textarea per `<section data-screen>` inside the active iteration,
   auto-populated by the dock (label = `data-nav-label` of that screen)
 
-The dock is toggled via a floating action button (bottom-left). See
+The dock is toggled via the 💬 FAB. The FAB stays visible AND clickable
+while the dock is open (clicking it toggles closed again), and the dock's
+right edge stops before the ☰ Menü-FAB so decisions remain reachable
+during feedback. The close button is a **minimise** (`−`), not a destroy:
+text content stays intact in `localStorage` when the dock is closed. See
 `deep-knowledge/templates.md` § Template: prototype for the full HTML/CSS/JS.
 
 ### Reload Resilience

--- a/plugins/devops/skills/devops-concept/deep-knowledge/templates.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/templates.md
@@ -5,7 +5,7 @@ Three page-level **templates** (layout modes) cover every concept use case:
 | Template | Layout | When to use |
 |---|---|---|
 | **decision** | Sidebar (~80/~20), multi-variant cards | Multi-option evaluation, trade-offs, architecture or tech decisions — the canonical "pick one" flow with bi-state (Verwerfen / Miteinbeziehen) per variant and multiple iterations |
-| **prototype** | Fullscreen content + overlay decision panel (FAB-toggled, right) + collapsible feedback dock (bottom, per-screen comments) | UI mockups, wireframes, visual design concepts, click-through flows — one artefact that needs maximum screen real estate, plus structured per-screen feedback |
+| **prototype** | Fullscreen content + overlay decision panel (☰ FAB right) + speech-bubble feedback dock anchored to the 💬 FAB (bottom-left), stops before the ☰ FAB so both stay clickable | UI mockups, wireframes, visual design concepts, click-through flows — one artefact that needs maximum screen real estate, plus structured per-screen feedback |
 | **free** | Sidebar (~80/~20), freeform body content | Analysis, walkthrough, brainstorm, explainer, timeline — structured content without forced variant framing. Bi-state evaluation is optional (opt-in per section) |
 
 **Content variants (analysis, plan, concept, comparison, dashboard, creative)
@@ -68,6 +68,7 @@ must see their own language. The locale hint is authoritative.
 | `panel.empty_implement_confirm`| Nothing was changed. Implement with feedback anyway? Claude will still write code. | Du hast nichts geändert. Trotzdem mit Feedback implementieren? Claude schreibt dann Code. |
 | `panel.toggle_open`            | Open decisions                 | Entscheidungen öffnen |
 | `panel.close`                  | Close                          | Schliessen |
+| `panel.minimize`               | Minimize                       | Minimieren |
 | `variant.include`              | Include                        | Miteinbeziehen |
 | `variant.discard`              | Discard                        | Verwerfen |
 | `iteration.label`              | Iterations                     | Iterationen |
@@ -796,13 +797,19 @@ The wiring is a single delegated click handler installed alongside
     </aside>
     <div class="panel-backdrop" id="panel-backdrop"></div>
 
-    <!-- Feedback dock (💬) — context-sensitive.
+    <!-- Feedback dock (💬) — context-sensitive Speech-Bubble overlay.
+         Anchored to the 💬 FAB (bottom-left): the FAB stays visible and
+         clickable, the dock floats above/around it like a chat bubble.
+         The right edge stops before the ☰ Menü-FAB so the user can still
+         reach decisions while the dock is open.
+         The close button minimises (does not destroy state) — user input
+         is preserved on close, no value is lost.
          * Top: ONE textarea for the active screen (swapped on navigation).
          * Bottom: ONE textarea for general notes, always visible. -->
     <aside class="feedback-dock" id="feedback-dock" data-open="false">
       <div class="feedback-dock-header">
         <strong>Feedback</strong>
-        <button id="feedback-close" class="feedback-close-btn" aria-label="{{panel.close}}">✕</button>
+        <button id="feedback-close" class="feedback-close-btn" aria-label="{{panel.minimize}}" title="{{panel.minimize}}">−</button>
       </div>
       <div class="feedback-section">
         <label>Aktueller Screen: <strong id="dock-screen-label">Welcome</strong></label>
@@ -895,8 +902,10 @@ section[data-screen][hidden] { display: none; }
 .feedback-fab { bottom: 2rem; left: 2rem; background: var(--warning-color, #d29922); }
 .panel-fab:hover,
 .feedback-fab:hover { transform: scale(1.1); }
-.panel-fab.hidden,
-.feedback-fab.hidden { opacity: 0; pointer-events: none; }
+/* Only the ☰ panel FAB hides when its panel opens (the decision panel is
+   a full overlay). The 💬 feedback FAB stays visible while the dock is
+   open so the user can toggle it back closed via the same FAB. */
+.panel-fab.hidden { opacity: 0; pointer-events: none; }
 
 .panel-close-btn,
 .feedback-close-btn {
@@ -934,17 +943,73 @@ section[data-screen][hidden] { display: none; }
 .screen-nav-item .screen-idx { color: var(--accent-color); font-weight: 600; margin-right: 0.5rem; }
 .screen-nav-item .has-notes { color: var(--warning-color); font-size: 0.75rem; }
 
-/* ── Feedback Dock (bottom, collapsible, context-sensitive) ── */
+/* ── Feedback Dock — Speech-Bubble anchored to the 💬 FAB ──
+   Geometry:
+   * left = FAB.left (2rem)               → bubble's left edge aligns with FAB
+   * right = FAB.right + 56 + 1rem        → reserves the ☰ Menü-FAB area
+   * bottom = FAB.bottom + 56 + 6px       → bubble sits directly above the FAB
+                                            with a hair of overlap so the
+                                            visual connection reads as "the
+                                            bubble grows out of the FAB".
+   * padding-left = 80px                  → input fields start to the right
+                                            of where the FAB visually lives,
+                                            so labels/textareas never sit
+                                            behind it (the FAB stays clickable
+                                            on top via higher z-index).
+   The FAB keeps its z-index above the dock so it remains visible and
+   clickable while the dock is open — clicking the FAB toggles the dock. */
 .feedback-dock {
-  position: fixed; left: 0; right: 0; bottom: -100%; max-height: 70vh;
-  padding: 1.5rem; background: var(--panel-bg, #161b22);
-  border-top: 1px solid var(--border-color, #30363d);
-  box-shadow: 0 -6px 20px rgba(0,0,0,0.35); z-index: 180; overflow-y: auto;
-  transition: bottom 0.3s ease;
-  display: flex; flex-direction: column; gap: 1.25rem;
+  position: fixed;
+  left: 2rem;
+  right: calc(2rem + 56px + 1rem);
+  bottom: calc(2rem + 56px - 6px);
+  max-height: min(60vh, 520px);
+  padding: 1.25rem 1.5rem 1.5rem 80px;
+  background: var(--panel-bg, #161b22);
+  border: 1px solid var(--border-color, #30363d);
+  border-radius: 18px;
+  box-shadow: 0 12px 32px rgba(0,0,0,0.45), 0 2px 6px rgba(0,0,0,0.25);
+  z-index: 180;
+  overflow-y: auto;
+  display: none;
+  flex-direction: column;
+  gap: 1.1rem;
+  transform-origin: 28px calc(100% + 22px); /* anchor: 💬 FAB centre below dock-bottom-left */
 }
-.feedback-dock[data-open="true"] { bottom: 0; }
-.feedback-dock-header { display: flex; justify-content: space-between; align-items: center; }
+.feedback-dock[data-open="true"] {
+  display: flex;
+  animation: feedback-dock-in 0.22s cubic-bezier(0.2, 0.9, 0.3, 1.2);
+}
+@keyframes feedback-dock-in {
+  from { opacity: 0; transform: translateY(8px) scale(0.94); }
+  to   { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+/* FAB sits above the dock so it stays visible AND clickable while the dock
+   is open. The dock's bottom edge overlaps the FAB's top edge by ~6px, so
+   the bubble visually reads as growing out of the FAB. */
+.feedback-fab { z-index: 220; }
+
+.feedback-dock-header {
+  display: flex; justify-content: space-between; align-items: center;
+  margin-bottom: 0.25rem;
+}
+.feedback-dock-header strong { font-size: 1rem; }
+
+/* Minimise button — visual cue is the underscore-low minus, not an ✕,
+   so the user understands their text is preserved (not destroyed). */
+.feedback-close-btn {
+  background: none; border: none; cursor: pointer;
+  color: var(--text-secondary, #8b949e);
+  font-size: 1.6rem; line-height: 1; font-weight: 500;
+  padding: 0 0.4rem 0.2rem; border-radius: 6px;
+  transition: background 0.15s, color 0.15s;
+}
+.feedback-close-btn:hover {
+  background: color-mix(in srgb, var(--text-color) 12%, transparent);
+  color: var(--text-color, #c9d1d9);
+}
+
 .feedback-section { display: flex; flex-direction: column; gap: 0.4rem; }
 .feedback-section label { font-size: 0.9rem; color: var(--text-secondary); font-weight: 500; }
 .feedback-section label strong { color: var(--accent-color); }
@@ -956,6 +1021,19 @@ section[data-screen][hidden] { display: none; }
 }
 .feedback-section textarea:focus { outline: none; border-color: var(--accent-color); }
 .feedback-divider { height: 1px; background: var(--border-color); margin: 0.25rem 0; }
+
+/* Narrow viewports: drop the padding-left reservation for the FAB and
+   let the bubble span almost the full width. The FAB still overlaps the
+   bottom-left corner, but on phone widths the user can scroll around it. */
+@media (max-width: 560px) {
+  .feedback-dock {
+    left: 0.75rem;
+    right: calc(0.75rem + 56px + 0.5rem);
+    bottom: calc(1rem + 56px - 4px);
+    padding: 1rem 1rem 1rem 64px;
+    border-radius: 14px;
+  }
+}
 
 /* Hidden per-screen textareas inside #screen-textareas: only active shown */
 #screen-textareas textarea[hidden] { display: none; }
@@ -1071,9 +1149,19 @@ DOM (just hidden), so each one's value persists independently via
   const dock = document.getElementById('feedback-dock');
   const dockToggle = document.getElementById('feedback-toggle');
   const dockClose = document.getElementById('feedback-close');
-  function closeDock() { dock.dataset.open = 'false'; dockToggle.classList.remove('hidden'); }
+  // The dock is a Speech-Bubble anchored to the 💬 FAB — the FAB stays
+  // visible and clickable while the dock is open, so clicking it toggles
+  // (open ↔ minimised). The X button is a *minimise*, not a destroy:
+  // closing the dock leaves all textarea content intact (localStorage
+  // persistence is untouched).
+  function openDock() { dock.dataset.open = 'true'; dockToggle.setAttribute('aria-expanded', 'true'); }
+  function closeDock() { dock.dataset.open = 'false'; dockToggle.setAttribute('aria-expanded', 'false'); }
   window.closeDock = closeDock;
-  dockToggle.addEventListener('click', () => { dock.dataset.open = 'true'; dockToggle.classList.add('hidden'); });
+  dockToggle.setAttribute('aria-expanded', 'false');
+  dockToggle.addEventListener('click', () => {
+    if (dock.dataset.open === 'true') closeDock();
+    else openDock();
+  });
   dockClose.addEventListener('click', closeDock);
 
   // Click outside the dock (anywhere on the prototype screen) closes it.

--- a/plugins/devops/skills/devops-concept/deep-knowledge/templates.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/templates.md
@@ -720,9 +720,16 @@ The wiring is a single delegated click handler installed alongside
       · <span id="active-screen-label">Welcome</span>
     </div>
 
-    <!-- Two FABs — the only floating UI besides the screen itself. -->
+    <!-- Two FABs — the only floating UI besides the screen itself.
+         The 💬 FAB carries two labels: the dock toggle swaps aria-label
+         between them based on aria-expanded so screen-reader users
+         always hear the correct next action ("Open" vs "Minimize"). -->
     <button id="panel-toggle" class="panel-fab" aria-label="{{panel.toggle_open}}">☰</button>
-    <button id="feedback-toggle" class="feedback-fab" aria-label="{{proto.feedback_toggle}}">💬</button>
+    <button id="feedback-toggle" class="feedback-fab"
+            aria-label="{{proto.feedback_toggle}}"
+            aria-expanded="false"
+            data-label-open="{{proto.feedback_toggle}}"
+            data-label-close="{{panel.minimize}}">💬</button>
 
     <!-- Decision panel (☰) — contains: iteration-tabs, screen-nav, submit.
          No section-TOC here: the screen-nav replaces it for prototype. -->
@@ -1022,16 +1029,19 @@ section[data-screen][hidden] { display: none; }
 .feedback-section textarea:focus { outline: none; border-color: var(--accent-color); }
 .feedback-divider { height: 1px; background: var(--border-color); margin: 0.25rem 0; }
 
-/* Narrow viewports: drop the padding-left reservation for the FAB and
-   let the bubble span almost the full width. The FAB still overlaps the
-   bottom-left corner, but on phone widths the user can scroll around it. */
+/* Narrow viewports (≤560px): lift the bubble ABOVE the 💬 FAB instead
+   of having it overlap. With ~150px reserved for FAB + Menü-FAB on a
+   320px phone the inner content column would otherwise collapse to an
+   unusable width. The FAB ends up below the dock, still visible and
+   still toggleable. */
 @media (max-width: 560px) {
   .feedback-dock {
     left: 0.75rem;
     right: calc(0.75rem + 56px + 0.5rem);
-    bottom: calc(1rem + 56px - 4px);
-    padding: 1rem 1rem 1rem 64px;
+    bottom: calc(1rem + 56px + 8px);
+    padding: 1rem;
     border-radius: 14px;
+    transform-origin: 28px calc(100% + 28px);
   }
 }
 
@@ -1154,10 +1164,28 @@ DOM (just hidden), so each one's value persists independently via
   // (open ↔ minimised). The X button is a *minimise*, not a destroy:
   // closing the dock leaves all textarea content intact (localStorage
   // persistence is untouched).
-  function openDock() { dock.dataset.open = 'true'; dockToggle.setAttribute('aria-expanded', 'true'); }
-  function closeDock() { dock.dataset.open = 'false'; dockToggle.setAttribute('aria-expanded', 'false'); }
+  // Accessibility:
+  //   * aria-expanded reflects open/closed state on the FAB
+  //   * aria-label swaps between data-label-open / data-label-close so
+  //     screen-reader users hear the correct next action
+  //   * on close, focus is restored to the FAB if it was inside the dock
+  //     (the dock disappears via display:none, so leaving focus there
+  //     would orphan it)
+  const LABEL_OPEN = dockToggle.dataset.labelOpen || dockToggle.getAttribute('aria-label');
+  const LABEL_CLOSE = dockToggle.dataset.labelClose || LABEL_OPEN;
+  function openDock() {
+    dock.dataset.open = 'true';
+    dockToggle.setAttribute('aria-expanded', 'true');
+    dockToggle.setAttribute('aria-label', LABEL_CLOSE);
+  }
+  function closeDock() {
+    const focusWasInside = dock.contains(document.activeElement);
+    dock.dataset.open = 'false';
+    dockToggle.setAttribute('aria-expanded', 'false');
+    dockToggle.setAttribute('aria-label', LABEL_OPEN);
+    if (focusWasInside) dockToggle.focus();
+  }
   window.closeDock = closeDock;
-  dockToggle.setAttribute('aria-expanded', 'false');
   dockToggle.addEventListener('click', () => {
     if (dock.dataset.open === 'true') closeDock();
     else openDock();

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.74.0",
+  "version": "0.75.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

Concept prototype-template feedback dock redesigned as a **speech bubble anchored to the 💬 FAB**. Previously the dock was a full-width bottom bar that covered both the 💬 and ☰ FABs while open, and its `✕` button suggested destructive action even though textarea content is preserved in `localStorage`.

After this change:

- **💬 FAB stays visible and clickable** while the dock is open — clicking it toggles open↔close.
- **Right edge stops before the ☰ Menü-FAB**, so decisions remain reachable during feedback.
- **`padding-left: 80px`** reserves the FAB area on desktop; content (labels, textareas) starts beside the FAB, never behind it.
- **`✕` → `−`** (minimise) with `aria-label="{{panel.minimize}}"`. Content preserved across close/reopen.
- **a11y**: `aria-expanded` reflects state, `aria-label` swaps via `data-label-open` / `data-label-close`, focus is restored to the FAB on close from inside the dock.
- **Mobile (≤560px)**: bubble lifts fully above the FAB instead of overlapping, so phones don't squeeze the inner content column.

New locale key: `panel.minimize` (Minimize / Minimieren).

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` — 103 tests pass
- [x] Codex review gate — 3 findings (2 medium, 1 low) all applied inline in commit 8a68c36
- [ ] Manual: `/devops-plugin-update` in a consumer project, regenerate a prototype concept page, verify FAB stays clickable and minimise-button preserves textarea content

🤖 Generated with [Claude Code](https://claude.com/claude-code)