### PR TITLE
feat(ship): pre-merge CI gate + post-merge deploy watcher (0.85.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.84.0"
+    "version": "0.85.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.84.0",
+      "version": "0.85.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.84.0",
+      "version": "0.85.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [0.85.0] — 2026-05-24
+
+### Added
+
+- **plugins/devops/mcp-server/ship/lib/github.js** — new `watchPRChecks(prNumber, opts, {timeoutSec, intervalSec})` wraps `gh pr checks --watch --fail-fast` with a hard timeout. Four-outcome contract (`passed` / `no-checks` / `failed` / `timeout`) plus a graceful "transient noise" branch that treats an exit-non-zero with no recorded failures as `passed`. Strips ANSI from any surfaced stderr. 6 new unit tests (21/21 in `github.test.js`).
+- **plugins/devops/mcp-server/ship/tools/release.js** — Pre-Merge CI Checks Gate. After PR create/reuse and before merge, `ship_release` now blocks on `watchPRChecks`. On `failed` / `timeout` returns `success: false`, `checksBlocked: true`, `failedChecks: [{name, link}]` and leaves the PR open. New schema fields: `skipChecks` (default `false`) and `checksTimeoutSec` (default 600, range 30–3600). Env `DEVOPS_SHIP_SKIP_CHECKS=1` provides an alternative bypass for hot-fixes. Result carries `checks: { status, passed, failed, pending }` for the completion card.
+- **plugins/devops/scripts/post-merge-watcher.js** — new background CLI script spawned after a successful merge to `main`. Polls `gh run list` for the workflow triggered by the merge SHA (5 s → 30 s exponential backoff, 5 min initial-detect window), then `gh run watch --exit-status` until the workflow finishes or the configured `--max-wait` (default 1800 s) elapses. Writes incremental state to `<repo>/.claude/.ship-watcher/<merge-sha>.json` (`watching → complete`, plus `ci`, `verify`, `overall` fields). Fires a best-effort Windows `NotifyIcon` toast on CI fail / timeout / deploy-verify fail.
+- **plugins/devops/scripts/post-merge-watcher.js** — Phase-2 deploy verify. When `--verify-config` points at a project `reference.md` containing a `verify:` block, the watcher (after CI passes) polls the configured target. `mode: http` probes a URL with optional `expected_status`, `selector` (regex on body), and `expected` (with `$VERSION` placeholder expanded to the shipped tag). `mode: command` runs an arbitrary shell command (exit 0 = success). Configurable `poll_interval_seconds` (default 15) and `timeout_seconds` (default 600). Hand-rolled YAML parser accepts the `verify:` block either inline or inside a fenced ```yaml block.
+- **plugins/devops/hooks/session-start/ss.ship.verify.js** — new SessionStart hook that surfaces unack'd post-merge watcher results from `<cwd>/.claude/.ship-watcher/*.json`. Reports completed runs with their CI + deploy-verify status, lists in-flight watchers with elapsed minutes, auto-acknowledges entries older than 24 h. Marks surfaced reports as `acknowledged: true` in-place so they don't repeat on the next session start. Silent when the watcher dir is absent or empty.
+- **plugins/devops/skills/devops-ship/deep-knowledge/post-merge-verify.md** — new reference doc for the `verify:` opt-in format. Field reference table for both `http` and `command` modes, failure-handling matrix (CI fails, CI passes verify fails, no CI configured, watcher killed mid-run), worked examples for SPA-on-Vercel, NPM registry publish probe, and static site with version meta tag.
+- **plugins/devops/hooks/hooks.json** — registers `ss.ship.verify` in the SessionStart hook chain after `ss.git.sync`.
+
+### Changed
+
+- **plugins/devops/skills/devops-ship/SKILL.md** — Step 4 documents the new pre-merge CI gate, the `skipChecks` / `checksTimeoutSec` parameters, and the bypass env var. New Step 4b describes how to spawn the post-merge watcher (bash + PowerShell variants) and when to skip it (intermediate merges, repos without `.github/workflows/`, explicit `--no-watch`). Result schema in Step 4 gains the `checks` field.
+- **plugins/devops/skills/devops-ship/deep-knowledge/quality-gates.md** — new "Pre-Merge CI Checks Gate" section documents the four outcomes, the 10-min default timeout, and the two bypass paths (parameter vs env var).
+- **plugins/devops/skills/devops-ship/deep-knowledge/release-flow.md** — new "Pre-Merge CI Checks Gate" subsection between PR create and merge explains the gate, its outcomes, and the hot-fix bypass — closes the historical failure mode where lokal grün + merge resulted in main being red without anyone noticing.
+- **plugins/devops/skills/devops-ship/reference.md** — quick example for the `verify:` block plus a link to the full reference doc.
+- **plugins/devops/deep-knowledge/skill-extension-guide.md** — new "Post-merge deploy verification" section anchors the cross-skill `verify:` extension format next to the existing `deliver:` field.
+- **plugins/devops/.claude-plugin/plugin.json** — version `0.84.0 → 0.85.0`
+
 ## [0.84.0] — 2026-05-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.84.0**
+**Version: 0.85.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.84.0",
+  "version": "0.85.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/deep-knowledge/skill-extension-guide.md
+++ b/plugins/devops/deep-knowledge/skill-extension-guide.md
@@ -163,6 +163,28 @@ after upload. Canonical use case: shipping HA YAML configs managed in git.
 For projects that only edit files in-place with no delivery step. `deliver: none` makes
 `/devops-ship` skip Step 4a entirely.
 
+## Post-merge deploy verification
+
+Independent of `deliver:`, projects can opt into a background watcher that probes
+production after CI goes green. Add a `verify:` block to the same
+`{project}/.claude/skills/ship/reference.md`:
+
+```yaml
+verify:
+  mode: http
+  url: https://my-app.example.com
+  expected_status: 200
+  selector: '<meta name="version" content="([^"]+)"'
+  expected: "$VERSION"
+  timeout_seconds: 600
+```
+
+Full field reference: see [`skills/devops-ship/deep-knowledge/post-merge-verify.md`](../skills/devops-ship/deep-knowledge/post-merge-verify.md).
+
+Failures (CI red or verify probe failing) land in `<repo>/.claude/.ship-watcher/<sha>.json`
+and surface at the next SessionStart via the `ss.ship.verify` hook, plus a
+best-effort Windows toast at the moment of failure.
+
 ## Agent extensions
 
 Same pattern applies to agents:

--- a/plugins/devops/hooks/hooks.json
+++ b/plugins/devops/hooks/hooks.json
@@ -12,6 +12,7 @@
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-start/ss.tokens.scan.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-start/ss.git.check.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-start/ss.git.sync.js" },
+          { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-start/ss.ship.verify.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-start/ss.concept.resume.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-start/ss.team.changelog.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-start/ss.flow.selfcalibration.js", "_deprecated": "moved to UserPromptSubmit — kept as fallback for older runtimes" }

--- a/plugins/devops/hooks/session-start/ss.ship.verify.js
+++ b/plugins/devops/hooks/session-start/ss.ship.verify.js
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+/**
+ * @hook ss.ship.verify
+ * @version 0.1.0
+ * @event SessionStart
+ * @plugin devops
+ * @description Surface results from the post-merge watcher (post-ship CI +
+ *   optional deploy verify). Reads <cwd>/.claude/.ship-watcher/*.json and:
+ *
+ *     - reports completed runs that have not yet been acknowledged
+ *     - flags watcher state files older than 24h as stale (auto-acknowledged)
+ *     - mentions in-flight watchers ("ship verify still running")
+ *
+ *   Acknowledged entries are marked in-place (no deletion) so the user can
+ *   re-inspect history with `gh run view <id>`.
+ *
+ *   Silent when there are no watcher files at all.
+ */
+
+require('../lib/plugin-guard');
+
+const fs = require('fs');
+const path = require('path');
+
+const cwd = process.cwd();
+const watcherDir = path.join(cwd, '.claude', '.ship-watcher');
+const STALE_MS = 24 * 60 * 60 * 1000;
+
+if (!fs.existsSync(watcherDir)) process.exit(0);
+
+let entries;
+try {
+  entries = fs.readdirSync(watcherDir).filter((f) => f.endsWith('.json'));
+} catch {
+  process.exit(0);
+}
+if (entries.length === 0) process.exit(0);
+
+const reports = [];
+const inflight = [];
+
+for (const file of entries) {
+  const full = path.join(watcherDir, file);
+  let data;
+  try {
+    data = JSON.parse(fs.readFileSync(full, 'utf8'));
+  } catch {
+    continue;
+  }
+
+  const startedMs = data.startedAt ? new Date(data.startedAt).getTime() : 0;
+  const age = Date.now() - startedMs;
+
+  if (data.status === 'watching') {
+    if (age > STALE_MS) {
+      // Mark stale-acknowledged so it does not nag forever
+      data.acknowledged = true;
+      data.staleAt = new Date().toISOString();
+      try { fs.writeFileSync(full, JSON.stringify(data, null, 2)); } catch {}
+      continue;
+    }
+    inflight.push(data);
+    continue;
+  }
+
+  if (data.status === 'complete' && !data.acknowledged) {
+    reports.push({ file: full, data });
+  }
+}
+
+if (reports.length === 0 && inflight.length === 0) process.exit(0);
+
+const out = [];
+out.push('Post-ship deploy verification — surface this summary AS-IS to the user as the FIRST action of this turn (Lang: user-preference):');
+out.push('');
+
+for (const { data } of reports) {
+  const prRef = data.pr ? `PR #${data.pr}` : `commit ${data.mergeSha?.slice(0, 7) || '?'}`;
+  const icon = data.overall === 'success' ? '✓' : (data.overall === 'timeout' ? '⏱' : '✗');
+  out.push(`${icon} **Ship verify — ${prRef} on \`${data.base}\`**`);
+
+  if (data.ci) {
+    if (data.ci.status === 'success') {
+      out.push(`  - CI (${data.ci.workflowName || 'workflow'}): passed`);
+    } else if (data.ci.status === 'no-run') {
+      out.push('  - CI: no workflow triggered (repo has no push-event CI)');
+    } else {
+      const linkPart = data.ci.runUrl ? ` — ${data.ci.runUrl}` : '';
+      out.push(`  - CI (${data.ci.workflowName || 'workflow'}): **${data.ci.status}** (${data.ci.conclusion || 'no conclusion'})${linkPart}`);
+    }
+  }
+
+  if (data.verify) {
+    if (data.verify.status === 'success') {
+      out.push(`  - Deploy verify (${data.verify.mode}): passed → ${data.verify.target}`);
+    } else {
+      out.push(`  - Deploy verify (${data.verify.mode}): **${data.verify.status}** after ${data.verify.attempts} attempt(s) — ${data.verify.lastError || 'no error detail'}`);
+    }
+  } else if (data.hasVerifyConfig === false) {
+    // not configured — no line needed
+  }
+
+  out.push('');
+}
+
+for (const data of inflight) {
+  const prRef = data.pr ? `PR #${data.pr}` : `commit ${data.mergeSha?.slice(0, 7) || '?'}`;
+  const mins = Math.round((Date.now() - new Date(data.startedAt).getTime()) / 60_000);
+  out.push(`◷ **Ship verify still running** — ${prRef} on \`${data.base}\` (${mins}m elapsed)`);
+  if (data.ci?.runUrl) out.push(`  - Run: ${data.ci.runUrl}`);
+  out.push('');
+}
+
+// Mark surfaced reports as acknowledged in-place so they don't nag next session.
+// History stays on disk for `gh run view` reference.
+for (const { file, data } of reports) {
+  data.acknowledged = true;
+  data.acknowledgedAt = new Date().toISOString();
+  try { fs.writeFileSync(file, JSON.stringify(data, null, 2)); } catch {}
+}
+
+process.stdout.write(out.join('\n') + '\n');
+process.exit(0);

--- a/plugins/devops/mcp-server/ship/lib/github.js
+++ b/plugins/devops/mcp-server/ship/lib/github.js
@@ -121,10 +121,14 @@ export function findExistingPR({ base, head }, opts) {
  * Watch a PR's CI checks until they complete, fail, or timeout.
  *
  * Returns:
- *   { status: "passed",     checks: [...] }                       — all green
- *   { status: "no-checks",  checks: [] }                          — no CI configured on this PR
- *   { status: "failed",     checks, failed, pending, error }      — at least one check failed
- *   { status: "timeout",    checks, failed, pending, error }      — did not complete within timeoutSec
+ *   { status: "passed",      checks: [...] }                       — all green
+ *   { status: "no-checks",   checks: [] }                          — no CI configured on this PR
+ *   { status: "failed",      checks, failed, pending, error }      — at least one check failed
+ *   { status: "timeout",     checks, failed, pending, error }      — did not complete within timeoutSec, OR
+ *                                                                    watch exited unexpectedly while checks were still pending
+ *   { status: "probe-error", error }                                — initial probe failed (auth/network) and the
+ *                                                                    state could not be determined; treated as block-worthy
+ *                                                                    by the caller so the gate is fail-closed.
  *
  * Never throws — callers branch on `status`.
  */
@@ -144,8 +148,9 @@ export function watchPRChecks(prNumber, opts, { timeoutSec = 600, intervalSec = 
     }
     // gh exits 8 = checks pending — that's expected, fall through to watch
     if (e.status !== 8) {
-      // Real failure (auth, network, PR not found) — surface but don't block
-      return { status: "no-checks", checks: [], probeError: stderr.slice(0, 300) };
+      // Real failure (auth, network, PR not found) — fail-closed: do NOT silently
+      // treat as "no checks", or the gate becomes a no-op when auth breaks.
+      return { status: "probe-error", error: `gh pr checks probe failed: ${stderr.slice(0, 300)}` };
     }
     initial = e.stdout?.toString() || "[]";
   }
@@ -216,8 +221,21 @@ export function watchPRChecks(prNumber, opts, { timeoutSec = 600, intervalSec = 
         error: `${failed.length} check(s) failed: ${failed.map((c) => c.name || c.workflow).join(", ")}`,
       };
     }
-    // Watch errored but no failures recorded — treat as transient, allow merge
+    // No failures recorded — but if checks are still pending, watch died early.
+    // Treating that as "passed" would let the merge race ahead of pending CI;
+    // surface it as timeout so the caller blocks (fail-closed).
     const stderr = (watchErr.stderr?.toString() || watchErr.message || "").replace(ANSI_PATTERN, "");
+    if (pending.length > 0) {
+      return {
+        status: "timeout",
+        checks: finalChecks,
+        failed,
+        pending,
+        error: `gh pr checks --watch exited early with ${pending.length} check(s) still pending: ${stderr.slice(0, 200)}`,
+      };
+    }
+    // No failures, no pending — everything had already finished cleanly before
+    // the noise. Treat as passed, but record the warning for the result.
     return { status: "passed", checks: finalChecks, watchWarning: stderr.slice(0, 300) };
   }
 

--- a/plugins/devops/mcp-server/ship/lib/github.js
+++ b/plugins/devops/mcp-server/ship/lib/github.js
@@ -118,6 +118,114 @@ export function findExistingPR({ base, head }, opts) {
 }
 
 /**
+ * Watch a PR's CI checks until they complete, fail, or timeout.
+ *
+ * Returns:
+ *   { status: "passed",     checks: [...] }                       — all green
+ *   { status: "no-checks",  checks: [] }                          — no CI configured on this PR
+ *   { status: "failed",     checks, failed, pending, error }      — at least one check failed
+ *   { status: "timeout",    checks, failed, pending, error }      — did not complete within timeoutSec
+ *
+ * Never throws — callers branch on `status`.
+ */
+export function watchPRChecks(prNumber, opts, { timeoutSec = 600, intervalSec = 10 } = {}) {
+  // Initial probe — distinguishes "no checks at all" from "checks present".
+  // gh exits non-zero with "no checks reported" when nothing is wired up.
+  let initial;
+  try {
+    initial = gh(
+      ["pr", "checks", String(prNumber), "--json", "bucket,state,name,workflow,link"],
+      opts,
+    );
+  } catch (e) {
+    const stderr = (e.stderr?.toString() || e.message || "").replace(ANSI_PATTERN, "");
+    if (/no checks/i.test(stderr) || /no required checks/i.test(stderr)) {
+      return { status: "no-checks", checks: [] };
+    }
+    // gh exits 8 = checks pending — that's expected, fall through to watch
+    if (e.status !== 8) {
+      // Real failure (auth, network, PR not found) — surface but don't block
+      return { status: "no-checks", checks: [], probeError: stderr.slice(0, 300) };
+    }
+    initial = e.stdout?.toString() || "[]";
+  }
+
+  let initialChecks;
+  try {
+    initialChecks = JSON.parse(initial);
+  } catch {
+    initialChecks = [];
+  }
+  if (!initialChecks || initialChecks.length === 0) {
+    return { status: "no-checks", checks: [] };
+  }
+
+  // Block on gh's own --watch loop. Wrap with our own timeout to bound it hard.
+  let watchErr = null;
+  try {
+    execFileSync(
+      "gh",
+      ["pr", "checks", String(prNumber), "--watch", "--fail-fast", "--interval", String(intervalSec)],
+      {
+        cwd: opts?.cwd || process.cwd(),
+        encoding: "utf8",
+        timeout: timeoutSec * 1000,
+        stdio: ["pipe", "pipe", "pipe"],
+      },
+    );
+  } catch (e) {
+    watchErr = e;
+  }
+
+  // Snapshot final state regardless of watch outcome.
+  let finalChecks = [];
+  try {
+    const raw = gh(
+      ["pr", "checks", String(prNumber), "--json", "bucket,state,name,workflow,link"],
+      opts,
+    );
+    finalChecks = JSON.parse(raw);
+  } catch (e) {
+    // gh exit 8 = pending; still try to read stdout
+    if (e.stdout) {
+      try { finalChecks = JSON.parse(e.stdout.toString()); } catch { /* keep [] */ }
+    }
+  }
+
+  const failed = finalChecks.filter((c) => c.bucket === "fail" || c.bucket === "cancel");
+  const pending = finalChecks.filter((c) => c.bucket === "pending");
+
+  if (watchErr) {
+    const isTimeout = watchErr.code === "ETIMEDOUT" || watchErr.signal === "SIGTERM";
+    if (isTimeout) {
+      return {
+        status: "timeout",
+        checks: finalChecks,
+        failed,
+        pending,
+        error: `PR checks did not complete within ${timeoutSec}s (${pending.length} still pending)`,
+      };
+    }
+    // gh exits non-zero when at least one check failed
+    if (failed.length > 0) {
+      return {
+        status: "failed",
+        checks: finalChecks,
+        failed,
+        pending,
+        error: `${failed.length} check(s) failed: ${failed.map((c) => c.name || c.workflow).join(", ")}`,
+      };
+    }
+    // Watch errored but no failures recorded — treat as transient, allow merge
+    const stderr = (watchErr.stderr?.toString() || watchErr.message || "").replace(ANSI_PATTERN, "");
+    return { status: "passed", checks: finalChecks, watchWarning: stderr.slice(0, 300) };
+  }
+
+  // Watch exited cleanly — all checks passed
+  return { status: "passed", checks: finalChecks };
+}
+
+/**
  * Create a GitHub release for a tag.
  * Notes are passed via stdin to avoid shell escaping issues.
  */

--- a/plugins/devops/mcp-server/ship/lib/github.test.js
+++ b/plugins/devops/mcp-server/ship/lib/github.test.js
@@ -6,7 +6,7 @@ vi.mock("node:child_process", () => ({
 }));
 
 import { execSync, execFileSync } from "node:child_process";
-import { createPR, mergePR, findExistingPR } from "./github.js";
+import { createPR, mergePR, findExistingPR, watchPRChecks } from "./github.js";
 
 beforeEach(() => {
   vi.resetAllMocks();
@@ -154,5 +154,83 @@ describe("findExistingPR", () => {
   test("swallows network errors and returns null", () => {
     execFileSync.mockImplementation(() => { throw new Error("net"); });
     expect(findExistingPR({ base: "main", head: "feat/x" })).toBeNull();
+  });
+});
+
+describe("watchPRChecks", () => {
+  test("returns no-checks when gh reports no checks configured", () => {
+    execFileSync.mockImplementation(() => {
+      const err = new Error("no checks");
+      err.stderr = Buffer.from("no checks reported on the 'feat/x' branch");
+      throw err;
+    });
+    const result = watchPRChecks(42);
+    expect(result.status).toBe("no-checks");
+    expect(result.checks).toEqual([]);
+  });
+
+  test("returns no-checks when initial probe returns empty array", () => {
+    execFileSync.mockReturnValueOnce("[]");
+    const result = watchPRChecks(42);
+    expect(result.status).toBe("no-checks");
+  });
+
+  test("returns passed when watch exits cleanly and all checks are pass", () => {
+    const checks = JSON.stringify([
+      { bucket: "pass", state: "SUCCESS", name: "build", workflow: "CI" },
+      { bucket: "pass", state: "SUCCESS", name: "test", workflow: "CI" },
+    ]);
+    execFileSync
+      .mockReturnValueOnce(checks)  // initial probe
+      .mockReturnValueOnce("")       // watch blocks then exits 0
+      .mockReturnValueOnce(checks);  // final snapshot
+    const result = watchPRChecks(42);
+    expect(result.status).toBe("passed");
+    expect(result.checks).toHaveLength(2);
+  });
+
+  test("returns failed with details when watch exits non-zero and a check failed", () => {
+    const initial = JSON.stringify([
+      { bucket: "pending", state: "IN_PROGRESS", name: "build", workflow: "CI" },
+    ]);
+    const finalChecks = JSON.stringify([
+      { bucket: "fail", state: "FAILURE", name: "build", workflow: "CI", link: "https://x/run/1" },
+    ]);
+    execFileSync
+      .mockReturnValueOnce(initial)
+      .mockImplementationOnce(() => { const e = new Error("watch failed"); e.status = 1; throw e; })
+      .mockReturnValueOnce(finalChecks);
+    const result = watchPRChecks(42);
+    expect(result.status).toBe("failed");
+    expect(result.failed).toHaveLength(1);
+    expect(result.failed[0].name).toBe("build");
+    expect(result.error).toMatch(/1 check\(s\) failed/);
+  });
+
+  test("returns timeout when watch is killed by ETIMEDOUT", () => {
+    const initial = JSON.stringify([
+      { bucket: "pending", state: "QUEUED", name: "build", workflow: "CI" },
+    ]);
+    execFileSync
+      .mockReturnValueOnce(initial)
+      .mockImplementationOnce(() => { const e = new Error("timeout"); e.code = "ETIMEDOUT"; throw e; })
+      .mockReturnValueOnce(initial);
+    const result = watchPRChecks(42, undefined, { timeoutSec: 60 });
+    expect(result.status).toBe("timeout");
+    expect(result.pending).toHaveLength(1);
+    expect(result.error).toMatch(/60s/);
+  });
+
+  test("treats watch exit-1 without failures as passed (transient noise)", () => {
+    const initial = JSON.stringify([
+      { bucket: "pass", state: "SUCCESS", name: "build", workflow: "CI" },
+    ]);
+    execFileSync
+      .mockReturnValueOnce(initial)
+      .mockImplementationOnce(() => { const e = new Error("flaky"); e.status = 1; e.stderr = Buffer.from("network blip"); throw e; })
+      .mockReturnValueOnce(initial);
+    const result = watchPRChecks(42);
+    expect(result.status).toBe("passed");
+    expect(result.watchWarning).toMatch(/network blip/);
   });
 });

--- a/plugins/devops/mcp-server/ship/lib/github.test.js
+++ b/plugins/devops/mcp-server/ship/lib/github.test.js
@@ -221,7 +221,7 @@ describe("watchPRChecks", () => {
     expect(result.error).toMatch(/60s/);
   });
 
-  test("treats watch exit-1 without failures as passed (transient noise)", () => {
+  test("treats watch exit-1 without failures as passed (transient noise) ONLY when nothing pending", () => {
     const initial = JSON.stringify([
       { bucket: "pass", state: "SUCCESS", name: "build", workflow: "CI" },
     ]);
@@ -232,5 +232,32 @@ describe("watchPRChecks", () => {
     const result = watchPRChecks(42);
     expect(result.status).toBe("passed");
     expect(result.watchWarning).toMatch(/network blip/);
+  });
+
+  test("returns timeout when watch dies early with checks still pending (fail-closed)", () => {
+    const initial = JSON.stringify([
+      { bucket: "pending", state: "IN_PROGRESS", name: "build", workflow: "CI" },
+      { bucket: "pending", state: "QUEUED", name: "test", workflow: "CI" },
+    ]);
+    execFileSync
+      .mockReturnValueOnce(initial)
+      .mockImplementationOnce(() => { const e = new Error("flake"); e.status = 1; e.stderr = Buffer.from("ws closed"); throw e; })
+      .mockReturnValueOnce(initial);
+    const result = watchPRChecks(42);
+    expect(result.status).toBe("timeout");
+    expect(result.pending).toHaveLength(2);
+    expect(result.error).toMatch(/exited early/);
+  });
+
+  test("returns probe-error when initial gh call fails for non-pending non-no-checks reason (fail-closed)", () => {
+    execFileSync.mockImplementationOnce(() => {
+      const e = new Error("auth lost");
+      e.status = 4;
+      e.stderr = Buffer.from("could not refresh token");
+      throw e;
+    });
+    const result = watchPRChecks(42);
+    expect(result.status).toBe("probe-error");
+    expect(result.error).toMatch(/could not refresh token/);
   });
 });

--- a/plugins/devops/mcp-server/ship/tools/release.js
+++ b/plugins/devops/mcp-server/ship/tools/release.js
@@ -6,7 +6,7 @@
 import { z } from "zod";
 import { execFileSync } from "node:child_process";
 import { git, gitStrict, currentBranch, headShort, dirtyState, isWorktree, isRebasedOnto, fileOverlap } from "../lib/git.js";
-import { createPR, mergePR, createRelease, findExistingPR } from "../lib/github.js";
+import { createPR, mergePR, createRelease, findExistingPR, watchPRChecks } from "../lib/github.js";
 import { detectRepoMode } from "../lib/repo-mode.js";
 
 export const schema = z.object({
@@ -18,11 +18,13 @@ export const schema = z.object({
   prerelease: z.boolean().default(false).describe("Mark as pre-release (for 0.x versions)"),
   commitMessage: z.string().nullable().default(null).describe("If set, stage all and commit with this message before pushing"),
   mergeStrategy: z.enum(["squash", "merge", "rebase"]).default("squash").describe("PR merge strategy. Use 'merge' for overlapping files to preserve ancestry chain."),
+  skipChecks: z.boolean().default(false).describe("Skip the pre-merge CI checks gate. Use only for hot-fixes when CI is broken. Env DEVOPS_SHIP_SKIP_CHECKS=1 also forces skip."),
+  checksTimeoutSec: z.number().int().min(30).max(3600).default(600).describe("Max seconds to wait for PR CI checks before merging. Default 10 min."),
   cwd: z.string().describe("Working directory of the target repo (required — must be passed by the caller)"),
 });
 
 export async function handler(params) {
-  const { base, title, body, tag, releaseNotes, prerelease, commitMessage, mergeStrategy } = params;
+  const { base, title, body, tag, releaseNotes, prerelease, commitMessage, mergeStrategy, skipChecks, checksTimeoutSec } = params;
   const cwd = params.cwd;
   if (!cwd) throw new Error("cwd is required — MCP server runs in the plugin directory, not the target repo");
   const opts = { cwd };
@@ -121,6 +123,34 @@ export async function handler(params) {
     }
     result.pr = { number: pr.number, url: pr.url, title };
     result.mergeStrategy = mergeStrategy;
+
+    // Pre-Merge Checks Gate — wait for CI on the PR before merging.
+    // Bypass via skipChecks param or DEVOPS_SHIP_SKIP_CHECKS=1 env.
+    const checksBypassed = skipChecks || process.env.DEVOPS_SHIP_SKIP_CHECKS === "1";
+    if (!checksBypassed) {
+      const checkResult = watchPRChecks(pr.number, opts, { timeoutSec: checksTimeoutSec });
+      result.checks = {
+        status: checkResult.status,
+        passed: checkResult.checks?.filter((c) => c.bucket === "pass").length || 0,
+        failed: checkResult.failed?.length || 0,
+        pending: checkResult.pending?.length || 0,
+      };
+      if (checkResult.status === "failed" || checkResult.status === "timeout") {
+        result.success = false;
+        result.checksBlocked = true;
+        result.failedChecks = (checkResult.failed || []).map((c) => ({
+          name: c.name || c.workflow,
+          link: c.link,
+        }));
+        result.error =
+          `${checkResult.error}. PR #${pr.number} not merged. ` +
+          `Fix the failing checks and retry, or pass skipChecks:true for hot-fix override.`;
+        return result;
+      }
+      // status === "passed" or "no-checks" → continue
+    } else {
+      result.checks = { status: "skipped", reason: skipChecks ? "skipChecks param" : "DEVOPS_SHIP_SKIP_CHECKS env" };
+    }
 
     // Merge PR (delete branch; skip --delete-branch in worktrees
     // where gh tries to switch to base locally — cleanup handles branch deletion)

--- a/plugins/devops/mcp-server/ship/tools/release.js
+++ b/plugins/devops/mcp-server/ship/tools/release.js
@@ -135,7 +135,7 @@ export async function handler(params) {
         failed: checkResult.failed?.length || 0,
         pending: checkResult.pending?.length || 0,
       };
-      if (checkResult.status === "failed" || checkResult.status === "timeout") {
+      if (checkResult.status === "failed" || checkResult.status === "timeout" || checkResult.status === "probe-error") {
         result.success = false;
         result.checksBlocked = true;
         result.failedChecks = (checkResult.failed || []).map((c) => ({

--- a/plugins/devops/scripts/post-merge-watcher.js
+++ b/plugins/devops/scripts/post-merge-watcher.js
@@ -224,6 +224,11 @@ function notifyToast(title, message) {
   } catch { /* best-effort */ }
 }
 
+// Module-scope handle to the in-flight state so the top-level fatal handler
+// can mark it complete even when main() throws after the initial write.
+let activeState = null;
+let activeStateFile = null;
+
 async function main() {
   const args = parseArgs(process.argv);
   const cwd = args.cwd;
@@ -258,6 +263,8 @@ async function main() {
     hasVerifyConfig: !!verifyConfig,
   };
   writeState(stateFile, state);
+  activeState = state;
+  activeStateFile = stateFile;
 
   // Phase 1: locate the workflow run for our merge SHA
   let run = null;
@@ -332,5 +339,18 @@ async function main() {
 
 main().catch((e) => {
   console.error("post-merge-watcher fatal:", e.message);
+  // Ensure the state file does not stay in "watching" forever — flip it to
+  // a terminal failure so the SessionStart hook surfaces the crash instead of
+  // pretending the job is still running.
+  if (activeState && activeStateFile) {
+    try {
+      activeState.status = "complete";
+      activeState.overall = "failed";
+      activeState.finishedAt = new Date().toISOString();
+      activeState.fatalError = e.message?.slice(0, 500) || "unknown fatal error";
+      writeState(activeStateFile, activeState);
+      notifyToast("Ship Verify: Watcher Crashed", `${activeState.fatalError}`);
+    } catch { /* best-effort */ }
+  }
   process.exit(1);
 });

--- a/plugins/devops/scripts/post-merge-watcher.js
+++ b/plugins/devops/scripts/post-merge-watcher.js
@@ -1,0 +1,336 @@
+#!/usr/bin/env node
+/**
+ * @script post-merge-watcher
+ * @version 0.1.0
+ * @plugin devops
+ * @description Background watcher that runs after ship_release succeeds.
+ *   Waits for the GitHub Actions run on the merge commit, optionally probes
+ *   a production URL (verify extension), and writes a status file the next
+ *   session can surface. Best-effort PowerShell toast on failure.
+ *
+ * Usage:
+ *   node post-merge-watcher.js \
+ *     --cwd <repo-path> \
+ *     --base <branch> \
+ *     --merge-sha <sha> \
+ *     --pr <number> \
+ *     [--max-wait <seconds>]        # default 1800 (30 min)
+ *     [--verify-config <path>]      # optional reference.md with verify: block
+ *     [--state-dir <path>]          # default <cwd>/.claude/.ship-watcher
+ *     [--version <vX.Y.Z>]          # expands $VERSION placeholder in selectors
+ *
+ * State file: <state-dir>/<merge-sha>.json
+ *   { status: "watching" | "complete",
+ *     pr, base, mergeSha, startedAt, finishedAt,
+ *     ci: { status, runId, runUrl, workflowName, conclusion },
+ *     verify: { status, mode, target, attempts, lastError } | null,
+ *     overall: "pending" | "success" | "failed" | "timeout",
+ *     acknowledged: false }
+ */
+
+const { spawnSync, execFileSync } = require("node:child_process");
+const { mkdirSync, writeFileSync, readFileSync, existsSync } = require("node:fs");
+const { join, dirname } = require("node:path");
+
+const POLL_INITIAL_RUN_DETECT_MS = 5_000;
+const POLL_INITIAL_RUN_DETECT_MAX_MS = 5 * 60_000;
+const DEFAULT_MAX_WAIT_SEC = 1800;
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (!a.startsWith("--")) continue;
+    const key = a.slice(2);
+    const val = argv[i + 1] && !argv[i + 1].startsWith("--") ? argv[++i] : true;
+    out[key] = val;
+  }
+  return out;
+}
+
+function gh(args, cwd, { timeout = 30_000, allowFail = false } = {}) {
+  try {
+    return execFileSync("gh", args, {
+      cwd,
+      encoding: "utf8",
+      timeout,
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+  } catch (e) {
+    if (allowFail) return null;
+    throw e;
+  }
+}
+
+function writeState(stateFile, data) {
+  mkdirSync(dirname(stateFile), { recursive: true });
+  writeFileSync(stateFile, JSON.stringify(data, null, 2));
+}
+
+function findRunForSha({ cwd, base, mergeSha }) {
+  const raw = gh(
+    ["run", "list", "--branch", base, "--limit", "20", "--json", "databaseId,headSha,status,conclusion,workflowName,url,createdAt"],
+    cwd,
+    { allowFail: true },
+  );
+  if (!raw) return null;
+  let runs;
+  try { runs = JSON.parse(raw); } catch { return null; }
+  return runs.find((r) => r.headSha && (r.headSha === mergeSha || r.headSha.startsWith(mergeSha))) || null;
+}
+
+function watchRun({ cwd, runId, maxWaitSec }) {
+  try {
+    execFileSync("gh", ["run", "watch", String(runId), "--exit-status", "--interval", "15"], {
+      cwd,
+      encoding: "utf8",
+      timeout: maxWaitSec * 1000,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    return { ok: true };
+  } catch (e) {
+    const isTimeout = e.code === "ETIMEDOUT" || e.signal === "SIGTERM";
+    return { ok: false, isTimeout, status: e.status };
+  }
+}
+
+function getFinalRunStatus({ cwd, runId }) {
+  const raw = gh(
+    ["run", "view", String(runId), "--json", "status,conclusion,workflowName,url"],
+    cwd,
+    { allowFail: true },
+  );
+  if (!raw) return null;
+  try { return JSON.parse(raw); } catch { return null; }
+}
+
+/**
+ * Parse a verify: yaml block from a reference.md.
+ * Looks for a fenced ```yaml block whose root key is `verify:`, falls back
+ * to scanning the raw file body. Accepts only the documented keys; no nesting.
+ */
+function parseVerifyConfig(refPath) {
+  if (!refPath || !existsSync(refPath)) return null;
+  const text = readFileSync(refPath, "utf8");
+  const fenceMatch = text.match(/```ya?ml\s*\n([\s\S]*?)\n```/i);
+  const body = fenceMatch ? fenceMatch[1] : text;
+  if (!/^\s*verify\s*:/m.test(body)) return null;
+
+  const cfg = {};
+  let inVerify = false;
+  for (const line of body.split(/\r?\n/)) {
+    if (/^verify\s*:/.test(line)) { inVerify = true; continue; }
+    if (!inVerify) continue;
+    if (/^\S/.test(line) && line.trim() !== "") break;
+    const m = line.match(/^\s+([a-zA-Z_]+)\s*:\s*(.+?)\s*$/);
+    if (!m) continue;
+    let [, key, val] = m;
+    val = val.replace(/^["']|["']$/g, "");
+    if (/^\d+$/.test(val)) val = Number(val);
+    cfg[key] = val;
+  }
+  if (Object.keys(cfg).length === 0) return null;
+  cfg.mode = cfg.mode || "http";
+  cfg.poll_interval_seconds = cfg.poll_interval_seconds || 15;
+  cfg.timeout_seconds = cfg.timeout_seconds || 600;
+  return cfg;
+}
+
+async function probeHttp({ url, expectedStatus, selector, expected, version }) {
+  const expandedSelector = selector ? String(selector) : null;
+  const expandedExpected = expected ? String(expected).replace(/\$VERSION/g, version || "") : null;
+  try {
+    const res = await fetch(url, { redirect: "follow" });
+    if (expectedStatus && res.status !== expectedStatus) {
+      return { ok: false, error: `HTTP ${res.status}, expected ${expectedStatus}` };
+    }
+    if (expandedSelector && expandedExpected) {
+      const responseBody = await res.text();
+      const re = new RegExp(expandedSelector);
+      const m = responseBody.match(re);
+      if (!m) return { ok: false, error: `Selector /${expandedSelector}/ not matched in response body` };
+      const captured = m[1] || m[0];
+      if (!captured.includes(expandedExpected)) {
+        return { ok: false, error: `Selector match "${captured.slice(0, 80)}" does not contain expected "${expandedExpected}"` };
+      }
+    }
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, error: e.message?.slice(0, 200) || "fetch failed" };
+  }
+}
+
+async function runVerify({ config, version }) {
+  if (!config) return null;
+  const result = {
+    status: "running",
+    mode: config.mode,
+    target: config.url || config.command,
+    attempts: 0,
+    lastError: null,
+  };
+  const startedAt = Date.now();
+  const deadline = startedAt + config.timeout_seconds * 1000;
+  const intervalMs = config.poll_interval_seconds * 1000;
+
+  while (Date.now() < deadline) {
+    result.attempts++;
+    if (config.mode === "http") {
+      const probe = await probeHttp({
+        url: config.url,
+        expectedStatus: config.expected_status,
+        selector: config.selector,
+        expected: config.expected,
+        version,
+      });
+      if (probe.ok) {
+        result.status = "success";
+        return result;
+      }
+      result.lastError = probe.error;
+    } else {
+      const cmd = String(config.command || "");
+      const res = spawnSync(cmd, { shell: true, encoding: "utf8", timeout: 30_000 });
+      if (res.status === 0) {
+        result.status = "success";
+        return result;
+      }
+      result.lastError = (res.stderr || res.stdout || `exit ${res.status}`).toString().slice(0, 200);
+    }
+    if (Date.now() + intervalMs >= deadline) break;
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  result.status = "failed";
+  return result;
+}
+
+function notifyToast(title, message) {
+  if (process.platform !== "win32") return;
+  const safe = (s) => String(s).replace(/'/g, "''");
+  const ps =
+    `Add-Type -AssemblyName System.Windows.Forms; ` +
+    `$n = New-Object System.Windows.Forms.NotifyIcon; ` +
+    `$n.Icon = [System.Drawing.SystemIcons]::Information; ` +
+    `$n.Visible = $true; ` +
+    `$n.ShowBalloonTip(8000, '${safe(title)}', '${safe(message)}', 'Info'); ` +
+    `Start-Sleep -Seconds 9; ` +
+    `$n.Dispose()`;
+  try {
+    spawnSync("powershell", ["-NoProfile", "-WindowStyle", "Hidden", "-Command", ps], {
+      timeout: 15_000,
+      stdio: "ignore",
+      detached: true,
+    });
+  } catch { /* best-effort */ }
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  const cwd = args.cwd;
+  const base = args.base;
+  const mergeSha = args["merge-sha"];
+
+  if (!cwd || !base || !mergeSha) {
+    console.error("Usage: post-merge-watcher.js --cwd <path> --base <branch> --merge-sha <sha> [--pr N] [--max-wait sec] [--verify-config path] [--version vX.Y.Z]");
+    process.exit(2);
+  }
+
+  const pr = args.pr ? Number(args.pr) : null;
+  const maxWaitSec = args["max-wait"] ? Number(args["max-wait"]) : DEFAULT_MAX_WAIT_SEC;
+  const stateDir = args["state-dir"] || join(cwd, ".claude", ".ship-watcher");
+  const verifyConfigPath = args["verify-config"] || null;
+  const version = args.version || null;
+
+  const stateFile = join(stateDir, `${mergeSha}.json`);
+  const verifyConfig = parseVerifyConfig(verifyConfigPath);
+
+  const state = {
+    status: "watching",
+    pr,
+    base,
+    mergeSha,
+    startedAt: new Date().toISOString(),
+    finishedAt: null,
+    ci: null,
+    verify: null,
+    overall: "pending",
+    acknowledged: false,
+    hasVerifyConfig: !!verifyConfig,
+  };
+  writeState(stateFile, state);
+
+  // Phase 1: locate the workflow run for our merge SHA
+  let run = null;
+  let waited = 0;
+  let pollMs = POLL_INITIAL_RUN_DETECT_MS;
+  while (waited < POLL_INITIAL_RUN_DETECT_MAX_MS) {
+    run = findRunForSha({ cwd, base, mergeSha });
+    if (run) break;
+    await new Promise((r) => setTimeout(r, pollMs));
+    waited += pollMs;
+    pollMs = Math.min(pollMs * 1.5, 30_000);
+  }
+
+  if (!run) {
+    state.ci = { status: "no-run", note: "No GitHub Actions workflow triggered by this merge — repo may not have CI configured for push events." };
+    if (!verifyConfig) {
+      state.overall = "success";
+      state.status = "complete";
+      state.finishedAt = new Date().toISOString();
+      writeState(stateFile, state);
+      return;
+    }
+  } else {
+    state.ci = { status: "watching", runId: run.databaseId, runUrl: run.url, workflowName: run.workflowName };
+    writeState(stateFile, state);
+
+    const watch = watchRun({ cwd, runId: run.databaseId, maxWaitSec });
+    const final = getFinalRunStatus({ cwd, runId: run.databaseId });
+    state.ci = {
+      status: watch.ok ? "success" : (watch.isTimeout ? "timeout" : "failed"),
+      runId: run.databaseId,
+      runUrl: run.url,
+      workflowName: run.workflowName,
+      conclusion: final?.conclusion || null,
+    };
+    if (!watch.ok) {
+      state.overall = watch.isTimeout ? "timeout" : "failed";
+      state.status = "complete";
+      state.finishedAt = new Date().toISOString();
+      writeState(stateFile, state);
+      const title = watch.isTimeout ? "Ship Verify: CI Timeout" : "Ship Verify: CI Failed";
+      const msg = `PR #${pr || "?"} on ${base}: ${state.ci.workflowName} (${state.ci.conclusion || state.ci.status}). ${run.url}`;
+      notifyToast(title, msg);
+      return;
+    }
+  }
+
+  // Phase 2: verify (optional, per-project extension)
+  if (verifyConfig) {
+    state.verify = { status: "running", mode: verifyConfig.mode, target: verifyConfig.url || verifyConfig.command };
+    writeState(stateFile, state);
+    const verifyResult = await runVerify({ config: verifyConfig, version });
+    state.verify = verifyResult;
+    if (verifyResult.status !== "success") {
+      state.overall = "failed";
+      state.status = "complete";
+      state.finishedAt = new Date().toISOString();
+      writeState(stateFile, state);
+      notifyToast(
+        "Ship Verify: Deploy Probe Failed",
+        `PR #${pr || "?"}: ${verifyResult.lastError || "verify failed"}. Target: ${verifyResult.target}`,
+      );
+      return;
+    }
+  }
+
+  state.overall = "success";
+  state.status = "complete";
+  state.finishedAt = new Date().toISOString();
+  writeState(stateFile, state);
+}
+
+main().catch((e) => {
+  console.error("post-merge-watcher fatal:", e.message);
+  process.exit(1);
+});

--- a/plugins/devops/skills/devops-ship/SKILL.md
+++ b/plugins/devops/skills/devops-ship/SKILL.md
@@ -209,9 +209,15 @@ See `deep-knowledge/call-examples.md` for the three reference payloads
 For intermediate merges: no tag, no release notes, no version commit —
 the tool automatically skips tag/release creation when `base` is not `main`.
 
-The tool handles: commit (optional), rebase verification, push (force-with-lease after rebase), PR create (or reuse with mergeability check), merge (squash or merge commit), tag (main only), GitHub release (main only).
+The tool handles: commit (optional), rebase verification, push (force-with-lease after rebase), PR create (or reuse with mergeability check), **pre-merge CI checks gate (waits for green)**, merge (squash or merge commit), tag (main only), GitHub release (main only).
 
-Returns: `{ branch, commit, rebased, pushed, pr: {number, url}, merged, mergeStrategy, intermediate, tag, tagVerified, release }`.
+Returns: `{ branch, commit, rebased, pushed, pr: {number, url}, checks: {status, passed, failed, pending}, merged, mergeStrategy, intermediate, tag, tagVerified, release }`.
+
+**Pre-merge CI gate** (default ON): after PR create, `ship_release` runs `gh pr checks --watch` (default 600s timeout). If checks fail or timeout → `success: false`, `checksBlocked: true`, PR stays open, branch not deleted. Render `ship-blocked` card with the failing check names + run URLs.
+
+- Hot-fix bypass: pass `skipChecks: true` or set `DEVOPS_SHIP_SKIP_CHECKS=1`. Result records `checks.status: "skipped"` so the card flags it.
+- Tune timeout per call: `checksTimeoutSec: <30..3600>`.
+- See `deep-knowledge/quality-gates.md → Pre-Merge CI Checks Gate` for the full state matrix.
 
 **If `rebaseRequired: true`**: the branch is not rebased onto base. Go back to Step 1b and rebase before retrying.
 
@@ -249,6 +255,44 @@ consumer configuration — not yet implemented in this release (they fall throug
 `none` intentionally).
 
 See `deep-knowledge/skill-extension-guide.md -> Delivery targets` for reference.md examples.
+
+## Step 4b — Spawn Post-Merge Watcher (final ship only)
+
+**Skip this step for intermediate merges** — only relevant when shipping to main.
+
+After `ship_release` returns `success: true` and `merged: "main"`, spawn the post-merge
+watcher in the background. It waits for the GitHub Actions run triggered by the merge
+and (if configured) probes the production URL — all without blocking the ship flow.
+
+```bash
+# Background — fire and forget; result lands in <cwd>/.claude/.ship-watcher/<sha>.json
+nohup node "${CLAUDE_PLUGIN_ROOT}/scripts/post-merge-watcher.js" \
+  --cwd "<cwd>" \
+  --base "main" \
+  --merge-sha "<ship_release.mergeSha>" \
+  --pr "<ship_release.pr.number>" \
+  --max-wait 1800 \
+  --verify-config "<cwd>/.claude/skills/ship/reference.md" \
+  --version "<ship_version_bump.vNew or empty>" \
+  > /dev/null 2>&1 &
+```
+
+On Windows (PowerShell), use `Start-Process` with `-WindowStyle Hidden` instead of `nohup`:
+```powershell
+Start-Process -WindowStyle Hidden -FilePath "node" -ArgumentList @("$env:CLAUDE_PLUGIN_ROOT/scripts/post-merge-watcher.js", "--cwd", "<cwd>", "--base", "main", "--merge-sha", "<sha>", "--pr", "<n>", "--max-wait", "1800", "--verify-config", "<cwd>/.claude/skills/ship/reference.md", "--version", "<vNew>")
+```
+
+The watcher writes status to `<cwd>/.claude/.ship-watcher/<merge-sha>.json` and the
+`ss.ship.verify` hook surfaces unack'd results at the next SessionStart. On failure,
+a best-effort Windows toast fires immediately.
+
+**Skip the watcher entirely** when:
+- `intermediate: true` (no CI on intermediate merges typically)
+- The repo has no `.github/workflows/` directory (check with `Glob`)
+- User passed `--no-watch` to the ship trigger (interpret intent from the user's message)
+
+Pass `state.watcher = { spawned: true, sha: "<sha>" }` (or `spawned: false`) into the
+completion card in Step 6 so it can render "Deploy-Verify läuft im Hintergrund".
 
 ## Step 5a — Continue-Intent Check (auto-detect keep-mode)
 

--- a/plugins/devops/skills/devops-ship/deep-knowledge/post-merge-verify.md
+++ b/plugins/devops/skills/devops-ship/deep-knowledge/post-merge-verify.md
@@ -84,6 +84,20 @@ verify:
 
 Note: `$VERSION` is also expanded in `command` mode.
 
+### Security note for `command:` mode
+
+The `command:` string is passed to `spawnSync(cmd, { shell: true })` from the
+watcher process — so anything in this field runs with your user's permissions,
+in the watcher's working directory, with no sandboxing. **Only enable
+`command:` mode for repositories you trust to author this field.** A malicious
+PR that adds a `command:` line could exfiltrate or destroy data the next time
+a ship completes.
+
+If you operate a multi-contributor repo where untrusted PRs can modify
+`reference.md`, prefer `mode: http` exclusively, or move the verify block
+into a file outside the repo (point `--verify-config` at e.g.
+`~/.claude/verify/<repo>.md`).
+
 ## Example: Static site with version meta tag
 
 ```yaml

--- a/plugins/devops/skills/devops-ship/deep-knowledge/post-merge-verify.md
+++ b/plugins/devops/skills/devops-ship/deep-knowledge/post-merge-verify.md
@@ -1,0 +1,105 @@
+# Post-Merge Deploy Verification
+
+Optional per-project extension. Opt-in by adding a `verify:` block to your
+project's `{project}/.claude/skills/ship/reference.md`.
+
+The post-merge watcher (`scripts/post-merge-watcher.js`) reads this block
+**after** GitHub Actions on the merge commit have gone green, and probes the
+configured target. Result lands in
+`<repo>/.claude/.ship-watcher/<merge-sha>.json` and is surfaced by the
+`ss.ship.verify` SessionStart hook in the next session.
+
+## Format
+
+The watcher accepts the `verify:` block either inline in the file body or
+inside a fenced ` ```yaml ` block (preferred — keeps it visible as code in
+GitHub previews).
+
+```yaml
+verify:
+  mode: http                 # http (default) | command
+  url: https://example.com   # required for mode: http
+  expected_status: 200       # optional; default = no status check
+  selector: 'data-version="([^"]+)"'   # optional regex on response body (first capture group used)
+  expected: "$VERSION"       # optional; $VERSION expands to the just-shipped tag (vX.Y.Z)
+  poll_interval_seconds: 15  # default 15
+  timeout_seconds: 600       # default 600 (10 min)
+
+# For command mode:
+# verify:
+#   mode: command
+#   command: "./scripts/check-deploy.sh"
+#   poll_interval_seconds: 30
+#   timeout_seconds: 900
+```
+
+### Field reference
+
+| Field | Mode | Purpose |
+|---|---|---|
+| `mode` | both | `http` (default) probes a URL; `command` runs a shell command |
+| `url` | http | Production URL to probe |
+| `expected_status` | http | Required HTTP status code (omit to skip status check) |
+| `selector` | http | Regex applied to response body; first capture group is checked against `expected` |
+| `expected` | http | String the captured group must contain. `$VERSION` placeholder expands to the just-shipped tag |
+| `command` | command | Shell command. Exit 0 = success, anything else = retry |
+| `poll_interval_seconds` | both | Pause between retries |
+| `timeout_seconds` | both | Hard deadline. `failed` once exceeded |
+
+## Failure handling
+
+- **CI fails** → watcher writes `overall: "failed"`, fires PowerShell toast,
+  does NOT run the verify block.
+- **CI passes, verify fails** → `overall: "failed"`, toast, state file
+  carries `verify.lastError` for triage.
+- **CI passes, verify passes** → `overall: "success"`, silent. Surfaced
+  silently at next SessionStart (still ack'd to clear the queue).
+- **CI does not exist** → `ci: { status: "no-run" }`, verify still runs if
+  configured. Pure-frontend repos without CI but with a deploy hook can use
+  this pattern.
+- **Watcher process killed before completion** → state file stays in
+  `status: "watching"`. The SessionStart hook auto-acknowledges entries
+  older than 24h.
+
+## Example: SPA on Vercel
+
+```yaml
+verify:
+  mode: http
+  url: https://my-app.example.com/api/health
+  expected_status: 200
+  poll_interval_seconds: 20
+  timeout_seconds: 900
+```
+
+## Example: NPM package on registry
+
+```yaml
+verify:
+  mode: command
+  command: "npm view my-package version | grep -q $VERSION"
+  poll_interval_seconds: 30
+  timeout_seconds: 1200
+```
+
+Note: `$VERSION` is also expanded in `command` mode.
+
+## Example: Static site with version meta tag
+
+```yaml
+verify:
+  mode: http
+  url: https://docs.example.com
+  expected_status: 200
+  selector: '<meta name="version" content="([^"]+)"'
+  expected: "$VERSION"
+  timeout_seconds: 600
+```
+
+## Disabling
+
+Remove the `verify:` block (or rename to `_verify:`) — the watcher then
+only tracks CI status, not the deploy.
+
+To skip the watcher entirely, pass `--no-watch` in the ship trigger or
+remove the spawn step from a project-specific ship `SKILL.md` extension.

--- a/plugins/devops/skills/devops-ship/deep-knowledge/quality-gates.md
+++ b/plugins/devops/skills/devops-ship/deep-knowledge/quality-gates.md
@@ -33,6 +33,28 @@ Run the full test suite only if:
 If the full suite already passed on the **same build-ID** earlier in the
 session → skip. Log: `Tests skipped — already passed on build <hash>`.
 
+## Pre-Merge CI Checks Gate
+
+After the PR is created (or reused) and before the merge, `ship_release`
+calls `gh pr checks --watch --fail-fast` on the PR number. Default timeout:
+**600s** (10 min), configurable via `checksTimeoutSec`.
+
+Outcomes:
+- **all green** → merge proceeds. Result includes `checks: { status: "passed", passed: N }`.
+- **no checks configured** → silent skip (e.g. new repos without CI). `checks: { status: "no-checks" }`.
+- **at least one failure** → `success: false`, `checksBlocked: true`, `failedChecks: [...]`. PR stays open, branch not deleted. Skill → ship-blocked card.
+- **timeout** → `success: false`, `checksBlocked: true`. PR stays open. Skill → ship-blocked card with retry hint.
+
+### Bypass (hot-fix only)
+
+Two ways to skip the gate when CI itself is broken and a hot-fix must land:
+
+1. Pass `skipChecks: true` to `ship_release`.
+2. Set `DEVOPS_SHIP_SKIP_CHECKS=1` in the environment.
+
+Either path records `checks: { status: "skipped", reason: "..." }` in the result
+so the completion card can flag the bypass.
+
 ## Build-ID
 
 After a successful build, generate the build-ID:

--- a/plugins/devops/skills/devops-ship/deep-knowledge/release-flow.md
+++ b/plugins/devops/skills/devops-ship/deep-knowledge/release-flow.md
@@ -17,6 +17,19 @@ Create a pull request via the GitHub API:
 - Base branch: `main`
 - Include a `## Summary` and `## Test plan` section in the body
 
+## Pre-Merge CI Checks Gate
+
+Between PR creation and merge, `ship_release` waits for `gh pr checks --watch`
+to finish (default 10-min timeout). See `quality-gates.md → Pre-Merge CI Checks Gate`.
+
+- **green** → continue to merge
+- **failed / timeout** → return success: false, do NOT merge, render `ship-blocked` card
+- **no checks configured** → silent skip
+- **bypass**: `skipChecks: true` or `DEVOPS_SHIP_SKIP_CHECKS=1` (hot-fix only)
+
+This prevents the historical failure mode where lokal grün + merge → CI rot auf
+`main` without anyone noticing.
+
 ## Merge PR
 
 Merge the PR via the GitHub API:

--- a/plugins/devops/skills/devops-ship/reference.md
+++ b/plugins/devops/skills/devops-ship/reference.md
@@ -32,4 +32,25 @@ Create project-specific ship rules in your project:
 - `src/version.ts` contains `export const VERSION = 'X.Y.Z'`
 ```
 
+## Post-merge deploy verification (opt-in)
+
+Add a `verify:` block to **this** `reference.md` to make the post-merge
+watcher probe production after CI goes green. See
+[`deep-knowledge/post-merge-verify.md`](deep-knowledge/post-merge-verify.md)
+for the full field reference. Quick example:
+
+```yaml
+verify:
+  mode: http
+  url: https://my-app.example.com
+  expected_status: 200
+  selector: '<meta name="version" content="([^"]+)"'
+  expected: "$VERSION"
+  timeout_seconds: 600
+```
+
+Without a `verify:` block the watcher only confirms the GitHub Actions
+run on the merge commit. Failures (CI or verify) surface at the next
+SessionStart and via Windows toast.
+
 This pattern applies to ALL plugin skills, not just ship.

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.84.0",
+  "version": "0.85.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

Three-layer post-merge verification so `/devops-ship` no longer silently reports green when CI fails on `main` or when the production deploy lags behind the merge.

- **Pre-Merge CI Gate** — `ship_release` now blocks on `gh pr checks --watch --fail-fast` after PR create and before merge (default 10 min timeout). Fails closed on probe errors and on watch-died-with-pending. Hot-fix bypass: `skipChecks: true` or `DEVOPS_SHIP_SKIP_CHECKS=1`.
- **Post-Merge Watcher** — new `plugins/devops/scripts/post-merge-watcher.js` spawned after a successful merge to `main`. Polls for the GitHub Actions workflow on the merge SHA, watches it to completion, optionally probes a production URL, writes status to `<repo>/.claude/.ship-watcher/<sha>.json`, fires Windows toast on fail.
- **`verify:` Extension** — per-project opt-in in `{project}/.claude/skills/ship/reference.md`. `mode: http` probes a URL with optional `expected_status`, `selector` (regex on body), and `expected` (with `$VERSION` placeholder). `mode: command` runs a shell command. Documented security limitation: command mode is unsandboxed, only enable in trusted repos.
- **`ss.ship.verify` SessionStart hook** — surfaces unack'd watcher results at the next session, marks them acknowledged in place, auto-expires entries older than 24 h.

## Test plan

- [x] vitest: 161/161 (full suite), including 8 new tests covering probe-error, fail-closed-when-pending, and the four happy paths of `watchPRChecks`
- [x] eslint: clean across changed files
- [x] node --check on watcher script + dry-run of the session-start hook (silent without state files)
- [ ] Real ship in a consumer project with green CI — verify Pre-Merge-Gate passes and watcher spawns
- [ ] Real ship with a deliberately failing check — verify gate blocks the merge
- [ ] Add a `verify:` block in a consumer project, ship, and verify the deploy probe fires after CI