### PR TITLE
feat(local-llm): tier-aware gate, hard-gate, auto-retry (0.77.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.76.0"
+    "version": "0.77.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.76.0",
+      "version": "0.77.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.76.0",
+      "version": "0.77.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.77.0] — 2026-05-16
+
+### Added
+
+- **plugins/devops/scripts/check-local-llm.js** — now surfaces the benchmark `tier` (`high` | `medium` | `low` | `pending`) in its single-line JSON output so sub-agents can scale delegation ambition without having to read the SessionStart hook themselves. When `tier === "low"` the probe returns `ready: false, phase: "tier_disabled"` instead of `ready: true` — sub-agents get an explicit skip signal where previously they only saw `ready: true` and had no tier context (the LOW prose directive emitted by `ss.llm.health.js` never reached freshly-spawned sub-agent contexts).
+- **plugins/local-llm/mcp-server/index.js** — `local_generate` enforces the tier=LOW gate in code: it reads the benchmark cache before each call and fails fast with `phase: "tier_disabled"` (no AnythingLLM round-trip, no 5-minute Ollama timeout). Previously the gate was prose-only, so a noncompliant agent could still drive the local backend.
+- **plugins/local-llm/mcp-server/index.js** — auto-retry once on transient backend failure (HTTP 5xx or `errorType: "timeout"`). Catches Ollama cold-loads after model swaps and VRAM contention without the agent having to retry from its side. On second failure the hint includes "retried once, still failing — restart Ollama / AnythingLLM" so the user knows the local backend, not the request, is at fault. The error JSON now also carries `retried: true|false`.
+
+### Changed
+
+- **plugins/devops/deep-knowledge/local-llm-delegation.md** — Gate section documents the new four-shape JSON contract (high/medium/pending → ready, tier_disabled → not ready) plus the MCP-side auto-retry, so agents stop double-retrying on transient failures.
+- **plugins/devops/.claude-plugin/plugin.json** — version `0.76.0 → 0.77.0`
+- **plugins/local-llm/.claude-plugin/plugin.json** — version `0.76.0 → 0.77.0`
+
 ## [0.76.0] — 2026-05-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.76.0**
+**Version: 0.77.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.76.0",
+  "version": "0.77.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/deep-knowledge/local-llm-delegation.md
+++ b/plugins/devops/deep-knowledge/local-llm-delegation.md
@@ -11,13 +11,16 @@ Before the first write, probe the local backend ONCE:
 node "${CLAUDE_PLUGIN_ROOT}/scripts/check-local-llm.js"
 ```
 
-Output is single-line JSON. Three shapes:
+Output is single-line JSON. Four shapes:
 
-- `{"ready": true, "tool": "local_generate"}` — delegation enabled for this session.
-- `{"ready": false, "phase": "needs_api_key" | "not_installed" | ...}` — skip delegation. Continue normally, write code directly. **Do not prompt the user or block** — the plugin signals the user separately.
-- `{"ready": false, "phase": "error"}` — probe failed. Skip delegation.
+- `{"ready": true, "tool": "local_generate", "tier": "high"}` — delegate proactively: boilerplate AND well-specified simple logic (>20 lines).
+- `{"ready": true, "tool": "local_generate", "tier": "medium"}` — pure boilerplate only (types, simple DTOs, no branching). Apply the conservative >60-line threshold below.
+- `{"ready": true, "tool": "local_generate", "tier": "pending"}` — benchmark running in background. Defensively treat as MEDIUM.
+- `{"ready": false, "phase": "tier_disabled" | "needs_api_key" | "not_installed" | ...}` — skip delegation. Continue normally, write code directly. **Do not prompt the user or block** — the plugin signals the user separately. `tier_disabled` means the last benchmark scored LOW; the MCP server enforces this in code too, so `local_generate` calls will fail-fast.
 
 Cache the answer in memory for the rest of the agent run. If `ready: false`, never call `local_generate` in this session.
+
+The MCP server also auto-retries once on transient backend failures (HTTP 5xx, timeout) — if you get `error: true, retried: true, phase: "request_failed"` back, the local backend is genuinely broken; do not retry from your side, write the code directly.
 
 ## When to delegate (GREEN tier — all conditions required)
 

--- a/plugins/devops/scripts/check-local-llm.js
+++ b/plugins/devops/scripts/check-local-llm.js
@@ -1,16 +1,23 @@
 #!/usr/bin/env node
 /**
  * @script check-local-llm
- * @version 0.1.0
+ * @version 0.2.0
  * @plugin devops
  * @description Single-call status probe for the local-llm plugin. Prints
  *   one JSON line to stdout so implementation agents can decide whether
  *   to delegate mechanical code generation.
  *
  *   Output shapes (stdout, single line):
- *     {"ready":true,"tool":"local_generate","workspace":"<slug>"}
+ *     {"ready":true,"tool":"local_generate","workspace":"<slug>","tier":"high|medium|low|pending"}
  *     {"ready":false,"phase":"needs_api_key"|"not_installed"|...,"hint":"..."}
  *     {"ready":false,"phase":"error","hint":"..."}
+ *
+ *   The `tier` field reflects the benchmark cache at
+ *   ~/.claude/cache/local-llm-benchmark.json:
+ *     - "high"    → delegate proactively (boilerplate + simple logic)
+ *     - "medium"  → pure boilerplate only
+ *     - "low"     → ready:false override; MCP enforces the gate too
+ *     - "pending" → cache missing or running; treat as MEDIUM
  *
  *   The result is cached on disk for 30 seconds so parallel agents hitting
  *   this script do not all probe AnythingLLM simultaneously. Cache path:
@@ -110,7 +117,20 @@ function emit(obj) {
     emit(result);
   }
 
-  const result = { ready: true, tool: 'local_generate', workspace: workspaceSlug };
+  let tier = 'pending';
+  try {
+    const tierCache = require(path.join(libDir, 'anythingllm-tier-cache.js'));
+    const cache = tierCache.readCache();
+    if (cache && cache.tier) tier = cache.tier;
+  } catch { /* tier optional, fall back to pending */ }
+
+  if (tier === 'low') {
+    const result = { ready: false, phase: 'tier_disabled', hint: 'Local model failed probe tasks (tier LOW). Generation gated off. Switch model in AnythingLLM and delete ~/.claude/cache/local-llm-benchmark.json.', tier };
+    writeCache(result);
+    emit(result);
+  }
+
+  const result = { ready: true, tool: 'local_generate', workspace: workspaceSlug, tier };
   writeCache(result);
   emit(result);
 })().catch((err) => {

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.76.0",
+  "version": "0.77.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/local-llm/mcp-server/index.js
+++ b/plugins/local-llm/mcp-server/index.js
@@ -32,6 +32,7 @@ const LIB_ROOT = resolve(__dirname, "..", "hooks", "lib");
 
 const http = require(join(LIB_ROOT, "anythingllm-http.js"));
 const lifecycle = require(join(LIB_ROOT, "anythingllm-lifecycle.js"));
+const tierCache = require(join(LIB_ROOT, "anythingllm-tier-cache.js"));
 const { resolveConfig, hasApiKey, USER_CONFIG_PATH } = require(join(LIB_ROOT, "anythingllm-config.js"));
 
 const CONFIG = resolveConfig();
@@ -203,6 +204,27 @@ server.registerTool(
       };
     }
 
+    // Hard-gate at tier=low — the SessionStart hook says "DISABLED" in prose,
+    // but a noncompliant agent could still call this tool. Enforce in code.
+    const cache = tierCache.readCache();
+    if (cache && cache.tier === "low") {
+      return {
+        content: [{
+          type: "text",
+          text: JSON.stringify({
+            error: true,
+            phase: "tier_disabled",
+            tier: "low",
+            score: cache.score,
+            hint: `Local model failed probe tasks (tier LOW, score ${Number(cache.score).toFixed(2)}). ` +
+                  `Generation is gated off to prevent token waste on broken output. ` +
+                  `Switch to a stronger model in AnythingLLM, then delete ~/.claude/cache/local-llm-benchmark.json ` +
+                  `to trigger a re-benchmark on the next session.`,
+          }),
+        }],
+      };
+    }
+
     const lang = language || "the appropriate language";
     const baseSystemPrompt =
       "You are a code generation assistant. Output ONLY the requested code — " +
@@ -217,7 +239,7 @@ server.registerTool(
     if (context) userPrompt += `\n\nContext (existing code to follow):\n${context}`;
     userPrompt += "\n\nGenerate the code:";
 
-    const result = await http.chatCompletion(BASE_URL, API_KEY, {
+    const completionArgs = {
       workspaceSlug: WORKSPACE_SLUG,
       messages: [
         { role: "system", content: systemPrompt },
@@ -225,9 +247,28 @@ server.registerTool(
       ],
       temperature: temperature ?? TEMPERATURE_DEFAULT,
       maxTokens: MAX_TOKENS_DEFAULT,
-    });
+    };
+
+    let result = await http.chatCompletion(BASE_URL, API_KEY, completionArgs);
+
+    // Auto-fallback: 1× retry on transient backend failure (5xx or timeout).
+    // Ollama frequently 500's on first request after a model swap (cold load)
+    // and on VRAM contention. A single retry catches both without blocking
+    // the agent or wasting more tokens than necessary.
+    const isTransient = !result.ok && (
+      (typeof result.status === "number" && result.status >= 500) ||
+      result.errorType === "timeout"
+    );
+    if (isTransient) {
+      result = await http.chatCompletion(BASE_URL, API_KEY, completionArgs);
+    }
 
     if (!result.ok) {
+      const baseHint = result.error || result.errorType || "unknown";
+      const guidance = isTransient
+        ? " — retried once, still failing. The local backend likely crashed or is out of VRAM. " +
+          "Restart Ollama / AnythingLLM and try again, or fall back to writing the code directly."
+        : "";
       return {
         content: [{
           type: "text",
@@ -235,7 +276,8 @@ server.registerTool(
             error: true,
             phase: "request_failed",
             status: result.status,
-            hint: result.error || result.errorType,
+            retried: isTransient,
+            hint: baseHint + guidance,
           }),
         }],
       };


### PR DESCRIPTION
## Summary

The local-llm benchmark tier (LOW/MEDIUM/HIGH) never reached sub-agents, and the "DISABLED at LOW" rule was prose-only — a noncompliant agent could still drive the local backend, eating a 5-minute Ollama timeout per call. This PR closes both gaps and adds resilience to transient Ollama failures.

- `check-local-llm.js` now surfaces `tier` in its JSON output and returns `ready: false, phase: "tier_disabled"` at LOW — sub-agents get an explicit skip signal.
- `local_generate` (MCP) enforces the same gate in code: tier=LOW fails fast without hitting AnythingLLM.
- Transient backend failures (HTTP 5xx, timeout) auto-retry once before surfacing — catches Ollama cold-loads after model swaps and VRAM contention. On second failure the hint tells the user to restart Ollama/AnythingLLM.

## Test plan

- [x] npm run lint — clean
- [x] npm test — 103/103 passing
- [x] `node check-local-llm.js` returns new shape with `tier` field
- [x] Live: `local_generate` probe against `gemma3n:e4b` returns sanitized code (~169 tokens, finishReason=stop)
- [ ] Next SessionStart: benchmark spawns against `gemma3n:e4b`, tier transitions `pending → medium|high`