### PR TITLE
fix(concept): hard-enforce real Edge browser to open page (0.86.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.86.0"
+    "version": "0.86.1"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.86.0",
+      "version": "0.86.1",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.86.0",
+      "version": "0.86.1",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.86.1] — 2026-05-27
+
+### Fixed
+
+- **plugins/devops/skills/devops-concept/SKILL.md** — Step 3 now hard-enforces that the concept page MUST be opened in the user's real Edge browser via `start "" msedge "http://localhost:<port>/<file>"` (Windows) / `open -a "Microsoft Edge"` (macOS) / `microsoft-edge` (Linux). New "MANDATORY — Real Edge browser only" block names `mcp__Claude_Preview__preview_start` / `preview_*`, `mcp__plugin_playwright_playwright__browser_navigate`, and silent `file://` print-and-stop as forbidden substitutes, with an explicit note that `mcp__Claude_Preview__*` stays in `allowed-tools` only for `preview_eval` during Step 5 page updates. The previous text said "open in Edge" but buried the exact shell invocation in `deep-knowledge/bridge-server.md`, so sessions frequently fell back to the in-IDE preview pane — which has no heartbeat connection and breaks the whole concept flow. If the shell command errors, the skill now requires Claude to surface the exact error and ask the user how to proceed (Edge protocol handler, manual paste, or another browser) instead of silently degrading to preview.
+- **plugins/devops/skills/devops-concept/deep-knowledge/bridge-server.md** — Step 6 mirrors the same prohibition and fallback rule so the deep-knowledge path defends independently of the SKILL.md path.
+- **plugins/devops/skills/devops-concept/deep-knowledge/monitoring.md** — Scope warning added to the `preview_eval` entry: it is allowed only for JS eval inside the already-open Edge tab, never for opening the concept page.
+
 ## [0.86.0] — 2026-05-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.86.0**
+**Version: 0.86.1**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.86.0",
+  "version": "0.86.1",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/skills/devops-concept/SKILL.md
+++ b/plugins/devops/skills/devops-concept/SKILL.md
@@ -388,8 +388,51 @@ pattern list and common failure modes.
 
 ## Step 3 — Open in Browser
 
-Open the generated HTML file **inside the user's existing Edge window** — never
-open a separate browser window.
+Open the generated HTML file **inside the user's existing Edge window** as
+a new tab — NEVER open a separate browser window.
+
+### MANDATORY — Real Edge browser only
+
+The concept page MUST be opened in the user's **real Edge browser** via the
+OS shell. **Forbidden alternatives** that will produce a broken session:
+
+- ❌ **Never** use `mcp__Claude_Preview__preview_start` / `preview_*` to
+  display the page. The preview pane is a sandboxed in-IDE iframe — it
+  has no heartbeat connection, no cron polling, and the user cannot
+  interact with it the way the concept flow needs. `mcp__Claude_Preview__*`
+  is in `allowed-tools` ONLY for `preview_eval` during Step 5 page
+  updates, never for opening the page.
+- ❌ **Never** use `mcp__plugin_playwright_playwright__browser_navigate`
+  to open the page. Playwright spawns its own browser instance — the user
+  will not see it.
+- ❌ **Never** print "Concept opened at file:///… open it in your browser"
+  and stop. The bridge server requires the page to be loaded via
+  `http://localhost:{port}/…`, not `file://`.
+
+The **only** correct invocation is the OS `start`/`open` shell command
+that hands the URL to the user's default Edge window, which then opens
+a new tab. The exact command per platform:
+
+```bash
+# Windows (this project's primary target)
+start "" msedge "http://localhost:$PORT/$(basename $HTML_PATH)"
+
+# macOS
+open -a "Microsoft Edge" "http://localhost:$PORT/$(basename $HTML_PATH)"
+
+# Linux
+microsoft-edge "http://localhost:$PORT/$(basename $HTML_PATH)" &
+```
+
+The empty `""` on Windows is required — without it, `cmd.exe` interprets
+the first quoted argument as a window title.
+
+**If the `start "" msedge …` command errors** (Edge not installed, not in
+PATH), do NOT silently fall back to the preview MCP. Tell the user the
+exact error and ask whether to try the Edge protocol handler
+(`start microsoft-edge:"http://localhost:$PORT/…"`) or another browser
+they prefer. The whole concept flow assumes a real, user-visible browser
+window — there is no usable degraded mode.
 
 ### Concept Bridge Server + Edge
 
@@ -401,7 +444,7 @@ concept, **send the first heartbeat AND verify it round-trips with a
 non-zero `claude_ts`** (see `deep-knowledge/bridge-server.md` § Step 5 —
 the read-back is mandatory; a naked POST leaves a dead-bridge failure
 mode invisible until the user submits and gets no response), then open
-the page in the user's existing Edge window.
+the page in the user's existing Edge window using the exact command above.
 
 The state file (`port`, `html_path`, `slug`, `server_pid`, `cron_id`,
 `started_at`) is what makes the concept survivable across Claude restarts:

--- a/plugins/devops/skills/devops-concept/deep-knowledge/bridge-server.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/bridge-server.md
@@ -213,15 +213,32 @@ AND provides HTTP endpoints for heartbeat and decision exchange.
    self-pulse keeps `server_ts` fresh even when the request-handling
    thread is wedged.
 
-6. Open in Edge (reuses the running instance, adds a tab):
+6. **Open the page in the user's real Edge browser** (reuses the running
+   instance, adds a tab). This step is non-negotiable:
+
    ```bash
-   # Windows
+   # Windows (primary target)
    start "" msedge "http://localhost:{port}/{filename}"
    ```
    On macOS: `open -a "Microsoft Edge" "http://…"`, on Linux: `microsoft-edge "http://…"`.
 
    The empty `""` is required on Windows — without it, `cmd.exe` interprets
    the first quoted argument as a window title.
+
+   **NEVER substitute one of these instead of the shell command above:**
+   - `mcp__Claude_Preview__preview_start` / `preview_*` — sandboxed iframe,
+     no heartbeat, user cannot use it as the concept page.
+   - `mcp__plugin_playwright_playwright__browser_navigate` — opens a
+     separate Playwright-controlled browser the user does not see.
+   - Just printing the `http://localhost:{port}/…` URL to the user — the
+     user expects the page to open automatically, not to copy-paste a URL.
+
+   If `start "" msedge …` exits non-zero (Edge missing / not in PATH),
+   surface the exact error to the user and ask them how to proceed
+   (Edge protocol handler `start microsoft-edge:"http://…"`, manually
+   pasting the URL, or another installed browser). Do NOT silently fall
+   back to the preview MCP — the concept flow needs a real visible
+   browser window with an active tab.
 
 7. After monitoring ends (user says "fertig"/"done", aborts, clicks
    "Concept beenden" on the final-report panel, or Step 6 of SKILL.md

--- a/plugins/devops/skills/devops-concept/deep-knowledge/monitoring.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/monitoring.md
@@ -170,6 +170,13 @@ browser eval tools are still useful:
 - playwright: `browser_evaluate("...")`
 - preview: `preview_eval("...")`
 
+**Scope warning:** `preview_eval` is allowed here for evaluating JS inside
+the **already-open** Edge tab. It is NEVER allowed for *opening* the
+concept page — see SKILL.md § Step 3 (MANDATORY — Real Edge browser only)
+and bridge-server.md § Step 6. Opening via the preview MCP would replace
+the user's real Edge tab with a sandboxed in-IDE iframe that has no
+heartbeat connection and breaks the whole concept flow.
+
 If no eval tool works, inform the user via chat what was processed instead
 of updating the page live. The page can be manually refreshed.
 

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.86.0",
+  "version": "0.86.1",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

- `/devops-concept` was silently opening the page in the in-IDE preview pane instead of the user's real Edge browser. The preview pane has no heartbeat connection, no cron polling, and breaks the whole concept flow.
- Step 3 of the skill now prominently carries the exact `start "" msedge "..."` invocation (plus macOS/Linux variants) and an explicit forbidden list naming `mcp__Claude_Preview__preview_start`, Playwright `browser_navigate`, and silent `file://` print-and-stop as substitutes.
- Bridge-server § Step 6 and monitoring.md § JS-Eval fallback mirror the same prohibition so each entry point defends independently. On Edge launch failure the skill now requires Claude to surface the error and ask the user (Edge protocol handler / manual paste / other browser) — no silent degrade to preview.

## Test plan

- [x] `npm run lint` — 0 issues
- [x] `npm run test` — 166/166 vitest passing
- [ ] Manual smoke: next `/devops-concept` invocation opens the page in the real Edge window (verified by user)