### PR TITLE
feat(devops): harden + polish — fixes, tests, i18n (0.78.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.77.0"
+    "version": "0.78.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.77.0",
+      "version": "0.78.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.77.0",
+      "version": "0.78.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [0.78.0] — 2026-05-16
+
+### Added
+
+- **plugins/devops/mcp-server/ship/lib/repo-mode.test.js** — new vitest suite (7 tests) covering `detectRepoMode` (`none` / `git` / `git-no-remote` branches) and `isGitRepo`. Uses `vi.mock('node:child_process')` to stub `execFileSync`; asserts cwd is propagated and the second `git remote get-url` invocation only runs after `rev-parse` succeeds.
+- **plugins/devops/mcp-server/ship/lib/sentinel.test.js** — new vitest suite (10 tests) covering `sentinelPath` (platform-correct trailing path, starts-with cwd, POSIX constant), `writeSentinel` (empty/null/undefined cwd → false, ts+pid JSON shape, auto-creates `.claude/`, false when cwd is a file), and `clearSentinel` (empty cwd, removes existing, no-throw on missing). Uses `fs.mkdtempSync` per test for isolation.
+- **plugins/devops/hooks/lib/locale.test.js** — new vitest suite (18 tests) covering `DEFAULT_LOCALE`/`SUPPORTED` constants, `detectFromPrompt` (umlaut, multi-marker, single-marker, case-insensitive), `getLocale`/`setLocale` round-trip + unsupported-value rejection, `ensureLocale` fresh/cached semantics, and `t()` fallback chain (lang bucket → en bucket → key itself). `beforeEach` purges only `dotclaude-locale-vitest-locale-*` tmp files to avoid touching live Claude Code session caches.
+- **plugins/devops/mcp-server/ship/lib/github.test.js** — new vitest suite (15 tests) covering `createPR` (URL parse, stdin body), `mergePR` success (squash default, `--delete-branch` flag, merge-strategy override), and the new exp-backoff retry path: ANSI-stripped stderr in error messages, 500-char cap, throws on persistent CLOSED state, throws after 3 failed attempts with sanitized stderr. Mocks `node:child_process`.
+
+### Changed
+
+- **plugins/devops/mcp-server/ship/lib/github.js** — `mergePR` retry block now captures stderr from each failed `gh pr view` attempt, strips ANSI escape sequences (regex built at runtime via `String.fromCharCode(27)` to keep no-control-regex eslint rule happy), caps to 500 chars, and appends to the final error message. Linear `2s, 4s` backoff replaced with exponential `1s ± 10%`, `3s ± 10%` (`Math.pow(3, attempt-1)` × `0.9 + Math.random() * 0.2`). execSync timeout bumped 10s → 15s to accommodate the wider jitter band.
+- **plugins/devops/hooks/session-start/ss.plugin.update.js** — output strings refactored to go through `locale.t(key, lang, DICT)` instead of hard-coded English. New DE translations supplied for all 4 user-facing strings (header, restart notice, deep-knowledge re-read hint, "show as-is" instruction). SessionStart fires before any user prompt, so `lang` is currently hard-coded to `'en'`; the DICT is pre-wired so a future improvement that reads hook stdin for `session_id` can switch languages without restructuring.
+- **plugins/devops/hooks/pre-tool-use/pre.main.guard.js** — all 4 lines of BLOCKED stderr output now carry an explicit `[pre.main.guard]` prefix so Claude can attribute the message when multiple hooks output simultaneously.
+- **plugins/devops/hooks/user-prompt-submit/prompt.git.sync.js** — throttle skip is no longer silent: writes `[prompt.git.sync] ✓ skipped (throttled, last sync Xm ago, retry in Ym)` to stderr before exit so the deferred sync is visible in hook output.
+- **plugins/local-llm/hooks/session-start/ss.llm.deps.js** — silent `process.exit(0)` on unset `CLAUDE_PLUGIN_DATA` now prefixed with a `console.error('[local-llm] ⚠ ...')` warning so users see why local-llm features aren't bootstrapped.
+- **plugins/devops/scripts/build-id.js** — error message now carries the `✗ ` emoji prefix to match the convention used in hooks (✓/⚠/✗).
+- **plugins/devops/skills/devops-autonomous/SKILL.md** — added `version: 0.1.0` to frontmatter (matched the dominant pattern across other skills).
+- **plugins/devops/skills/devops-learn/SKILL.md** — `description` frontmatter trimmed from ~13 to ~8 lines (removed the `Handles four targets: (1)..(4)` enumeration; targets are still listed inline as `(skill, skill-extension, deep-knowledge, or as a last resort CLAUDE.md)` and the full routing table lives in body Step 5). Reduces Claude skill-matcher load.
+- **plugins/devops/docs/architecture.html** — version label bumped `v0.18.2 → v0.76.0`, headline counts updated (`10 → 29 hooks, 10 → 20 skills, 10 → 11 agents`), nav-link counts realigned. Added a `<div role="note">` warning banner under the lead paragraph indicating that content below still mirrors the v0.18.2 baseline and skill/hook/agent listings need regeneration. New CSS: `nav a:focus-visible` (2px accent outline + 2px offset, no background override so focus is distinct from hover), `@media (prefers-reduced-motion: reduce)` block disabling transitions on nav links and summary chevrons. `<nav>` element gains `role="navigation"` + `aria-label="Main navigation"` for screen readers.
+- **plugins/devops/.claude-plugin/plugin.json** — version `0.77.0 → 0.78.0`
+
 ## [0.77.0] — 2026-05-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.77.0**
+**Version: 0.78.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.77.0",
+  "version": "0.78.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/docs/architecture.html
+++ b/plugins/devops/docs/architecture.html
@@ -24,6 +24,7 @@
   nav h2:first-child { margin-top: 0; }
   nav a { display: block; padding: .3rem .6rem; color: var(--accent); text-decoration: none; font-size: .9rem; border-radius: 4px; transition: background .15s; }
   nav a:hover { background: var(--bg3); }
+  nav a:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
   .nav-brand { font-size: 1.1rem; font-weight: 700; color: var(--text); margin-bottom: .3rem; display: block; }
   .nav-version { font-size: .75rem; color: var(--text2); display: block; margin-bottom: 1rem; padding-bottom: 1rem; border-bottom: 1px solid var(--border); }
 
@@ -95,6 +96,12 @@
     main { margin-left: 0; padding: 1.5rem; }
   }
 
+  /* Reduced motion */
+  @media (prefers-reduced-motion: reduce) {
+    nav a { transition: none; }
+    summary::before { transition: none; }
+  }
+
   /* Scroll offset for anchors */
   [id] { scroll-margin-top: 1rem; }
 
@@ -112,9 +119,9 @@
 <div class="wrapper">
 
 <!-- ==================== SIDEBAR NAV ==================== -->
-<nav>
+<nav role="navigation" aria-label="Main navigation">
   <span class="nav-brand">devops</span>
-  <span class="nav-version">v0.18.2 &middot; MIT &middot; Jerry0022</span>
+  <span class="nav-version">v0.76.0 &middot; MIT &middot; Jerry0022</span>
 
   <h2>Overview</h2>
   <a href="#overview">Architecture Overview</a>
@@ -122,11 +129,11 @@
   <a href="#extension-model">3-Layer Extension Model</a>
 
   <h2>Lifecycle</h2>
-  <a href="#hooks">Hooks (10)</a>
+  <a href="#hooks">Hooks (29)</a>
   <a href="#hook-flow">Hook Execution Flow</a>
 
   <h2>Skills</h2>
-  <a href="#skills">Skills Overview (10)</a>
+  <a href="#skills">Skills Overview (20)</a>
   <a href="#skill-ship">/devops-ship</a>
   <a href="#skill-commit">/devops-commit</a>
   <a href="#skill-flow">/devops-flow</a>
@@ -144,7 +151,7 @@
   <a href="#mcp-ship">dotclaude-ship (5 tools)</a>
 
   <h2>Agents</h2>
-  <a href="#agents">Agents (10)</a>
+  <a href="#agents">Agents (11)</a>
 
   <h2>Automation</h2>
   <a href="#scheduled-tasks">Scheduled Tasks</a>
@@ -161,11 +168,15 @@
 
 <!-- ===== OVERVIEW ===== -->
 <section id="overview">
-<h1>Architecture Documentation <small>devops v0.18.2</small></h1>
+<h1>Architecture Documentation <small>devops v0.76.0</small></h1>
 <p class="lead">
-  A comprehensive DevOps automation plugin for Claude Code &mdash; 10 hooks, 10 skills, 10 agents,
+  A comprehensive DevOps automation plugin for Claude Code &mdash; 29 hooks, 20 skills, 11 agents,
   2 MCP servers, a deterministic completion card engine, and a 3-layer extension system.
 </p>
+<div role="note" style="margin:.4rem 0 1.4rem;padding:.6rem .9rem;background:var(--bg2);border-left:3px solid var(--warn);border-radius:4px;color:var(--text2);font-size:.85rem;">
+  &#9888; Content below mirrors the v0.18.2 baseline. Skill/hook/agent listings are not auto-regenerated yet &mdash;
+  see <code>plugins/devops/skills/</code>, <code>hooks/hooks.json</code>, and <code>agents/</code> for the canonical roster.
+</div>
 
 <div class="card-grid">
   <div class="card">
@@ -1094,7 +1105,7 @@
 <hr>
 
 <footer style="text-align:center;color:var(--text2);font-size:.8rem;padding:2rem 0">
-  devops v0.18.2 &middot; MIT License &middot; Jerry0022<br>
+  devops v0.76.0 &middot; MIT License &middot; Jerry0022<br>
   Generated 2026-04-01
 </footer>
 

--- a/plugins/devops/hooks/pre-tool-use/pre.main.guard.js
+++ b/plugins/devops/hooks/pre-tool-use/pre.main.guard.js
@@ -91,10 +91,10 @@ process.stdin.on('end', () => {
   if (branch !== 'main' && branch !== 'master') process.exit(0);
 
   process.stderr.write(
-    `BLOCKED: Write operation on local '${branch}' is not allowed.\n` +
-    `Rule: Never commit/merge/push directly on ${branch}. Work on a branch derived from origin/${branch} and land via /devops-ship.\n` +
-    `Fix: git fetch origin && git switch -c <feat/topic> origin/${branch}\n` +
-    `Bypass (only if the user explicitly asked to work on ${branch}): set env DEVOPS_ALLOW_MAIN=1 for this single command.\n`
+    `[pre.main.guard] BLOCKED: Write operation on local '${branch}' is not allowed.\n` +
+    `[pre.main.guard] Rule: Never commit/merge/push directly on ${branch}. Work on a branch derived from origin/${branch} and land via /devops-ship.\n` +
+    `[pre.main.guard] Fix: git fetch origin && git switch -c <feat/topic> origin/${branch}\n` +
+    `[pre.main.guard] Bypass (only if the user explicitly asked to work on ${branch}): set env DEVOPS_ALLOW_MAIN=1 for this single command.\n`
   );
   process.exit(2);
 });

--- a/plugins/devops/hooks/session-start/ss.plugin.update.js
+++ b/plugins/devops/hooks/session-start/ss.plugin.update.js
@@ -20,6 +20,29 @@ require('../lib/plugin-guard');
 const { execSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
+const { t } = require('../lib/locale');
+
+// Translations for user-facing output. SessionStart fires before any user
+// prompt — there is no detected locale yet and no session_id in hook input
+// here. Default to English; the DICT is pre-wired so a future improvement
+// (e.g. reading hook stdin for session_id and calling getLocale) can switch
+// languages without restructuring the output.
+const DICT = {
+  en: {
+    header: 'Plugin updates applied (workaround for claude-code#14061):',
+    restart: '⚡ **Plugin updated ({names}) — restart Claude to activate the new version.**',
+    dk_reread: 'Deep-knowledge index may have changed — re-read INDEX.md on next relevant task.',
+    show_asis: 'Show the user this restart notice as-is.',
+  },
+  de: {
+    header: 'Plugin-Updates angewendet (Workaround für claude-code#14061):',
+    restart: '⚡ **Plugin aktualisiert ({names}) — Claude neu starten, um die neue Version zu aktivieren.**',
+    dk_reread: 'Deep-Knowledge-Index hat sich evtl. geändert — INDEX.md beim nächsten relevanten Task neu lesen.',
+    show_asis: 'Diese Restart-Notice dem User unverändert zeigen.',
+  },
+};
+
+const lang = 'en';
 
 const home = process.env.HOME || process.env.USERPROFILE || '';
 const marketplacesDir = path.join(home, '.claude', 'plugins', 'marketplaces');
@@ -308,7 +331,7 @@ if (mcpAffected.length > 0) {
 
 if (updated.length === 0) process.exit(0);
 
-const lines = ['Plugin updates applied (workaround for claude-code#14061):'];
+const lines = [t('header', lang, DICT)];
 lines.push('');
 for (const u of updated) {
   const status = u.verified ? '✓ cache rebuilt' : `⚠ ${u.error}`;
@@ -321,9 +344,9 @@ lines.push('');
 const upgrades = updated.filter(u => !u.cacheRepair && u.verified);
 if (upgrades.length > 0) {
   const names = upgrades.map(u => `${u.name} v${u.to}`).join(', ');
-  lines.push(`⚡ **Plugin updated (${names}) — restart Claude to activate the new version.**`);
-  lines.push('Deep-knowledge index may have changed — re-read INDEX.md on next relevant task.');
-  lines.push('Show the user this restart notice as-is.');
+  lines.push(t('restart', lang, DICT).replace('{names}', names));
+  lines.push(t('dk_reread', lang, DICT));
+  lines.push(t('show_asis', lang, DICT));
   lines.push('');
   notifyDesktop('Claude Plugin Updated', `${names} — restart Claude to activate.`);
 }

--- a/plugins/devops/hooks/user-prompt-submit/prompt.git.sync.js
+++ b/plugins/devops/hooks/user-prompt-submit/prompt.git.sync.js
@@ -39,7 +39,11 @@ const THROTTLE_MS = 15 * 60 * 1000; // 15 minutes
 try {
   if (fs.existsSync(THROTTLE_FILE)) {
     const lastSync = parseInt(fs.readFileSync(THROTTLE_FILE, 'utf8'), 10);
-    if (Date.now() - lastSync < THROTTLE_MS) {
+    const ageMs = Date.now() - lastSync;
+    if (ageMs < THROTTLE_MS) {
+      const ageMin = Math.round(ageMs / 60000);
+      const remainMin = Math.ceil((THROTTLE_MS - ageMs) / 60000);
+      process.stderr.write(`[prompt.git.sync] ✓ skipped (throttled, last sync ${ageMin}m ago, retry in ${remainMin}m)\n`);
       process.exit(0);
     }
   }

--- a/plugins/devops/mcp-server/ship/lib/github.js
+++ b/plugins/devops/mcp-server/ship/lib/github.js
@@ -7,6 +7,9 @@ import { execSync, execFileSync } from "node:child_process";
 
 const DEFAULT_TIMEOUT = 30_000;
 
+// ANSI escape pattern built at runtime to avoid literal control chars in source.
+const ANSI_PATTERN = new RegExp(String.fromCharCode(27) + "\\[[0-9;]*[A-Za-z]", "g");
+
 function gh(args, opts = {}) {
   const { cwd = process.cwd(), timeout = DEFAULT_TIMEOUT } = opts;
   return execFileSync("gh", args, {
@@ -55,23 +58,28 @@ export function mergePR(prNumber, base = "main", opts, flags = {}) {
   const args = ["pr", "merge", String(prNumber), `--${strategy}`, "--admin"];
   if (!flags.skipDeleteBranch) args.push("--delete-branch");
   gh(args, opts);
-  // Verify the PR is actually in MERGED state (retry up to 3 times with 2s backoff
-  // to handle transient network errors or GitHub eventual consistency)
+  // Verify the PR is actually in MERGED state with exponential backoff + jitter
+  // (1s, 3s typical) to handle transient network errors or GitHub eventual consistency
   let state = null;
+  let lastError = null;
   for (let attempt = 1; attempt <= 3; attempt++) {
     try {
       state = gh(["pr", "view", String(prNumber), "--json", "state", "-q", ".state"], opts);
       if (state === "MERGED") break;
-    } catch {
-      // Network error on state check — retry
+    } catch (e) {
+      const raw = e.stderr?.toString() || e.message || "";
+      // Strip ANSI escape sequences; cap to 500 chars to avoid leaking long auth-bearing output
+      lastError = raw.replace(ANSI_PATTERN, "").slice(0, 500);
     }
     if (attempt < 3) {
-      // Synchronous sleep for retry backoff
-      execSync(`node -e "setTimeout(()=>{},${attempt * 2000})"`, { timeout: 10_000 });
+      const baseMs = 1000 * Math.pow(3, attempt - 1);
+      const jitterMs = Math.round(baseMs * (0.9 + Math.random() * 0.2));
+      execSync(`node -e "setTimeout(()=>{},${jitterMs})"`, { timeout: 15_000 });
     }
   }
   if (state !== "MERGED") {
-    throw new Error(`PR #${prNumber} merge verification failed after 3 attempts — state is "${state || "unknown"}", expected "MERGED"`);
+    const detail = lastError ? ` (last error: ${lastError.trim()})` : "";
+    throw new Error(`PR #${prNumber} merge verification failed after 3 attempts — state is "${state || "unknown"}", expected "MERGED"${detail}`);
   }
   // Fetch updated base branch and get the merge commit
   execSync(`git fetch origin ${base}`, {
@@ -125,4 +133,3 @@ export function createRelease({ tag, title, notes, prerelease = false }, opts) {
     stdio: ["pipe", "pipe", "pipe"],
   });
 }
-

--- a/plugins/devops/scripts/build-id.js
+++ b/plugins/devops/scripts/build-id.js
@@ -82,6 +82,6 @@ try {
   const hash = combined.substring(0, 7);
   process.stdout.write(hash + '\n');
 } catch (e) {
-  process.stderr.write(`build-id error: ${e.message}\n`);
+  process.stderr.write(`✗ build-id error: ${e.message}\n`);
   process.exit(1);
 }

--- a/plugins/devops/skills/devops-autonomous/SKILL.md
+++ b/plugins/devops/skills/devops-autonomous/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: devops-autonomous
+version: 0.1.0
 description: >-
   Fully autonomous agent orchestration for when the user is away from the PC.
   Runs agents without supervision (implementation, desktop interaction, live

--- a/plugins/devops/skills/devops-learn/SKILL.md
+++ b/plugins/devops/skills/devops-learn/SKILL.md
@@ -4,18 +4,12 @@ version: 0.1.0
 description: >-
   Capture a long-term learning/correction and route it to the correct project-
   specific instructions (skill, skill-extension, deep-knowledge, or as a last
-  resort CLAUDE.md) — NOT to personal feedback memory. After persisting, prunes
-  any now-duplicate `feedback_*.md` auto-memory entries with confirmation.
-  Handles four targets:
-  (1) the devops plugin source itself when invoked from dotclaude, (2) a project-
-  specific skill-extension when invoked from a consumer project and the learning
-  fits an existing plugin skill, (3) a new project-specific skill or deep-knowledge
-  file otherwise, (4) a different project entirely — via GitHub issue if the repo
-  has a GitHub remote, otherwise via a copy-pastable prompt block. Asks before
-  any global or cross-project file change that is not an issue.
-  Triggers ONLY on explicit invocation: "/devops-learn", "lerne das", "merk dir das
-  fürs Projekt", "remember this for the project", "capture learning". Do NOT
-  trigger for one-off conversational corrections or for personal feedback memory.
+  resort CLAUDE.md) — NOT to personal feedback memory. Also prunes now-duplicate
+  `feedback_*.md` entries with confirmation. Routing details live in the skill
+  body (Step 5 table). Triggers ONLY on explicit invocation: "/devops-learn",
+  "lerne das", "merk dir das fürs Projekt", "remember this for the project",
+  "capture learning". Do NOT trigger for one-off conversational corrections or
+  for personal feedback memory.
 argument-hint: "<learning text>"
 allowed-tools: Bash(git *), AskUserQuestion, Read, Write, Edit, Glob, Grep, Skill, mcp__plugin_devops_dotclaude-completion__render_completion_card
 ---

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.77.0",
+  "version": "0.78.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/local-llm/hooks/session-start/ss.llm.deps.js
+++ b/plugins/local-llm/hooks/session-start/ss.llm.deps.js
@@ -18,6 +18,7 @@ const PLUGIN_ROOT = process.env.CLAUDE_PLUGIN_ROOT || resolve(__dirname, "../.."
 
 const PLUGIN_DATA = process.env.CLAUDE_PLUGIN_DATA;
 if (!PLUGIN_DATA) {
+  console.error("[local-llm] ⚠ CLAUDE_PLUGIN_DATA not set — skipping MCP dependency install. Local-LLM features will be unavailable.");
   process.exit(0);
 }
 


### PR DESCRIPTION
## Summary

Harden + polish bundle for 0.78.0:

- **4 hook UX fixes**: `pre.main.guard` stderr prefix; `prompt.git.sync` throttle skip is no longer silent; `ss.llm.deps` warns on unset `CLAUDE_PLUGIN_DATA`; `ss.plugin.update` i18n infrastructure (`locale.js` DICT, en-only on SessionStart, pre-wired for future)
- **`github.js mergePR`**: stderr sanitization (ANSI strip via `String.fromCharCode(27)` to keep eslint happy, 500-char cap against auth-bearing leaks), exp backoff with jitter (`1s, 3s ±10%`) replaces linear `2s, 4s`
- **4 new vitest suites**: `repo-mode` (7), `sentinel` (10), `locale` (18), `github` (15) — +50 tests, suite **103 → 153**. `locale.test.js` `beforeEach` purges only the `dotclaude-locale-vitest-locale-` prefix so live Claude Code session caches stay intact
- **`architecture.html`**: version + counts updated (10→29 hooks, 10→20 skills, 10→11 agents), a11y (focus-visible, aria-label, prefers-reduced-motion), stale-content banner pointing to canonical roster
- **`devops-learn` description trimmed**; `build-id` error emoji prefix; `devops-autonomous` version field

## Test plan

- [x] vitest: 153/153 passed (+50)
- [x] eslint: clean
- [x] redteam pass: proceed (R1 prod-cache delete, R2 decorative i18n, R7 HTML invalid — all mitigated)
- [x] codex-safe.sh: usage limit hit (non-blocker per skill spec)