### PR TITLE
feat(autonomous): harden against UNC, API limits, session hangs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.78.1"
+    "version": "0.79.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.78.1",
+      "version": "0.79.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.78.1",
+      "version": "0.79.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.79.0] — 2026-05-17
+
+### Added
+
+- **plugins/devops/scripts/autonomous-watchdog.js** — new helper that registers a Windows Scheduled Task as an external deadman switch for `/devops-autonomous`. Subcommands `register <flag-path> <hours>` / `flag [flag-path]` / `unregister [task-name]` / `status [task-name]`. The scheduled task fires at the configured hour mark, checks for the done-flag, and force-shuts the PC via the absolute `$env:SystemRoot\System32\shutdown.exe` path if the flag is missing. Sentinel-driven destructive operations validate strictly: task names must match `^ClaudeAutonomousWatchdog-\d+$`, helper-script paths must live directly under `%TEMP%` with the expected `claude-autonomous-watchdog-*.ps1` filename. No-arg `flag` reads the persisted `flagPath` from the sentinel so cwd drift between arm-time and write-time cannot misroute the signal. No-op on non-Windows platforms.
+- **plugins/devops/skills/devops-autonomous/SKILL.md** — new Step 4d "External Shutdown Watchdog" (only when shutdown=yes) registers the scheduled task with an 8h default budget. Step 0.5 (Resume) re-arms the watchdog when resuming with shutdown=yes. New Step 8c "Watchdog Done-Flag Handling" with a Status × shutdown-exit decision matrix (COMPLETED + 8b success → flag yes; INTERRUPTED + 8b success → flag yes; either + 8b fail → flag no, watchdog fires; BLOCKED → flag yes per the original never-shut-down rule).
+- **plugins/devops/deep-knowledge/autonomous-execution.md** — new "API-Error-Handling" section: rate-limit detection signals (`Server is temporarily limiting requests`, `429 Too Many Requests`, `overloaded_error`, etc.), exponential-backoff schedule (30s → 2min → 10min), and bail protocol that writes a `blockedOn` field into `AUTONOMOUS-RESUME.json` and falls through to Step 8. Documents why the in-skill rate-limit logic doesn't see Anthropic API errors on Claude's own inference calls and the external watchdog is the only defense for that mode.
+
+### Changed
+
+- **plugins/devops/skills/devops-autonomous/SKILL.md** — Step 8b shutdown command rewritten to route via PowerShell with an absolute `$env:SystemRoot\System32\shutdown.exe` path. Replaces the previous `shutdown /s /t 60 /c "..."` Bash form that silently failed under UNC CWDs (cmd.exe drops to `%SystemRoot%`) and was vulnerable to quote-stripping when wrapped in `cmd.exe /c '...'`. Trailing `; exit $LASTEXITCODE` on the PowerShell command ensures `$?` in Bash captures the native `shutdown.exe` exit, not powershell.exe's. Step 8b also captures `$SHUTDOWN_EXIT` so Step 8c's matrix can detect failed in-session shutdowns and leave the external watchdog armed.
+- **plugins/devops/skills/devops-autonomous/SKILL.md** — Step 6 (Error Handling) gains a new category "API Rate-Limit / Server Throttle" pointing at the deep-knowledge protocol. Status hierarchy unchanged (COMPLETED > INTERRUPTED > BLOCKED), but INTERRUPTED is now also the resting state after rate-limit bail.
+- **plugins/devops/.claude-plugin/plugin.json** — version `0.78.1 → 0.79.0`
+
 ## [0.78.1] — 2026-05-16
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.78.1**
+**Version: 0.79.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.78.1",
+  "version": "0.79.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/deep-knowledge/autonomous-execution.md
+++ b/plugins/devops/deep-knowledge/autonomous-execution.md
@@ -65,3 +65,100 @@ If during autonomous execution a permission is needed that wasn't primed in Step
 6. Proceed to Step 7 (Report) with status **INTERRUPTED**.
 7. Proceed to Step 8 (Shutdown) — **shutdown IS executed** if the user chose it.
    The resume file ensures continuity on next boot.
+
+## API-Error-Handling
+
+When an upstream API throttles or rate-limits during autonomous execution, the
+session can't simply wait forever — the user is AFK, the watchdog is ticking,
+and indefinite hangs are exactly what brought the PC down the wrong way last time.
+
+### Detection — what counts as a rate-limit signal
+
+Match against tool output (Bash stderr, MCP tool errors, HTTP responses) for any of:
+
+- `Server is temporarily limiting requests`
+- `not your usage limit` (Anthropic's specific phrasing for global throttle)
+- `Rate limited`, `rate_limit_exceeded`, `429 Too Many Requests`
+- `quota exceeded`, `RESOURCE_EXHAUSTED` (Google/GCP)
+- `ThrottlingException` (AWS)
+- `overloaded_error` (Anthropic's overload signal — different from rate-limit but same handling)
+
+**False positives to ignore**: literal occurrences inside code being read/written
+(source files, tests, docs about rate-limiting). Only treat as a signal when the
+phrase appears in a tool *result* / error output, not in file content.
+
+**Important limitation**: Anthropic API errors on Claude's OWN inference calls
+are handled by the Claude Code client, NOT visible to in-skill code. The session
+will appear to "hang" from the user's perspective. The external watchdog from
+Step 4d is the only defense for that case — keep it armed.
+
+### Backoff Schedule
+
+On first detection, apply exponential backoff with three attempts:
+
+| Attempt | Wait before retry | Total elapsed |
+|---------|-------------------|---------------|
+| 1 (initial fail) | 30 s | 30 s |
+| 2 | 2 min | ~2.5 min |
+| 3 | 10 min | ~12.5 min |
+
+If the operation still fails after attempt 3, transition to **bail** below.
+
+During each wait, log the attempt to the report and (if applicable) use the wait
+time for non-API work — local linting, doc generation, file reorgs that don't
+need network. Never spin-loop the API.
+
+### Bail Protocol
+
+After 3 failed attempts on the same operation, or immediately on a hard signal
+(HTTP 401/403 indicating revoked credentials, not throttling):
+
+1. **Do NOT ask the user.** AFK. Lockout applies.
+2. Log to the report: the failing API, the signal observed, the wait/retry
+   history, and what was supposed to happen next.
+3. Commit all completed work locally (implement mode).
+4. Write `AUTONOMOUS-RESUME.json` with `missingPermission` replaced by a
+   `blockedOn` field describing the API failure:
+   ```json
+   {
+     "task": "<original goal>",
+     "mode": "<implement|analyze>",
+     "blockedOn": {
+       "type": "api-rate-limit",
+       "service": "<anthropic|supabase|openai|...>",
+       "signal": "<exact phrase observed>",
+       "lastAttempt": "<ISO-8601>",
+       "operation": "<what was being done>"
+     },
+     "progress": "<summary of what was completed>",
+     "remaining": "<what couldn't be done>",
+     "shutdownRequested": <true|false>,
+     "branch": "<current-branch-name>",
+     "timestamp": "<ISO-8601>"
+   }
+   ```
+5. Generate the report (Step 7) with status **INTERRUPTED**.
+6. Proceed to Step 8 (Shutdown) normally if the user chose it. Step 8c writes
+   the done-flag only if Step 8b succeeded — so a failed in-session shutdown
+   still leaves the watchdog armed.
+7. **Critical**: if the rate-limit prevents Step 7 itself from running (e.g.
+   `render_completion_card` MCP call also throttled), skip the HTML report and
+   write a minimal `AUTONOMOUS-INTERRUPTED.txt` instead:
+   ```
+   STATUS: INTERRUPTED (API rate-limit during finalization)
+   See AUTONOMOUS-RESUME.json for state.
+   ```
+   Then still attempt Step 8. If even Bash is unavailable, the external watchdog
+   from Step 4d will fire at the 6h mark and force shutdown regardless.
+
+### Why the watchdog is critical here
+
+The whole reason Step 4d exists is the case "Claude's own inference API is
+throttled and the session is wedged from the user's POV". In that scenario,
+none of the above in-skill logic runs — Claude isn't making any tool calls
+because the platform itself isn't dispatching to Claude. The Windows Scheduled
+Task runs independently of Claude, checks for the done-flag, and forces
+shutdown if the session never got far enough to write it.
+
+This is **not** redundancy with the in-session shutdown — it's a different
+layer protecting against a different failure mode.

--- a/plugins/devops/scripts/autonomous-watchdog.js
+++ b/plugins/devops/scripts/autonomous-watchdog.js
@@ -1,0 +1,205 @@
+#!/usr/bin/env node
+/**
+ * autonomous-watchdog.js — External shutdown safety net for devops-autonomous.
+ *
+ * Registers a Windows Scheduled Task that fires after N hours. The task checks
+ * for a "done-flag" file; if it's missing, the task force-shuts the PC down.
+ *
+ * Why this is needed: when Claude is AFK and hits an Anthropic API rate-limit,
+ * a crashed subagent, or a wakelock-style hang, the in-session Step 8 shutdown
+ * is never reached. The scheduled task fires *independently* of Claude, so the
+ * shutdown still happens.
+ *
+ * Subcommands (stdout: JSON):
+ *   register <flag-path> <hours>   Create one-shot task firing in N hours.
+ *                                  Stores sentinel under TEMP for later cleanup.
+ *                                  → { ok, taskName, flagPath, fireAt }
+ *
+ *   flag <flag-path>               Write the completion flag (signals success).
+ *                                  → { ok, flagPath }
+ *
+ *   unregister [task-name]         Delete the scheduled task + helper script.
+ *                                  Uses sentinel if task-name omitted.
+ *                                  → { ok, taskName, deleted }
+ *
+ *   status [task-name]             Check if the task still exists.
+ *                                  → { ok, taskName, active }
+ *
+ * Platform: Windows-only (uses schtasks.exe). No-op on other platforms.
+ */
+
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const TASK_PREFIX = 'ClaudeAutonomousWatchdog';
+const SENTINEL_FILE = path.join(os.tmpdir(), 'claude-autonomous-watchdog.json');
+
+function fail(msg) {
+  process.stdout.write(JSON.stringify({ ok: false, error: msg }) + '\n');
+  process.exit(1);
+}
+
+function ok(extra) {
+  process.stdout.write(JSON.stringify({ ok: true, ...extra }) + '\n');
+  process.exit(0);
+}
+
+if (process.platform !== 'win32') {
+  ok({ skipped: true, reason: 'non-windows platform' });
+}
+
+const [, , subcmd, ...args] = process.argv;
+
+function readSentinel() {
+  if (!fs.existsSync(SENTINEL_FILE)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(SENTINEL_FILE, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function writeSentinel(data) {
+  fs.writeFileSync(SENTINEL_FILE, JSON.stringify(data, null, 2));
+}
+
+function deleteSentinel() {
+  if (fs.existsSync(SENTINEL_FILE)) {
+    try { fs.unlinkSync(SENTINEL_FILE); } catch { /* ignore */ }
+  }
+}
+
+if (subcmd === 'register') {
+  const [flagPathRaw, hoursRaw] = args;
+  if (!flagPathRaw || !hoursRaw) fail('Usage: register <flag-path> <hours>');
+  const hours = Number(hoursRaw);
+  if (!Number.isFinite(hours) || hours < 0.1 || hours > 24) {
+    fail('hours must be 0.1..24');
+  }
+  const flagPath = path.resolve(flagPathRaw);
+
+  // Clean up any previous watchdog first — only one active at a time.
+  const prev = readSentinel();
+  if (prev?.taskName) {
+    spawnSync('schtasks.exe', ['/Delete', '/TN', prev.taskName, '/F'],
+      { encoding: 'utf8' });
+    if (prev.scriptPath && fs.existsSync(prev.scriptPath)) {
+      try { fs.unlinkSync(prev.scriptPath); } catch { /* ignore */ }
+    }
+  }
+
+  const taskName = `${TASK_PREFIX}-${Date.now()}`;
+  const fireAt = new Date(Date.now() + hours * 3600_000);
+
+  // Write a separate PowerShell script — robust escaping, self-deletes after run.
+  const scriptPath = path.join(os.tmpdir(),
+    `claude-autonomous-watchdog-${Date.now()}.ps1`);
+  const psScript =
+`$ErrorActionPreference = 'Continue'
+$flag = '${flagPath.replace(/'/g, "''")}'
+$logPath = Join-Path $env:TEMP 'claude-autonomous-watchdog.log'
+$ts = (Get-Date -Format 'o')
+if (Test-Path $flag) {
+  Add-Content -Path $logPath -Value "[$ts] flag present at $flag — no action"
+} else {
+  Add-Content -Path $logPath -Value "[$ts] flag MISSING at $flag — forcing shutdown"
+  & "$env:SystemRoot\\System32\\shutdown.exe" /s /t 0 /c "Claude autonomous watchdog: session unresponsive after ${hours}h, forcing shutdown"
+}
+# Self-delete this script after run
+try { Remove-Item -Path $MyInvocation.MyCommand.Path -Force -ErrorAction SilentlyContinue } catch {}
+`;
+  fs.writeFileSync(scriptPath, psScript, 'utf8');
+
+  const sd = `${String(fireAt.getMonth() + 1).padStart(2, '0')}/` +
+             `${String(fireAt.getDate()).padStart(2, '0')}/` +
+             `${fireAt.getFullYear()}`;
+  const st = `${String(fireAt.getHours()).padStart(2, '0')}:` +
+             `${String(fireAt.getMinutes()).padStart(2, '0')}`;
+  const tr = `powershell.exe -NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -File "${scriptPath}"`;
+
+  const result = spawnSync('schtasks.exe', [
+    '/Create',
+    '/TN', taskName,
+    '/SC', 'ONCE',
+    '/SD', sd,
+    '/ST', st,
+    '/TR', tr,
+    '/F',
+  ], { encoding: 'utf8' });
+
+  if (result.status !== 0) {
+    fail(`schtasks /Create failed: ${(result.stderr || result.stdout || '').trim()}`);
+  }
+
+  writeSentinel({
+    taskName,
+    flagPath,
+    scriptPath,
+    fireAt: fireAt.toISOString(),
+    hours,
+  });
+
+  ok({ taskName, flagPath, fireAt: fireAt.toISOString(), scriptPath });
+}
+
+if (subcmd === 'flag') {
+  const [flagPathRaw] = args;
+  if (!flagPathRaw) fail('Usage: flag <flag-path>');
+  const flagPath = path.resolve(flagPathRaw);
+  fs.mkdirSync(path.dirname(flagPath), { recursive: true });
+  fs.writeFileSync(flagPath, JSON.stringify({
+    doneAt: new Date().toISOString(),
+    note: 'Autonomous session reached completion (Step 7).',
+  }, null, 2));
+  ok({ flagPath });
+}
+
+if (subcmd === 'unregister') {
+  let taskName = args[0];
+  const sentinel = readSentinel();
+  if (!taskName) {
+    if (!sentinel) ok({ skipped: true, reason: 'no sentinel' });
+    taskName = sentinel.taskName;
+  }
+
+  const result = spawnSync('schtasks.exe',
+    ['/Delete', '/TN', taskName, '/F'], { encoding: 'utf8' });
+
+  // Not-found is acceptable — the task may have already fired or never existed.
+  const notFound = /cannot find|nicht gefunden/i.test(
+    (result.stderr || '') + (result.stdout || '')
+  );
+  if (result.status !== 0 && !notFound) {
+    fail(`schtasks /Delete failed: ${(result.stderr || result.stdout || '').trim()}`);
+  }
+
+  // Best-effort cleanup of helper script
+  if (sentinel?.scriptPath && fs.existsSync(sentinel.scriptPath)) {
+    try { fs.unlinkSync(sentinel.scriptPath); } catch { /* ignore */ }
+  }
+  deleteSentinel();
+
+  ok({ taskName, deleted: !notFound });
+}
+
+if (subcmd === 'status') {
+  let taskName = args[0];
+  const sentinel = readSentinel();
+  if (!taskName) {
+    if (!sentinel) ok({ active: false, reason: 'no sentinel' });
+    taskName = sentinel.taskName;
+  }
+  const result = spawnSync('schtasks.exe',
+    ['/Query', '/TN', taskName], { encoding: 'utf8' });
+  ok({
+    taskName,
+    active: result.status === 0,
+    fireAt: sentinel?.fireAt,
+    flagPath: sentinel?.flagPath,
+  });
+}
+
+fail(`Unknown subcommand: ${subcmd || '(empty)'}. ` +
+  `Use: register | flag | unregister | status`);

--- a/plugins/devops/scripts/autonomous-watchdog.js
+++ b/plugins/devops/scripts/autonomous-watchdog.js
@@ -15,7 +15,10 @@
  *                                  Stores sentinel under TEMP for later cleanup.
  *                                  → { ok, taskName, flagPath, fireAt }
  *
- *   flag <flag-path>               Write the completion flag (signals success).
+ *   flag [flag-path]               Write the completion flag (signals success).
+ *                                  If omitted, reads flagPath from the sentinel
+ *                                  written at register time — recommended path,
+ *                                  avoids cwd drift between arm and flag-write.
  *                                  → { ok, flagPath }
  *
  *   unregister [task-name]         Delete the scheduled task + helper script.
@@ -71,6 +74,33 @@ function deleteSentinel() {
   }
 }
 
+// --- Validation guards for sentinel-derived destructive operations ---
+// The sentinel file lives under %TEMP% and is world-writable in same-user
+// scope. Any same-user process could tamper with it to redirect deletions
+// to arbitrary task names or files. Validate strictly before acting.
+
+const SCRIPT_PREFIX = 'claude-autonomous-watchdog-';
+const SCRIPT_SUFFIX = '.ps1';
+
+function isValidWatchdogTaskName(taskName) {
+  if (typeof taskName !== 'string') return false;
+  // Must match exactly: <PREFIX>-<digits>
+  const re = new RegExp(`^${TASK_PREFIX}-\\d+$`);
+  return re.test(taskName);
+}
+
+function isValidWatchdogScriptPath(scriptPath) {
+  if (typeof scriptPath !== 'string' || scriptPath.length === 0) return false;
+  const tempDir = path.resolve(os.tmpdir());
+  const absPath = path.resolve(scriptPath);
+  // Must live directly under TEMP (no traversal, no sibling dirs)
+  if (path.dirname(absPath).toLowerCase() !== tempDir.toLowerCase()) return false;
+  const basename = path.basename(absPath);
+  if (!basename.startsWith(SCRIPT_PREFIX)) return false;
+  if (!basename.endsWith(SCRIPT_SUFFIX)) return false;
+  return true;
+}
+
 if (subcmd === 'register') {
   const [flagPathRaw, hoursRaw] = args;
   if (!flagPathRaw || !hoursRaw) fail('Usage: register <flag-path> <hours>');
@@ -81,13 +111,15 @@ if (subcmd === 'register') {
   const flagPath = path.resolve(flagPathRaw);
 
   // Clean up any previous watchdog first — only one active at a time.
+  // Sentinel is untrusted (same-user TEMP); validate before destructive ops.
   const prev = readSentinel();
-  if (prev?.taskName) {
+  if (prev?.taskName && isValidWatchdogTaskName(prev.taskName)) {
     spawnSync('schtasks.exe', ['/Delete', '/TN', prev.taskName, '/F'],
       { encoding: 'utf8' });
-    if (prev.scriptPath && fs.existsSync(prev.scriptPath)) {
-      try { fs.unlinkSync(prev.scriptPath); } catch { /* ignore */ }
-    }
+  }
+  if (prev?.scriptPath && isValidWatchdogScriptPath(prev.scriptPath) &&
+      fs.existsSync(prev.scriptPath)) {
+    try { fs.unlinkSync(prev.scriptPath); } catch { /* ignore */ }
   }
 
   const taskName = `${TASK_PREFIX}-${Date.now()}`;
@@ -146,12 +178,24 @@ try { Remove-Item -Path $MyInvocation.MyCommand.Path -Force -ErrorAction Silentl
 
 if (subcmd === 'flag') {
   const [flagPathRaw] = args;
-  if (!flagPathRaw) fail('Usage: flag <flag-path>');
-  const flagPath = path.resolve(flagPathRaw);
+  let flagPath;
+  if (flagPathRaw) {
+    flagPath = path.resolve(flagPathRaw);
+  } else {
+    // No path supplied → use the one persisted at registration time.
+    // This is the recommended path because it avoids cwd-drift between
+    // arm-time and flag-write-time (Codex finding #2).
+    const sentinel = readSentinel();
+    if (!sentinel?.flagPath) {
+      fail('No flag-path supplied and no sentinel found ' +
+        '(call register first, or pass an explicit path).');
+    }
+    flagPath = sentinel.flagPath;
+  }
   fs.mkdirSync(path.dirname(flagPath), { recursive: true });
   fs.writeFileSync(flagPath, JSON.stringify({
     doneAt: new Date().toISOString(),
-    note: 'Autonomous session reached completion (Step 7).',
+    note: 'Autonomous session reached completion (Step 8c).',
   }, null, 2));
   ok({ flagPath });
 }
@@ -162,6 +206,12 @@ if (subcmd === 'unregister') {
   if (!taskName) {
     if (!sentinel) ok({ skipped: true, reason: 'no sentinel' });
     taskName = sentinel.taskName;
+  }
+
+  // Reject task names that don't match our prefix — protects against a
+  // tampered sentinel pointing at unrelated scheduled tasks.
+  if (!isValidWatchdogTaskName(taskName)) {
+    fail(`Refusing to delete task with unexpected name format: ${taskName}`);
   }
 
   const result = spawnSync('schtasks.exe',
@@ -175,8 +225,10 @@ if (subcmd === 'unregister') {
     fail(`schtasks /Delete failed: ${(result.stderr || result.stdout || '').trim()}`);
   }
 
-  // Best-effort cleanup of helper script
-  if (sentinel?.scriptPath && fs.existsSync(sentinel.scriptPath)) {
+  // Best-effort cleanup of helper script (only if path matches expected layout)
+  if (sentinel?.scriptPath &&
+      isValidWatchdogScriptPath(sentinel.scriptPath) &&
+      fs.existsSync(sentinel.scriptPath)) {
     try { fs.unlinkSync(sentinel.scriptPath); } catch { /* ignore */ }
   }
   deleteSentinel();

--- a/plugins/devops/skills/devops-autonomous/SKILL.md
+++ b/plugins/devops/skills/devops-autonomous/SKILL.md
@@ -284,9 +284,9 @@ user verbally: the session must stay running.
 **Skip entirely if Step 2 Question 3 was "Nein, nur Bericht".** Nothing to enforce.
 
 If the user chose "Ja, herunterfahren", register a Windows Scheduled Task that
-fires after 6 hours as a deadman switch. The task checks for a done-flag (which
-Step 7 writes on successful completion); if the flag is missing, it force-shuts
-the PC down via the absolute `shutdown.exe` path.
+fires after 8 hours as a deadman switch. The task checks for a done-flag (which
+**Step 8c** writes after a successful shutdown call); if the flag is missing,
+it force-shuts the PC down via the absolute `shutdown.exe` path.
 
 This is the **last line of defense** against:
 - Anthropic API rate-limit hangs (Step 6 retry exhaustion or unhandled cases)
@@ -299,9 +299,14 @@ the session. That's its whole point.
 
 ```bash
 FLAG_PATH="$PWD/AUTONOMOUS-DONE.flag"
-WATCHDOG_OUT=$(node "$CLAUDE_PLUGIN_ROOT/scripts/autonomous-watchdog.js" register "$FLAG_PATH" 6)
+WATCHDOG_OUT=$(node "$CLAUDE_PLUGIN_ROOT/scripts/autonomous-watchdog.js" register "$FLAG_PATH" 8)
 echo "$WATCHDOG_OUT"  # → {"ok":true, "taskName":"ClaudeAutonomousWatchdog-...", ...}
 ```
+
+The absolute `$FLAG_PATH` is **persisted in the watchdog sentinel** (TEMP file)
+at registration time. Step 8c reads it back from the sentinel rather than
+recomputing it from `$PWD` — that way a later `cd` in some tool step can't
+make Step 8c write a flag the watchdog doesn't check.
 
 Parse the JSON output:
 - `ok: true` → save `taskName` as `$WATCHDOG_TASK`, set `$WATCHDOG_REGISTERED=true`
@@ -309,9 +314,11 @@ Parse the JSON output:
   log a one-line warning into the report ("⚠ External watchdog konnte nicht
   angelegt werden — in-session shutdown ist alleinige Absicherung"). Continue.
 
-**Budget tuning**: 6h covers realistic autonomous-task durations (analysis +
-implement + tests + build + verify + report) with headroom. Override only if
-the user declared an explicitly long task during intake ("8h migration", "run
+**Budget tuning**: 8h covers realistic autonomous-task durations (analysis +
+implement + tests + build + verify + report) with headroom that includes the
+worst-case Step 8a wait (30 min) plus the API-error backoff schedule (~12 min)
+without crowding the watchdog firing window. Override only if the user
+declared an explicitly long task during intake ("12h migration", "run
 overnight benchmark") — bump to `12` or `24` (script enforces ≤ 24h).
 
 ### Post-Confirmation Lockout
@@ -388,8 +395,9 @@ Use `$BROWSER_TOOL` (from Step 3b) for all browser-based visual verification.
   is temporarily limiting requests", "Rate limited", HTTP 429, etc.): exponential
   backoff (30s → 2min → 10min), then save progress and bail to INTERRUPTED. See
   full protocol in `deep-knowledge/autonomous-execution.md` § API-Error-Handling.
-  **Do NOT write the watchdog done-flag** — the external watchdog from Step 4d
-  is the ultimate fallback if Claude itself can't reach the API to run Steps 7-8.
+  Flag-writing is handled by Step 8c's decision matrix — if rate-limiting
+  prevents Step 7 or Step 8 from running at all, no flag is written and the
+  external watchdog from Step 4d fires as the safety net.
 - **Minor** (single test fail, linter warning, optional enhancement): log and continue
 - **Related bugs** in same codebase context: fix them, log in report
 - **Truly stuck**: commit work locally, write report with BLOCKED status, never shut down
@@ -499,13 +507,15 @@ PowerShell tolerates UNC CWDs natively, and the absolute `$env:SystemRoot\System
 path bypasses any PATH/CWD interaction:
 
 ```bash
-powershell.exe -NoProfile -Command '& "$env:SystemRoot\System32\shutdown.exe" /s /t 60 /c "Autonomous task completed. Shutting down in 60s. shutdown /a to abort."'
+powershell.exe -NoProfile -Command '& "$env:SystemRoot\System32\shutdown.exe" /s /t 60 /c "Autonomous task completed. Shutting down in 60s. shutdown /a to abort."; exit $LASTEXITCODE'
 SHUTDOWN_EXIT=$?
 ```
 
-**Capture the exit code** as `$SHUTDOWN_EXIT`. `shutdown.exe` returns 0 on
-success; anything else means the call did NOT schedule a shutdown. Step 8c
-uses this to decide whether to disarm the watchdog.
+**Capture the exit code** as `$SHUTDOWN_EXIT`. The trailing `; exit $LASTEXITCODE`
+is **mandatory** — without it, `$?` in Bash captures `powershell.exe`'s own exit
+(usually 0 even when the inner native call failed), not `shutdown.exe`'s exit.
+`shutdown.exe` returns 0 on success; anything else means the call did NOT
+schedule a shutdown. Step 8c uses this to decide whether to disarm the watchdog.
 
 **INTERRUPTED:** Shutdown is safe because progress is saved in `AUTONOMOUS-RESUME.json`
 and committed locally. The user can resume on next boot via Step 0.5.
@@ -532,10 +542,12 @@ to **not** shut down when it fires):
 | INTERRUPTED | ≠ 0 (failed) | **No**      | Same — watchdog enforces what 8b couldn't |
 | BLOCKED     | (skipped)    | **Yes**     | Original rule: BLOCKED never shuts down. Stand the watchdog down too |
 
-Command (only when writing the flag):
+Command (only when writing the flag) — **omit the path** so the script reads
+the persisted `flagPath` from the sentinel rather than re-deriving it from
+`$PWD`:
 
 ```bash
-node "$CLAUDE_PLUGIN_ROOT/scripts/autonomous-watchdog.js" flag "$PWD/AUTONOMOUS-DONE.flag"
+node "$CLAUDE_PLUGIN_ROOT/scripts/autonomous-watchdog.js" flag
 ```
 
 We deliberately do NOT call `unregister` on the scheduled task — leaving it

--- a/plugins/devops/skills/devops-autonomous/SKILL.md
+++ b/plugins/devops/skills/devops-autonomous/SKILL.md
@@ -74,6 +74,8 @@ If found:
    > Options (fixed order):
    > 1. label: "Nur Bericht (empfohlen)" — description: "Ergebnisse als Report, PC bleibt an."
    > 2. label: "Herunterfahren" — description: "PC fährt nach Abschluss herunter. Wartet vorher, falls andere Claude-Sessions (egal welches Projekt) noch arbeiten."
+- **If shutdown=yes**: run Step 4d to re-arm the external watchdog (the previous
+  watchdog already fired or was deleted — we need a fresh one for this run).
 - Delete the resume file
 - Skip Steps 1-4, jump directly to Step 5 with the resumed context
 - On completion, proceed normally through Steps 7-8
@@ -277,6 +279,41 @@ in-flight question. Log once: "Autostart verschoben — offene Frage aktiv."
 Claude session before the timeout elapses, auto-start will NOT fire. Tell the
 user verbally: the session must stay running.
 
+### 4d — External Shutdown Watchdog (only if shutdown=yes)
+
+**Skip entirely if Step 2 Question 3 was "Nein, nur Bericht".** Nothing to enforce.
+
+If the user chose "Ja, herunterfahren", register a Windows Scheduled Task that
+fires after 6 hours as a deadman switch. The task checks for a done-flag (which
+Step 7 writes on successful completion); if the flag is missing, it force-shuts
+the PC down via the absolute `shutdown.exe` path.
+
+This is the **last line of defense** against:
+- Anthropic API rate-limit hangs (Step 6 retry exhaustion or unhandled cases)
+- Subagent crashes that leave the orchestrator waiting
+- Wakelocks, hung file handles, or any "session alive but not progressing" failure mode
+- Bash quoting bugs in the in-session shutdown command itself
+
+The watchdog runs **outside** Claude — it cannot be blocked by anything inside
+the session. That's its whole point.
+
+```bash
+FLAG_PATH="$PWD/AUTONOMOUS-DONE.flag"
+WATCHDOG_OUT=$(node "$CLAUDE_PLUGIN_ROOT/scripts/autonomous-watchdog.js" register "$FLAG_PATH" 6)
+echo "$WATCHDOG_OUT"  # → {"ok":true, "taskName":"ClaudeAutonomousWatchdog-...", ...}
+```
+
+Parse the JSON output:
+- `ok: true` → save `taskName` as `$WATCHDOG_TASK`, set `$WATCHDOG_REGISTERED=true`
+- `ok: false` or `skipped: true` (non-Windows) → set `$WATCHDOG_REGISTERED=false`,
+  log a one-line warning into the report ("⚠ External watchdog konnte nicht
+  angelegt werden — in-session shutdown ist alleinige Absicherung"). Continue.
+
+**Budget tuning**: 6h covers realistic autonomous-task durations (analysis +
+implement + tests + build + verify + report) with headroom. Override only if
+the user declared an explicitly long task during intake ("8h migration", "run
+overnight benchmark") — bump to `12` or `24` (script enforces ≤ 24h).
+
 ### Post-Confirmation Lockout
 
 **After the user confirms, ZERO user interaction is allowed.**
@@ -347,13 +384,20 @@ Use `$BROWSER_TOOL` (from Step 3b) for all browser-based visual verification.
 - **Late Permission** (unanticipated permission needed during execution): save progress,
   write `AUTONOMOUS-RESUME.json`, generate INTERRUPTED report, **execute shutdown if
   requested**. See "Late Permission Handling" in Step 5.
+- **API Rate-Limit / Server Throttle** (Anthropic or 3rd-party API returns "Server
+  is temporarily limiting requests", "Rate limited", HTTP 429, etc.): exponential
+  backoff (30s → 2min → 10min), then save progress and bail to INTERRUPTED. See
+  full protocol in `deep-knowledge/autonomous-execution.md` § API-Error-Handling.
+  **Do NOT write the watchdog done-flag** — the external watchdog from Step 4d
+  is the ultimate fallback if Claude itself can't reach the API to run Steps 7-8.
 - **Minor** (single test fail, linter warning, optional enhancement): log and continue
 - **Related bugs** in same codebase context: fix them, log in report
 - **Truly stuck**: commit work locally, write report with BLOCKED status, never shut down
 
 **Status hierarchy:** COMPLETED > INTERRUPTED > BLOCKED.
-INTERRUPTED means useful work was done but couldn't finish due to missing permission.
-The resume file enables continuation. Shutdown is safe because progress is saved.
+INTERRUPTED means useful work was done but couldn't finish due to missing permission
+or an upstream rate-limit. The resume file enables continuation. Shutdown is safe
+because progress is saved.
 
 ## Step 7 — Report & Completion
 
@@ -439,16 +483,62 @@ stays empty and the sentinel falls through. The loop then waits on its own
 session too — burns the full 30 min cap before shutdown. Safer than cutting
 off other sessions by accident.
 
-### 8b — Execute Shutdown
+### 8b — Execute Shutdown (COMPLETED / INTERRUPTED)
+
+**Always shell out via PowerShell with an absolute path to `shutdown.exe`.**
+The naked Bash form (`shutdown /s /t 60 /c "..."`) is unreliable in two cases
+seen in production:
+
+1. **UNC CWD** (e.g. session running from `\\nas\share\...`): cmd.exe rejects
+   UNC paths as CWD ("UNC-Pfade werden nicht unterstützt") and silently switches
+   to `%SystemRoot%`, breaking the rest of the command line.
+2. **Bash quoting**: single-quoted args (`'shutdown /s /t 60'`) work in Bash but
+   CMD treats `'` as a literal — the whole token becomes one unknown command.
+
+PowerShell tolerates UNC CWDs natively, and the absolute `$env:SystemRoot\System32\shutdown.exe`
+path bypasses any PATH/CWD interaction:
 
 ```bash
-shutdown /s /t 60 /c "Autonomous task completed. Shutting down in 60s. Run 'shutdown /a' to abort."
+powershell.exe -NoProfile -Command '& "$env:SystemRoot\System32\shutdown.exe" /s /t 60 /c "Autonomous task completed. Shutting down in 60s. shutdown /a to abort."'
+SHUTDOWN_EXIT=$?
 ```
+
+**Capture the exit code** as `$SHUTDOWN_EXIT`. `shutdown.exe` returns 0 on
+success; anything else means the call did NOT schedule a shutdown. Step 8c
+uses this to decide whether to disarm the watchdog.
 
 **INTERRUPTED:** Shutdown is safe because progress is saved in `AUTONOMOUS-RESUME.json`
 and committed locally. The user can resume on next boot via Step 0.5.
 
-**BLOCKED:** Skip shutdown — user must intervene immediately, data integrity may be at risk.
+**BLOCKED:** Do NOT run Step 8b at all — jump straight to Step 8c. Original rule
+stands: data integrity may be at risk, user must intervene.
 
 **Never ask about shutdown inline.** The decision was made in Step 2 (or Step 0.5 on
 resume). Just execute it (after the 8a wait).
+
+### 8c — Watchdog Done-Flag Handling
+
+Only relevant if Step 4d armed a watchdog (`$WATCHDOG_REGISTERED == true`).
+Skip entirely if no watchdog was registered (shutdown=no or registration failed).
+
+Decision matrix — when to write `AUTONOMOUS-DONE.flag` (which tells the watchdog
+to **not** shut down when it fires):
+
+| Status      | Step 8b exit | Write flag? | Why |
+|-------------|--------------|-------------|-----|
+| COMPLETED   | 0 (success)  | **Yes**     | In-session shutdown handled it; watchdog must stand down |
+| INTERRUPTED | 0 (success)  | **Yes**     | Same — shutdown is happening, watchdog redundant |
+| COMPLETED   | ≠ 0 (failed) | **No**      | In-session shutdown failed → watchdog is the fallback, let it fire |
+| INTERRUPTED | ≠ 0 (failed) | **No**      | Same — watchdog enforces what 8b couldn't |
+| BLOCKED     | (skipped)    | **Yes**     | Original rule: BLOCKED never shuts down. Stand the watchdog down too |
+
+Command (only when writing the flag):
+
+```bash
+node "$CLAUDE_PLUGIN_ROOT/scripts/autonomous-watchdog.js" flag "$PWD/AUTONOMOUS-DONE.flag"
+```
+
+We deliberately do NOT call `unregister` on the scheduled task — leaving it
+armed but flag-satisfied is simpler and self-cleans (the task fires once, sees
+the flag, exits, and removes its helper script). If you ever need to clean it
+up earlier (e.g. user manually resumes), use the `unregister` subcommand.

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.78.1",
+  "version": "0.79.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

Three independent failure modes saw an autonomous overnight run leave the PC up:

- **UNC CWD breaks cmd.exe shutdown** — session ran from `\\nas\share\...`, all three shutdown attempts failed silently (`head` not in CMD, escape bug, single-quotes treated as literal). Step 8b now routes via PowerShell + absolute `shutdown.exe` path + `; exit $LASTEXITCODE` so `$?` in Bash reflects the native call.
- **API rate-limits left sessions wedged** — Anthropic "Server is temporarily limiting requests" pauses indefinitely from the user's POV. New Step 6 category + full backoff protocol in deep-knowledge.
- **No external safety net** — any wedge that blocks in-session Step 8 from running (API hang, crashed subagent, hook deadlock) left the PC running forever. New Step 4d registers a Windows Scheduled Task as a deadman switch (8h default, fires + force-shutdown if `AUTONOMOUS-DONE.flag` is missing).

Codex pre-ship review caught 5 follow-up issues (exit-code propagation, flag-path drift, sentinel-validation security, watchdog/Step-8a race, doc inconsistencies) — all addressed in the second commit before merge.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 153/153 passing across 11 suites
- [x] `node --check autonomous-watchdog.js` — syntax OK
- [x] `autonomous-watchdog.js status` (no sentinel) → `{ok:true, active:false}`
- [x] `autonomous-watchdog.js flag` (no sentinel) → friendly "no sentinel found" error
- [x] Codex review (rc=0) — all 5 findings addressed in commit 5312a65
- [ ] Live AFK run with shutdown=yes (next overnight autonomous session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)