### PR TITLE
feat(devops): concept notes/disposition + ship reopen-tracker (0.82.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.81.0"
+    "version": "0.82.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.81.0",
+      "version": "0.82.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.81.0",
+      "version": "0.82.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ node_modules/
 .claude/usage-live.json
 .claude/.ship-in-progress
 .claude/concept-active.json
+.claude/session-opened-files.json
 # Plugin-managed runtime dirs
 .claude/.plugin-version
 .claude/hooks/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [0.82.0] — 2026-05-23
+
+### Added
+
+- **plugins/devops/skills/devops-concept/deep-knowledge/templates.md** — per-decision note textareas (closes [#158](https://github.com/Jerry0022/dotclaude/issues/158)). Every Bi-State `[data-decision]` group now ships with an adjacent `<textarea data-comment="$id-note">` so the user can attach a free-form override ("only for X", "with variant Y") to the include/discard choice. New `ensureCommentSlots()` JS safety net auto-injects the slot on `DOMContentLoaded` (idempotent, runs before `restoreState` so typed values survive reload). New locale keys `decision.comment_label` / `decision.comment_placeholder`. Validation gate pattern #31 enforces the helper's presence.
+- **plugins/devops/skills/devops-concept/deep-knowledge/templates.md** — disposition control on the final-report panel (closes [#159](https://github.com/Jerry0022/dotclaude/issues/159)). New `panel-dispose-concept` fieldset (always visible while `panel-final-report` is active) carries three radios (discard / keep / gitignore) plus an optional `moveTo` text input and a new "Concept beenden" button. `submitDisposeConcept()` POSTs `action: "dispose-concept"`; `submitCreateIssues()` also includes the current disposition state in its payload. Validation gate patterns #32 / #33. Locale keys `final.dispose_*` (heading, hint, mode labels, button, status). Default = `discard`.
+- **plugins/devops/skills/devops-concept/SKILL.md** — Step 6a is rewritten as Cleanup-By-Disposition (closes [#159](https://github.com/Jerry0022/dotclaude/issues/159)). Explicit branches for `discard` / `keep` / `gitignore` modes with optional `moveTo`. Safety rules: project-root-relative `moveTo` (reject `..` and absolute paths), full filename gitignore patterns (`docs/concepts/{date}-{slug}.*` — bare `{slug}.*` does NOT match), shell-quoted `--` terminated path commands, append-only `.gitignore` edits with dedupe grep, swallow `git rm --cached` errors for never-tracked files.
+- **plugins/devops/scripts/session-open-tracker.js** — new CLI script (closes [#160](https://github.com/Jerry0022/dotclaude/issues/160)). Tracks every `file://` URL the session opens (`track <abs-path> [--context=<tag>]`) and re-opens them from the main-repo path after `ship_cleanup` removes the worktree (`reopen-main --worktree=<abs-path>`). Storage at `<main-repo>/.claude/session-opened-files.json` (24h TTL, 50-entry cap, path-normalized de-dupe). Browser launch failures preserve entries for retry; genuinely-missing main-repo files are consumed. Wired into `/devops-ship` Step 5c, `devops-autonomous` Step 7c, `devops-repo-health` Step 8.
+- **plugins/devops/deep-knowledge/browser-file-urls.md** + **plugins/devops/deep-knowledge/skill-extension-guide.md** — documented the tracker contract for project-side skill extensions that open `file://` URLs.
+
+### Changed
+
+- **plugins/devops/skills/devops-concept/SKILL.md** — `File Location` section reflects new ephemeral-by-default policy (concept HTMLs only land in git when the user explicitly picks "Im Projekt behalten"). Step 5b adds `action: "dispose-concept"` to the expected final-report submissions. Submit-handler step for `create-issues` now records the bundled `disposition` for Step 6a.
+- **plugins/devops/skills/devops-concept/deep-knowledge/bridge-server.md** — Step 7 cleanup explicitly defers on-disk artefact disposition to SKILL.md § Step 6a — Cleanup-By-Disposition.
+- **plugins/devops/skills/devops-concept/deep-knowledge/validation-gate.md** — mandatory shared-pattern count `30 → 33`. New patterns #31 `ensureCommentSlots`, #32 `panel-dispose-concept`, #33 `submitDisposeConcept`.
+- **plugins/devops/skills/devops-ship/SKILL.md** — Step 5 split into 5a (capture session context) / 5b (ExitWorktree + ship_cleanup) / 5c (re-open session-opened files). Step 5c invokes `session-open-tracker.js reopen-main --worktree=$WORKTREE_PATH` after cleanup so browser tabs into the deleted worktree silently switch to the merged main-repo path.
+- **plugins/devops/skills/devops-autonomous/SKILL.md** — Step 7c pairs the `start msedge file://…` open with a `session-open-tracker.js track` call (context `autonomous-report`).
+- **plugins/devops/skills/devops-repo-health/SKILL.md** — Step 8 pairs its `start msedge file://…` open with a `session-open-tracker.js track` call (context `repo-health`).
+- **plugins/devops/skills/devops-project-setup/SKILL.md** + **.gitignore** — `.claude/session-opened-files.json` (and `concept-active.json`) added to the recommended consumer `.gitignore` block, plus this repo's own `.gitignore`.
+- **plugins/devops/.claude-plugin/plugin.json** — version `0.81.0 → 0.82.0`
+
 ## [0.81.0] — 2026-05-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.81.0**
+**Version: 0.82.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.81.0",
+  "version": "0.82.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/deep-knowledge/browser-file-urls.md
+++ b/plugins/devops/deep-knowledge/browser-file-urls.md
@@ -64,6 +64,28 @@ If the output shows `file:///c/Users/...` (no colon), the URL is broken.
 - `devops-repo-health` (interactive branch report)
 - any future skill that writes an HTML file and opens it in a browser
 
+## Pair every `file://` open with a tracker call (issue #160)
+
+When the opened file lives inside a worktree, `/devops-ship` will later
+remove that worktree and the user's browser tab will 404. The session
+tracker keeps a list of every file the session opened so the ship skill
+can re-open it from the equivalent main-repo path post-cleanup:
+
+```bash
+start msedge "file:///$(cygpath -m "$ABS_PATH")"
+
+# Track the open so /devops-ship Step 5c can re-open from main repo after
+# ship_cleanup nukes the worktree.
+node "$CLAUDE_PLUGIN_ROOT/scripts/session-open-tracker.js" track \
+  "$(cygpath -w "$ABS_PATH")" \
+  --context=<short-tag>
+```
+
+`cygpath -w` produces the Windows-style absolute path (`C:\Users\…`) the
+tracker compares against the worktree root. The `--context` flag is
+optional but useful in `/devops-ship` Step 5c logs (`concept`,
+`autonomous-report`, `repo-health`, etc.).
+
 ## Cross-platform note
 
 On macOS/Linux `$(pwd)` already returns an absolute POSIX path, so

--- a/plugins/devops/deep-knowledge/skill-extension-guide.md
+++ b/plugins/devops/deep-knowledge/skill-extension-guide.md
@@ -173,6 +173,49 @@ Same pattern applies to agents:
 
 Override responsibilities, tools, or collaboration rules per project.
 
+## Session-opened files (file:// URL tracking)
+
+When a project-side skill extension opens a local HTML file in the browser
+via `file://` (instead of the bridge-server's `http://localhost:…`), the
+URL becomes invalid as soon as `/devops-ship` cleans up the worktree the
+file lived in. The user sees a 404 / blank tab and thinks the content
+itself is broken — when in reality the merged HTML is fine at the
+equivalent path inside the main repo.
+
+To opt into the automatic re-open behaviour, call the session-open
+tracker right after every `start msedge "file://…"` your extension issues:
+
+```bash
+node "$CLAUDE_PLUGIN_ROOT/scripts/session-open-tracker.js" track \
+  "<absolute native path of the file>" \
+  --context=<short-tag>
+```
+
+- `<absolute native path>`: on Windows, run `cygpath -w` over a Git-Bash
+  path first; on macOS/Linux a plain absolute path is enough.
+- `--context=<tag>` is optional metadata used in `/devops-ship` logs
+  (e.g. `concept`, `prototype`, `mockup`, `report`). Pick whatever makes
+  the trail readable.
+
+`/devops-ship` Step 5c invokes the tracker's `reopen-main` subcommand
+after `ship_cleanup` removes the worktree:
+
+```bash
+node "$CLAUDE_PLUGIN_ROOT/scripts/session-open-tracker.js" reopen-main \
+  --worktree="$WORKTREE_PATH"
+```
+
+The script reads `<main-repo>/.claude/session-opened-files.json`,
+filters entries that lived under the cleaned-up worktree, maps each to
+the main-repo equivalent path, and re-opens every still-existing file
+in Edge.
+
+**When to opt in:** every skill extension that ships an interactive HTML
+artefact (decision panel, prototype, analysis report) anchored to a
+worktree path. If you only ever open `http://localhost:…` URLs (e.g. via
+the concept bridge server), tracking is unnecessary because the URL is
+already invalid the moment the bridge server is killed.
+
 ## Scaffolding
 
 Run `/devops-extend-skill` to interactively scaffold an extension for any plugin skill.

--- a/plugins/devops/scripts/session-open-tracker.js
+++ b/plugins/devops/scripts/session-open-tracker.js
@@ -256,9 +256,9 @@ function cmdReopenMain(argv) {
   const store = pruneStale(loadStore(file));
   const wtNorm = normalizePath(wt);
 
-  const consumed = [];
   const reopened = [];
   const missing = [];
+  const launchFailed = [];
 
   const surviving = [];
   for (const entry of store.files) {
@@ -273,14 +273,17 @@ function cmdReopenMain(argv) {
     // Compute the relative path within the worktree, then re-anchor to main.
     const relative = path.relative(wt, entry.path);
     if (relative.startsWith("..") || path.isAbsolute(relative)) {
-      // Defensive: relative path escapes the worktree — skip this entry.
+      // Defensive: relative path escapes the worktree — keep so it doesn't
+      // silently disappear from the audit trail.
       surviving.push(entry);
       continue;
     }
     const mainPath = path.resolve(mainRoot, relative);
-    consumed.push(entry);
 
     if (!fs.existsSync(mainPath)) {
+      // File genuinely doesn't exist at the main path (deleted during the
+      // session, never made it through the merge). No point keeping the
+      // entry — drop it.
       missing.push(mainPath);
       continue;
     }
@@ -288,11 +291,21 @@ function cmdReopenMain(argv) {
     if (dryRun) {
       console.log(`[dry-run] would open ${mainPath}`);
       reopened.push(mainPath);
+      // Don't mutate `surviving` in dry-run — the store stays as-is.
+      surviving.push(entry);
       continue;
     }
 
-    if (openInBrowser(mainPath)) reopened.push(mainPath);
-    else missing.push(mainPath);
+    if (openInBrowser(mainPath)) {
+      reopened.push(mainPath);
+      // Successful open — drop the entry from the store (consumed).
+    } else {
+      // Browser launch failed (spawn error). Preserve the entry so a
+      // future invocation can retry once the launcher is healthy again,
+      // and so the user's audit trail isn't silently lost.
+      launchFailed.push(mainPath);
+      surviving.push(entry);
+    }
   }
 
   store.files = surviving;
@@ -304,7 +317,8 @@ function cmdReopenMain(argv) {
     worktree: wt,
     reopened,
     missing,
-    consumed: consumed.length
+    launchFailed,
+    consumed: reopened.length + missing.length
   };
   console.log(JSON.stringify(summary, null, 2));
 }

--- a/plugins/devops/scripts/session-open-tracker.js
+++ b/plugins/devops/scripts/session-open-tracker.js
@@ -1,0 +1,393 @@
+#!/usr/bin/env node
+/**
+ * session-open-tracker.js — track file:// URLs opened during a Claude session
+ * and re-open them from the main-repo path after a worktree gets cleaned up.
+ *
+ * GitHub: dotclaude#160
+ *
+ * Background
+ * ----------
+ * Many devops skills (devops-concept, devops-autonomous, …) write a local HTML
+ * artefact inside the current worktree and open it via `start msedge "file://…"`.
+ * When `/devops-ship` later runs `ship_cleanup`, the worktree directory is
+ * pruned and the user's browser tab now 404s on a path that no longer exists.
+ *
+ * The merged HTML still lives at the equivalent path inside the main repo,
+ * so this script tracks every file Claude opens and — after ship cleanup —
+ * re-opens each file from the main-repo path so the user's browser tab
+ * silently picks up the live version.
+ *
+ * Storage
+ * -------
+ * The tracking file lives at `<main-repo>/.claude/session-opened-files.json`,
+ * intentionally OUTSIDE the worktree so it survives `ship_cleanup`. Schema:
+ *
+ *   {
+ *     "version": 1,
+ *     "files": [
+ *       { "path": "<abs>", "openedAt": "<iso-ms-utc>", "context": "<tag>" }
+ *     ]
+ *   }
+ *
+ * Subcommands
+ * -----------
+ *   track <abs-path> [--context=<tag>]
+ *     Appends an entry to the tracking file. Idempotent (de-dupes by path,
+ *     keeping the most recent `openedAt`). Maintains a 50-entry max and a
+ *     24h TTL.
+ *
+ *   list [--json]
+ *     Prints the tracked entries.
+ *
+ *   reopen-main --worktree=<abs-path> [--dry-run]
+ *     Reads the tracking file, finds entries under the given worktree path,
+ *     maps each to the main-repo equivalent, and opens the still-existing
+ *     ones in Edge. After re-opening, the consumed entries are pruned.
+ *
+ *   prune
+ *     Drop stale entries (TTL).
+ */
+
+const fs = require("node:fs");
+const path = require("node:path");
+const child_process = require("node:child_process");
+
+const STORE_VERSION = 1;
+const TTL_MS = 24 * 60 * 60 * 1000;
+const MAX_ENTRIES = 50;
+
+// ---------------------------------------------------------------------------
+// Git helpers
+// ---------------------------------------------------------------------------
+
+/** Run a git command in `cwd`, return stdout trimmed. Throws on non-zero. */
+function git(args, cwd) {
+  return child_process
+    .execFileSync("git", args, { cwd, stdio: ["ignore", "pipe", "pipe"] })
+    .toString()
+    .trim();
+}
+
+/** Best-effort: returns trimmed stdout or null on failure. */
+function gitSafe(args, cwd) {
+  try { return git(args, cwd); } catch { return null; }
+}
+
+/**
+ * Resolve the main-repo working tree root from `cwd`.
+ *
+ * Strategy:
+ *   1. `git rev-parse --git-common-dir` returns the shared `.git/` directory.
+ *      For a worktree this is the MAIN repo's `.git/`. Its parent directory
+ *      is the main-repo working tree.
+ *   2. Fall back to `git worktree list --porcelain` (first `worktree …` entry
+ *      is always the main one).
+ *   3. Fall back to `git rev-parse --show-toplevel` if neither of the above
+ *      works (e.g. not in a git repo at all → returns null).
+ */
+function resolveMainRepoRoot(cwd) {
+  const commonDir = gitSafe(["rev-parse", "--git-common-dir"], cwd);
+  if (commonDir) {
+    // commonDir is usually `.git` or an absolute path. Make it absolute.
+    const absCommon = path.isAbsolute(commonDir)
+      ? commonDir
+      : path.resolve(cwd, commonDir);
+    // The working tree root is the parent of `.git/`. If commonDir already
+    // ends with `.git`, the parent dir is the main repo root.
+    if (path.basename(absCommon) === ".git") {
+      return path.dirname(absCommon);
+    }
+  }
+
+  const listing = gitSafe(["worktree", "list", "--porcelain"], cwd);
+  if (listing) {
+    const firstLine = listing.split(/\r?\n/).find(l => l.startsWith("worktree "));
+    if (firstLine) return firstLine.slice("worktree ".length).trim();
+  }
+
+  return gitSafe(["rev-parse", "--show-toplevel"], cwd);
+}
+
+// ---------------------------------------------------------------------------
+// Store helpers
+// ---------------------------------------------------------------------------
+
+/** Absolute path to the JSON store, anchored at the main repo root. */
+function storePath(cwd) {
+  const main = resolveMainRepoRoot(cwd);
+  if (!main) return null;
+  return path.join(main, ".claude", "session-opened-files.json");
+}
+
+function loadStore(file) {
+  if (!file || !fs.existsSync(file)) {
+    return { version: STORE_VERSION, files: [] };
+  }
+  try {
+    const raw = fs.readFileSync(file, "utf8");
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") {
+      return { version: STORE_VERSION, files: [] };
+    }
+    if (!Array.isArray(parsed.files)) parsed.files = [];
+    parsed.version = STORE_VERSION;
+    return parsed;
+  } catch {
+    return { version: STORE_VERSION, files: [] };
+  }
+}
+
+function saveStore(file, store) {
+  if (!file) return false;
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, JSON.stringify(store, null, 2) + "\n", "utf8");
+  return true;
+}
+
+/** Normalize a path for comparison: absolute, lowercased on Windows. */
+function normalizePath(p) {
+  if (!p) return "";
+  let abs = path.resolve(p);
+  // On Windows, fs is case-insensitive — comparing strings naively misses
+  // matches between C:\foo and c:\foo. Lowercase consistently.
+  if (process.platform === "win32") abs = abs.toLowerCase();
+  return abs;
+}
+
+function pruneStale(store) {
+  const now = Date.now();
+  store.files = store.files.filter(entry => {
+    const opened = Date.parse(entry.openedAt || "");
+    if (!opened || Number.isNaN(opened)) return false;
+    return now - opened <= TTL_MS;
+  });
+  // Cap total entries — drop oldest first.
+  if (store.files.length > MAX_ENTRIES) {
+    store.files.sort((a, b) => Date.parse(a.openedAt) - Date.parse(b.openedAt));
+    store.files = store.files.slice(store.files.length - MAX_ENTRIES);
+  }
+  return store;
+}
+
+// ---------------------------------------------------------------------------
+// Subcommands
+// ---------------------------------------------------------------------------
+
+function cmdTrack(argv) {
+  const positional = argv.filter(a => !a.startsWith("--"));
+  const flags = parseFlags(argv);
+  const filePath = positional[0];
+  if (!filePath) {
+    console.error("track: expected an absolute file path");
+    process.exit(1);
+  }
+  const abs = path.resolve(filePath);
+  const context = flags.context || null;
+  const cwd = process.cwd();
+  const file = storePath(cwd);
+  if (!file) {
+    // Not in a git repo — silently skip. Tracking only matters for repos
+    // that go through /devops-ship.
+    return;
+  }
+  const store = pruneStale(loadStore(file));
+  const normalized = normalizePath(abs);
+  // De-dupe: drop any existing entry with the same path, keep most recent.
+  store.files = store.files.filter(e => normalizePath(e.path) !== normalized);
+  store.files.push({
+    path: abs,
+    openedAt: new Date().toISOString(),
+    ...(context ? { context } : {})
+  });
+  saveStore(file, store);
+}
+
+function cmdList(argv) {
+  const flags = parseFlags(argv);
+  const cwd = process.cwd();
+  const file = storePath(cwd);
+  const store = file ? loadStore(file) : { version: STORE_VERSION, files: [] };
+  if (flags.json) {
+    console.log(JSON.stringify(store, null, 2));
+    return;
+  }
+  if (!store.files.length) {
+    console.log("(no tracked files)");
+    return;
+  }
+  for (const entry of store.files) {
+    const ctx = entry.context ? ` [${entry.context}]` : "";
+    console.log(`${entry.openedAt}${ctx}  ${entry.path}`);
+  }
+}
+
+function cmdPrune() {
+  const cwd = process.cwd();
+  const file = storePath(cwd);
+  if (!file) return;
+  const store = pruneStale(loadStore(file));
+  saveStore(file, store);
+}
+
+/**
+ * Re-open every tracked file that lives under `--worktree=<path>` from the
+ * main-repo equivalent path. Used by `/devops-ship` Step 5 after
+ * `ship_cleanup` has removed the worktree.
+ */
+function cmdReopenMain(argv) {
+  const flags = parseFlags(argv);
+  const wt = flags.worktree;
+  if (!wt) {
+    console.error("reopen-main: --worktree=<abs-path> is required");
+    process.exit(1);
+  }
+  const dryRun = !!flags["dry-run"];
+  const cwd = process.cwd();
+  const mainRoot = resolveMainRepoRoot(cwd);
+  if (!mainRoot) {
+    console.error("reopen-main: could not resolve main repo root from cwd");
+    process.exit(1);
+  }
+  const file = storePath(cwd);
+  if (!file || !fs.existsSync(file)) {
+    // No tracking file — nothing to do.
+    return;
+  }
+  const store = pruneStale(loadStore(file));
+  const wtNorm = normalizePath(wt);
+
+  const consumed = [];
+  const reopened = [];
+  const missing = [];
+
+  const surviving = [];
+  for (const entry of store.files) {
+    const entryNorm = normalizePath(entry.path);
+
+    // Only act on entries that lived inside the worktree we just cleaned up.
+    if (!entryNorm.startsWith(wtNorm + path.sep) && entryNorm !== wtNorm) {
+      surviving.push(entry);
+      continue;
+    }
+
+    // Compute the relative path within the worktree, then re-anchor to main.
+    const relative = path.relative(wt, entry.path);
+    if (relative.startsWith("..") || path.isAbsolute(relative)) {
+      // Defensive: relative path escapes the worktree — skip this entry.
+      surviving.push(entry);
+      continue;
+    }
+    const mainPath = path.resolve(mainRoot, relative);
+    consumed.push(entry);
+
+    if (!fs.existsSync(mainPath)) {
+      missing.push(mainPath);
+      continue;
+    }
+
+    if (dryRun) {
+      console.log(`[dry-run] would open ${mainPath}`);
+      reopened.push(mainPath);
+      continue;
+    }
+
+    if (openInBrowser(mainPath)) reopened.push(mainPath);
+    else missing.push(mainPath);
+  }
+
+  store.files = surviving;
+  if (!dryRun) saveStore(file, store);
+
+  // Single-line summary so /devops-ship can relay it.
+  const summary = {
+    mainRoot,
+    worktree: wt,
+    reopened,
+    missing,
+    consumed: consumed.length
+  };
+  console.log(JSON.stringify(summary, null, 2));
+}
+
+// ---------------------------------------------------------------------------
+// Browser launcher
+// ---------------------------------------------------------------------------
+
+/**
+ * Open `absPath` as a file:// URL in Microsoft Edge. Returns true on success.
+ * Strategy by platform:
+ *   - win32: `cmd /c start "" msedge "file:///<windows-path>"`
+ *   - darwin: `open -a "Microsoft Edge" "file://<path>"`
+ *   - linux: `microsoft-edge "file://<path>"` (best-effort)
+ */
+function openInBrowser(absPath) {
+  const fileUrl = toFileUrl(absPath);
+  try {
+    if (process.platform === "win32") {
+      // Resolve any worktree-mountpoint quirks via a plain Windows path.
+      child_process.spawn("cmd.exe", ["/c", "start", "", "msedge", fileUrl], {
+        detached: true,
+        stdio: "ignore"
+      }).unref();
+    } else if (process.platform === "darwin") {
+      child_process.spawn("open", ["-a", "Microsoft Edge", fileUrl], {
+        detached: true,
+        stdio: "ignore"
+      }).unref();
+    } else {
+      child_process.spawn("microsoft-edge", [fileUrl], {
+        detached: true,
+        stdio: "ignore"
+      }).unref();
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Convert a native absolute path to a browser-safe file:// URL. */
+function toFileUrl(absPath) {
+  const abs = path.resolve(absPath);
+  if (process.platform === "win32") {
+    // file:///C:/Users/... — three slashes, native separator -> forward slash.
+    return "file:///" + abs.replace(/\\/g, "/");
+  }
+  return "file://" + abs;
+}
+
+// ---------------------------------------------------------------------------
+// CLI entry
+// ---------------------------------------------------------------------------
+
+function parseFlags(argv) {
+  const out = {};
+  for (const a of argv) {
+    if (!a.startsWith("--")) continue;
+    const eq = a.indexOf("=");
+    if (eq === -1) out[a.slice(2)] = true;
+    else out[a.slice(2, eq)] = a.slice(eq + 1);
+  }
+  return out;
+}
+
+function main() {
+  const [, , cmd, ...rest] = process.argv;
+  switch (cmd) {
+    case "track":       return cmdTrack(rest);
+    case "list":        return cmdList(rest);
+    case "prune":       return cmdPrune();
+    case "reopen-main": return cmdReopenMain(rest);
+    default:
+      console.error(
+        "usage:\n" +
+        "  session-open-tracker.js track <abs-path> [--context=<tag>]\n" +
+        "  session-open-tracker.js list [--json]\n" +
+        "  session-open-tracker.js prune\n" +
+        "  session-open-tracker.js reopen-main --worktree=<abs-path> [--dry-run]"
+      );
+      process.exit(1);
+  }
+}
+
+main();

--- a/plugins/devops/skills/devops-autonomous/SKILL.md
+++ b/plugins/devops/skills/devops-autonomous/SKILL.md
@@ -443,6 +443,14 @@ missing drive colon → `ERR_FILE_NOT_FOUND`):
 
 ```bash
 start msedge "file:///$(cygpath -m "$(pwd)")/AUTONOMOUS-REPORT.html"
+
+# Track the opened report so /devops-ship can re-open it from the main-repo
+# path after worktree cleanup (issue #160). cygpath -w yields a Windows-style
+# absolute path that session-open-tracker.js can compare against the
+# worktree root later.
+node "$CLAUDE_PLUGIN_ROOT/scripts/session-open-tracker.js" track \
+  "$(cygpath -w "$(pwd)/AUTONOMOUS-REPORT.html")" \
+  --context=autonomous-report
 ```
 
 See `deep-knowledge/browser-file-urls.md` for the full rule.

--- a/plugins/devops/skills/devops-concept/SKILL.md
+++ b/plugins/devops/skills/devops-concept/SKILL.md
@@ -744,16 +744,18 @@ will surface a phantom resume hint pointing at a server that no longer
 exists. The `kill` is best-effort: if the user already closed the
 terminal that spawned the server, the PID may be gone, which is fine.
 
-**Apply disposition on the concept files** (`docs/concepts/{date}-{slug}.html`
-and `docs/concepts/{date}-{slug}-decisions.json`):
+**Apply disposition on the concept files.** Files are named
+`docs/concepts/{date}-{slug}.html` and `docs/concepts/{date}-{slug}-decisions.json`
+— always include the `{date}-` prefix in patterns; bare `{slug}` does
+NOT match.
 
 | `mode` | `moveTo` | Action |
 |---|---|---|
-| `discard` | (any) | `rm -f <html> <decisions.json>` — `moveTo` is ignored. |
+| `discard` | (any) | `rm -f -- "<html>" "<decisions.json>"` — `moveTo` is ignored. |
 | `keep` | null | No file change. Files remain at their original git-tracked path. |
-| `keep` | set | `mkdir -p <moveTo>` then `git mv` (if tracked, else `mv`) both files into `<moveTo>/`. Files remain git-tracked at the new path. |
-| `gitignore` | null | Files stay at original path. Append `docs/concepts/{slug}.*` to `.gitignore` if not already covered. Run `git rm --cached <html> <decisions.json>` to untrack them if they were already added. |
-| `gitignore` | set | `mkdir -p <moveTo>` then `mv` both files into `<moveTo>/`. Append `<moveTo>/{slug}.*` to `.gitignore` if not already covered. Run `git rm --cached` on the original tracked entries. |
+| `keep` | set | `mkdir -p -- "<moveTo>"` then `git mv -- "<html>" "<moveTo>/"` (if tracked, else `mv -- "<html>" "<moveTo>/"`); same for the decisions JSON. Files remain git-tracked at the new path. |
+| `gitignore` | null | Files stay at original path. Append `docs/concepts/{date}-{slug}.*` to `.gitignore` if not already covered. Run `git rm --cached -- "<html>" "<decisions.json>"` to untrack them if they were already added. |
+| `gitignore` | set | `mkdir -p -- "<moveTo>"` then `mv -- "<html>" "<moveTo>/"`; same for the decisions JSON. Append `<moveTo>/{date}-{slug}.*` to `.gitignore` if not already covered. Run `git rm --cached -- "<original-html>" "<original-decisions.json>"` on the original tracked entries. |
 
 **Safety rules:**
 
@@ -762,13 +764,23 @@ and `docs/concepts/{date}-{slug}-decisions.json`):
   Reject any path that resolves outside the project root, contains
   `..`, or is absolute — fall back to the non-`moveTo` branch and
   surface a warning to the user.
+- All path-bearing shell commands (`rm`, `mv`, `git mv`, `git rm`,
+  `mkdir`) MUST use the `--` argument terminator AND double-quote
+  every path interpolation, so `moveTo` values containing spaces or
+  shell metacharacters land as a single literal argument. Never
+  inline a raw `{path}` substitution.
+- `.gitignore` patterns use the FULL filename including the date
+  prefix (`docs/concepts/{date}-{slug}.*`), NOT bare `{slug}.*` — the
+  shorter pattern silently fails to match the timestamp-prefixed
+  files this skill produces.
 - Never delete a file that does NOT match the
   `docs/concepts/{date}-{slug}.*` pattern for THIS session's slug.
   Other concept HTML files in `docs/concepts/` belong to other
   sessions and MUST be preserved.
 - `.gitignore` edits are append-only. Before appending, grep for an
-  existing exact match (the `{slug}.*` or `{slug}.html` line) — if it
-  already exists, skip the append. Never rewrite or reorder the file.
+  existing exact match (the full `docs/concepts/{date}-{slug}.*` line)
+  — if it already exists, skip the append. Never rewrite or reorder
+  the file.
 - If `git rm --cached` errors because the file was never tracked,
   swallow the error and continue — the file is already in the right
   state for `.gitignore`.

--- a/plugins/devops/skills/devops-concept/SKILL.md
+++ b/plugins/devops/skills/devops-concept/SKILL.md
@@ -198,6 +198,14 @@ The content area is reserved for the actual concept.
 - **Selectors/sliders**: For prioritization, weighting, or rating
 - **Comment fields**: Inline text areas for notes on each section —
   use `width: 100%` within their container, `min-height: 80px` for usability
+- **Per-decision note textarea (MANDATORY for every `[data-decision]` group):**
+  every Bi-State variant/finding card MUST carry an adjacent
+  `<textarea data-comment="$decisionId-note">` so the user can attach a
+  free-form override (e.g. "only for X", "with variant Y") to the include/
+  discard choice. See `deep-knowledge/templates.md` § Comment Slot Injection
+  for the HTML pattern, the `ensureCommentSlots()` JS safety net, and the
+  rationale. Skipping this is the most common interactive-element regression
+  — the user has nowhere to caveat their selection.
 - **Submit button**: Prominent "Entscheidungen abschicken" button in the
   decision panel sidebar
 
@@ -340,8 +348,13 @@ Write to: `docs/concepts/{timestamp}-{slug}.html`
 Full example: `docs/concepts/2026-04-12-auth-middleware-redesign.html`
 
 - Create the `docs/concepts/` directory if it doesn't exist
-- This directory is **git-tracked** — concepts are project artifacts meant
-  to be shared with other repo users
+- The directory is git-tracked by default, but **individual concept files
+  default to discard**. See § Disposition Control in
+  `deep-knowledge/templates.md` and Step 6a. Concepts are project artifacts
+  only when the user explicitly chooses "Im Projekt behalten" on the
+  final-report panel; the default cleanup deletes both HTML and decisions
+  JSON. Power users may also opt for "Nur lokal / .gitignore" to keep
+  files locally without polluting the repo
 - **One file per concept session** — all iterations live inside the same
   HTML file as separate `<section data-iteration="N">` blocks, switched via
   tabs in the decision panel (see "Iteration Tabs" below). There are no
@@ -516,24 +529,43 @@ Branch on it:
 **`action: "create-issues"` ("Issues erstellen" button — only on final report):**
 1. Read the `items` array from the payload — each entry is a selected open
    question / TODO `{ id, title, type, selected: true }`.
-2. For each selected item, invoke the **devops-new-issue** skill with the
+2. Read the `disposition` sub-object from the same payload — even if the
+   user never touches "Concept beenden", `submitCreateIssues` always
+   bundles the current disposition state for Step 6 cleanup. Store it
+   for use in Step 6a; do NOT apply it now — issue routing and cleanup
+   are decoupled so the user can still review the page before closing.
+3. For each selected item, invoke the **devops-new-issue** skill with the
    item's title and type. Capture the resulting issue number + URL.
-3. Update the final-report HTML: in the open-questions section, replace
+4. Update the final-report HTML: in the open-questions section, replace
    each created item's label with `[Issue #NNN] {title}` (linked to the
    issue URL), disable the checkbox, and add a small ✓ badge.
-4. POST `/reload` so the browser shows the updated state. If every item
+5. POST `/reload` so the browser shows the updated state. If every item
    was processed, the "Issues erstellen" button auto-hides on reload
    (panel JS gates it on the presence of un-created checkable items).
-5. Then POST `/reset` with the captured `_version` as usual.
-6. The concept session stays open — the user may still review previous
+6. Then POST `/reset` with the captured `_version` as usual.
+7. The concept session stays open — the user may still review previous
    iteration tabs but cannot trigger further iterate/implement actions
    from the final report.
+
+**`action: "dispose-concept"` ("Concept beenden" button — only on final report):**
+1. Read the `disposition` sub-object from the payload — shape
+   `{ mode: "discard" | "keep" | "gitignore", moveTo: string | null }`.
+2. Do NOT apply the cleanup here — instead, record the disposition for
+   Step 6a (which is the authoritative cleanup step) and signal session
+   end. Treat this submission as the explicit "fertig" signal from the
+   user.
+3. POST `/reset` with the captured `_version` so the bridge stops
+   surfacing this submission as `_pending`.
+4. Proceed to Step 6 — Completion Card. The disposition recorded here
+   drives the cleanup branch in Step 6a.
 
 **Critical invariant:** a submit with `action: "iterate"` MUST NEVER cause
 code or file changes outside of the concept HTML file itself. The user
 relies on that guarantee to explore ideas safely. `action: "create-issues"`
 only writes GitHub issues + the final-report HTML — no code/file changes
-in the project tree.
+in the project tree. `action: "dispose-concept"` only triggers Step 6
+cleanup — no code/file changes either, just disposition of the concept's
+own HTML / decisions JSON artefacts.
 ### 5c. Update the Page
 After processing, **append a new tab** to the same HTML file and signal
 the browser to reload. This is the ONLY update path — there is no
@@ -651,10 +683,16 @@ Return to Step 4 (monitor for next submission). The loop continues until:
 - The user says "fertig" / "done" in chat
 - There are no more decisions to make (all items processed)
 
-If the active section is the final report, the only submission Claude
-expects is `action: "create-issues"` (when open questions / TODOs are
-present). All other action types from the final-report panel should be
-treated as protocol errors and reported back to the user.
+If the active section is the final report, the submissions Claude expects
+are:
+- `action: "create-issues"` — fired by the "Issues erstellen" button when
+  open questions / TODOs are present and at least one is selected.
+- `action: "dispose-concept"` — fired by the always-visible "Concept
+  beenden" button. Carries the file disposition decision (discard /
+  keep / gitignore + optional moveTo).
+
+All other action types from the final-report panel should be treated as
+protocol errors and reported back to the user.
 
 ### 5e. Persist
 Write a cumulative summary to `docs/concepts/{same-timestamp}-{same-slug}-decisions.json`
@@ -667,11 +705,29 @@ The feedback loop ends when the user is satisfied (user says "fertig"/"done",
 closes the page, or all items are processed). Then **clean up the
 bridge-server state** and render a completion card.
 
-### 6a. Clean up the active-concept state
+### 6a. Clean up the active-concept state — Cleanup-By-Disposition
 
-Before rendering the completion card, dispose of the bridge server and
-its state file in this exact order (per `deep-knowledge/bridge-server.md`
-§ Step 7):
+Before rendering the completion card, dispose of the bridge server, its
+state file, AND the on-disk concept artefacts. The on-disk steps depend
+on the user's disposition choice (see `deep-knowledge/templates.md`
+§ Disposition Control for the UI + payload shape).
+
+**Determine the disposition** in this order of preference:
+
+1. The last `dispose-concept` payload received this session → use its
+   `disposition` field directly.
+2. Otherwise, the last `create-issues` payload's `disposition` field.
+3. Otherwise (no payload carried a disposition — old session, user
+   aborted, page closed before clicking either final-report button):
+   default to `{ mode: "discard", moveTo: null }`.
+
+The default = `discard` is deliberate. Most concept sessions are one-shot
+refinements whose outcome already landed in commits / GitHub issues /
+the implement step. Persisting the HTML in git by default accumulates
+silt in `docs/concepts/`. Power users opt in to `keep` or `gitignore`
+via the final-report panel.
+
+**Cleanup procedure (always):**
 
 ```bash
 kill $SERVER_PID 2>/dev/null
@@ -683,6 +739,42 @@ Then `CronDelete <cron_id>`. Removing `concept-active.json` is mandatory
 will surface a phantom resume hint pointing at a server that no longer
 exists. The `kill` is best-effort: if the user already closed the
 terminal that spawned the server, the PID may be gone, which is fine.
+
+**Apply disposition on the concept files** (`docs/concepts/{date}-{slug}.html`
+and `docs/concepts/{date}-{slug}-decisions.json`):
+
+| `mode` | `moveTo` | Action |
+|---|---|---|
+| `discard` | (any) | `rm -f <html> <decisions.json>` — `moveTo` is ignored. |
+| `keep` | null | No file change. Files remain at their original git-tracked path. |
+| `keep` | set | `mkdir -p <moveTo>` then `git mv` (if tracked, else `mv`) both files into `<moveTo>/`. Files remain git-tracked at the new path. |
+| `gitignore` | null | Files stay at original path. Append `docs/concepts/{slug}.*` to `.gitignore` if not already covered. Run `git rm --cached <html> <decisions.json>` to untrack them if they were already added. |
+| `gitignore` | set | `mkdir -p <moveTo>` then `mv` both files into `<moveTo>/`. Append `<moveTo>/{slug}.*` to `.gitignore` if not already covered. Run `git rm --cached` on the original tracked entries. |
+
+**Safety rules:**
+
+- `moveTo` is treated as a project-relative path. Resolve it relative to
+  the project root (NOT the worktree root if you happen to be in one).
+  Reject any path that resolves outside the project root, contains
+  `..`, or is absolute — fall back to the non-`moveTo` branch and
+  surface a warning to the user.
+- Never delete a file that does NOT match the
+  `docs/concepts/{date}-{slug}.*` pattern for THIS session's slug.
+  Other concept HTML files in `docs/concepts/` belong to other
+  sessions and MUST be preserved.
+- `.gitignore` edits are append-only. Before appending, grep for an
+  existing exact match (the `{slug}.*` or `{slug}.html` line) — if it
+  already exists, skip the append. Never rewrite or reorder the file.
+- If `git rm --cached` errors because the file was never tracked,
+  swallow the error and continue — the file is already in the right
+  state for `.gitignore`.
+
+**Reporting:** the completion card's `changes` array should include one
+short line describing the disposition action that was applied (e.g.
+"Concept-Files verworfen", "Concept-Files behalten unter docs/architecture/",
+"Concept-Files in .gitignore aufgenommen"). Skip this line for the
+default `discard` path when the user explicitly aborted the session
+without ever opening the final-report panel.
 
 ### 6b. Render the completion card
 

--- a/plugins/devops/skills/devops-concept/deep-knowledge/bridge-server.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/bridge-server.md
@@ -194,8 +194,9 @@ AND provides HTTP endpoints for heartbeat and decision exchange.
    The empty `""` is required on Windows — without it, `cmd.exe` interprets
    the first quoted argument as a window title.
 
-7. After monitoring ends (user says "fertig"/"done", aborts, or Step 6 of
-   SKILL.md fires the completion card), clean up in this order:
+7. After monitoring ends (user says "fertig"/"done", aborts, clicks
+   "Concept beenden" on the final-report panel, or Step 6 of SKILL.md
+   fires the completion card), run the bridge-side cleanup:
    ```bash
    kill $SERVER_PID 2>/dev/null  # or `kill %1` if still in shell scope
    rm -f .claude/concept-active.json
@@ -204,3 +205,11 @@ AND provides HTTP endpoints for heartbeat and decision exchange.
    MUST be removed when the concept session is intentionally ended,
    otherwise the next SessionStart will surface a phantom resume hint for a
    server that no longer exists.
+
+   The **on-disk concept artefacts** (`docs/concepts/{date}-{slug}.html`
+   and the matching `-decisions.json`) are handled by `SKILL.md` § Step 6a
+   — Cleanup-By-Disposition. The bridge-side cleanup above is concerned
+   only with the server / state file / cron; disposition of the HTML
+   itself is driven by the user's final-report choice (`discard` /
+   `keep` / `gitignore` + optional `moveTo`) and runs as part of the
+   same Step 6 in SKILL.md.

--- a/plugins/devops/skills/devops-concept/deep-knowledge/templates.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/templates.md
@@ -71,6 +71,8 @@ must see their own language. The locale hint is authoritative.
 | `panel.minimize`               | Minimize                       | Minimieren |
 | `variant.include`              | Include                        | Miteinbeziehen |
 | `variant.discard`              | Discard                        | Verwerfen |
+| `decision.comment_label`       | Note / override (optional)     | Notiz / Override (optional) |
+| `decision.comment_placeholder` | e.g. "only for X", "with variant Y"… | z.B. „nur für X", „mit Variante Y"… |
 | `iteration.label`              | Iterations                     | Iterationen |
 | `iteration.active_suffix`      | · active                       | · aktiv |
 | `iteration.final_tab`          | Final report                   | Abschlussbericht |
@@ -84,6 +86,20 @@ must see their own language. The locale hint is authoritative.
 | `final.create_issues_running`  | Creating issues …              | Issues werden erstellt … |
 | `final.create_issues_done`     | Issues created                 | Issues erstellt |
 | `final.issue_link_prefix`      | Issue                          | Issue |
+| `final.dispose_heading`        | Keep concept files?            | Concept-Files behalten? |
+| `final.dispose_hint`           | Default = discard. Decisions already landed in commits/issues — the HTML rarely needs to live in git. | Default = verwerfen. Entscheidungen sind bereits in Commits/Issues — die HTML-Datei muss selten in git bleiben. |
+| `final.dispose_discard`        | Discard (default)              | Verwerfen (Standard) |
+| `final.dispose_discard_hint`   | Delete HTML + decisions JSON, no git entry. | HTML + Decisions-JSON löschen, kein git-Eintrag. |
+| `final.dispose_keep`           | Keep in project                | Im Projekt behalten |
+| `final.dispose_keep_hint`      | Files stay in docs/concepts/ and become git-tracked artefacts. | Files bleiben in docs/concepts/ und sind git-getrackte Artefakte. |
+| `final.dispose_gitignore`      | Local only / .gitignore        | Nur lokal / .gitignore |
+| `final.dispose_gitignore_hint` | Files stay locally, an entry is appended to .gitignore. | Files bleiben lokal, ein Eintrag wird zur .gitignore hinzugefügt. |
+| `final.dispose_move_label`     | Move to (optional):            | Verschieben nach (optional): |
+| `final.dispose_move_placeholder` | e.g. docs/architecture/      | z.B. docs/architecture/ |
+| `final.dispose_btn`            | End concept                    | Concept beenden |
+| `final.dispose_btn_hint`       | Closes the concept session and applies the file disposition above. | Schliesst die Concept-Session und wendet die Datei-Disposition oben an. |
+| `final.dispose_running`        | Cleaning up …                  | Räume auf … |
+| `final.dispose_done`           | Concept ended.                 | Concept beendet. |
 | `proto.feedback_title`         | Feedback                       | Feedback |
 | `proto.feedback_toggle`        | Open feedback                  | Feedback öffnen |
 | `proto.feedback_general`       | General notes on this prototype | Allgemeine Anmerkungen zum Prototyp |
@@ -248,10 +264,10 @@ the `[ui-locale: ...]` hint produced.
       </div>
 
       <!-- Final-report state: shown when the active section carries
-           data-final-report. No iterate/implement submit; the only
-           interactive control is the conditional "Issues erstellen"
-           button, gated on the presence of a [data-open-questions]
-           block with at least one un-created checkable item. -->
+           data-final-report. No iterate/implement submit; controls are
+           the conditional "Issues erstellen" button (gated on
+           [data-open-questions] content) and the always-visible
+           disposition fieldset that drives Step 6 cleanup. -->
       <div id="panel-final-report" style="display: none;">
         <div class="final-report-indicator">
           <span class="check-icon">✓</span>
@@ -271,6 +287,65 @@ the `[ui-locale: ...]` hint produced.
             <span aria-hidden="true">✓</span> {{final.create_issues_done}}
           </p>
         </div>
+
+        <!-- Disposition fieldset: always visible on the final-report panel.
+             Drives Step 6 cleanup behaviour (discard / keep / gitignore /
+             optional moveTo). Default = discard, matching the typical
+             one-shot refinement workflow where decisions already landed
+             in commits/issues and the HTML is no longer needed. -->
+        <fieldset id="panel-dispose-concept" class="dispose-fieldset">
+          <legend>{{final.dispose_heading}}</legend>
+          <p class="hint dispose-hint">{{final.dispose_hint}}</p>
+
+          <label class="dispose-option">
+            <input type="radio" name="dispose-mode" value="discard" checked>
+            <span class="dispose-label">
+              <strong>{{final.dispose_discard}}</strong>
+              <span class="dispose-sub">{{final.dispose_discard_hint}}</span>
+            </span>
+          </label>
+
+          <label class="dispose-option">
+            <input type="radio" name="dispose-mode" value="keep">
+            <span class="dispose-label">
+              <strong>{{final.dispose_keep}}</strong>
+              <span class="dispose-sub">{{final.dispose_keep_hint}}</span>
+            </span>
+          </label>
+
+          <label class="dispose-option">
+            <input type="radio" name="dispose-mode" value="gitignore">
+            <span class="dispose-label">
+              <strong>{{final.dispose_gitignore}}</strong>
+              <span class="dispose-sub">{{final.dispose_gitignore_hint}}</span>
+            </span>
+          </label>
+
+          <div class="dispose-move-row">
+            <label for="dispose-move-to">{{final.dispose_move_label}}</label>
+            <input id="dispose-move-to"
+                   name="dispose-move-to"
+                   type="text"
+                   autocomplete="off"
+                   spellcheck="false"
+                   placeholder="{{final.dispose_move_placeholder}}">
+          </div>
+
+          <div class="submit-gap" aria-hidden="true"></div>
+
+          <button id="dispose-concept-btn" class="implement-btn dispose-btn">
+            <span aria-hidden="true">⤓</span>
+            {{final.dispose_btn}}
+          </button>
+          <p class="hint hint-warn">{{final.dispose_btn_hint}}</p>
+
+          <p class="hint hint-running" data-dispose-state="running" hidden>
+            <span aria-hidden="true">⏳</span> {{final.dispose_running}}
+          </p>
+          <p class="hint hint-done" data-dispose-state="done" hidden>
+            <span aria-hidden="true">✓</span> {{final.dispose_done}}
+          </p>
+        </fieldset>
       </div>
     </aside>
   </div>
@@ -355,6 +430,13 @@ exactly two options.
 
 ### HTML
 
+Every `[data-decision]` group MUST be followed by an adjacent
+`<textarea data-comment="$decisionId-note">` so the user can attach a
+free-form override (e.g. "only for X", "with variant Y") to the bi-state
+choice. Place the textarea inside the same row container so the comment is
+visually anchored to the card. The catch-all `collectAllFormFields` picks
+it up via `data-comment` without any collector change.
+
 ```html
 <div class="variant-evaluation" data-decision="variant-a" data-label="Variant A">
   <div class="eval-group">
@@ -367,12 +449,26 @@ exactly two options.
       <span class="eval-label">Miteinbeziehen</span>
     </label>
   </div>
+  <div class="field-row decision-comment-row">
+    <label for="variant-a-note">{{decision.comment_label}}</label>
+    <textarea id="variant-a-note"
+              data-comment="variant-a-note"
+              placeholder="{{decision.comment_placeholder}}"
+              rows="2"></textarea>
+  </div>
 </div>
 ```
 
 Legacy class names `tri-state-group` / `tri-state-option` / `tri-state-label`
 are deprecated but still accepted by the CSS selectors below for backward
 compatibility.
+
+**Backwards compatibility:** older pages that emitted the bi-state group
+without the textarea are upgraded at runtime by `ensureCommentSlots()` (see
+§ Shared Systems → Comment Slot Injection). Generated pages SHOULD still
+emit the textarea inline so the validation gate and `localStorage` restore
+see it immediately, but the JS safety net guarantees the user always has
+the override slot.
 
 ### CSS
 
@@ -466,6 +562,45 @@ compatibility.
 .eval-option:has(input:not(:checked)):hover,
 .tri-state-option:has(input:not(:checked)):hover {
   opacity: 1;
+}
+
+/* Per-decision comment row — slotted directly under the bi-state group so
+   the override is visually anchored to the variant card. Width tracks the
+   group width via the container; min-height keeps it usable on dense pages. */
+.decision-comment-row {
+  margin-top: 0.6rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+.decision-comment-row label {
+  font-size: 0.78rem;
+  color: var(--text-muted, #8b949e);
+  font-weight: 500;
+  letter-spacing: 0.01em;
+}
+.decision-comment-row textarea {
+  width: 100%;
+  min-height: 48px;
+  padding: 0.5rem 0.65rem;
+  border-radius: 8px;
+  border: 1px solid var(--border-color, #30363d);
+  background: color-mix(in srgb, var(--bg-color, #0d1117) 80%, transparent);
+  color: var(--text-color, #c9d1d9);
+  font: inherit;
+  font-size: 0.85rem;
+  line-height: 1.4;
+  resize: vertical;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+.decision-comment-row textarea:focus {
+  outline: none;
+  border-color: var(--accent-color, #58a6ff);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent-color, #58a6ff) 30%, transparent);
+}
+.decision-comment-row textarea::placeholder {
+  color: var(--text-muted, #8b949e);
+  opacity: 0.6;
 }
 ```
 
@@ -1904,6 +2039,96 @@ document.addEventListener('DOMContentLoaded', () => {
   color: var(--warning-color, #d29922);
 }
 
+/* Disposition fieldset — controls Step 6 cleanup. Always rendered on the
+   final-report panel; default selection is "discard" (matches the typical
+   one-shot refinement workflow). The fieldset visually separates from the
+   create-issues block above with a thin top divider. */
+.dispose-fieldset {
+  margin-top: 1.25rem;
+  padding: 0.85rem 0.95rem 1rem;
+  border: 1px solid var(--border-color, #30363d);
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--bg-color, #0d1117) 70%, transparent);
+}
+.dispose-fieldset legend {
+  padding: 0 0.4rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-color, #c9d1d9);
+}
+.dispose-fieldset .dispose-hint {
+  margin: 0 0 0.75rem 0;
+  color: var(--text-secondary, #8b949e);
+  font-size: 0.78rem;
+  line-height: 1.4;
+}
+.dispose-fieldset .dispose-option {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.55rem;
+  padding: 0.45rem 0.5rem;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+.dispose-fieldset .dispose-option:hover {
+  background: color-mix(in srgb, var(--accent-color, #58a6ff) 8%, transparent);
+}
+.dispose-fieldset .dispose-option input[type="radio"] {
+  margin-top: 0.25rem;
+  accent-color: var(--accent-color, #58a6ff);
+}
+.dispose-fieldset .dispose-label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+.dispose-fieldset .dispose-label strong {
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+.dispose-fieldset .dispose-sub {
+  font-size: 0.74rem;
+  color: var(--text-secondary, #8b949e);
+  line-height: 1.4;
+}
+.dispose-fieldset .dispose-move-row {
+  margin-top: 0.65rem;
+  padding-top: 0.65rem;
+  border-top: 1px dashed var(--border-color, #30363d);
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+.dispose-fieldset .dispose-move-row label {
+  font-size: 0.78rem;
+  color: var(--text-secondary, #8b949e);
+  font-weight: 500;
+}
+.dispose-fieldset .dispose-move-row input {
+  width: 100%;
+  padding: 0.45rem 0.6rem;
+  border-radius: 6px;
+  border: 1px solid var(--border-color, #30363d);
+  background: color-mix(in srgb, var(--bg-color, #0d1117) 80%, transparent);
+  color: var(--text-color, #c9d1d9);
+  font: inherit;
+  font-size: 0.82rem;
+}
+.dispose-fieldset .dispose-move-row input:focus {
+  outline: none;
+  border-color: var(--accent-color, #58a6ff);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent-color, #58a6ff) 30%, transparent);
+}
+.dispose-fieldset .dispose-btn { margin-top: 0; }
+.dispose-fieldset .dispose-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.dispose-fieldset .hint[data-dispose-state="running"] {
+  color: var(--accent-color, #58a6ff);
+}
+.dispose-fieldset .hint[data-dispose-state="done"] {
+  color: var(--success-color, #3fb950);
+}
+
 /* Iteration tab styling for the final-report tab — distinct from
    numbered iteration tabs so the closing step reads as a milestone. */
 .iteration-tab[data-final-report] {
@@ -2048,7 +2273,13 @@ function restoreState() {
   } catch (e) { /* corrupt storage — ignore */ }
 }
 
-document.addEventListener('DOMContentLoaded', restoreState);
+document.addEventListener('DOMContentLoaded', () => {
+  // Inject missing per-decision comment slots BEFORE restoring state so the
+  // restored textarea values land on real DOM nodes. See § Comment Slot
+  // Injection for why this safety net exists.
+  if (typeof ensureCommentSlots === 'function') ensureCommentSlots();
+  restoreState();
+});
 document.addEventListener('change', saveState);
 document.addEventListener('input', saveState);
 ```
@@ -2057,8 +2288,87 @@ document.addEventListener('input', saveState);
 - Use `localStorage` with a 24-hour TTL
 - Save on every `change` and `input` event — not just on submit
 - Restore runs on `DOMContentLoaded` — before the user sees the page
+- `ensureCommentSlots()` runs IMMEDIATELY before `restoreState()` — see
+  § Comment Slot Injection for the rationale (must inject the slots before
+  the restore step rehydrates their values)
 - The `concept-submitted` class is NOT persisted
 - Theme preference IS persisted — prevents dark/light flash on reload
+
+## Comment Slot Injection
+
+Every Bi-State `[data-decision]` group SHOULD ship with an inline adjacent
+`<textarea data-comment="$decisionId-note">` so the user can attach a
+free-form override to their include/discard choice (e.g. "only for X",
+"with variant Y", or any open question that does not fit a binary toggle).
+
+Generated pages must emit the textarea inline. To upgrade older pages that
+were generated before this rule existed — and as a runtime safety net if
+Claude forgets to add it during a one-off generation — every concept page
+also ships `ensureCommentSlots()`. It iterates over every `[data-decision]`
+group and injects a textarea where one is missing. The function runs once
+on `DOMContentLoaded` BEFORE `restoreState()` so the restore step can
+rehydrate previously typed comments into the newly-injected nodes.
+
+The catch-all `collectAllFormFields` picks up the textareas via
+`data-comment` without any collector change (see § collectDecisions
+dispatcher — the dispatcher already reads `el.dataset.comment` as a
+fallback key).
+
+```javascript
+function ensureCommentSlots() {
+  document.querySelectorAll('[data-decision]').forEach(group => {
+    // Anchor: prefer the surrounding card/section so the textarea ends up
+    // inside the same visual unit. Fall back to the group's parent if no
+    // recognised wrapper exists.
+    const card = group.closest('.pattern-card, .role-card, .variant-evaluation, section[id]')
+              || group.parentElement;
+    if (!card) return;
+
+    // Skip if the card already has a comment slot — works for both inline
+    // emission and prior runs of ensureCommentSlots().
+    if (card.querySelector('textarea[data-comment]')) return;
+
+    const id = (group.dataset.decision || group.id || '').trim();
+    if (!id) return;  // unnamed group — nothing useful to key the textarea by
+    const commentKey = id + '-note';
+
+    const row = document.createElement('div');
+    row.className = 'field-row decision-comment-row';
+
+    const label = document.createElement('label');
+    label.setAttribute('for', commentKey);
+    label.textContent = '{{decision.comment_label}}';
+
+    const ta = document.createElement('textarea');
+    ta.id = commentKey;
+    ta.dataset.comment = commentKey;
+    ta.placeholder = '{{decision.comment_placeholder}}';
+    ta.rows = 2;
+
+    row.appendChild(label);
+    row.appendChild(ta);
+
+    // Insert right after the bi-state group when both share the same parent;
+    // otherwise append to the card so the override is visually attached.
+    if (group.nextSibling && group.parentNode === card) {
+      group.parentNode.insertBefore(row, group.nextSibling);
+    } else {
+      card.appendChild(row);
+    }
+  });
+}
+```
+
+**Notes:**
+- `{{decision.comment_label}}` and `{{decision.comment_placeholder}}` MUST be
+  replaced with the locale-resolved strings at generation time (see § UI Locale).
+- `ensureCommentSlots()` is idempotent — re-running it does nothing once
+  every group has a textarea, so it is safe to call multiple times (e.g.
+  after a Claude-driven iteration append).
+- Iteration appends MUST also call `ensureCommentSlots()` after the new
+  section is inserted; the `DOMContentLoaded` hook only fires on full
+  reloads. Either trigger it manually or rely on the next `/reload` POST
+  which forces a `location.reload()`.
 
 ## collectDecisions (dispatcher)
 
@@ -2373,7 +2683,16 @@ async function submitCreateIssues() {
     el.hidden = el.dataset.issuesState !== 'running';
   });
 
-  const payload = { submitted: true, action: 'create-issues', items };
+  // Always ship the current disposition state so Claude can apply Step 6
+  // cleanup based on the user's choice. If the user only clicks
+  // "Issues erstellen" and the disposition button never fires, this
+  // payload still carries the disposition for cleanup.
+  const payload = {
+    submitted: true,
+    action: 'create-issues',
+    items,
+    disposition: collectDisposition()
+  };
   const container = document.getElementById('concept-decisions');
   if (container) container.textContent = JSON.stringify(payload);
   document.body.classList.add('concept-submitted');
@@ -2393,6 +2712,56 @@ async function submitCreateIssues() {
 
 document.getElementById('create-issues-btn')
   ?.addEventListener('click', submitCreateIssues);
+
+// --- Final-report "Concept beenden" / dispose-concept action ---
+// Always available on the final-report panel. Submits the user's
+// disposition choice (discard | keep | gitignore + optional moveTo) and
+// signals Claude to run Step 6 cleanup. Independent from create-issues —
+// the user may end the concept without ever creating issues, or click
+// both in any order.
+function collectDisposition() {
+  const radio = document.querySelector('input[name="dispose-mode"]:checked');
+  const moveEl = document.getElementById('dispose-move-to');
+  const mode = radio ? radio.value : 'discard';
+  const moveTo = (moveEl && moveEl.value.trim()) ? moveEl.value.trim() : null;
+  return { mode, moveTo };
+}
+
+async function submitDisposeConcept() {
+  const active = document.querySelector('section[data-iteration][data-active]');
+  if (!active || !active.hasAttribute('data-final-report')) return;
+
+  const fs = document.getElementById('panel-dispose-concept');
+  const btn = document.getElementById('dispose-concept-btn');
+  if (!fs || !btn) return;
+
+  btn.disabled = true;
+  fs.querySelectorAll('.hint[data-dispose-state]').forEach(el => {
+    el.hidden = el.dataset.disposeState !== 'running';
+  });
+
+  const payload = {
+    submitted: true,
+    action: 'dispose-concept',
+    disposition: collectDisposition()
+  };
+  const container = document.getElementById('concept-decisions');
+  if (container) container.textContent = JSON.stringify(payload);
+  document.body.classList.add('concept-submitted');
+
+  try {
+    await fetch('/decisions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+  } catch (e) {
+    localStorage.setItem(STORAGE_KEY + '-pending', JSON.stringify(payload));
+  }
+}
+
+document.getElementById('dispose-concept-btn')
+  ?.addEventListener('click', submitDisposeConcept);
 
 // Recompute gating whenever the user toggles a checkbox inside the
 // open-questions section. The generic change listener (for saveState)
@@ -3035,6 +3404,68 @@ checkboxes is currently checked.
 Both gates run client-side only — Claude never enables/disables the
 button via the bridge; instead it controls visibility indirectly by
 disabling checkboxes when it writes the issue-routed HTML.
+
+### Disposition Control
+
+The disposition fieldset (`#panel-dispose-concept`) is **always visible**
+when the panel is in `panel-final-report` mode — it is not gated on
+open-questions content. Its three radios + optional `moveTo` text input
+drive Step 6 cleanup behaviour. The user chooses how the concept files
+should land on disk before closing the session.
+
+**Disposition modes:**
+
+| `mode` | Step 6 cleanup behaviour |
+|---|---|
+| `discard` *(default)* | Delete the concept HTML AND the matching `-decisions.json` from `docs/concepts/`. |
+| `keep` | Leave the files in place (or under `moveTo` if set). They remain git-tracked. |
+| `gitignore` | Leave the files in place (or under `moveTo` if set) AND append `docs/concepts/{slug}.*` (or the moved path glob) to the repo's `.gitignore` if not already covered. |
+
+**Optional `moveTo` (string):** the user may type a target directory
+(e.g. `docs/architecture/decisions/`). When set, Claude `mv`s both the
+HTML file AND the decisions JSON to that directory FIRST, then applies
+the `mode` semantics. Empty / whitespace-only input is treated as null.
+
+**Payload shape:**
+
+```json
+{ "mode": "discard" | "keep" | "gitignore", "moveTo": "docs/architecture/" | null }
+```
+
+Both `create-issues` and `dispose-concept` payloads carry the same
+`disposition` sub-object. The contract is documented in `SKILL.md`
+§ Step 6 — Cleanup-By-Disposition.
+
+**Backward compatibility:** old concept sessions that submitted a
+`create-issues` payload without a `disposition` field, or any submission
+that ended the session before this control existed, default to
+`disposition: { mode: "discard", moveTo: null }`. The default is
+intentionally aggressive — most one-shot refinements do not need to
+persist the HTML in git, and a stray opt-out is cheaper to fix
+(re-render or check-in manually) than a stale concept directory full of
+forgotten artefacts.
+
+### `submitCreateIssues` + `submitDisposeConcept` interplay
+
+The two final-report submissions are independent and may fire in any
+order, including just one of them:
+
+- **Issues only** — user clicks "Issues erstellen" with checked items.
+  Payload `action: "create-issues"` carries `items[]` + `disposition`.
+  Claude routes issues per Step 5b § create-issues branch, then runs
+  Step 6 cleanup with the bundled disposition.
+- **Dispose only** — user clicks "Concept beenden" without ever
+  touching the issue list (or there is no `[data-open-questions]`
+  block at all). Payload `action: "dispose-concept"` carries only
+  `disposition`. Claude skips issue routing and runs Step 6 cleanup
+  directly.
+- **Issues then dispose** — both fire in sequence. Step 6 runs after
+  the second submission with the latest disposition state. Issue
+  routing is not repeated.
+
+A `disposition` payload is **never replayed** — once Step 6 has been
+applied, subsequent payloads (e.g. an offline-queue replay) are
+ignored on the server side by the standard `_version` mismatch guard.
 
 ## Design System
 

--- a/plugins/devops/skills/devops-concept/deep-knowledge/validation-gate.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/validation-gate.md
@@ -41,10 +41,19 @@ Every concept page must contain these 29 patterns, regardless of template:
 | 27 | `Date.now() - _lastHeartbeatTs` (millis vs. millis) | Both sides of the staleness comparison MUST be in milliseconds since the Unix epoch. Server returns `claude_ts` in ms; browser uses `Date.now()`. Never divide either side by 1000 — a millis-vs-seconds mix-up produces a giant negative age that always evaluates as "fresh" and silently hides outages. |
 | 28 | `panel-final-report` | Final-report panel element. Auto-shown by `showIteration()` when the active section carries `data-final-report`; replaces `panel-ready` (no iterate/implement buttons). |
 | 29 | `updateCreateIssuesPanel` | Gating function that toggles the "Issues erstellen" button visibility + enabled state based on the active section's `[data-open-questions]` content. Must be called from `showIteration()` so panel state stays consistent on tab switch. |
+| 30 | `ensureCommentSlots` | Auto-injects an adjacent `<textarea data-comment="$decisionId-note">` for every `[data-decision]` bi-state group that lacks one. MUST be called from `DOMContentLoaded` BEFORE `restoreState` so the restore step rehydrates the typed values onto real nodes. See templates.md § Comment Slot Injection. |
+| 31 | `panel-dispose-concept` | Disposition fieldset on the final-report panel. Always visible while `panel-final-report` is active; carries the discard / keep / gitignore radio group + optional `moveTo` input. See templates.md § Disposition Control. |
+| 32 | `submitDisposeConcept` | JS handler wired to `#dispose-concept-btn`. POSTs `action: "dispose-concept"` with the current disposition payload so Step 6a can run the cleanup branch. |
 
 **Failure for 21 / 22:** if either pattern is missing, the page is rejected
 at the post-generation gate. See § Generic Form Collection below for the
 required pattern.
+
+**Failure for 30:** if the page renders bi-state cards without comment slots
+AND `ensureCommentSlots` is missing, the user has nowhere to attach
+free-form overrides to their include/discard choices. Fix the HTML (emit
+the textarea inline per § Bi-State Variant Evaluation) and ship the JS
+safety net (per § Comment Slot Injection) before opening.
 
 ## Generic Form Collection (mandatory for all templates)
 

--- a/plugins/devops/skills/devops-project-setup/SKILL.md
+++ b/plugins/devops/skills/devops-project-setup/SKILL.md
@@ -79,6 +79,8 @@ See `deep-knowledge/claude-directory-structure.md` for the canonical `.claude/` 
 .claude/.cache/
 .claude/*.log
 .claude/token-config.json
+.claude/concept-active.json
+.claude/session-opened-files.json
 ```
 
 ### 2.3 — Secrets (mandatory, always included)

--- a/plugins/devops/skills/devops-repo-health/SKILL.md
+++ b/plugins/devops/skills/devops-repo-health/SKILL.md
@@ -208,6 +208,12 @@ new tab in running Edge, user's profile context, Claude extension for interactio
 
 ```bash
 start "" msedge "file:///$(cygpath -m "{filepath}")"
+
+# Track the opened report so /devops-ship can re-open it from the main-repo
+# path after a future worktree cleanup (issue #160).
+node "$CLAUDE_PLUGIN_ROOT/scripts/session-open-tracker.js" track \
+  "$(cygpath -w "{filepath}")" \
+  --context=repo-health
 ```
 
 **Windows note:** always run `{filepath}` through `cygpath -m` before

--- a/plugins/devops/skills/devops-ship/SKILL.md
+++ b/plugins/devops/skills/devops-ship/SKILL.md
@@ -252,6 +252,20 @@ See `deep-knowledge/skill-extension-guide.md -> Delivery targets` for reference.
 
 ## Step 5 — Cleanup
 
+### 5a. Capture session context
+
+**Before any cleanup action**, capture two pieces of state for Step 5c:
+
+1. The current worktree path (if running inside one) — capture via
+   `pwd` / `git rev-parse --show-toplevel` BEFORE `ExitWorktree` runs.
+   Save it as `$WORKTREE_PATH`. Skip this if not in a worktree.
+2. The resolved main-repo root via `git rev-parse --git-common-dir` and
+   walking to its parent (or `git worktree list --porcelain` first entry).
+   Save it as `$MAIN_REPO_ROOT`. Step 5c re-resolves this internally but
+   capturing it here makes the cleanup trail easier to log.
+
+### 5b. Exit worktree + ship_cleanup
+
 **If in a worktree**: call `ExitWorktree(action: "remove")` FIRST to release the CWD lock.
 
 If `ExitWorktree` **fails** (e.g. directory locked by another process): **STOP**. Do not proceed to cleanup.
@@ -274,7 +288,46 @@ The tool will refuse to run if still inside a worktree — it returns an error r
 **Only own branch/worktree.** Never clean up other branches or worktrees.
 **Only after confirmed merge.** If Step 4 failed, preserve everything.
 
-If `success: false` → log warning but continue to Step 6. Cleanup failures are non-fatal — the merge already landed.
+If `success: false` → log warning but continue to Step 5c (re-opening files
+is still useful) then Step 6. Cleanup failures are non-fatal — the merge
+already landed.
+
+### 5c. Re-open session-opened files from main-repo path
+
+After `ship_cleanup` completes, every file:// URL the session opened from
+inside `$WORKTREE_PATH` is now dead (the worktree directory has been
+pruned). The merged HTML still lives at the equivalent path inside the
+main repo, so re-open every tracked file from there so the user's browser
+tab silently picks up the live version.
+
+Skip this step entirely when `$WORKTREE_PATH` was empty in 5a (the ship
+ran directly from the main checkout, no path rewrite needed).
+
+```bash
+node "$CLAUDE_PLUGIN_ROOT/scripts/session-open-tracker.js" reopen-main \
+  --worktree="$WORKTREE_PATH"
+```
+
+The script:
+- Reads `<main-repo>/.claude/session-opened-files.json` (the tracking
+  file is anchored at the main repo root so it survives worktree
+  cleanup — see `scripts/session-open-tracker.js` for the storage
+  contract).
+- Filters tracked entries to those that were under `$WORKTREE_PATH`.
+- Maps each filtered entry to the main-repo equivalent (`relative
+  path within worktree` → `<main-repo>/<relative>`).
+- Opens every still-existing file in Edge via the standard
+  `start "" msedge "file:///…"` pattern.
+- Prints a JSON summary `{ reopened: [...], missing: [...], consumed }`.
+
+Treat the summary as informational. Any entries listed under `missing`
+mean the file did not survive the merge (likely deleted during the
+session) — that is expected and not a ship failure.
+
+**Background — issue #160.** Without this step, `/devops-ship` silently
+invalidates every browser tab that was pointing into the worktree. The
+user sees a 404 / blank tab and reasonably concludes the concept page
+itself is broken, when in reality the content is fine at the main path.
 
 ## Step 6 — Completion Card
 

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.81.0",
+  "version": "0.82.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
Closes #158, closes #159, closes #160.

## Summary

Three concept/ship-skill features bundled into one release.

### #158 — Per-decision note textareas
Every Bi-State `[data-decision]` group on a concept page now ships with an adjacent `<textarea data-comment="$id-note">` so the user can attach a free-form override ("only for X", "with variant Y") to their include/discard choice. New `ensureCommentSlots()` JS safety net auto-injects the slot on `DOMContentLoaded` (idempotent, runs before `restoreState` so typed values survive reload). Validation gate pattern #31 enforces presence.

### #159 — Final-report disposition control
The `panel-final-report` mode now carries an always-visible disposition fieldset — three radios (discard / keep / gitignore) plus optional `moveTo` path input plus a "Concept beenden" button that POSTs `action: "dispose-concept"`. The disposition also rides on every `create-issues` payload. SKILL.md Step 6a is rewritten as **Cleanup-By-Disposition** with explicit branches, safety rules (no escape outside project root, `--` argument terminators with double-quoted paths, full filename gitignore patterns with `{date}-{slug}.*`, append-only `.gitignore` edits). Default = `discard`, backward-compatible for old payloads.

### #160 — `/devops-ship` re-opens session-opened files
New `plugins/devops/scripts/session-open-tracker.js` tracks every `file://` URL the session opens. `/devops-ship` Step 5c invokes its `reopen-main --worktree=$WORKTREE_PATH` after `ship_cleanup` removes the worktree so the user's browser tab silently swaps to the live main-repo path. Browser launch failures preserve entries for retry. Wired into `devops-autonomous` Step 7c, `devops-repo-health` Step 8, and documented in `browser-file-urls.md` + `skill-extension-guide.md` for project-side extensions.

## Notes

- Branch also carries a merge of `origin/main` to fold in the post-submit content-dimmer feature from [#162](https://github.com/Jerry0022/dotclaude/pull/162). `submitDisposeConcept` plays along (adds `body.content-dimmed`, calls `showContentDimmer()`).
- Validation gate pattern count: 30 → 33.

## Test plan

- [x] `npm test` — 153/153 passing
- [x] `npm run lint` — clean
- [x] Manual: generated a sample concept HTML with all three bi-state cards (one without inline textarea) + the dispose fieldset and verified in Chrome MCP: all three cards have textareas (variant-c auto-injected), 3 disposition radios with discard checked by default, `collectDisposition()` + `allFields` return the expected payload shape.
- [x] Tracker round-trip: tracked an inside-worktree path + an outside path; `reopen-main` consumed only the worktree path, dropped genuinely-missing files, would preserve entries on launch failure.
- [x] Codex review gate — 3 findings, all fixed in `fd3849b`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)