### PR TITLE
feat(hooks): workspace-setup warning in ss.git.check (0.80.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.79.0"
+    "version": "0.80.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.79.0",
+      "version": "0.80.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.79.0",
+      "version": "0.80.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.80.0] — 2026-05-23
+
+### Added
+
+- **plugins/devops/hooks/session-start/ss.git.check.js** — extended to flag workspace-setup issues alongside the existing stale-changes check. New `checkWorkspace(cwd)` raises three cases at session start: ⚠ on `main`/`master` in the repo root (write ops would be blocked reactively by `pre.main.guard`/`pre.edit.branch`), ⚠ detached `HEAD` in the repo root (commits would not belong to any branch), and a mild suggestion when in the repo root on a feature branch. In-worktree-on-main stays silent — handled by `prompt.worktree.branch-guard`. When raised, the hook writes a stdout instruction telling Claude to call `AskUserQuestion` as the first action with three resolution paths (worktree+branch / ship-first / take-along via stash + pop). Hook version `0.3.0 → 0.4.0`.
+
+### Changed
+
+- **plugins/devops/hooks/session-start/ss.git.check.js** — when both workspace and stale issues are detected, the uncommitted/unpushed lines for the current repo collapse into a single `Pending:` line under the Workspace section so the AskUserQuestion has the full picture; remaining stale items (stash, other repos) render under an `Additional in current repo:` / `**<label>**` sub-header. `dirty.push` now records the repo `dir` so the workspace section can locate the current-repo issues.
+- **plugins/devops/.claude-plugin/plugin.json** — version `0.79.0 → 0.80.0`
+
+### Notes
+
+- `DEVOPS_ALLOW_MAIN=1` scopes to the main-branch case only (its semantic meaning). Detached-HEAD and feature-branch-no-worktree are not silenced by that flag.
+- `.claude/.ship-in-progress` sentinel silences the workspace check completely while the ship pipeline runs.
+
 ## [0.79.0] — 2026-05-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.79.0**
+**Version: 0.80.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.79.0",
+  "version": "0.80.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/hooks/session-start/ss.git.check.js
+++ b/plugins/devops/hooks/session-start/ss.git.check.js
@@ -11,11 +11,14 @@
  *   Workspace check (current repo only):
  *     - On main/master without worktree → high-priority warning, suggests
  *       worktree + feature branch (or ship-first if uncommitted exist).
+ *     - Detached HEAD without worktree → high-priority warning (commits
+ *       would not belong to any branch).
  *     - Not in worktree on feature branch → mild suggestion to isolate.
  *     - In worktree on main → silent (prompt.worktree.branch-guard handles).
  *
  *   Bypass for workspace check (stale check still runs):
- *     - DEVOPS_ALLOW_MAIN=1 in environment
+ *     - DEVOPS_ALLOW_MAIN=1 silences only the main-branch case (its
+ *       semantic scope), not detached-HEAD or feature-branch-no-worktree
  *     - .claude/.ship-in-progress sentinel exists (ship pipeline active)
  */
 
@@ -137,17 +140,22 @@ function checkRepo(dir) {
 }
 
 function currentBranch(dir) {
-  return run('git symbolic-ref --quiet --short HEAD', dir);
+  return run('git symbolic-ref --quiet --short HEAD', dir) || null;
 }
 
 function checkWorkspace(dir) {
-  if (process.env.DEVOPS_ALLOW_MAIN === '1') return null;
   if (sentinelActive(dir)) return null;
-  const branch = currentBranch(dir);
-  if (!branch) return null;
   const inWorktree = isLinkedWorktree(dir);
   if (inWorktree) return null;
+  const branch = currentBranch(dir);
+  if (!branch) {
+    // Detached HEAD in repo root — always high severity (risky state).
+    return { type: 'detached-no-worktree', branch: 'detached HEAD', severity: 'high' };
+  }
   const onMain = branch === 'main' || branch === 'master';
+  // DEVOPS_ALLOW_MAIN scopes to the main-branch case only — its semantic
+  // meaning is "I'm allowed to work on main", not a global mute.
+  if (onMain && process.env.DEVOPS_ALLOW_MAIN === '1') return null;
   return {
     type: onMain ? 'on-main-no-worktree' : 'no-worktree',
     branch,
@@ -228,28 +236,43 @@ if (workspace) {
   out.push('Workspace check at session start. Show this summary AS-IS and call AskUserQuestion as the FIRST action of this turn:');
   out.push('');
   out.push('**Workspace setup**');
-  if (workspace.severity === 'high') {
-    out.push(`- ⚠ On \`${workspace.branch}\` in repo root (not in a worktree) — write ops will be blocked by pre.main.guard / pre.edit.branch`);
-  } else {
-    out.push(`- On \`${workspace.branch}\` in repo root (not in a worktree)`);
+  switch (workspace.type) {
+    case 'on-main-no-worktree':
+      out.push(`- ⚠ On \`${workspace.branch}\` in repo root (not in a worktree) — write ops will be blocked by pre.main.guard / pre.edit.branch`);
+      break;
+    case 'detached-no-worktree':
+      out.push('- ⚠ Detached HEAD in repo root (not in a worktree) — commits will not belong to any branch');
+      break;
+    default:
+      out.push(`- On \`${workspace.branch}\` in repo root (not in a worktree)`);
   }
   if (hasChanges) {
     out.push(`- Pending: ${pendingIssues.map(i => i.label).join(', ')}`);
   }
   out.push('');
   out.push('Ask the user (in their language) via AskUserQuestion. Suggested options:');
-  out.push('  - Worktree + Feature-Branch anlegen (recommended)');
   if (hasChanges) {
-    out.push(`  - Erst Changes auf \`${workspace.branch}\` shippen, dann Worktree anlegen`);
+    out.push('  - Worktree + Feature-Branch anlegen');
+    out.push('  - Erst aktuelle Changes shippen (commit + push), dann Worktree anlegen (recommended)');
     out.push('  - Changes mitnehmen in neuen Worktree (git stash → create → pop)');
+  } else {
+    out.push('  - Worktree + Feature-Branch anlegen (recommended)');
   }
-  out.push('  - Hier bleiben (bypass: DEVOPS_ALLOW_MAIN=1 für diese Session)');
+  if (workspace.severity === 'high' && workspace.type === 'on-main-no-worktree') {
+    out.push('  - Hier bleiben (bypass: DEVOPS_ALLOW_MAIN=1 für diese Session)');
+  } else {
+    out.push('  - Hier bleiben (Warning bleibt informativ — kein Bypass-Flag nötig)');
+  }
   out.push('');
   out.push('Resolution per option:');
   out.push('  - Worktree+branch: `git worktree add ../<feature> -b claude/<feature>` then cd there');
-  out.push('  - Ship-first: invoke /devops-ship, then create worktree');
-  out.push('  - Take-along: `git stash`, create worktree, `cd <worktree>`, `git stash pop`');
-  out.push('  - Stay: set env `DEVOPS_ALLOW_MAIN=1` for this session');
+  if (hasChanges) {
+    out.push('  - Ship-first: invoke /devops-ship, then create worktree');
+    out.push('  - Take-along: `git stash`, create worktree, `cd <worktree>`, `git stash pop`');
+  }
+  if (workspace.type === 'on-main-no-worktree') {
+    out.push('  - Stay: set env `DEVOPS_ALLOW_MAIN=1` for this session to silence main-branch checks');
+  }
   out.push('');
 }
 

--- a/plugins/devops/hooks/session-start/ss.git.check.js
+++ b/plugins/devops/hooks/session-start/ss.git.check.js
@@ -1,15 +1,26 @@
 #!/usr/bin/env node
 /**
  * @hook ss.git.check
- * @version 0.3.0
+ * @version 0.4.0
  * @event SessionStart
  * @plugin devops
- * @description Check for stale uncommitted/unpushed changes at session start.
- *   Filters out active worktree branches to avoid false positives.
+ * @description Check for stale changes AND workspace setup issues at session
+ *   start. Filters out active worktree branches to avoid false positives.
  *   Silent when clean. Outputs structured CTAs when issues are found.
+ *
+ *   Workspace check (current repo only):
+ *     - On main/master without worktree → high-priority warning, suggests
+ *       worktree + feature branch (or ship-first if uncommitted exist).
+ *     - Not in worktree on feature branch → mild suggestion to isolate.
+ *     - In worktree on main → silent (prompt.worktree.branch-guard handles).
+ *
+ *   Bypass for workspace check (stale check still runs):
+ *     - DEVOPS_ALLOW_MAIN=1 in environment
+ *     - .claude/.ship-in-progress sentinel exists (ship pipeline active)
  */
 
 require('../lib/plugin-guard');
+const { isActive: sentinelActive } = require('../lib/ship-sentinel');
 
 const { execSync } = require('child_process');
 const fs = require('fs');
@@ -125,6 +136,25 @@ function checkRepo(dir) {
   return issues;
 }
 
+function currentBranch(dir) {
+  return run('git symbolic-ref --quiet --short HEAD', dir);
+}
+
+function checkWorkspace(dir) {
+  if (process.env.DEVOPS_ALLOW_MAIN === '1') return null;
+  if (sentinelActive(dir)) return null;
+  const branch = currentBranch(dir);
+  if (!branch) return null;
+  const inWorktree = isLinkedWorktree(dir);
+  if (inWorktree) return null;
+  const onMain = branch === 'main' || branch === 'master';
+  return {
+    type: onMain ? 'on-main-no-worktree' : 'no-worktree',
+    branch,
+    severity: onMain ? 'high' : 'low',
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Cleanup stale session temp files (older than 24h)
 // ---------------------------------------------------------------------------
@@ -174,31 +204,88 @@ const dirty = [];
 for (const repo of repos) {
   const issues = checkRepo(repo.dir);
   if (issues.length > 0) {
-    dirty.push({ label: repo.label, issues });
+    dirty.push({ label: repo.label, dir: repo.dir, issues });
   }
 }
 
-if (dirty.length === 0) {
+const workspace = checkWorkspace(cwd);
+
+if (dirty.length === 0 && !workspace) {
   process.exit(0);
 }
 
 // Build structured output with CTAs
-const out = ['Stale changes found at session start. Show the user this summary as-is:'];
-out.push('');
+const out = [];
+
+if (workspace) {
+  const stagedTypes = new Set(['uncommitted', 'unpushed']);
+  const currentDirty = dirty.find(d => d.dir === cwd);
+  const pendingIssues = currentDirty
+    ? currentDirty.issues.filter(i => stagedTypes.has(i.type))
+    : [];
+  const hasChanges = pendingIssues.length > 0;
+
+  out.push('Workspace check at session start. Show this summary AS-IS and call AskUserQuestion as the FIRST action of this turn:');
+  out.push('');
+  out.push('**Workspace setup**');
+  if (workspace.severity === 'high') {
+    out.push(`- ⚠ On \`${workspace.branch}\` in repo root (not in a worktree) — write ops will be blocked by pre.main.guard / pre.edit.branch`);
+  } else {
+    out.push(`- On \`${workspace.branch}\` in repo root (not in a worktree)`);
+  }
+  if (hasChanges) {
+    out.push(`- Pending: ${pendingIssues.map(i => i.label).join(', ')}`);
+  }
+  out.push('');
+  out.push('Ask the user (in their language) via AskUserQuestion. Suggested options:');
+  out.push('  - Worktree + Feature-Branch anlegen (recommended)');
+  if (hasChanges) {
+    out.push(`  - Erst Changes auf \`${workspace.branch}\` shippen, dann Worktree anlegen`);
+    out.push('  - Changes mitnehmen in neuen Worktree (git stash → create → pop)');
+  }
+  out.push('  - Hier bleiben (bypass: DEVOPS_ALLOW_MAIN=1 für diese Session)');
+  out.push('');
+  out.push('Resolution per option:');
+  out.push('  - Worktree+branch: `git worktree add ../<feature> -b claude/<feature>` then cd there');
+  out.push('  - Ship-first: invoke /devops-ship, then create worktree');
+  out.push('  - Take-along: `git stash`, create worktree, `cd <worktree>`, `git stash pop`');
+  out.push('  - Stay: set env `DEVOPS_ALLOW_MAIN=1` for this session');
+  out.push('');
+}
+
+const staleHeaderShown = !workspace && dirty.length > 0;
+if (staleHeaderShown) {
+  out.push('Stale changes found at session start. Show the user this summary as-is:');
+  out.push('');
+}
+
 for (const r of dirty) {
-  out.push(`**${r.label}**`);
+  const lines = [];
   for (const issue of r.issues) {
+    if (workspace && r.dir === cwd
+        && (issue.type === 'uncommitted' || issue.type === 'unpushed')) {
+      continue;
+    }
     switch (issue.type) {
       case 'uncommitted':
       case 'unpushed':
-        out.push(`- ${issue.label} → run \`/devops-ship\` to commit, push & create PR`);
+        lines.push(`- ${issue.label} → run \`/devops-ship\` to commit, push & create PR`);
         break;
       case 'stash':
-        out.push(`- ${issue.label} → review with \`git stash list\`, then \`git stash pop\` or \`git stash drop\``);
+        lines.push(`- ${issue.label} → review with \`git stash list\`, then \`git stash pop\` or \`git stash drop\``);
         break;
     }
   }
-  out.push('');
+  if (lines.length > 0) {
+    const header = workspace && r.dir === cwd
+      ? 'Additional in current repo:'
+      : `**${r.label}**`;
+    out.push(header);
+    out.push(...lines);
+    out.push('');
+  }
 }
+
+if (out.length === 0) process.exit(0);
 
 process.stdout.write(out.join('\n'));

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.79.0",
+  "version": "0.80.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

`ss.git.check` now flags workspace-setup issues at SessionStart in addition to the existing stale-changes check:

- ⚠ **main/master without worktree** → high warning (write ops would be blocked reactively by `pre.main.guard` / `pre.edit.branch`)
- ⚠ **Detached HEAD without worktree** → high warning (commits would not belong to any branch)
- **Feature branch in repo root** → mild suggestion to isolate work in a worktree

When triggered, the hook writes a stdout instruction telling Claude to call `AskUserQuestion` as the first action with three resolution paths:

1. Worktree + Feature-Branch anlegen
2. Erst aktuelle Changes shippen, dann Worktree anlegen *(recommended when uncommitted changes exist)*
3. Changes mitnehmen in neuen Worktree (`git stash` → create → `pop`)

Closes the gap where `pre.main.guard` only blocks reactively after the first edit attempt — the workspace situation is now flagged once at session start with an actionable choice.

## Bypass

- `DEVOPS_ALLOW_MAIN=1` — scoped to the **main-branch case only** (semantic correctness). Detached-HEAD and feature-branch-no-worktree are not silenced.
- `.claude/.ship-in-progress` sentinel — silences during ship pipeline.

## Tests

- `npm run lint`: clean
- `npm test`: 153 / 153 passing
- Codex review: 3 findings (semantic scope of `DEVOPS_ALLOW_MAIN`, detached-HEAD edge case, ship-first recommended marker) — all addressed pre-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)