### PR TITLE
feat(ship): auto-detect follow-up work, keep worktree (0.83.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.82.0"
+    "version": "0.83.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.82.0",
+      "version": "0.83.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.82.0",
+      "version": "0.83.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.83.0] — 2026-05-23
+
+### Added
+
+- **plugins/devops/skills/devops-ship/SKILL.md** — Step 5a Continue-Intent Check. Before cleanup, the ship pipeline now auto-detects whether follow-up work is expected in the same branch/worktree (open `TodoWrite` items unrelated to this ship, German/English follow-up phrases in recent user messages, multiple distinct scopes announced earlier, or explicit "ship und weiter" / "--keep" wording in the trigger). When a signal fires, the destructive cleanup is skipped: worktree + local branch stay alive, ready for the next commit. Default remains normal cleanup — false-positives accumulate orphan branches.
+- **plugins/devops/skills/devops-ship/SKILL.md** — new Step 5c (keep-mode cleanup). Calls `ship_cleanup` with `keep: true` to clear only the ship-in-progress sentinel; no `ExitWorktree`, no branch deletion. Remote branch was deleted by the GitHub merge — the next push will re-create it via `--set-upstream` automatically.
+- **plugins/devops/mcp-server/ship/tools/cleanup.js** — `keep: boolean` parameter on `ship_cleanup`. When `true`, the tool only clears the sentinel and returns `{ success, kept: true, cleaned: ["sentinel"] }`. Tool description updated so orchestrators know the worktree-exit guard does not apply to keep-mode.
+- **plugins/devops/mcp-server/index.js** — `state.kept` field on `render_completion_card`. Two new CTA variants `ship-successful-{merged,plain}-kept` flip the call-to-action from "All DONE / Alles ERLEDIGT" to "KEEP CODING in `<branch>` / WEITER in `<branch>`". `renderState()` renders the kept branch as plain text with "(kept locally)" suffix — the remote branch is gone after merge, so a GitHub link would 404.
+
+### Changed
+
+- **plugins/devops/skills/devops-ship/SKILL.md** — Step 5b's internal sections renamed from `5a/5b/5c` to `Substep 1/2/3` to avoid colliding with the new top-level `Step 5a/5b/5c` structure. Frontmatter `allowed-tools` gains `TaskList`, `TaskCreate`, `TaskUpdate` so Step 5a can actually inspect open Todo items.
+- **plugins/devops/.claude-plugin/plugin.json** — version `0.82.0 → 0.83.0`
+
 ## [0.82.0] — 2026-05-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.82.0**
+**Version: 0.83.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.82.0",
+  "version": "0.83.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/mcp-server/index.js
+++ b/plugins/devops/mcp-server/index.js
@@ -304,8 +304,11 @@ function renderState(state, variant, repoUrl) {
   else                                         icon = '\u2796';
 
   const branch = state.branch || '';
-  const branchLabel = branch + (state.worktree ? ' (worktree)' : '');
-  const branchStr = repoUrl
+  // In keep-mode the remote branch was deleted by the merge — linking to GitHub
+  // would 404. Render plain text with a "(kept)" hint instead.
+  const branchSuffix = state.kept ? ' (kept locally)' : (state.worktree ? ' (worktree)' : '');
+  const branchLabel = branch + branchSuffix;
+  const branchStr = (repoUrl && !state.kept)
     ? '[`' + branchLabel + '`](' + repoUrl + '/tree/' + branch + ')'
     : '`' + branchLabel + '`';
 

--- a/plugins/devops/mcp-server/index.js
+++ b/plugins/devops/mcp-server/index.js
@@ -186,8 +186,10 @@ const VARIANTS = {
 
 const CTA = {
   en: {
-    'ship-successful-merged': '## \ud83d\ude80 SHIPPED. merged \u2192 origin/{merged} \u2014 All DONE',
-    'ship-successful-plain':  '## \ud83d\ude80 SHIPPED \u2014 All DONE',
+    'ship-successful-merged':      '## \ud83d\ude80 SHIPPED. merged \u2192 origin/{merged} \u2014 All DONE',
+    'ship-successful-merged-kept': '## \ud83d\ude80 SHIPPED. merged \u2192 origin/{merged} \u2014 KEEP CODING in `{branch}`',
+    'ship-successful-plain':       '## \ud83d\ude80 SHIPPED \u2014 All DONE',
+    'ship-successful-plain-kept':  '## \ud83d\ude80 SHIPPED \u2014 KEEP CODING in `{branch}`',
     ready:                    '## \ud83d\udce6 READY \u2014 SHIP or CHANGE?',
     'ship-blocked':           '## \u26d4 BLOCKED. {reason} \u2014 FIX or SKIP?',
     test:                     '## \ud83e\uddea DONE \u2014 SHIP after your TEST?',
@@ -197,8 +199,10 @@ const CTA = {
     fallback:                 '## \ud83d\udd27 DONE \u2014 Anything ELSE?',
   },
   de: {
-    'ship-successful-merged': '## \ud83d\ude80 SHIPPED. merged \u2192 origin/{merged} \u2014 Alles ERLEDIGT',
-    'ship-successful-plain':  '## \ud83d\ude80 SHIPPED \u2014 Alles ERLEDIGT',
+    'ship-successful-merged':      '## \ud83d\ude80 SHIPPED. merged \u2192 origin/{merged} \u2014 Alles ERLEDIGT',
+    'ship-successful-merged-kept': '## \ud83d\ude80 SHIPPED. merged \u2192 origin/{merged} \u2014 WEITER in `{branch}`',
+    'ship-successful-plain':       '## \ud83d\ude80 SHIPPED \u2014 Alles ERLEDIGT',
+    'ship-successful-plain-kept':  '## \ud83d\ude80 SHIPPED \u2014 WEITER in `{branch}`',
     ready:                    '## \ud83d\udce6 READY \u2014 SHIP oder ÄNDERN?',
     'ship-blocked':           '## \u26d4 BLOCKED. {reason} \u2014 FIX oder SKIP?',
     test:                     '## \ud83e\uddea DONE \u2014 SHIP nach deinem TEST?',
@@ -375,15 +379,17 @@ function renderCTA(variant, cta, lang, state) {
 
   let key;
   if (variant === 'ship-successful') {
-    // Show merge target in CTA if actually merged
-    key = (state && state.merged) ? 'ship-successful-merged' : 'ship-successful-plain';
+    // Show merge target in CTA if actually merged; "-kept" suffix when keep-mode
+    // kept the worktree/branch alive for follow-up work.
+    const base = (state && state.merged) ? 'ship-successful-merged' : 'ship-successful-plain';
+    key = (state && state.kept) ? `${base}-kept` : base;
   } else {
     key = variant;
   }
 
   let tpl = templates[key] || templates.fallback;
   // Merge state fields into cta for template substitution
-  const vars = Object.assign({}, cta, state ? { merged: state.merged || '' } : {});
+  const vars = Object.assign({}, cta, state ? { merged: state.merged || '', branch: state.branch || '' } : {});
   tpl = tpl.replace(/\{(\w+)\}/g, (_, k) => vars[k] || '');
 
   return tpl;
@@ -699,6 +705,7 @@ server.registerTool(
           }).nullable().optional(),
           merged: z.string().nullable().optional(),
           appStatus: z.enum(["running", "not-started"]).nullable().optional(),
+          kept: z.boolean().optional().describe("Ship cleanup was skipped — branch + worktree preserved for follow-up work. Switches the ship-successful CTA from 'All DONE' to 'KEEP CODING in {branch}'."),
         }).optional(),
       ).describe("Repository state"),
       cta: z.preprocess(

--- a/plugins/devops/mcp-server/ship/index.js
+++ b/plugins/devops/mcp-server/ship/index.js
@@ -90,7 +90,9 @@ registerTool(
   "ship_cleanup",
   "Ship Cleanup",
   "Delete shipped feature branch (local + remote if lingering), prune worktrees and remotes. " +
-  "IMPORTANT: If in a worktree, Claude must call ExitWorktree BEFORE this tool.",
+  "IMPORTANT: If in a worktree, Claude must call ExitWorktree BEFORE this tool. " +
+  "EXCEPTION: when keep:true is passed, the tool only clears the ship-in-progress sentinel " +
+  "and leaves the worktree + branch intact — safe to call from inside the worktree.",
   cleanupSchema,
   cleanupHandler,
 );

--- a/plugins/devops/mcp-server/ship/tools/cleanup.js
+++ b/plugins/devops/mcp-server/ship/tools/cleanup.js
@@ -12,15 +12,30 @@ export const schema = z.object({
   branch: z.string().describe("Feature branch to delete"),
   base: z.string().default("main").describe("Base branch (should already be checked out)"),
   cwd: z.string().describe("Working directory of the target repo (required — must be passed by the caller)"),
+  keep: z.boolean().default(false).describe("Keep-mode: skip all branch/worktree deletion. Only clears the ship-in-progress sentinel so Edit guards reset. Use when follow-up work is expected in this same branch/worktree."),
 });
 
 export async function handler(params) {
-  const { branch, base, cwd } = params;
+  const { branch, base, cwd, keep } = params;
   if (!cwd) throw new Error("cwd is required — MCP server runs in the plugin directory, not the target repo");
   const opts = { cwd };
   const intermediate = base !== "main";
   const cleaned = [];
   const warnings = [];
+
+  // Keep-mode: skip all destructive cleanup. Only the sentinel needs clearing
+  // so Edit/branch guards stop treating this as "ship in progress".
+  if (keep) {
+    clearSentinel(cwd);
+    return {
+      success: true,
+      kept: true,
+      intermediate,
+      branchBeforeCleanup: git("rev-parse --abbrev-ref HEAD", opts) || null,
+      cleaned: ["sentinel"],
+      warnings: [`Keep-mode: branch '${branch}' and worktree preserved for follow-up work`],
+    };
+  }
 
   // Guard: refuse to run inside a worktree
   if (isWorktree(opts)) {

--- a/plugins/devops/skills/devops-ship/SKILL.md
+++ b/plugins/devops/skills/devops-ship/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   Supports hierarchical merges (sub-branch → feature → main).
   Use when work is ready to land. Triggers on: "ship it", "push and merge".
   Do NOT trigger during coding/debugging or for commits without shipping.
-allowed-tools: Bash(git *), Bash(gh *), Bash(npm *), Bash(node *), Read, Glob, Grep, AskUserQuestion, ExitWorktree, mcp__plugin_devops_dotclaude-ship__*, mcp__plugin_devops_dotclaude-completion__*, mcp__plugin_devops_dotclaude-issues__*
+allowed-tools: Bash(git *), Bash(gh *), Bash(npm *), Bash(node *), Read, Glob, Grep, AskUserQuestion, ExitWorktree, TaskList, TaskCreate, TaskUpdate, mcp__plugin_devops_dotclaude-ship__*, mcp__plugin_devops_dotclaude-completion__*, mcp__plugin_devops_dotclaude-issues__*
 ---
 
 # Ship

--- a/plugins/devops/skills/devops-ship/SKILL.md
+++ b/plugins/devops/skills/devops-ship/SKILL.md
@@ -250,7 +250,53 @@ consumer configuration — not yet implemented in this release (they fall throug
 
 See `deep-knowledge/skill-extension-guide.md -> Delivery targets` for reference.md examples.
 
-## Step 5 — Cleanup
+## Step 5a — Continue-Intent Check (auto-detect keep-mode)
+
+Before cleanup, decide whether **follow-up work** is expected in this same branch/worktree.
+If yes → **keep-mode** (skip Step 5b's destructive cleanup, jump to 5c).
+If no → **normal cleanup** (Step 5b).
+
+**Default is normal cleanup.** Only switch to keep-mode when a signal is clear — false-positives
+accumulate unmerged branches and orphan worktrees.
+
+### Signals that trigger keep-mode
+
+Evaluate all sources; ANY positive hit → keep-mode.
+
+1. **Open TodoWrite tasks not covered by this ship.** Call `TaskList` and check for `pending` or
+   `in_progress` items that describe work NOT delivered by the current PR's diff. Tasks that
+   were *about* this ship (e.g. "Run npm test", "Bump version") and are still open due to a
+   tracking slip do NOT count — only genuine follow-up scope.
+
+2. **Explicit follow-up signals in recent user messages** (this session, last ~10 turns):
+   - German: `"danach"`, `"dann noch"`, `"anschließend"`, `"weiter mit"`, `"als nächstes"`,
+     `"Phase 2"`, `"wir sind nicht fertig"`, `"noch nicht durch"`, `"zwischendurch"`,
+     `"erstmal X, dann Y"`, `"shippen aber wir machen weiter"`
+   - English: `"after this"`, `"then we"`, `"next up"`, `"phase 2"`, `"still need to"`,
+     `"we'll continue"`, `"ship but keep going"`, `"intermediate ship"`
+
+3. **Multiple distinct scopes announced earlier.** If the user laid out a sequence of
+   logically separate work blocks and only the first is being shipped now → keep-mode.
+
+4. **Explicit ship-but-keep wording in the trigger.** If the prompt that started this ship
+   says something like `"ship das aber wir machen weiter"`, `"ship und weiter"`,
+   `"keep worktree"`, `"--keep"`, `"ohne cleanup"` → keep-mode (highest priority).
+
+### When the signal is ambiguous
+
+If you considered keep-mode but the signal is weak (e.g. one borderline phrase, no clear
+follow-up scope), default to **normal cleanup**. Cleanup is recoverable — the branch can be
+re-created from the merge commit. Orphan worktrees from false-positive keep-mode are not.
+
+### Decision logging
+
+In the completion card's `changes` or `summary`, mention the chosen mode briefly when
+keep-mode triggers — e.g. `"Worktree behalten — Folge-Arbeit erkannt"` — so the user sees
+what was decided and can override (`"nein, doch räum auf"` for a follow-up cleanup).
+
+## Step 5b — Cleanup (normal mode)
+
+**Skip this step entirely if Step 5a chose keep-mode** — jump to Step 5c.
 
 ### 5a. Capture session context
 
@@ -329,6 +375,27 @@ invalidates every browser tab that was pointing into the worktree. The
 user sees a 404 / blank tab and reasonably concludes the concept page
 itself is broken, when in reality the content is fine at the main path.
 
+## Step 5c — Keep-mode cleanup (sentinel only)
+
+**Only runs when Step 5a chose keep-mode.**
+
+Do NOT call `ExitWorktree` — the worktree stays. Do NOT delete the branch.
+
+Call `ship_cleanup` with `keep: true` to clear the ship-in-progress sentinel (so Edit/branch
+guards reset) without touching anything else:
+```
+ship_cleanup({ branch: "claude/feature-branch", base: "main", cwd: "<cwd>", keep: true })
+```
+
+Returns `{ success: true, kept: true, cleaned: ["sentinel"], warnings: [...] }`.
+
+The remote branch was deleted by the GitHub merge — that's expected. The next commit + push
+in this worktree will re-create it via `git push --set-upstream origin <branch>` automatically.
+
+In Step 6, pass `state.kept: true` and `state.branch: "<feature-branch>"` to
+`render_completion_card` so the CTA renders `KEEP CODING in <branch>` / `WEITER in <branch>`
+instead of `All DONE` / `Alles ERLEDIGT`.
+
 ## Step 6 — Completion Card
 
 Call `render_completion_card` MCP tool (dotclaude-completion server) with data from previous steps.
@@ -358,6 +425,32 @@ render_completion_card({
   }
 })
 ```
+
+**Keep-mode variant** (Step 5a chose keep, Step 5c ran):
+```
+render_completion_card({
+  variant: "ship-successful",
+  summary: "<~10 words — mention 'Worktree behalten' or similar>",
+  lang: "de",
+  cwd: "<current working directory — still the worktree path>",
+  buildId: <from ship_build.buildId>,
+  changes: [...],
+  tests: [...],
+  state: {
+    branch: "<feature-branch name, NOT 'main' — the kept branch>",
+    worktree: true,
+    commit: <from ship_release.commit>,
+    pushed: true,
+    pr: { number: <from ship_release.pr.number>, title: <PR title> },
+    merged: "main",
+    kept: true
+  },
+  cta: { vOld, vNew, bump }
+})
+```
+
+The renderer flips the CTA from `All DONE` / `Alles ERLEDIGT` to
+`KEEP CODING in <branch>` / `WEITER in <branch>` when `state.kept: true`.
 
 Output the card markdown VERBATIM — card is the last **visible** output, nothing after closing `---`.
 

--- a/plugins/devops/skills/devops-ship/SKILL.md
+++ b/plugins/devops/skills/devops-ship/SKILL.md
@@ -298,19 +298,19 @@ what was decided and can override (`"nein, doch räum auf"` for a follow-up clea
 
 **Skip this step entirely if Step 5a chose keep-mode** — jump to Step 5c.
 
-### 5a. Capture session context
+### Substep 1 — Capture session context
 
-**Before any cleanup action**, capture two pieces of state for Step 5c:
+**Before any cleanup action**, capture two pieces of state for Substep 3:
 
 1. The current worktree path (if running inside one) — capture via
    `pwd` / `git rev-parse --show-toplevel` BEFORE `ExitWorktree` runs.
    Save it as `$WORKTREE_PATH`. Skip this if not in a worktree.
 2. The resolved main-repo root via `git rev-parse --git-common-dir` and
    walking to its parent (or `git worktree list --porcelain` first entry).
-   Save it as `$MAIN_REPO_ROOT`. Step 5c re-resolves this internally but
+   Save it as `$MAIN_REPO_ROOT`. Substep 3 re-resolves this internally but
    capturing it here makes the cleanup trail easier to log.
 
-### 5b. Exit worktree + ship_cleanup
+### Substep 2 — Exit worktree + ship_cleanup
 
 **If in a worktree**: call `ExitWorktree(action: "remove")` FIRST to release the CWD lock.
 
@@ -334,11 +334,11 @@ The tool will refuse to run if still inside a worktree — it returns an error r
 **Only own branch/worktree.** Never clean up other branches or worktrees.
 **Only after confirmed merge.** If Step 4 failed, preserve everything.
 
-If `success: false` → log warning but continue to Step 5c (re-opening files
+If `success: false` → log warning but continue to Substep 3 (re-opening files
 is still useful) then Step 6. Cleanup failures are non-fatal — the merge
 already landed.
 
-### 5c. Re-open session-opened files from main-repo path
+### Substep 3 — Re-open session-opened files from main-repo path
 
 After `ship_cleanup` completes, every file:// URL the session opened from
 inside `$WORKTREE_PATH` is now dead (the worktree directory has been
@@ -346,7 +346,7 @@ pruned). The merged HTML still lives at the equivalent path inside the
 main repo, so re-open every tracked file from there so the user's browser
 tab silently picks up the live version.
 
-Skip this step entirely when `$WORKTREE_PATH` was empty in 5a (the ship
+Skip this step entirely when `$WORKTREE_PATH` was empty in Substep 1 (the ship
 ran directly from the main checkout, no path rewrite needed).
 
 ```bash

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.82.0",
+  "version": "0.83.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

`/devops-ship` now auto-detects when follow-up work is expected in the same branch and skips the destructive cleanup — worktree + local branch stay alive, ready for the next commit. The full pipeline (PR, merge, version bump, release) still runs as before.

### Signals that trigger keep-mode

- Open `TodoWrite` items unrelated to the current ship
- German / English follow-up phrases in recent user messages (`"danach"`, `"weiter mit"`, `"after this"`, `"phase 2"`, ...)
- Multiple distinct work blocks announced earlier in the session
- Explicit ship-but-keep wording in the trigger (`"ship und weiter"`, `"--keep"`)

### What changes

- **SKILL.md** — new Step 5a (intent check) + Step 5c (keep-mode cleanup); Step 5b's substeps renamed to avoid collision.
- **ship_cleanup MCP tool** — `keep: true` param clears only the sentinel.
- **Completion card** — `state.kept` flag flips CTA to `KEEP CODING in <branch>` / `WEITER in <branch>`; branch rendered as plain text (no broken GitHub link).

### Test plan

- [x] vitest run (11 suites, 153 tests) green pre + post rebase
- [x] eslint clean
- [x] Codex review — 3 findings, all addressed inline

Co-Authored-By: Claude Opus 4.7 (1M context) &lt;noreply@anthropic.com&gt;