### PR TITLE
feat(concept): final-report panel + issue creation flow (0.76.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.75.0"
+    "version": "0.76.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.75.0",
+      "version": "0.76.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.75.0",
+      "version": "0.76.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [0.76.0] — 2026-05-14
+
+### Added
+
+- **plugins/devops/skills/devops-concept/SKILL.md** — implement-action path now produces an **Abschlussbericht** (final report) instead of another regular iteration. New `Final-report append (implement only)` subsection in Step 5c describes the structure: a `<section data-iteration="N+1" data-final-report data-active>` containing several `<section id data-nav-label>` blocks (Zusammenfassung, Geänderte Dateien, Tests, optional Offene Fragen & TODOs, optional Nächste Schritte). Right panel auto-switches to `panel-final-report` mode — no iterate/implement buttons. New `action: "create-issues"` handling in Step 5b (and new "Critical invariant" note): processes the selected open-questions items via the `devops-new-issue` skill, then rewrites the HTML so each routed item carries a linked `[Issue #NNN]` badge and a disabled checkbox.
+- **plugins/devops/skills/devops-concept/deep-knowledge/templates.md** — new `Final Report Panel` reference section with HTML pattern for the report body, the `<section data-open-questions>` checkbox list (items default `checked`, attributes `data-issue-title` / `data-issue-type` drive the create-issues payload), and the after-routing rewrite pattern (disabled checkbox + `.oq-issue-link` anchor). New `panel-final-report` HTML block in the shared decision-panel skeleton with a conditional `#panel-create-issues` sub-block. Locale-table gains 12 keys: `iteration.final_tab`, `final.status`, `final.hint`, `final.open_questions`, `final.create_issues_btn`, `final.create_issues_hint`, `final.create_issues_none`, `final.create_issues_running`, `final.create_issues_done`, `final.issue_link_prefix` (de + en).
+- **plugins/devops/skills/devops-concept/deep-knowledge/templates.md** — `updateCreateIssuesPanel()` gating function (recomputes on `DOMContentLoaded`, `iteration:changed`, and any `change` inside `[data-open-questions]`). Panel visible iff active section has `data-final-report` AND contains a `[data-open-questions]` block AND that block has at least one non-disabled checkbox. Button enabled iff additionally at least one checkbox is currently checked. `submitCreateIssues()` collects selected items, POSTs `{action: "create-issues", items: [...]}` to `/decisions`, falls back to the offline submit queue on network error.
+- **plugins/devops/skills/devops-concept/deep-knowledge/templates.md** — `showIteration()` detects `data-final-report` on the active section and swaps `panel-ready` for `panel-final-report` (also gates `panel-submitted` to non-final live iterations). Iteration-tabs example updated to show the `data-final-report` tab variant with label `{{iteration.final_tab}}`. New CSS for `.iteration-tab[data-final-report]` (success-color border + ✓ prefix), `#panel-final-report` indicator + hint, `#panel-create-issues` state hints (none / running / done), and `.open-questions-list` items with `.oq-issue-link` badge styling.
+- **plugins/devops/skills/devops-concept/deep-knowledge/iteration-rules.md** — situation table gains two new rows: "Implementation finished (Step 5b implement branch)" → append `data-final-report` section + tab labelled `{{iteration.final_tab}}`; "Issues created from final report (`action: "create-issues"`)" → rewrite open-questions `<li>` items in place (disabled checkbox + `.oq-issue-link`), no new section appended.
+- **plugins/devops/skills/devops-concept/deep-knowledge/validation-gate.md** — Phase-1 mandatory pattern count bumped from 27 to 29. New patterns: 28 `panel-final-report` (final-report panel element), 29 `updateCreateIssuesPanel` (panel-gating function called from `showIteration()`).
+
+### Changed
+
+- **plugins/devops/.claude-plugin/plugin.json** — version `0.75.0 → 0.76.0`
+
 ## [0.75.0] — 2026-05-14
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.75.0**
+**Version: 0.76.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.75.0",
+  "version": "0.76.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/skills/devops-concept/SKILL.md
+++ b/plugins/devops/skills/devops-concept/SKILL.md
@@ -361,7 +361,7 @@ and `deep-knowledge/templates.md` § Iteration Tabs for the reference HTML.
 
 ### Post-Generation Validation (mandatory gate)
 
-After writing the HTML file, grep it for the 27 mandatory interactive
+After writing the HTML file, grep it for the 29 mandatory interactive
 patterns (heartbeat, panel states, iteration tabs, section TOC, reload
 polling, generic form-collection catch-all scoped to the active
 iteration, etc.).
@@ -489,7 +489,7 @@ Branch on it:
    - For free-template findings: apply the Miteinbeziehen findings as fixes
    - For prototypes: build the designed UI/flow with the feedback applied
 3. **Signal completion to the panel.** Right after the implementation work
-   is done — and BEFORE the iteration append + `/reload` in Step 5c — POST
+   is done — and BEFORE the final-report append + `/reload` in Step 5c — POST
    the implemented phase so the submit panel's third progress step lights
    up while the user is still looking at it. Pass the `_version` noted in
    Step 5a so a stale worker cannot pin "implemented" onto a newer
@@ -507,18 +507,44 @@ Branch on it:
    The browser polls `/decisions` every 5 s and reads `_phase` from the
    response — so the ✓ next to "Implementierung abgeschlossen" appears
    within ~5 s. The subsequent `/reload` (Step 5c) replaces the panel
-   with the new iteration shortly after.
-4. After the implementation is done, still append a new iteration that
-   shows "implementiert — siehe commit {hash}" as a frozen record, so the
-   concept page stays the source of truth for what happened
+   with the final report shortly after.
+4. After the implementation is done, append a **Final Report**
+   (`Abschlussbericht`) section instead of a regular iteration. This is the
+   closing artefact of the concept session — see Step 5c §
+   "Final-report append (implement only)" for the structure.
+
+**`action: "create-issues"` ("Issues erstellen" button — only on final report):**
+1. Read the `items` array from the payload — each entry is a selected open
+   question / TODO `{ id, title, type, selected: true }`.
+2. For each selected item, invoke the **devops-new-issue** skill with the
+   item's title and type. Capture the resulting issue number + URL.
+3. Update the final-report HTML: in the open-questions section, replace
+   each created item's label with `[Issue #NNN] {title}` (linked to the
+   issue URL), disable the checkbox, and add a small ✓ badge.
+4. POST `/reload` so the browser shows the updated state. If every item
+   was processed, the "Issues erstellen" button auto-hides on reload
+   (panel JS gates it on the presence of un-created checkable items).
+5. Then POST `/reset` with the captured `_version` as usual.
+6. The concept session stays open — the user may still review previous
+   iteration tabs but cannot trigger further iterate/implement actions
+   from the final report.
 
 **Critical invariant:** a submit with `action: "iterate"` MUST NEVER cause
 code or file changes outside of the concept HTML file itself. The user
-relies on that guarantee to explore ideas safely.
+relies on that guarantee to explore ideas safely. `action: "create-issues"`
+only writes GitHub issues + the final-report HTML — no code/file changes
+in the project tree.
 ### 5c. Update the Page
-After processing, **append a new iteration tab** to the same HTML file and
-signal the browser to reload. This is the ONLY update path — there is no
+After processing, **append a new tab** to the same HTML file and signal
+the browser to reload. This is the ONLY update path — there is no
 separate "in-place edit" vs. "new file" distinction anymore.
+
+For `action: "iterate"` → append a regular iteration section.
+For `action: "implement"` → append a **final-report section** (one-time,
+see § "Final-report append (implement only)" below).
+For `action: "create-issues"` → no new section; rewrite the existing
+final-report HTML in place (replace processed items with linked
+`[Issue #NNN]` labels) and POST `/reload`.
 
 Procedure on every iteration (including the very first response to feedback).
 
@@ -572,11 +598,63 @@ Do NOT write a redirect file. Do NOT create a new `-v{N}` file. The entire
 concept session — first render, every iteration, "nochmal neu" reworks —
 lives in the single `{date}-{slug}.html`.
 
+### Final-report append (implement only)
+
+When `action: "implement"` is being processed, step 3 of the procedure above
+differs: instead of appending a regular iteration, append a **final-report
+section**. Everything else (freeze previous, /reload, /reset, version
+preservation) stays identical.
+
+1. Freeze the previous iteration the same way (step 1–2 above).
+2. Append a `<section data-iteration="{N+1}" data-final-report data-active>`
+   to the same file. This carries the `data-final-report` flag so the
+   panel auto-switches to `panel-final-report` mode (no iterate/implement
+   buttons — see `deep-knowledge/templates.md` § Final Report Panel).
+3. Inside, render a structured report with several `<section id data-nav-label>`
+   blocks so the existing TOC auto-populates. Recommended structure
+   (Claude picks which sections actually fit the concept):
+   - **Zusammenfassung** — what was implemented in one paragraph + commit hash
+   - **Geänderte Dateien** — bulleted list with brief rationale per file
+   - **Tests / Verifikation** — what was run, what passed, what was skipped
+   - **Offene Fragen & TODOs** *(optional, see below)* — checkbox list of
+     things noted during implementation that were intentionally left out,
+     bugs found but not fixed, doc gaps, future improvements
+   - **Nächste Schritte** *(optional)* — recommendations for follow-up work
+4. Append a new entry in the `.iteration-tabs` bar for the final report.
+   **Tab label MUST be `iteration.final_tab`** (locale: "Abschlussbericht" /
+   "Final report"), NOT "Iteration N+1". Mark it `aria-selected="true"` and
+   carry `data-final-report` so the tab-bar JS can style it distinctly.
+5. Set `submitted: false` in `#concept-decisions`, remove `concept-submitted`
+   from `<body>`. The submit-button reset is irrelevant because the
+   final-report panel doesn't surface iterate/implement at all.
+6. /reload → /reset as steps 5–6 above.
+
+**Open questions / TODOs section — when to include:**
+
+Include the `<section data-open-questions>` block only when there are real
+items worth tracking as GitHub issues — things you knowingly deferred,
+bugs surfaced but out of scope, doc gaps, follow-up refactors. Skip it
+entirely (do NOT render an empty stub) when the implementation is
+genuinely clean. The presence of this section is what surfaces the
+"Issues erstellen" button in the panel — see `deep-knowledge/templates.md`
+§ Final Report Panel for the HTML pattern. Default each `<input
+type="checkbox">` to `checked` so the user opts items OUT rather than IN.
+
+**No further iterations from the final report.** The panel deliberately
+omits the iterate/implement buttons. If the user wants more work after
+the final report, they can start a new concept session — that's a clear
+new scope, not an additional iteration on a closed one.
+
 ### 5d. Resume Monitoring
 Return to Step 4 (monitor for next submission). The loop continues until:
 - The user closes the page
 - The user says "fertig" / "done" in chat
 - There are no more decisions to make (all items processed)
+
+If the active section is the final report, the only submission Claude
+expects is `action: "create-issues"` (when open questions / TODOs are
+present). All other action types from the final-report panel should be
+treated as protocol errors and reported back to the user.
 
 ### 5e. Persist
 Write a cumulative summary to `docs/concepts/{same-timestamp}-{same-slug}-decisions.json`

--- a/plugins/devops/skills/devops-concept/deep-knowledge/iteration-rules.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/iteration-rules.md
@@ -13,6 +13,8 @@ selections, read-only comments).
 | First generation | Write the file with `<section data-iteration="1" data-active>` and one tab "Iteration 1" | Tab 1 active |
 | Feedback loop iteration (Step 5c) | Append `<section data-iteration="N+1" data-active>` to the same file, remove `data-active` from the previous section, freeze it, add a new tab and make it active | New tab "Iteration N+1" auto-active, old tab selectable and read-only |
 | Fundamental rework ("nochmal neu") | Same as a feedback iteration — just another tab. The full history stays visible. | Another tab appended |
+| Implementation finished (Step 5b implement branch) | Append `<section data-iteration="N+1" data-final-report data-active>` with the Abschlussbericht structure. Add a new tab carrying `data-final-report` and label `{{iteration.final_tab}}` ("Abschlussbericht" / "Final report") — NEVER "Iteration N+1". Freeze the previous section the same way. | New tab "Abschlussbericht" auto-active. Right panel switches to `panel-final-report` (no iterate/implement buttons). At most one final-report section per concept session. |
+| Issues created from final report (`action: "create-issues"`) | Do NOT append a new section. Rewrite the existing `[data-open-questions]` `<li>` items: add `disabled` to processed checkboxes, append an `.oq-issue-link` `<a>` with the GitHub issue URL. Keep `data-active` on the final-report section. | Same final-report tab stays active; routed items become read-only audit entries. `updateCreateIssuesPanel()` auto-hides the button once every checkbox in the section is disabled. |
 
 **Rules:**
 - **Never create a second file** for iterations of the same concept — always

--- a/plugins/devops/skills/devops-concept/deep-knowledge/templates.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/templates.md
@@ -73,7 +73,17 @@ must see their own language. The locale hint is authoritative.
 | `variant.discard`              | Discard                        | Verwerfen |
 | `iteration.label`              | Iterations                     | Iterationen |
 | `iteration.active_suffix`      | · active                       | · aktiv |
+| `iteration.final_tab`          | Final report                   | Abschlussbericht |
 | `nav.sections`                 | Sections                       | Abschnitte |
+| `final.status`                 | Implementation complete        | Implementierung abgeschlossen |
+| `final.hint`                   | The implementation is done. Review the report on the left. | Die Implementierung ist abgeschlossen. Sieh dir den Bericht links an. |
+| `final.open_questions`         | Open questions & TODOs         | Offene Fragen & TODOs |
+| `final.create_issues_btn`      | Create issues                  | Issues erstellen |
+| `final.create_issues_hint`     | Creates GitHub issues for the selected items via devops-new-issue. | Erstellt GitHub-Issues für die ausgewählten Punkte via devops-new-issue. |
+| `final.create_issues_none`     | No items selected.             | Keine Punkte ausgewählt. |
+| `final.create_issues_running`  | Creating issues …              | Issues werden erstellt … |
+| `final.create_issues_done`     | Issues created                 | Issues erstellt |
+| `final.issue_link_prefix`      | Issue                          | Issue |
 | `proto.feedback_title`         | Feedback                       | Feedback |
 | `proto.feedback_toggle`        | Open feedback                  | Feedback öffnen |
 | `proto.feedback_general`       | General notes on this prototype | Allgemeine Anmerkungen zum Prototyp |
@@ -235,6 +245,32 @@ the `[ui-locale: ...]` hint produced.
         </ol>
         <p class="submitted-hint">{{panel.submitted_hint}}</p>
         <div class="waiting-animation"><span class="dot"></span><span class="dot"></span><span class="dot"></span></div>
+      </div>
+
+      <!-- Final-report state: shown when the active section carries
+           data-final-report. No iterate/implement submit; the only
+           interactive control is the conditional "Issues erstellen"
+           button, gated on the presence of a [data-open-questions]
+           block with at least one un-created checkable item. -->
+      <div id="panel-final-report" style="display: none;">
+        <div class="final-report-indicator">
+          <span class="check-icon">✓</span>
+          <strong>{{final.status}}</strong>
+        </div>
+        <p class="final-report-hint">{{final.hint}}</p>
+        <div id="panel-create-issues" hidden>
+          <button id="create-issues-btn" class="primary submit-btn" disabled>{{final.create_issues_btn}}</button>
+          <p class="hint">{{final.create_issues_hint}}</p>
+          <p class="hint hint-none" data-issues-state="none" hidden>
+            <span aria-hidden="true">⚠</span> {{final.create_issues_none}}
+          </p>
+          <p class="hint hint-running" data-issues-state="running" hidden>
+            <span aria-hidden="true">⏳</span> {{final.create_issues_running}}
+          </p>
+          <p class="hint hint-done" data-issues-state="done" hidden>
+            <span aria-hidden="true">✓</span> {{final.create_issues_done}}
+          </p>
+        </div>
       </div>
     </aside>
   </div>
@@ -1833,6 +1869,99 @@ document.addEventListener('DOMContentLoaded', () => {
   opacity: 0.5;
   cursor: not-allowed;
 }
+
+/* Final-report panel. No iterate/implement controls — only the closing
+   indicator + optional "Issues erstellen" block. Uses the same indicator
+   visual language as the submitted panel for continuity. */
+#panel-final-report .final-report-indicator {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+  color: var(--success-color, #3fb950);
+  font-weight: 600;
+}
+#panel-final-report .check-icon {
+  font-size: 1.1rem;
+}
+#panel-final-report .final-report-hint {
+  margin: 0 0 1rem 0;
+  color: var(--text-secondary, #8b949e);
+  font-size: 0.85rem;
+  line-height: 1.5;
+}
+#panel-create-issues #create-issues-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+#panel-create-issues .hint[data-issues-state="running"] {
+  color: var(--accent-color, #58a6ff);
+}
+#panel-create-issues .hint[data-issues-state="done"] {
+  color: var(--success-color, #3fb950);
+}
+#panel-create-issues .hint[data-issues-state="none"] {
+  color: var(--warning-color, #d29922);
+}
+
+/* Iteration tab styling for the final-report tab — distinct from
+   numbered iteration tabs so the closing step reads as a milestone. */
+.iteration-tab[data-final-report] {
+  border-color: var(--success-color, #3fb950);
+  color: var(--success-color, #3fb950);
+}
+.iteration-tab[data-final-report][aria-selected="true"] {
+  background: color-mix(in srgb, var(--success-color, #3fb950) 15%, transparent);
+  border-color: var(--success-color, #3fb950);
+  color: var(--text-color, #c9d1d9);
+}
+.iteration-tab[data-final-report][aria-selected="true"]::before {
+  content: "✓ ";
+  color: var(--success-color, #3fb950);
+}
+.iteration-tab[data-final-report]:not([aria-selected="true"])::before {
+  content: "";
+}
+
+/* Open-questions section — checkbox list with optional "[Issue #NNN]"
+   linked badges once items have been routed to GitHub. */
+section[data-open-questions] .open-questions-list {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+section[data-open-questions] .open-questions-list li {
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--border-color, #30363d);
+  border-radius: 6px;
+  background: var(--bg-subtle, transparent);
+}
+section[data-open-questions] .open-questions-list label {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  cursor: pointer;
+}
+section[data-open-questions] .open-questions-list input[type="checkbox"]:disabled + .oq-label {
+  opacity: 0.7;
+}
+section[data-open-questions] .oq-issue-link {
+  display: inline-block;
+  margin-left: 0.5rem;
+  padding: 1px 6px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--success-color, #3fb950);
+  border: 1px solid var(--success-color, #3fb950);
+  border-radius: 4px;
+  text-decoration: none;
+}
+section[data-open-questions] .oq-issue-link:hover {
+  background: color-mix(in srgb, var(--success-color, #3fb950) 15%, transparent);
+}
 ```
 
 ## State Persistence (localStorage + TTL)
@@ -2176,6 +2305,105 @@ async function submitWithAction(action) {
 wireSubmit('submit-iterate-btn', 'iterate');
 wireSubmit('submit-implement-btn', 'implement');
 
+// --- Final-report "Issues erstellen" action ---
+// Gating rules (only ALL of these true → panel visible + button enabled):
+//   1. Active section carries data-final-report.
+//   2. Active section contains a [data-open-questions] block.
+//   3. That block has at least one un-created (still-checkable, not
+//      disabled) checkbox.
+//   4. At least one of those checkboxes is currently checked.
+// On click: POST /decisions { action: "create-issues", items: [...] }
+// then disable + show "running" hint. Claude rewrites the open-questions
+// HTML with linked [Issue #NNN] labels and POSTs /reload — the reload
+// re-enters this gating logic with disabled checkboxes, so the button
+// auto-hides once all items are routed.
+function updateCreateIssuesPanel() {
+  const wrap = document.getElementById('panel-create-issues');
+  const btn = document.getElementById('create-issues-btn');
+  if (!wrap || !btn) return;
+  const active = document.querySelector('section[data-iteration][data-active]');
+  const isFinal = !!(active && active.hasAttribute('data-final-report'));
+  const oqBlock = isFinal ? active.querySelector('[data-open-questions]') : null;
+  const pendingBoxes = oqBlock
+    ? oqBlock.querySelectorAll('input[type="checkbox"]:not(:disabled)')
+    : [];
+  const visible = isFinal && pendingBoxes.length > 0;
+  wrap.hidden = !visible;
+  if (!visible) return;
+  const checked = Array.from(pendingBoxes).some(el => el.checked);
+  btn.disabled = !checked;
+  // Reset transient state hints whenever the gating recomputes (e.g.
+  // after a reload that added Issue badges to some items).
+  wrap.querySelectorAll('.hint[data-issues-state]').forEach(el => {
+    el.hidden = el.dataset.issuesState !== 'none' || checked;
+  });
+}
+
+async function submitCreateIssues() {
+  const active = document.querySelector('section[data-iteration][data-active]');
+  if (!active || !active.hasAttribute('data-final-report')) return;
+  const oqBlock = active.querySelector('[data-open-questions]');
+  if (!oqBlock) return;
+
+  const items = Array.from(
+    oqBlock.querySelectorAll('input[type="checkbox"]:not(:disabled)')
+  )
+    .filter(el => el.checked)
+    .map(el => {
+      const labelEl = el.closest('label')?.querySelector('.oq-label');
+      return {
+        id: el.name || el.id || '',
+        title: el.dataset.issueTitle
+            || (labelEl ? labelEl.textContent.trim() : ''),
+        type: el.dataset.issueType || 'chore',
+        selected: true
+      };
+    });
+
+  const wrap = document.getElementById('panel-create-issues');
+  const btn = document.getElementById('create-issues-btn');
+  if (!items.length) {
+    wrap?.querySelector('.hint[data-issues-state="none"]')
+        ?.removeAttribute('hidden');
+    return;
+  }
+
+  btn.disabled = true;
+  wrap.querySelectorAll('.hint[data-issues-state]').forEach(el => {
+    el.hidden = el.dataset.issuesState !== 'running';
+  });
+
+  const payload = { submitted: true, action: 'create-issues', items };
+  const container = document.getElementById('concept-decisions');
+  if (container) container.textContent = JSON.stringify(payload);
+  document.body.classList.add('concept-submitted');
+
+  try {
+    await fetch('/decisions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+  } catch (e) {
+    // Offline — queue alongside the regular pending submit so it retries
+    // on reconnect via retryPendingSubmission().
+    localStorage.setItem(STORAGE_KEY + '-pending', JSON.stringify(payload));
+  }
+}
+
+document.getElementById('create-issues-btn')
+  ?.addEventListener('click', submitCreateIssues);
+
+// Recompute gating whenever the user toggles a checkbox inside the
+// open-questions section. The generic change listener (for saveState)
+// fires the same event, so we just hook into the same channel.
+document.addEventListener('change', e => {
+  if (e.target && e.target.matches('section[data-open-questions] input[type="checkbox"]')) {
+    updateCreateIssuesPanel();
+  }
+});
+document.addEventListener('DOMContentLoaded', updateCreateIssuesPanel);
+
 // --- Offline Submit Queue ---
 async function retryPendingSubmission() {
   const pendingKey = STORAGE_KEY + '-pending';
@@ -2510,14 +2738,27 @@ prototype and free include them identically.
     Iteration 1
   </button>
   <button class="iteration-tab" role="tab"
-          data-iteration="2" aria-selected="true" aria-controls="iter-2">
+          data-iteration="2" aria-selected="false" aria-controls="iter-2">
     Iteration 2
+  </button>
+  <!-- Final-report tab: same DOM contract (data-iteration carries the
+       running counter), distinct labelling + the data-final-report
+       flag so .iteration-tab[data-final-report] CSS + panel JS pick
+       it up. The label is the locale string {{iteration.final_tab}},
+       NEVER "Iteration N". Only the implement-action path appends
+       this — at most one per concept session. -->
+  <button class="iteration-tab" role="tab" data-final-report
+          data-iteration="3" aria-selected="true" aria-controls="iter-3">
+    {{iteration.final_tab}}
   </button>
 </nav>
 
 <main>
   <section id="iter-1" data-iteration="1" hidden>…frozen round 1…</section>
-  <section id="iter-2" data-iteration="2" data-active>…active round 2…</section>
+  <section id="iter-2" data-iteration="2" hidden>…frozen round 2…</section>
+  <section id="iter-3" data-iteration="3" data-final-report data-active>
+    …final report (Abschlussbericht)…
+  </section>
 </main>
 ```
 
@@ -2528,6 +2769,10 @@ Rules:
   (see "Freezing Past Iterations").
 - Tabs stay clickable — switching tab reveals the chosen section and
   hides all others.
+- A concept session has **at most one** `data-final-report` section.
+  Once it exists, no further iterate/implement submissions are
+  accepted (the panel-final-report has no such buttons). Only
+  `action: "create-issues"` may still fire from the final-report tab.
 
 ### Tab Bar CSS
 
@@ -2603,17 +2848,25 @@ function showIteration(n) {
   });
   const activeSec = document.querySelector('section[data-iteration][data-active]');
   const isLive = activeSec && String(activeSec.dataset.iteration) === String(n);
+  // The live section may be a regular iteration OR a final report. The
+  // panel switches between three live states (ready / submitted / final)
+  // plus the frozen state for non-live tabs.
+  const isFinal = isLive && activeSec.hasAttribute('data-final-report');
   document.body.classList.toggle('viewing-frozen', !isLive);
+  document.body.classList.toggle('viewing-final', !!isFinal);
   const panelReady = document.getElementById('panel-ready');
   const panelSubmitted = document.getElementById('panel-submitted');
   const panelFrozen = document.getElementById('panel-frozen');
-  if (panelReady) panelReady.style.display = isLive ? 'block' : 'none';
+  const panelFinal = document.getElementById('panel-final-report');
+  if (panelReady) panelReady.style.display = (isLive && !isFinal) ? 'block' : 'none';
   if (panelSubmitted) {
     const submitted = document.body.classList.contains('concept-submitted');
-    panelSubmitted.style.display = (isLive && submitted) ? 'block' : 'none';
+    panelSubmitted.style.display = (isLive && !isFinal && submitted) ? 'block' : 'none';
   }
+  if (panelFinal) panelFinal.style.display = isFinal ? 'block' : 'none';
   if (panelFrozen) panelFrozen.style.display = isLive ? 'none' : 'block';
   if (typeof buildSectionNav === 'function') buildSectionNav();
+  if (typeof updateCreateIssuesPanel === 'function') updateCreateIssuesPanel();
   document.dispatchEvent(new CustomEvent('iteration:changed'));
 }
 
@@ -2645,6 +2898,143 @@ async function pollReload() {
 setInterval(pollReload, 3000);
 document.addEventListener('DOMContentLoaded', pollReload);
 ```
+
+## Final Report Panel
+
+The final-report section closes a concept session. It is appended via the
+implement-action branch of Step 5b (see `SKILL.md` § Final-report append).
+The right-side panel automatically switches to `panel-final-report` mode
+when `showIteration()` detects `data-final-report` on the active section
+— no iterate / implement buttons, only an optional "Issues erstellen"
+button gated on the presence of open questions / TODOs.
+
+### Final-report section HTML
+
+The body of the section is structured like a multi-section freeform
+report — every `<section id data-nav-label>` inside it surfaces in the
+section TOC automatically. Open questions / TODOs use a dedicated
+`<section data-open-questions>` wrapper around a checkbox list.
+
+```html
+<section id="iter-3" data-iteration="3" data-final-report data-active>
+  <div class="iteration-intro">
+    <h2>{{iteration.final_tab}}</h2>
+    <p>Kurze Einleitung — was wurde umgesetzt, in welcher Form.</p>
+  </div>
+
+  <section id="summary" data-nav-label="Zusammenfassung">
+    <h3>Zusammenfassung</h3>
+    <p>Was wurde gebaut, mit welchem Commit.</p>
+  </section>
+
+  <section id="changed-files" data-nav-label="Geänderte Dateien">
+    <h3>Geänderte Dateien</h3>
+    <ul>
+      <li><code>src/auth/middleware.ts</code> — Token-Validierung neu</li>
+    </ul>
+  </section>
+
+  <section id="tests" data-nav-label="Tests &amp; Verifikation">
+    <h3>Tests &amp; Verifikation</h3>
+    <p>Was lief, was wurde übersprungen, mit Begründung.</p>
+  </section>
+
+  <!-- Optional — render only when there are real follow-ups to track.
+       Each <li> is one item; data-issue-title + data-issue-type drive
+       the "Issues erstellen" payload. Checkboxes default to `checked`. -->
+  <section id="open-questions"
+           data-nav-label="{{final.open_questions}}"
+           data-open-questions>
+    <h3>{{final.open_questions}}</h3>
+    <ul class="open-questions-list">
+      <li>
+        <label>
+          <input type="checkbox"
+                 name="oq-saml-edge"
+                 data-issue-title="[BUG] Auth fails for SAML users"
+                 data-issue-type="bug"
+                 checked>
+          <span class="oq-label">Auth fails for SAML users — observed during smoke test, out of scope here</span>
+        </label>
+      </li>
+      <li>
+        <label>
+          <input type="checkbox"
+                 name="oq-docs-refresh"
+                 data-issue-title="[DOCS] Update auth README"
+                 data-issue-type="docs"
+                 checked>
+          <span class="oq-label">Update auth README to reflect new middleware contract</span>
+        </label>
+      </li>
+    </ul>
+  </section>
+
+  <section id="next-steps" data-nav-label="Nächste Schritte">
+    <h3>Nächste Schritte</h3>
+    <ul>
+      <li>Performance-Profiling unter Last (siehe offene Frage oben)</li>
+    </ul>
+  </section>
+</section>
+```
+
+### Open-questions item attributes
+
+| Attribute | Purpose |
+|---|---|
+| `name` (or `id`) | Stable identifier reused in the `create-issues` payload's `item.id` |
+| `data-issue-title` | Verbatim title used by `devops-new-issue` (`[TYPE] Imperative title`). REQUIRED for the button to produce a valid GitHub issue |
+| `data-issue-type` | Maps to the issue label (`bug`, `feature`, `refactor`, `chore`, `docs`, `design`). Defaults to `chore` if omitted |
+| `checked` | Default `true` — user opts out, not in |
+| `disabled` | Set by Claude after the item has been routed (becomes `[Issue #NNN]`) so the gating logic in `updateCreateIssuesPanel()` ignores it |
+
+### After issues are created — HTML rewrite pattern
+
+When Claude processes `action: "create-issues"`, the response loop
+rewrites each routed `<li>` so the user sees the resulting issue
+number + link. The checkbox stays in the DOM but is disabled, which
+keeps `restoreState()` consistent across reloads:
+
+```html
+<li>
+  <label>
+    <input type="checkbox"
+           name="oq-saml-edge"
+           data-issue-title="[BUG] Auth fails for SAML users"
+           data-issue-type="bug"
+           checked disabled>
+    <span class="oq-label">Auth fails for SAML users — observed during smoke test, out of scope here</span>
+    <a class="oq-issue-link"
+       href="https://github.com/{owner}/{repo}/issues/123"
+       target="_blank"
+       rel="noopener noreferrer">{{final.issue_link_prefix}} #123</a>
+  </label>
+</li>
+```
+
+Once every `<li>` in the section is `disabled`, `updateCreateIssuesPanel()`
+hides the "Issues erstellen" button automatically — the section becomes a
+read-only audit log of what was routed.
+
+### Panel gating rules
+
+`updateCreateIssuesPanel()` (see § Two-Button Submit) recomputes on:
+- `DOMContentLoaded`
+- `iteration:changed` (via `showIteration()`)
+- any `change` event on a `[data-open-questions] input[type="checkbox"]`
+
+The panel is **visible** iff all of:
+1. Active section has `data-final-report`.
+2. Active section contains a `[data-open-questions]` block.
+3. That block has at least one `:not(:disabled)` checkbox.
+
+The button is **enabled** iff additionally at least one of those
+checkboxes is currently checked.
+
+Both gates run client-side only — Claude never enables/disables the
+button via the bridge; instead it controls visibility indirectly by
+disabling checkboxes when it writes the issue-routed HTML.
 
 ## Design System
 

--- a/plugins/devops/skills/devops-concept/deep-knowledge/validation-gate.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/validation-gate.md
@@ -7,7 +7,7 @@ template-specific extras selected by `<html data-template="...">`.
 
 ## Phase 1 — Shared patterns (ALL templates)
 
-Every concept page must contain these 27 patterns, regardless of template:
+Every concept page must contain these 29 patterns, regardless of template:
 
 | # | Pattern to grep | Purpose |
 |---|----------------|---------|
@@ -39,6 +39,8 @@ Every concept page must contain these 27 patterns, regardless of template:
 | 25 | `data.claude_ts` inside `pollHeartbeat` | The poller MUST read JSON and assign `claude_ts` (not `server_ts`, not the raw response object). HTTP-200 alone is not enough — the daemon self-pulse keeps `server_ts` fresh forever, so an HTTP-only check leaves the indicator green while Claude's cron is dead. |
 | 26 | `b.disabled = ` (or `btn.disabled = `) inside `checkClaudeConnection` | The heartbeat checker MUST actually toggle the submit buttons' `disabled` property — a visual-only warning lets the user keep submitting into a black hole during a stale heartbeat. |
 | 27 | `Date.now() - _lastHeartbeatTs` (millis vs. millis) | Both sides of the staleness comparison MUST be in milliseconds since the Unix epoch. Server returns `claude_ts` in ms; browser uses `Date.now()`. Never divide either side by 1000 — a millis-vs-seconds mix-up produces a giant negative age that always evaluates as "fresh" and silently hides outages. |
+| 28 | `panel-final-report` | Final-report panel element. Auto-shown by `showIteration()` when the active section carries `data-final-report`; replaces `panel-ready` (no iterate/implement buttons). |
+| 29 | `updateCreateIssuesPanel` | Gating function that toggles the "Issues erstellen" button visibility + enabled state based on the active section's `[data-open-questions]` content. Must be called from `showIteration()` so panel state stays consistent on tab switch. |
 
 **Failure for 21 / 22:** if either pattern is missing, the page is rejected
 at the post-generation gate. See § Generic Form Collection below for the

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.75.0",
+  "version": "0.76.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

After "Mit Feedback implementieren" finishes, the implement branch now appends a **final report (Abschlussbericht)** section instead of another regular iteration. The new tab is labelled "Abschlussbericht" and the right panel auto-switches to `panel-final-report` (no iterate/implement buttons). Section TOC continues to auto-populate from `[id][data-nav-label]` children, so the report navigates like any other concept page.

When Claude includes an optional `<section data-open-questions>` block with checkbox items (defaulting to `checked`), a conditional **"Issues erstellen"** button appears in the panel. Clicking it POSTs `action: "create-issues"` with the selected items, which the skill routes through `devops-new-issue`. Routed items are rewritten in place with a linked `[Issue #NNN]` badge and a disabled checkbox, so the button auto-hides once everything is routed.

### Key changes

- **SKILL.md** — new Step 5b create-issues branch + Step 5c "Final-report append (implement only)" subsection. Critical invariants documented (no further iterations from the final report; `create-issues` writes GitHub issues + the final-report HTML only).
- **templates.md** — `panel-final-report` HTML/CSS/JS, `showIteration()` swaps panel based on `data-final-report`, `updateCreateIssuesPanel()` gating function, `submitCreateIssues()` handler with offline-queue fallback, 12 new locale keys, distinct `.iteration-tab[data-final-report]` styling.
- **iteration-rules.md** — 2 new rows in the situation table (implementation finished, issues created from final report).
- **validation-gate.md** — mandatory pattern count `27 → 29` (`panel-final-report`, `updateCreateIssuesPanel`).

## Test plan

- [x] `npm test` — 103/103 passing
- [x] `npm run lint` — clean
- [ ] Manual: trigger an `implement` submission on an existing concept page, verify the new tab label + panel switching
- [ ] Manual: render a final report with `[data-open-questions]`, verify "Issues erstellen" button appears + creates real GitHub issues via devops-new-issue
- [ ] Manual: route some items, verify rewritten `<li>` + linked badge + button auto-hide once all items are disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)