### PR TITLE
feat(concept): post-submit content dimmer (0.81.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.80.0"
+    "version": "0.81.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.80.0",
+      "version": "0.81.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.80.0",
+      "version": "0.81.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.81.0] — 2026-05-23
+
+### Added
+
+- **plugins/devops/skills/devops-concept/deep-knowledge/templates.md** — post-submit content dimmer (`#content-dimmer`, `body.content-dimmed`). After a submit (`iterate`, `implement`, or `create-issues`), a fixed `rgba(0,0,0,0.4)` overlay with a 1.5 px backdrop blur is shown over the concept content area to focus attention on the decision panel and FABs. The dimmer is click-to-dismiss; an `Escape` keydown handler also dismisses it for keyboard-only users. It auto-clears on the next page reload (next iteration / final report) because `content-dimmed` is not persisted. Decision panel + FABs sit at higher z-index (`.concept-decision-panel` sidebar bumped to `z-index: 100`; prototype FABs/dock/backdrop/indicator already ≥ 90) so they paint above the dimmer and remain interactive. New helpers `showContentDimmer()` / `hideContentDimmer()`; `submitWithAction` and `submitCreateIssues` now add the body class and reveal the element, `restorePanelToReady` clears both.
+- **plugins/devops/skills/devops-concept/deep-knowledge/templates.md** — new `panel.dim_dismiss` locale key (en: "Dismiss overlay" / de: "Schimmer entfernen") used as `aria-label` + `title` on the dimmer element. Element is added to the Common Structure HTML and the prototype + free template HTML examples.
+
+### Changed
+
+- **plugins/devops/skills/devops-concept/deep-knowledge/validation-gate.md** — mandatory shared-pattern count `29 → 30`. New pattern #30 (`content-dimmer`) — generation without the dimmer is now rejected by the post-generation gate.
+- **plugins/devops/skills/devops-concept/SKILL.md** — submit-button behavior step 4 documents the new dimmer flip; the "29 mandatory interactive patterns" reference is updated to 30.
+- **plugins/devops/.claude-plugin/plugin.json** — version `0.80.0 → 0.81.0`
+
 ## [0.80.0] — 2026-05-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.80.0**
+**Version: 0.81.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.80.0",
+  "version": "0.81.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/skills/devops-concept/SKILL.md
+++ b/plugins/devops/skills/devops-concept/SKILL.md
@@ -314,7 +314,11 @@ signal Claude monitors.
 1. Collect all toggle/checkbox states → `decisions[]`
 2. Collect all comment field values → `comments[]`
 3. Set `submitted: true` in the JSON block
-4. Add class `concept-submitted` to `<body>`
+4. Add classes `concept-submitted` and `content-dimmed` to `<body>` and
+   reveal `#content-dimmer` so the content area visually fades. The decision
+   panel + FABs sit at higher z-index and stay clear + interactive. The
+   dimmer is click-to-dismiss; otherwise it auto-clears on the next page
+   reload (next iteration / final report).
 5. Switch the decision panel from "ready" to "submitted" state — showing a
    clear "Entscheidungen übermittelt" indicator with a hint to switch to the
    Claude chat (see `deep-knowledge/templates.md` § Submit Handler)
@@ -361,10 +365,10 @@ and `deep-knowledge/templates.md` § Iteration Tabs for the reference HTML.
 
 ### Post-Generation Validation (mandatory gate)
 
-After writing the HTML file, grep it for the 29 mandatory interactive
+After writing the HTML file, grep it for the 30 mandatory interactive
 patterns (heartbeat, panel states, iteration tabs, section TOC, reload
 polling, generic form-collection catch-all scoped to the active
-iteration, etc.).
+iteration, post-submit content dimmer, etc.).
 **If ANY pattern is missing → DO NOT open the page.** Fix the HTML first,
 then re-validate. See `deep-knowledge/validation-gate.md` for the full
 pattern list and common failure modes.

--- a/plugins/devops/skills/devops-concept/deep-knowledge/templates.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/templates.md
@@ -69,6 +69,7 @@ must see their own language. The locale hint is authoritative.
 | `panel.toggle_open`            | Open decisions                 | Entscheidungen öffnen |
 | `panel.close`                  | Close                          | Schliessen |
 | `panel.minimize`               | Minimize                       | Minimieren |
+| `panel.dim_dismiss`            | Dismiss overlay                | Schimmer entfernen |
 | `variant.include`              | Include                        | Miteinbeziehen |
 | `variant.discard`              | Discard                        | Verwerfen |
 | `iteration.label`              | Iterations                     | Iterationen |
@@ -275,6 +276,18 @@ the `[ui-locale: ...]` hint produced.
     </aside>
   </div>
 
+  <!-- Submitted-state content dimmer (all templates).
+       After a submit, body.content-dimmed flips this on. The dimmer covers
+       the content area and directs focus to the decision panel / FAB. The
+       panel + FABs are above z-index 50 so they paint over the dimmer and
+       stay visually clear and clickable. The dimmer itself is click-to-
+       dismiss; otherwise it auto-clears on the next page reload (new
+       iteration / final report) because `content-dimmed` is not persisted. -->
+  <div class="content-dimmer" id="content-dimmer"
+       role="button" tabindex="-1"
+       aria-label="{{panel.dim_dismiss}}"
+       title="{{panel.dim_dismiss}}" hidden></div>
+
   <script type="application/json" id="concept-decisions">
     {"submitted": false, "decisions": [], "comments": []}
   </script>
@@ -319,6 +332,9 @@ structured evaluation where the user wants to see the panel at all times.
   padding: 1.5rem;
   border-left: 1px solid var(--border-color);
   background: var(--panel-bg);
+  /* Above .content-dimmer (z-index 50) so the panel's solid background
+     visually punches through the dimmer instead of being tinted by it. */
+  z-index: 100;
 }
 /* Mobile: collapse to sticky bottom */
 @media (max-width: 768px) {
@@ -870,6 +886,12 @@ The wiring is a single delegated click handler installed alongside
       </div>
     </aside>
   </div>
+
+  <!-- Shared content dimmer — see Common Structure for behavior + CSS. -->
+  <div class="content-dimmer" id="content-dimmer"
+       role="button" tabindex="-1"
+       aria-label="{{panel.dim_dismiss}}"
+       title="{{panel.dim_dismiss}}" hidden></div>
 </body>
 </html>
 ```
@@ -1467,6 +1489,12 @@ bi-state. Claude chooses the structure that fits the content.
            have eval-{id} radios and mirrors their current state. -->
     </aside>
   </div>
+
+  <!-- Shared content dimmer — see Common Structure for behavior + CSS. -->
+  <div class="content-dimmer" id="content-dimmer"
+       role="button" tabindex="-1"
+       aria-label="{{panel.dim_dismiss}}"
+       title="{{panel.dim_dismiss}}" hidden></div>
 </body>
 </html>
 ```
@@ -1762,6 +1790,37 @@ document.addEventListener('DOMContentLoaded', () => {
   display: flex; align-items: center; gap: 0.35rem;
 }
 .hint-cache[hidden] { display: none; }
+
+/* Content dimmer — covers the content area after submit so the user's focus
+   lands on the decision panel / FAB. Decision panel, FABs, feedback dock,
+   panel backdrop, and screen-indicator all sit at z-index ≥ 90 (and the
+   sidebar panel was bumped to z-index 100), so they paint above the dimmer
+   and stay clear + interactive. The dimmer itself is click-to-dismiss.
+   Auto-clears on page reload (next iteration / final report) because the
+   body class is not persisted. */
+.content-dimmer {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  /* Theme-neutral grey overlay — works on dark and light backgrounds without
+     a CSS variable dependency. Same opacity range as .panel-backdrop. */
+  background: rgba(0, 0, 0, 0.4);
+  backdrop-filter: blur(1.5px);
+  -webkit-backdrop-filter: blur(1.5px);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.25s ease;
+  pointer-events: none;
+}
+body.content-dimmed .content-dimmer:not([hidden]) {
+  opacity: 1;
+  pointer-events: auto;
+}
+.content-dimmer[hidden] { display: none; }
+.content-dimmer:focus-visible {
+  outline: 2px solid var(--accent-color, #58a6ff);
+  outline-offset: -4px;
+}
 
 /* Submitted state */
 .submitted-indicator {
@@ -2276,7 +2335,8 @@ async function submitWithAction(action) {
   const data = collectDecisions(action);
   const container = document.getElementById('concept-decisions');
   container.textContent = JSON.stringify(data);
-  document.body.classList.add('concept-submitted');
+  document.body.classList.add('concept-submitted', 'content-dimmed');
+  showContentDimmer();
   _submittedAt = Date.now();
   _submittedReloadCounter = _bootReloadCounter;
   _submittedAction = action;
@@ -2304,6 +2364,27 @@ async function submitWithAction(action) {
 
 wireSubmit('submit-iterate-btn', 'iterate');
 wireSubmit('submit-implement-btn', 'implement');
+
+// --- Content dimmer (focus shifter after submit) ---
+// After a submit the user's attention belongs on the decision panel / FAB,
+// not on the now-frozen content. showContentDimmer reveals a fixed overlay
+// over the content area; the panel + FABs sit at higher z-index and stay
+// clear and clickable. The dimmer itself is click-to-dismiss — clicking
+// anywhere on it removes `content-dimmed` and hides the overlay, letting
+// the user re-engage with the content without losing the submitted state.
+// On page reload (next iteration / final report) the body class is naturally
+// gone, so no extra cleanup is needed.
+function showContentDimmer() {
+  const dim = document.getElementById('content-dimmer');
+  if (dim) dim.hidden = false;
+}
+function hideContentDimmer() {
+  const dim = document.getElementById('content-dimmer');
+  if (dim) dim.hidden = true;
+  document.body.classList.remove('content-dimmed');
+}
+document.getElementById('content-dimmer')
+  ?.addEventListener('click', hideContentDimmer);
 
 // --- Final-report "Issues erstellen" action ---
 // Gating rules (only ALL of these true → panel visible + button enabled):
@@ -2376,7 +2457,8 @@ async function submitCreateIssues() {
   const payload = { submitted: true, action: 'create-issues', items };
   const container = document.getElementById('concept-decisions');
   if (container) container.textContent = JSON.stringify(payload);
-  document.body.classList.add('concept-submitted');
+  document.body.classList.add('concept-submitted', 'content-dimmed');
+  showContentDimmer();
 
   try {
     await fetch('/decisions', {
@@ -2445,7 +2527,8 @@ function restorePanelToReady() {
     const btn = document.getElementById(id);
     if (btn) btn.disabled = false;
   });
-  document.body.classList.remove('concept-submitted');
+  document.body.classList.remove('concept-submitted', 'content-dimmed');
+  hideContentDimmer();
   _submittedAt = 0;
   _submittedReloadCounter = null;
   _submitInFlight = false;

--- a/plugins/devops/skills/devops-concept/deep-knowledge/templates.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/templates.md
@@ -2385,6 +2385,13 @@ function hideContentDimmer() {
 }
 document.getElementById('content-dimmer')
   ?.addEventListener('click', hideContentDimmer);
+// Keyboard escape — keyboard-only users can't click the dimmer, so let
+// Escape dismiss it. Only acts while the dimmer is actually visible.
+document.addEventListener('keydown', e => {
+  if (e.key !== 'Escape') return;
+  const dim = document.getElementById('content-dimmer');
+  if (dim && !dim.hidden) hideContentDimmer();
+});
 
 // --- Final-report "Issues erstellen" action ---
 // Gating rules (only ALL of these true → panel visible + button enabled):

--- a/plugins/devops/skills/devops-concept/deep-knowledge/validation-gate.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/validation-gate.md
@@ -7,7 +7,7 @@ template-specific extras selected by `<html data-template="...">`.
 
 ## Phase 1 — Shared patterns (ALL templates)
 
-Every concept page must contain these 29 patterns, regardless of template:
+Every concept page must contain these 30 patterns, regardless of template:
 
 | # | Pattern to grep | Purpose |
 |---|----------------|---------|
@@ -41,6 +41,7 @@ Every concept page must contain these 29 patterns, regardless of template:
 | 27 | `Date.now() - _lastHeartbeatTs` (millis vs. millis) | Both sides of the staleness comparison MUST be in milliseconds since the Unix epoch. Server returns `claude_ts` in ms; browser uses `Date.now()`. Never divide either side by 1000 — a millis-vs-seconds mix-up produces a giant negative age that always evaluates as "fresh" and silently hides outages. |
 | 28 | `panel-final-report` | Final-report panel element. Auto-shown by `showIteration()` when the active section carries `data-final-report`; replaces `panel-ready` (no iterate/implement buttons). |
 | 29 | `updateCreateIssuesPanel` | Gating function that toggles the "Issues erstellen" button visibility + enabled state based on the active section's `[data-open-questions]` content. Must be called from `showIteration()` so panel state stays consistent on tab switch. |
+| 30 | `content-dimmer` | Shared post-submit focus overlay. After a submit, `body.content-dimmed` flips it on; the decision panel + FABs sit at higher z-index and paint above it. Click-to-dismiss; auto-clears on page reload. See `templates.md` § Common Structure (HTML) and § Decision Panel State CSS for the reference implementation. |
 
 **Failure for 21 / 22:** if either pattern is missing, the page is rejected
 at the post-generation gate. See § Generic Form Collection below for the

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.80.0",
+  "version": "0.81.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

After a submit in `/devops-concept` (iterate / implement / create-issues), a click-dismissable grey overlay (`#content-dimmer`, `rgba(0,0,0,0.4)` + 1.5 px backdrop blur) fades the content area while the decision panel and FABs stay clear and interactive. The dimmer focuses the user's attention on the submitted-state UI without locking them out of the content — clicking the dimmer or pressing `Escape` dismisses it; otherwise it auto-clears on the next page reload (next iteration / final report) because `body.content-dimmed` is not persisted.

## Changes

- **HTML** — `#content-dimmer` added to Common Structure + prototype + free template HTML examples; new `panel.dim_dismiss` locale key (en: "Dismiss overlay" / de: "Schimmer entfernen").
- **CSS** — `.content-dimmer` rules (z-index 50, blur, themed via `rgba(0,0,0,0.4)`); `.concept-decision-panel` sidebar bumped to `z-index: 100` so the panel paints above the dimmer.
- **JS** — `showContentDimmer()` / `hideContentDimmer()` helpers; `submitWithAction` and `submitCreateIssues` add `body.content-dimmed` and reveal the dimmer; `restorePanelToReady` clears both. Click handler on the dimmer + global `Escape` keydown handler dismiss it.
- **Validation gate** — mandatory shared-pattern count `29 → 30`; new pattern #30 (`content-dimmer`).
- **Docs** — SKILL.md submit-behavior step 4 documents the dimmer flip.

## Test plan

- [ ] `/devops-plugin-update` in a consumer project picks up the new templates.
- [ ] `/devops-concept` generation produces a page that passes the 30-pattern validation gate.
- [ ] Submit an iteration → grey overlay appears over content; decision panel + FABs stay clear; click on overlay dismisses it; `Escape` also dismisses; next iteration reload clears it automatically.