### PR TITLE
feat(concept): watchdog kills ghost bridge servers (0.84.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.83.0"
+    "version": "0.84.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.83.0",
+      "version": "0.84.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.83.0",
+      "version": "0.84.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.84.0] — 2026-05-24
+
+### Added
+
+- **plugins/devops/scripts/concept-server.py** — server-side watchdog daemon. New `--html <relative-path>` and `--heartbeat-timeout-ms <ms>` CLI args. A daemon thread terminates the process when (a) `--html` is set and the watched concept HTML disappears for > 10 s (10 s grace covers mid-rewrite races), or (b) `_claude_ts` is non-zero and older than the heartbeat timeout (default 5 min). Closes the silent-failure mode where a deleted concept HTML left the bridge polling forever, accepting heartbeats from a cron whose Claude session was long gone.
+- **plugins/devops/scripts/concept-server.py** — `POST /shutdown` HTTP endpoint. Same-origin guard (no-Origin curl or page-served fetch are allowed; foreign Origin → 403). Replaces the unreliable `kill $SERVER_PID` cleanup which could target unrelated processes after Windows PID recycling. Responds 200 first, then exits via a short-delay daemon thread so the caller never sees a connection-reset error.
+- **plugins/devops/skills/devops-concept/deep-knowledge/bridge-server.md** — Step 3 cron template gains a Step 0 self-cleanup gate that runs BEFORE the heartbeat. The gate reads `.claude/concept-active.json` each tick and triggers `/shutdown` + `CronDelete` when the state file is missing, the port disagrees, or `html_path` is gone — preventing the cron from outliving the concept session it polls for.
+
+### Changed
+
+- **plugins/devops/scripts/concept-server.py** — argument parsing migrated from positional-only to `argparse` so the new flags don't break the existing `python concept-server.py <port> <directory>` call shape.
+- **plugins/devops/skills/devops-concept/deep-knowledge/bridge-server.md** — Step 2 (server launch) now passes `--html "docs/concepts/{date}-{slug}.html"` and the project root as the directory (NOT the worktree root — the watchdog resolves `--html` relative to cwd). Step 7 (cleanup) replaces `kill $SERVER_PID` with `curl -X POST /shutdown`; the PID-kill fallback was removed because the watchdog reaps any survivor within 30 s.
+- **plugins/devops/skills/devops-concept/SKILL.md** — Step 6a cleanup procedure switched to `/shutdown` with the same rationale.
+- **plugins/devops/hooks/session-start/ss.concept.resume.js** — consistency check before the heartbeat probe: `fs.existsSync(html_path)` runs first. When the file is gone, the hook POSTs `/shutdown` to any running bridge and deletes the state file, so no phantom resume hint is surfaced. The re-arm cron prompt mirrors the new Step 0 cleanup gate.
+- **plugins/devops/.claude-plugin/plugin.json** — version `0.83.0 → 0.84.0`
+
 ## [0.83.0] — 2026-05-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.83.0**
+**Version: 0.84.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.83.0",
+  "version": "0.84.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/hooks/session-start/ss.concept.resume.js
+++ b/plugins/devops/hooks/session-start/ss.concept.resume.js
@@ -81,6 +81,24 @@ function deleteState() {
   try { fs.unlinkSync(STATE_PATH); } catch { /* already gone */ }
 }
 
+/**
+ * Fire-and-forget POST /shutdown. We don't wait for the response — even on
+ * Windows with PID recycling, the server's listening socket is on the port
+ * we know, and the watchdog already handles the no-response case. Best-effort
+ * graceful termination; the watchdog is the safety net.
+ */
+function postShutdown(port, timeoutMs = 1500) {
+  return new Promise((resolve) => {
+    const req = http.request(
+      { host: '127.0.0.1', port, path: '/shutdown', method: 'POST', timeout: timeoutMs },
+      (res) => { res.resume(); res.on('end', resolve); }
+    );
+    req.on('timeout', () => { req.destroy(); resolve(); });
+    req.on('error', () => resolve());
+    req.end();
+  });
+}
+
 function isStale(state) {
   if (!state.started_at) return false;
   const t = Date.parse(state.started_at);
@@ -122,6 +140,20 @@ function probe(port, pathname, timeoutMs = 1500) {
   const state = readState();
   if (!state) process.exit(0);
 
+  // Consistency check: the concept HTML on disk is the source of truth for
+  // "is this session still real?" If the file is gone, the concept was
+  // discarded / moved / never persisted and any running bridge is an orphan.
+  // We do this BEFORE the heartbeat probe so a still-running ghost server
+  // gets shut down explicitly — relying on the watchdog alone would leave
+  // the server alive for up to 30 s after this hook returns, surfacing
+  // misleading "concept active" state in the meantime.
+  const htmlAbs = path.join(cwd, state.html_path);
+  if (!fs.existsSync(htmlAbs)) {
+    await postShutdown(state.port);
+    deleteState();
+    process.exit(0);
+  }
+
   const heartbeat = await probe(state.port, '/heartbeat');
   if (!heartbeat) {
     // Server gone. If the file is also stale, prune it; otherwise leave it
@@ -147,7 +179,13 @@ function probe(port, pathname, timeoutMs = 1500) {
   }
 
   const cronBody =
-    `Silently run both steps for the concept bridge on port ${state.port}: ` +
+    `Silently service the concept bridge on port ${state.port}. ` +
+    `(0) Self-cleanup gate (FIRST step every tick): Read \`.claude/concept-active.json\`. ` +
+    `Cleanup triggers if the file is missing, OR state.port ≠ ${state.port}, OR state.html_path does not exist on disk. ` +
+    `On trigger: (a) Bash: curl -s -X POST http://localhost:${state.port}/shutdown > /dev/null 2>&1 || true; ` +
+    `(b) CronDelete the cron_id from the still-readable state file — or, if the state file is gone, ` +
+    `CronList and delete every cron whose prompt mentions \`port ${state.port}\`. ` +
+    `Produce NO output and skip steps 1+2. ` +
     `(1) Heartbeat POST: Bash: curl -s -X POST http://localhost:${state.port}/heartbeat > /dev/null. ` +
     `(2) Pending check via /pending: Bash: curl -s http://localhost:${state.port}/pending | python -c "import sys,json; d=json.load(sys.stdin); print(\\'true\\' if d.get(\\'pending\\') else \\'false\\')". ` +
     `If exactly "false" → produce NO output (silent tick). ` +

--- a/plugins/devops/scripts/concept-server.py
+++ b/plugins/devops/scripts/concept-server.py
@@ -31,6 +31,24 @@ Replaces `python -m http.server` with a custom server that adds:
   `_picked_up_at` / `_phase` on success.
 - GET/POST /reload — Claude bumps a counter after rewriting the HTML file;
   the browser polls and reloads when the counter advances.
+- POST /shutdown — Graceful self-termination. Same-origin gate (curl with
+  no Origin header, or fetch from the served page). Used by the cleanup
+  path in /devops-concept Step 6 and by the watchdog when state files
+  vanish. PID-based kill is unreliable on Windows after process
+  recycling — an HTTP endpoint targets the live process by port.
+
+A background **watchdog daemon** terminates the process when:
+- `--html <path>` was passed and the file disappeared for > 10 s
+  (10 s grace covers the brief window during which Claude rewrites the
+  file in-place for the next iteration). This catches "concept HTML was
+  manually deleted / moved / never persisted" without needing the cron.
+- `_claude_ts` is older than `--heartbeat-timeout-ms` (default 5 min)
+  AND non-zero. A claude_ts of 0 means Claude has never pinged — that
+  is the bootstrap window before the first cron tick lands, NOT a dead
+  cron, so the watchdog tolerates it indefinitely until the first POST.
+The watchdog runs every 30 s. Both branches call `os._exit(0)` so the
+listening socket is released immediately — no graceful drain — because
+the only client at that point is a cron that should also be dying.
 
 This bypasses Chrome MCP JS injection limitations entirely. The page
 communicates with Claude through HTTP endpoints instead of requiring
@@ -45,12 +63,15 @@ REPL) while the server kept ticking. POST /heartbeat now updates ONLY
 `_claude_ts`, and the browser gates the indicator on that.
 
 Usage:
-    python concept-server.py <port> [directory]
+    python concept-server.py <port> [directory] [--html <relative-path>]
+                                                [--heartbeat-timeout-ms <ms>]
 
 Example:
-    python concept-server.py 8742 /path/to/.claude/devops-concept
+    python concept-server.py 8742 /path/to/project \
+        --html docs/concepts/2026-04-12-auth-redesign.html
 """
 
+import argparse
 import http.server
 import json
 import os
@@ -273,6 +294,33 @@ class ConceptBridgeHandler(http.server.SimpleHTTPRequestHandler):
                 _reload_counter += 1
                 counter = _reload_counter
             self._json_response({"ok": True, "counter": counter})
+        elif self.path == '/shutdown':
+            # Graceful self-termination. Accepted only from same-origin or
+            # no-Origin (curl). Cross-origin browser requests are rejected
+            # so a random tab can't kill the bridge. We reply 200 BEFORE
+            # exiting so the caller doesn't see a connection-reset error
+            # they'd have to special-case.
+            origin = self.headers.get('Origin')
+            host = self.headers.get('Host', '')
+            if origin is not None:
+                port_part = host.split(':')[-1] if ':' in host else ''
+                allowed = {
+                    f'http://{host}',
+                    f'http://localhost:{port_part}',
+                    f'http://127.0.0.1:{port_part}',
+                }
+                if origin not in allowed:
+                    self.send_error(403, "forbidden origin")
+                    return
+            self._json_response({"ok": True, "shutting_down": True})
+            # Flush the response, then exit on a short delay so the wfile
+            # has time to drain before the socket closes. os._exit skips
+            # atexit handlers; that's intentional — we don't want the
+            # daemon-thread teardown to hang.
+            threading.Thread(
+                target=lambda: (time.sleep(0.1), os._exit(0)),
+                daemon=True,
+            ).start()
         elif self.path == '/reset':
             # Optional body: {"version": N}. When present, only reset if N
             # matches the current server version — otherwise a newer submission
@@ -356,10 +404,80 @@ def _server_self_pulse(interval_s: int = 30):
         time.sleep(interval_s)
 
 
+def _watchdog(html_path, heartbeat_timeout_ms, interval_s=30, html_grace_s=10):
+    """Self-terminate when the concept state has obviously gone away.
+
+    Two independent conditions trigger shutdown:
+
+    1. **HTML disappeared.** If `--html` was given and the file no longer
+       exists, the concept session has been wiped out (manual delete,
+       failed write, never persisted on disk). We allow a `html_grace_s`
+       window during which the file can be absent without triggering
+       shutdown — this covers the brief moment Claude truncates the file
+       to rewrite it for the next iteration. The first absence stamps a
+       deadline; only an absence still present AFTER the deadline kills
+       the server. A re-appearance clears the deadline.
+
+    2. **Claude heartbeat stale.** Once `_claude_ts` is non-zero (Claude
+       has pinged at least once), the watchdog enforces that the gap to
+       now stays under `heartbeat_timeout_ms`. A dead cron — session
+       closed without cleanup, prompt loop dropped — will stop POSTing
+       and the watchdog reaps the server. A `_claude_ts` of 0 is the
+       legitimate bootstrap window before the first tick and is NEVER
+       a shutdown trigger; otherwise we'd race against the cron's first
+       fire and kill the server before it ever sees Claude.
+    """
+    html_missing_since = None
+    while True:
+        time.sleep(interval_s)
+        now_ms = int(time.time() * 1000)
+
+        if html_path:
+            exists = os.path.exists(html_path)
+            if not exists:
+                if html_missing_since is None:
+                    html_missing_since = now_ms
+                elif (now_ms - html_missing_since) > html_grace_s * 1000:
+                    sys.stderr.write(
+                        f"[watchdog] html_path gone for > {html_grace_s}s: "
+                        f"{html_path} — shutting down\n"
+                    )
+                    os._exit(0)
+            else:
+                html_missing_since = None
+
+        with _lock:
+            claude_ts = _claude_ts
+        if claude_ts > 0 and (now_ms - claude_ts) > heartbeat_timeout_ms:
+            sys.stderr.write(
+                f"[watchdog] claude_ts stale by {now_ms - claude_ts}ms "
+                f"(threshold {heartbeat_timeout_ms}ms) — shutting down\n"
+            )
+            os._exit(0)
+
+
 if __name__ == '__main__':
-    port = int(sys.argv[1]) if len(sys.argv) > 1 else 8700
-    directory = sys.argv[2] if len(sys.argv) > 2 else '.'
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument('port', nargs='?', default='8700')
+    parser.add_argument('directory', nargs='?', default='.')
+    parser.add_argument('--html', default=None,
+                        help='Relative path to the concept HTML inside <directory>. '
+                             'When set, the watchdog terminates the server if this '
+                             'file disappears for more than 10 s.')
+    parser.add_argument('--heartbeat-timeout-ms', type=int, default=5 * 60 * 1000,
+                        help='Max age of _claude_ts before the watchdog terminates. '
+                             'Default 300000 (5 min).')
+    args = parser.parse_args()
+
+    port = int(args.port)
+    directory = args.directory
     os.chdir(directory)
+
+    # The watchdog resolves `--html` against cwd AFTER chdir, so callers can
+    # pass repo-relative paths. We capture the absolute path so a later
+    # cwd-change (unlikely, but cheap to be defensive) cannot misdirect the
+    # existence check.
+    html_path = os.path.abspath(args.html) if args.html else None
 
     # Prime + self-pulse: the browser checks the heartbeat within 5s of page
     # load, so set `_server_ts` once before serving and then refresh every 30s
@@ -367,8 +485,15 @@ if __name__ == '__main__':
     # stays 0 until Claude actually POSTs — that's the whole point of the split.
     _server_ts = int(time.time() * 1000)
     threading.Thread(target=_server_self_pulse, daemon=True).start()
+    threading.Thread(
+        target=_watchdog,
+        args=(html_path, args.heartbeat_timeout_ms),
+        daemon=True,
+    ).start()
 
     with http.server.HTTPServer(('', port), ConceptBridgeHandler) as httpd:
         print(f"Concept bridge server on http://localhost:{port}/")
         print(f"Serving: {os.getcwd()}")
+        if html_path:
+            print(f"Watching: {html_path}")
         httpd.serve_forever()

--- a/plugins/devops/skills/devops-concept/SKILL.md
+++ b/plugins/devops/skills/devops-concept/SKILL.md
@@ -734,15 +734,19 @@ via the final-report panel.
 **Cleanup procedure (always):**
 
 ```bash
-kill $SERVER_PID 2>/dev/null
+curl -s -X POST http://localhost:$PORT/shutdown > /dev/null 2>&1 || true
 rm -f .claude/concept-active.json
 ```
 
-Then `CronDelete <cron_id>`. Removing `concept-active.json` is mandatory
-— if the file lingers, the next SessionStart's `ss.concept.resume` hook
-will surface a phantom resume hint pointing at a server that no longer
-exists. The `kill` is best-effort: if the user already closed the
-terminal that spawned the server, the PID may be gone, which is fine.
+Then `CronDelete <cron_id>`. `/shutdown` replaces the older `kill $SERVER_PID`:
+on Windows the PID could already be reused by an unrelated process, and
+swallowing `kill` errors hid that case. The HTTP endpoint targets the live
+server by port and is a no-op when the server is already dead. Removing
+`concept-active.json` is mandatory — if the file lingers, the next
+SessionStart's `ss.concept.resume` hook will surface a phantom resume hint
+pointing at a server that no longer exists. Even if `/shutdown` fails (server
+already gone, port unbound), the watchdog terminates any surviving instance
+within 30 s once the cron stops POSTing heartbeats.
 
 **Apply disposition on the concept files.** Files are named
 `docs/concepts/{date}-{slug}.html` and `docs/concepts/{date}-{slug}-decisions.json`

--- a/plugins/devops/skills/devops-concept/deep-knowledge/bridge-server.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/bridge-server.md
@@ -28,9 +28,12 @@ AND provides HTTP endpoints for heartbeat and decision exchange.
    PLUGIN_ROOT=$(ls -d ~/.claude/plugins/cache/dotclaude/devops/*/scripts/concept-server.py 2>/dev/null | head -1)
    ```
 
-2. Start the bridge server in the concept directory:
+2. Start the bridge server in the **project root** (NOT the worktree root —
+   the watchdog resolves `--html` against the cwd, and concept HTML lives in
+   the main project tree):
    ```bash
-   python "$PLUGIN_ROOT" {random-port} "{concept-dir}" &
+   python "$PLUGIN_ROOT" {random-port} "{project-root}" \
+       --html "docs/concepts/{date}-{slug}.html" &
    ```
    Use a random port (8700-8999) to avoid conflicts. Store the port as `$PORT`
    and the spawned background PID as `$SERVER_PID` (`echo $!` immediately
@@ -38,13 +41,39 @@ AND provides HTTP endpoints for heartbeat and decision exchange.
    in step 6 so the SessionStart resume hook can find this server again
    after a Claude restart.
 
+   **The `--html` flag is mandatory.** It arms the server-side watchdog:
+   if the concept HTML file disappears for > 10 s, the watchdog terminates
+   the bridge automatically — no orphan server can survive a manual
+   `rm docs/concepts/…`, a failed disposition step, or a worktree wipe.
+   The watchdog ALSO terminates if Claude's heartbeat goes stale for > 5
+   min (`--heartbeat-timeout-ms` default `300000`), catching the dead-cron
+   case (session closed without /shutdown, cron prompt loop dropped). Both
+   conditions independently guarantee the server cannot become a ghost.
+
 3. Set up the **combined heartbeat + auto-poll cron**. This single cron keeps
    the connection indicator green AND automatically picks up user submissions
    — no manual trigger needed from the user.
 
    ```
    CronCreate(cron: "* * * * *", recurring: true, prompt: <<EOF
-   Silently run both steps for the concept bridge on port {port}:
+   Silently service the concept bridge on port {port}.
+
+   (0) Self-cleanup gate (FIRST step every tick).
+       Read `.claude/concept-active.json` from the project root. Cleanup
+       triggers when ANY of these is true:
+         - The state file is missing.
+         - State.port ≠ {port} (this cron is for a stale session — a
+           newer concept overwrote the state file with a different port).
+         - State.html_path does not exist on disk.
+       On trigger:
+         - Bash: curl -s -X POST http://localhost:{port}/shutdown > /dev/null 2>&1 || true
+         - Then call CronDelete with the id from the (still-readable)
+           state file's `cron_id` field — OR, if the state file is gone
+           entirely, list crons via CronList and delete every cron whose
+           prompt mentions `port {port}` (a missing state file proves
+           the session is unrecoverable; sweeping by-port catches the
+           orphan even when the id is lost).
+       Produce NO user-visible output. Skip steps 1 and 2.
 
    (1) Heartbeat POST:
        Bash: curl -s -X POST http://localhost:{port}/heartbeat > /dev/null
@@ -198,13 +227,23 @@ AND provides HTTP endpoints for heartbeat and decision exchange.
    "Concept beenden" on the final-report panel, or Step 6 of SKILL.md
    fires the completion card), run the bridge-side cleanup:
    ```bash
-   kill $SERVER_PID 2>/dev/null  # or `kill %1` if still in shell scope
+   # Graceful shutdown via HTTP — survives PID recycling on Windows where
+   # `kill $SERVER_PID` may target a process that already exited and got
+   # its PID reused by an unrelated program. The server replies 200 then
+   # calls os._exit(0); the listening socket is released within ~100 ms.
+   curl -s -X POST http://localhost:$PORT/shutdown > /dev/null 2>&1 || true
    rm -f .claude/concept-active.json
    ```
    Also delete the polling cron via `CronDelete <cron_id>`. The state file
    MUST be removed when the concept session is intentionally ended,
    otherwise the next SessionStart will surface a phantom resume hint for a
    server that no longer exists.
+
+   **Fallback if /shutdown fails.** If the curl POST returns non-zero (server
+   already dead, port unbound, etc.) just continue — the state file removal
+   and cron deletion still need to happen. A PID-kill is no longer required
+   because the watchdog (added in step 2) would terminate any surviving
+   process within 30 s when the cron stops POSTing heartbeats.
 
    The **on-disk concept artefacts** (`docs/concepts/{date}-{slug}.html`
    and the matching `-decisions.json`) are handled by `SKILL.md` § Step 6a

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.83.0",
+  "version": "0.84.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

The concept bridge server could outlive its Claude session as a ghost process — accepting heartbeats from a long-dead cron, polling for a concept HTML that was already deleted. Four defense-in-depth layers now prevent that:

- **Server-side watchdog**: `concept-server.py` gains `--html` and `--heartbeat-timeout-ms`. A daemon thread terminates the process when `_claude_ts` is stale > 5 min OR the watched HTML disappears for > 10 s (grace window covers mid-rewrite races).
- **Cron-body self-cleanup gate**: every cron tick first checks `.claude/concept-active.json`. If missing, port mismatch, or `html_path` gone → `POST /shutdown` + `CronDelete` before any heartbeat fires.
- **Resume-hook consistency check**: `ss.concept.resume.js` verifies `html_path` on disk before probing the heartbeat. A ghost server tied to a deleted HTML is shut down explicitly instead of surfacing a phantom resume hint.
- **`POST /shutdown` HTTP endpoint**: same-origin gate (no-Origin curl or page-served fetch); replaces `kill $SERVER_PID` which was unreliable on Windows after PID recycling.

## Verification

End-to-end smoke tests:
- watchdog kills on `claude_ts` staleness ✓
- watchdog kills on HTML vanish after 10 s grace ✓
- `/shutdown` 200 + process exits ✓
- `/shutdown` 403 on foreign Origin ✓
- resume-hook cleans up ghost when HTML is missing ✓
- 153/153 unit tests pass, lint clean

## Test plan

- [x] Smoke test all four shutdown triggers individually
- [x] Vitest suite (153 tests)
- [x] eslint clean
- [ ] Real-world: open a concept page, manually delete the HTML, verify the bridge dies within ~40 s

🤖 Generated with [Claude Code](https://claude.com/claude-code)