### PR TITLE
feat(devops): #169 Desktop App docs + #165 concept gate

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.85.1"
+    "version": "0.86.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.85.1",
+      "version": "0.86.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.85.1",
+      "version": "0.86.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.86.0] — 2026-05-27
+
+### Added
+
+- **plugins/devops/deep-knowledge/claude-desktop-app-setup.md** — new reference doc for the Windows-only Claude Desktop App `bypassPermissionsModeEnabled` master switch. Explains the three independent bypass flags (`bypassPermissionsOptInByAccount`, `bypassPermissionsGateByAccount`, `bypassPermissionsModeEnabled`), why the master switch silently invalidates every CLI session when off (smoking-gun log line `[CCD] Downgrading session … bypassPermissionsModeEnabled pref is off`), diagnostic PowerShell snippets, the UI-preferred fix path, JSON-patch fallback with race-safe procedure for both the `%APPDATA%` and `%LOCALAPPDATA%\Packages\…` mirror locations, and a CLI-launcher robustness pattern (version-stable `current\` junction + Logon scheduled task) for users who bypass the Desktop App entirely. Closes #169.
+- **plugins/devops/skills/devops-project-setup/SKILL.md** — new Step 2c "Platform-specific permissions audit (Windows only)" between Step 2b and Step 3. Skipped on non-Windows. When the Claude Desktop App is detected (via `%APPDATA%\Claude\claude_desktop_config.json` presence), greps `%APPDATA%\Claude\logs\main.log` for the downgrade line and emits a WARNING when the master switch is off. `--fix` prints instructions to flip the UI toggle — never auto-patches JSON. New `### Platform Audit` section added to the Step 8 output report template.
+
+### Changed
+
+- **plugins/devops/skills/devops-concept/deep-knowledge/validation-gate.md** — Phase 1 shared-patterns table extended from 33 to 35 patterns. New patterns 34 (`submitCreateIssues`) and 35 (`collectDisposition`) catch the silent-failure mode where the final-report JS block is generated without the create-issues / dispose handlers — leaving the "Issues erstellen" and "Concept beenden" buttons visible but inert. New "Common failures this gate catches" entry documents the silent click-but-no-network-request symptom.
+- **plugins/devops/skills/devops-concept/SKILL.md** — Step 5c "Final-report append" gains a mandatory "Verbatim copy directive" requiring the final-report JS block (`updateCreateIssuesPanel`, `submitCreateIssues`, `collectDisposition`, `submitDisposeConcept`, the `change` listener for open-questions checkboxes, and the `DOMContentLoaded` wiring) to be copied verbatim from `deep-knowledge/templates.md` rather than reimplemented. Stale post-generation validation count `30 mandatory patterns` updated to `35`. Closes #165.
+
 ## [0.85.1] — 2026-05-24
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.85.1**
+**Version: 0.86.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.85.1",
+  "version": "0.86.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/deep-knowledge/INDEX.md
+++ b/plugins/devops/deep-knowledge/INDEX.md
@@ -12,6 +12,7 @@ Quick-reference for all deep-knowledge topics. Read this FIRST to find the right
 | [autonomous-execution.md](autonomous-execution.md) | Autonomous Execution — Gate, Guardrails, Late-Permission Protocol | Detailed execution rules for `devops-autonomous` Step 5. Read this at the sta... |
 | [browser-file-urls.md](browser-file-urls.md) | Browser File URLs (Windows + Git-Bash) | Cross-cutting rule: whenever a skill opens a local HTML file in a browser |
 | [browser-tool-strategy.md](browser-tool-strategy.md) | Browser Tool Strategy | > **Single-Source-of-Truth for test autonomy decisions:** see [test-autonomy.... |
+| [claude-desktop-app-setup.md](claude-desktop-app-setup.md) | Claude Desktop App Setup (Windows) | Windows-specific reference for Claude Desktop App launcher configuration and ... |
 | [claude-directory-structure.md](claude-directory-structure.md) | Claude Directory Structure Convention | All Claude Code configuration belongs inside `.claude/`. Nothing Claude-specific |
 | [code-defaults.md](code-defaults.md) | Code Defaults | Standard coding conventions enforced across all projects using the devops plu... |
 | [codex-integration.md](codex-integration.md) | Codex Integration | Cross-cutting reference for all points where `codex-plugin-cc` skills are |

--- a/plugins/devops/deep-knowledge/claude-desktop-app-setup.md
+++ b/plugins/devops/deep-knowledge/claude-desktop-app-setup.md
@@ -1,0 +1,131 @@
+# Claude Desktop App Setup (Windows)
+
+Windows-specific reference for Claude Desktop App launcher configuration and bypass-permissions mode.
+Referenced by `devops-project-setup` Step 2c and any skill that touches permission mode.
+
+## Which path applies to you?
+
+```
+Are you launching Claude Code from the Claude Desktop App (Electron)?
+  YES → Read this document in full. The Desktop App controls the permission mode.
+  NO  → You launch `claude.exe` directly from a terminal, shortcut, or scheduled task.
+        The CLI-level flags in your launcher matter; see "CLI-launcher robustness" below.
+        This doc is still worth reading for the Desktop App bypass-flags reference.
+```
+
+Confirm your launcher:
+
+```powershell
+Get-CimInstance Win32_Process -Filter "Name = 'claude.exe'" |
+  Where-Object { $_.ExecutablePath -like "*claude-code*" } |
+  Select-Object -ExpandProperty CommandLine
+```
+
+If the output contains `--permission-mode acceptEdits` and the parent is
+`Claude.exe` from `Program Files\WindowsApps\Claude_*`, the Desktop App is
+your launcher. Any `--dangerously-skip-permissions` flag on a shortcut or
+`.cmd` wrapper is silently overridden.
+
+---
+
+## The three bypass-permissions toggles
+
+The Desktop App stores its prefs in:
+- `%APPDATA%\Claude\claude_desktop_config.json`
+- Mirror (Store sandbox): `%LOCALAPPDATA%\Packages\Claude_pzs8sxrjxfjjc\LocalCache\Roaming\Claude\claude_desktop_config.json`
+
+All three keys live under `preferences`:
+
+| Key | Shape | What it gates |
+|-----|-------|---------------|
+| `bypassPermissionsOptInByAccount` | `{ "<acctId>": true }` | Account-level opt-in (warn-dialog acknowledgement) |
+| `bypassPermissionsGateByAccount` | `{ "<acctId>": true }` | Per-folder gate (per-folder warn acknowledgement) |
+| **`bypassPermissionsModeEnabled`** | **boolean** | **Master switch — without this, every session is downgraded `bypassPermissions → acceptEdits` at start** |
+
+The first two can be set through in-app flows (warning dialogs). The master
+switch is only reachable via **Settings → Bypass permissions mode** in the
+Desktop App UI. If it is `false` (or absent), the other two are irrelevant —
+the session is always downgraded.
+
+Read the current state:
+
+```powershell
+(Get-Content $env:APPDATA\Claude\claude_desktop_config.json -Raw |
+  ConvertFrom-Json).preferences |
+  Get-Member -MemberType NoteProperty |
+  Where-Object { $_.Name -match 'bypass|permission' }
+```
+
+---
+
+## Smoking-gun log line
+
+`%APPDATA%\Claude\logs\main.log` records a downgrade on every affected session:
+
+```
+[info] [CCD] Downgrading session local_xxxx bypassPermissions → acceptEdits at start — bypassPermissionsModeEnabled pref is off
+```
+
+Check for recent occurrences (last 200 lines):
+
+```powershell
+Get-Content "$env:APPDATA\Claude\logs\main.log" -Tail 200 |
+  Select-String "bypassPermissionsModeEnabled pref is off"
+```
+
+Any match means the master switch is off and every CLI session is running in
+`acceptEdits` mode regardless of CLI-level flags.
+
+---
+
+## Fix procedure
+
+### Preferred: UI toggle
+
+1. Open the Claude Desktop App.
+2. Go to **Settings → Bypass permissions mode**.
+3. Enable the toggle.
+4. Start a new Claude Code session — the downgrade line will no longer appear.
+
+### Fallback: JSON patch (use only when the UI is unreachable)
+
+Race-safe procedure — the app overwrites the file on exit, so patch order matters:
+
+1. Quit the Desktop App completely (check system tray).
+2. Open `%APPDATA%\Claude\claude_desktop_config.json`.
+3. Under `preferences`, set `"bypassPermissionsModeEnabled": true`.
+4. Apply the identical change to the Store mirror path:
+   `%LOCALAPPDATA%\Packages\Claude_pzs8sxrjxfjjc\LocalCache\Roaming\Claude\claude_desktop_config.json`
+   (path may vary by Store version — search for `claude_desktop_config.json`
+   under `%LOCALAPPDATA%\Packages\`).
+5. Restart the Desktop App.
+6. Verify: `Get-Content "$env:APPDATA\Claude\logs\main.log" -Tail 50 | Select-String "Downgrading"` should return nothing.
+
+Patching only one of the two paths is insufficient — the App reconciles them
+on startup and may restore the old value.
+
+---
+
+## CLI-launcher robustness (Direct CLI, no Desktop App)
+
+For users who invoke `claude.exe` directly, the Desktop App has no influence.
+The `--dangerously-skip-permissions` flag on the launcher is what matters.
+Common failure mode: a `.cmd` wrapper that uses `start ""` detaches the
+process and can drop argv inheritance for child worktree tabs.
+
+A robust setup:
+
+- Create a version-stable junction:
+  `%APPDATA%\Claude\claude-code\current\` → newest installed version directory.
+- A Logon scheduled task refreshes the junction after auto-updates:
+  ```powershell
+  # Example task action (adjust paths)
+  $target = (Get-ChildItem "$env:LOCALAPPDATA\AnthropicClaude" -Directory |
+    Sort-Object Name -Descending | Select-Object -First 1).FullName
+  cmd /c mklink /J "$env:APPDATA\Claude\claude-code\current" $target
+  ```
+- Point shortcuts and taskbar pins directly at
+  `current\claude.exe --dangerously-skip-permissions`, not through a `.cmd`
+  wrapper with `start ""`.
+
+This setup survives auto-updates without relinking shortcuts manually.

--- a/plugins/devops/skills/devops-concept/SKILL.md
+++ b/plugins/devops/skills/devops-concept/SKILL.md
@@ -378,7 +378,7 @@ and `deep-knowledge/templates.md` § Iteration Tabs for the reference HTML.
 
 ### Post-Generation Validation (mandatory gate)
 
-After writing the HTML file, grep it for the 30 mandatory interactive
+After writing the HTML file, grep it for the 35 mandatory interactive
 patterns (heartbeat, panel states, iteration tabs, section TOC, reload
 polling, generic form-collection catch-all scoped to the active
 iteration, post-submit content dimmer, etc.).
@@ -664,6 +664,19 @@ preservation) stays identical.
    from `<body>`. The submit-button reset is irrelevant because the
    final-report panel doesn't surface iterate/implement at all.
 6. /reload → /reset as steps 5–6 above.
+
+**Verbatim copy directive (mandatory):**
+The final-report JS block — `updateCreateIssuesPanel`, `submitCreateIssues`,
+`collectDisposition`, `submitDisposeConcept`, plus the `change` listener on
+`section[data-open-questions] input[type="checkbox"]` and the
+`DOMContentLoaded` wiring — MUST be copied verbatim from
+`deep-knowledge/templates.md` § Final-report append (the block starting at
+the comment `// --- Final-report "Issues erstellen" action ---`). Do NOT
+inline a simplified `updateCreateIssuesPanel` or omit the event-listener
+wiring; either omission is the regression that issue #165 reports.
+After writing, the post-generation validation gate
+(`deep-knowledge/validation-gate.md` Phase 1) MUST find patterns 28–35
+in the generated file.
 
 **Open questions / TODOs section — when to include:**
 

--- a/plugins/devops/skills/devops-concept/deep-knowledge/validation-gate.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/validation-gate.md
@@ -7,7 +7,7 @@ template-specific extras selected by `<html data-template="...">`.
 
 ## Phase 1 — Shared patterns (ALL templates)
 
-Every concept page must contain these 33 patterns, regardless of template:
+Every concept page must contain these 35 patterns, regardless of template:
 
 | # | Pattern to grep | Purpose |
 |---|----------------|---------|
@@ -45,6 +45,8 @@ Every concept page must contain these 33 patterns, regardless of template:
 | 31 | `ensureCommentSlots` | Auto-injects an adjacent `<textarea data-comment="$decisionId-note">` for every `[data-decision]` bi-state group that lacks one. MUST be called from `DOMContentLoaded` BEFORE `restoreState` so the restore step rehydrates the typed values onto real nodes. See templates.md § Comment Slot Injection. |
 | 32 | `panel-dispose-concept` | Disposition fieldset on the final-report panel. Always visible while `panel-final-report` is active; carries the discard / keep / gitignore radio group + optional `moveTo` input. See templates.md § Disposition Control. |
 | 33 | `submitDisposeConcept` | JS handler wired to `#dispose-concept-btn`. POSTs `action: "dispose-concept"` with the current disposition payload so Step 6a can run the cleanup branch. |
+| 34 | `submitCreateIssues` | JS handler wired to `#create-issues-btn`. POSTs `action: "create-issues"` with the selected open-question items plus the current disposition payload. Dropping this leaves the button visible but inert — no console error, no network request on click. |
+| 35 | `collectDisposition` | Reads the disposition fieldset (`dispose-mode` radio + optional `dispose-move-to` input) into the `{ mode, moveTo }` shape required by both `submitCreateIssues` and `submitDisposeConcept` payloads. Without this, both buttons throw at submit time. |
 
 **Failure for 21 / 22:** if either pattern is missing, the page is rejected
 at the post-generation gate. See § Generic Form Collection below for the
@@ -177,6 +179,7 @@ This is a **blocking gate** — no exceptions, no "this page doesn't need it".
 - Heartbeat poller does an HTTP-only check (no `await r.json()` + `claude_ts` assignment) → indicator stays green forever because the server self-pulse always returns 200, even when Claude's cron is dead
 - Heartbeat checker only toggles a CSS class, never sets `disabled` on the submit buttons → user can keep clicking submit during a stale heartbeat, every click rots in the bridge unnoticed
 - Staleness math mixes seconds and milliseconds (`Date.now() / 1000`, or `_lastHeartbeatTs * 1000`) → comparison flips negative, page renders "Claude verbunden" even when the heartbeat is hours old
+- `submitCreateIssues` / `collectDisposition` missing → final-report panel renders correctly but the "Issues erstellen" button does nothing on click (silent failure — no console error, no network request); same silent failure for "Concept beenden" if `collectDisposition` is missing from `submitDisposeConcept`
 
 The patterns in `templates.md` (§ Claude Connection Heartbeat, § Submit
 Handler, § State Persistence, § Template: prototype, § Template: free)

--- a/plugins/devops/skills/devops-project-setup/SKILL.md
+++ b/plugins/devops/skills/devops-project-setup/SKILL.md
@@ -133,6 +133,26 @@ splitting the volatile value into a separate gitignored file.
 Run `/devops-claude-md-lint` to check CLAUDE.md size and structure.
 Report the result in the final output under a `### CLAUDE.md` section.
 
+## Step 2c — Platform-specific permissions audit (Windows only)
+
+Skip entirely on non-Windows (`process.platform !== 'win32'`; or check `$env:OS` in PowerShell).
+
+1. **Detect Desktop App launcher**: probe `%APPDATA%\Claude\claude_desktop_config.json` existence.
+   - Not found → report `[INFO] Desktop App not detected — skip.` and continue to Step 3.
+2. **Grep for downgrade evidence** (last 200 lines of `%APPDATA%\Claude\logs\main.log`):
+   ```powershell
+   Get-Content "$env:APPDATA\Claude\logs\main.log" -Tail 200 |
+     Select-String "bypassPermissionsModeEnabled pref is off"
+   ```
+3. **Report**:
+   - Match found → `[WARNING] Desktop App master switch off — every session runs as acceptEdits.`
+   - No match → `[OK] No recent permission downgrade detected.`
+4. **`--fix` action**: print instructions to enable **Settings → Bypass permissions mode** in the
+   Desktop App UI. Do NOT auto-patch the JSON. Reference:
+   `deep-knowledge/claude-desktop-app-setup.md`
+
+Add the result to the Step 8 report under `### Platform Audit`.
+
 ## Step 3 — LICENSE
 
 If missing: ask user via AskUserQuestion (MIT, Apache 2.0, GPL 3.0, ISC, Proprietary).
@@ -188,6 +208,9 @@ extensions for any plugin skill:
 
 ### Additional files
 - [INFO] ...
+
+### Platform Audit
+- [WARNING/OK/INFO] ...
 
 ### Plugin Extensions
 - [INFO] Run /devops-extend-skill to scaffold extensions for plugin skills

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.85.1",
+  "version": "0.86.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
Closes #169
Closes #165

## Summary

- **#169** — New deep-knowledge doc for the Windows-only Claude Desktop App `bypassPermissionsModeEnabled` master switch trap, plus new Step 2c in `devops-project-setup` that audits `%APPDATA%\Claude\logs\main.log` for the downgrade line and emits a WARNING (no auto-patch — UI toggle only).
- **#165** — `devops-concept` post-generation validation gate extended (33 → 35 patterns): `submitCreateIssues` and `collectDisposition` now caught when stripped from generated HTML. SKILL.md Step 5c gains a mandatory verbatim-copy directive for the final-report JS block.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 166/166 passing
- [x] Manual: deep-knowledge doc renders, INDEX entry present
- [x] Manual: validation-gate count updated to 35, no stale `30 mandatory` refs
- [ ] Post-merge: smoke-run `/devops-project-setup --audit` on a Windows project to confirm Step 2c fires
- [ ] Post-merge: trigger `/devops-concept` and confirm gate catches missing `submitCreateIssues`