### PR TITLE
fix(concept): auto-create issues without manual JSON copy (0.86.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.86.1"
+    "version": "0.86.2"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.86.1",
+      "version": "0.86.2",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.86.1",
+      "version": "0.86.2",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.86.2] — 2026-05-28
+
+### Fixed
+
+- **plugins/devops/skills/devops-concept** — close the "you have to paste the JSON" gap when the concept final-report's "Issues erstellen" button fires. Previously the `submitCreateIssues` payload only carried `{ id, title, type, selected }`, and SKILL.md Step 5b told Claude to invoke the `devops-new-issue` skill — whose Step 1 runs an interactive `AskUserQuestion` for the body / labels. In a session driven by the concept-bridge cron, that prompt turned into a request for the user to copy decisions JSON from the console, exactly the regression that the iterate / implement branches had already eliminated. Three coordinated changes:
+  - **deep-knowledge/templates.md `submitCreateIssues`** — payload extended with `description` (from `data-issue-body` or the visible `.oq-label` text) plus optional project-context hints `role` / `module` / `milestone` (from `data-issue-*` attributes). Open-questions HTML template + attribute-reference table updated with worked examples, required/recommended/optional markers, and explicit "the auto-issue pipeline depends on these — generate them when you author the final report" guidance.
+  - **SKILL.md Step 5b · create-issues** — rewritten with a hard "Zero-prompt invariant" block. Claude now calls `gh issue create` directly with title/body/labels/milestone from the payload, never invokes `devops-new-issue` (which prompts), and resolves project-specific `role:*` / `module:*` labels by checking the payload first, then the project's `new-issue` extension via concept-context inference, and finally silently omitting the label rather than asking. Issue body always ends with a `_Created from concept: docs/concepts/{date}-{slug}.html_` backlink for future context recovery. Per-item `gh` failures surface to the user but don't block the remaining items — partial success beats silent loss.
+  - **deep-knowledge/bridge-server.md cron-prompt** — enumerates all four `action` values (`iterate`, `implement`, `create-issues`, `dispose-concept`) so the auto-poll cron does not implicitly assume `iterate`. New explicit "Zero-prompt invariant for create-issues + dispose-concept" callout in the cron body — the payload is self-sufficient by design, AskUserQuestion in either branch is the regression we are designing against.
+
 ## [0.86.1] — 2026-05-27
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.86.1**
+**Version: 0.86.2**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.86.1",
+  "version": "0.86.2",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/skills/devops-concept/SKILL.md
+++ b/plugins/devops/skills/devops-concept/SKILL.md
@@ -574,23 +574,70 @@ Branch on it:
    "Final-report append (implement only)" for the structure.
 
 **`action: "create-issues"` ("Issues erstellen" button — only on final report):**
-1. Read the `items` array from the payload — each entry is a selected open
-   question / TODO `{ id, title, type, selected: true }`.
+
+**Zero-prompt invariant.** The user already committed when they clicked
+"Issues erstellen". Asking a follow-up question — for issue body, labels,
+milestone, anything — is a UX regression equivalent to the old
+"paste the JSON from the console" anti-pattern. Every field needed to
+land a complete `gh issue create` call is in the payload OR derivable
+from the concept HTML in `docs/concepts/{date}-{slug}.html`. If a field
+is genuinely missing AND the project requires it, fall back to a sane
+default (silent) — never an `AskUserQuestion`. The only justified
+interruption is a hard `gh` failure that needs the user's eyes.
+
+1. Read the `items` array from the payload — each entry now carries
+   `{ id, title, type, description, role?, module?, milestone?, selected: true }`.
+   `description` falls back to the visible `.oq-label` text when the
+   author of the final-report did not set `data-issue-body`; either is
+   enough to skip prompting.
 2. Read the `disposition` sub-object from the same payload — even if the
    user never touches "Concept beenden", `submitCreateIssues` always
    bundles the current disposition state for Step 6 cleanup. Store it
    for use in Step 6a; do NOT apply it now — issue routing and cleanup
    are decoupled so the user can still review the page before closing.
-3. For each selected item, invoke the **devops-new-issue** skill with the
-   item's title and type. Capture the resulting issue number + URL.
-4. Update the final-report HTML: in the open-questions section, replace
+3. For each selected item, create the GitHub issue **directly via
+   `gh issue create`** — do NOT invoke the `devops-new-issue` skill,
+   which runs an interactive `AskUserQuestion` Step 1. Build the
+   command from the payload + concept-extension labels (see § Project
+   label enrichment below):
+
+   ```bash
+   gh issue create \
+     --title "<item.title>" \
+     --body  "<item.description>\n\n_Created from concept: docs/concepts/{date}-{slug}.html_" \
+     --label "type:<item.type><,role:R><,module:M>" \
+     [--milestone "<item.milestone>"]
+   ```
+
+   Capture the resulting issue number + URL from stdout. On `gh` error,
+   abort this item, surface the error to the user, and continue with
+   the remaining items — partial success beats silent loss.
+
+4. **Project label enrichment (role / module).** Before calling `gh`,
+   resolve project-specific labels in this order:
+   - If `item.role` / `item.module` is set in the payload → use directly.
+   - Else, check the project's `devops-new-issue` extension
+     (`{project}/.claude/skills/new-issue/reference.md` / `SKILL.md`)
+     for the declared label sets. If the concept's slug, file paths, or
+     final-report content unambiguously maps to exactly one role / module
+     value → apply it.
+   - Else → omit the label silently. NEVER ask. A minimal `type:*`-only
+     issue is preferable to interrupting the user.
+
+5. **Issue body composition.** Always end the body with a backlink:
+   `_Created from concept: docs/concepts/{date}-{slug}.html_`. This is
+   how the human reader (and future Claude session) recovers the
+   originating context months later. Prepend whatever richer body the
+   payload's `item.description` carries.
+
+6. Update the final-report HTML: in the open-questions section, replace
    each created item's label with `[Issue #NNN] {title}` (linked to the
    issue URL), disable the checkbox, and add a small ✓ badge.
-5. POST `/reload` so the browser shows the updated state. If every item
+7. POST `/reload` so the browser shows the updated state. If every item
    was processed, the "Issues erstellen" button auto-hides on reload
    (panel JS gates it on the presence of un-created checkable items).
-6. Then POST `/reset` with the captured `_version` as usual.
-7. The concept session stays open — the user may still review previous
+8. Then POST `/reset` with the captured `_version` as usual.
+9. The concept session stays open — the user may still review previous
    iteration tabs but cannot trigger further iterate/implement actions
    from the final report.
 

--- a/plugins/devops/skills/devops-concept/deep-knowledge/bridge-server.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/bridge-server.md
@@ -89,11 +89,29 @@ AND provides HTTP endpoints for heartbeat and decision exchange.
        If the output is exactly "true" → fetch the full payload and process:
          Bash: curl -s http://localhost:{port}/decisions
          • Parse the JSON. Note `_version`. Strip `_version` and `_processed_at`
-           before treating the rest as decision data.
-         • Process per Step 5 (Live Feedback Loop) — act on the user's choices
+           before treating the rest as decision data. Read `action` — it is
+           one of FOUR values, each with its own SKILL.md Step 5b branch:
+             - "iterate"        → next iteration on the concept page only
+             - "implement"      → apply real code changes + final-report
+             - "create-issues"  → autonomously run `gh issue create` for each
+                                  payload item; NO AskUserQuestion, the user
+                                  already committed by clicking the button
+             - "dispose-concept"→ record disposition, advance to Step 6
+           Process per Step 5 (Live Feedback Loop) — act on the user's choices
            (approve/tweak/reject, included options, comment-driven tweaks).
            Step 5c writes the new iteration to the HTML file and POSTs
            `/reload` BEFORE the reset below. Reset is the LAST action.
+
+         • **Zero-prompt invariant for create-issues + dispose-concept.**
+           These two branches MUST complete end-to-end without asking the
+           user anything. The payload (items[] for create-issues,
+           disposition{} for dispose-concept) is self-sufficient by design;
+           any missing optional field falls back to a sane default. If you
+           catch yourself reaching for AskUserQuestion in either branch,
+           stop — the answer is in the payload, the concept HTML, or the
+           project's new-issue extension. The user signed off by clicking
+           the button.
+
          • After the file rewrite AND the `/reload` POST have completed,
            reset conditionally — pass the noted version:
            Bash: curl -s -o /dev/null -w "%{http_code}" -X POST \

--- a/plugins/devops/skills/devops-concept/deep-knowledge/templates.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/templates.md
@@ -2749,11 +2749,23 @@ async function submitCreateIssues() {
     .filter(el => el.checked)
     .map(el => {
       const labelEl = el.closest('label')?.querySelector('.oq-label');
+      const labelText = labelEl ? labelEl.textContent.trim() : '';
+      // description = explicit data-issue-body wins; otherwise the visible
+      // .oq-label text. Either is enough for Claude to skip the
+      // devops-new-issue AskUserQuestion path — the user has already
+      // committed by clicking "Issues erstellen", we MUST NOT ask again.
+      const body = el.dataset.issueBody || labelText;
       return {
         id: el.name || el.id || '',
-        title: el.dataset.issueTitle
-            || (labelEl ? labelEl.textContent.trim() : ''),
+        title: el.dataset.issueTitle || labelText,
         type: el.dataset.issueType || 'chore',
+        description: body,
+        // Optional project-specific label hints — picked up by Claude when
+        // present, silently ignored when absent. Concept HTML is generated
+        // by Claude, so these are populated from concept context.
+        role: el.dataset.issueRole || null,
+        module: el.dataset.issueModule || null,
+        milestone: el.dataset.issueMilestone || null,
         selected: true
       };
     });
@@ -3400,8 +3412,15 @@ section TOC automatically. Open questions / TODOs use a dedicated
   </section>
 
   <!-- Optional — render only when there are real follow-ups to track.
-       Each <li> is one item; data-issue-title + data-issue-type drive
-       the "Issues erstellen" payload. Checkboxes default to `checked`. -->
+       Each <li> is one item; data-issue-* attributes feed the
+       "Issues erstellen" payload directly so Claude can call
+       `gh issue create` end-to-end without ever asking the user a
+       follow-up question. Mandatory attrs: data-issue-title,
+       data-issue-type. Recommended: data-issue-body (richer description
+       than the visible label; falls back to the .oq-label text).
+       Optional project-context hints (only when Claude can infer them
+       from the concept): data-issue-role, data-issue-module,
+       data-issue-milestone. Checkboxes default to `checked`. -->
   <section id="open-questions"
            data-nav-label="{{final.open_questions}}"
            data-open-questions>
@@ -3413,6 +3432,9 @@ section TOC automatically. Open questions / TODOs use a dedicated
                  name="oq-saml-edge"
                  data-issue-title="[BUG] Auth fails for SAML users"
                  data-issue-type="bug"
+                 data-issue-body="During smoke test of the new middleware, SAML logins failed with 'invalid assertion'. Out of scope for the auth-middleware-redesign concept (concept covered OIDC only). Reproduce: log in via SAML IdP in staging."
+                 data-issue-role="backend"
+                 data-issue-module="auth"
                  checked>
           <span class="oq-label">Auth fails for SAML users — observed during smoke test, out of scope here</span>
         </label>
@@ -3423,6 +3445,8 @@ section TOC automatically. Open questions / TODOs use a dedicated
                  name="oq-docs-refresh"
                  data-issue-title="[DOCS] Update auth README"
                  data-issue-type="docs"
+                 data-issue-body="auth/README.md still describes the old middleware contract (session-token cookie). Update to reflect the new bearer-token flow shipped under the auth-middleware-redesign concept."
+                 data-issue-module="auth"
                  checked>
           <span class="oq-label">Update auth README to reflect new middleware contract</span>
         </label>
@@ -3441,13 +3465,23 @@ section TOC automatically. Open questions / TODOs use a dedicated
 
 ### Open-questions item attributes
 
-| Attribute | Purpose |
-|---|---|
-| `name` (or `id`) | Stable identifier reused in the `create-issues` payload's `item.id` |
-| `data-issue-title` | Verbatim title used by `devops-new-issue` (`[TYPE] Imperative title`). REQUIRED for the button to produce a valid GitHub issue |
-| `data-issue-type` | Maps to the issue label (`bug`, `feature`, `refactor`, `chore`, `docs`, `design`). Defaults to `chore` if omitted |
-| `checked` | Default `true` — user opts out, not in |
-| `disabled` | Set by Claude after the item has been routed (becomes `[Issue #NNN]`) so the gating logic in `updateCreateIssuesPanel()` ignores it |
+The first three attributes are MANDATORY for the auto-issue pipeline.
+Without them Claude has no way to land a complete `gh issue create` call
+and would have to fall back to interactive prompting — which is exactly
+the regression we are designing against. Generate them when you author
+the final-report block; do not leave the user to fill them in.
+
+| Attribute | Required? | Purpose |
+|---|---|---|
+| `name` (or `id`) | yes | Stable identifier reused in the `create-issues` payload's `item.id` |
+| `data-issue-title` | yes | Verbatim title used by `gh issue create` (`[TYPE] Imperative title`). Without this the payload's `title` falls back to the visible `.oq-label` text, which usually breaks the title-format gate |
+| `data-issue-type` | yes | Maps to the issue label (`bug`, `feature`, `refactor`, `chore`, `docs`, `design`). Defaults to `chore` if omitted — set it explicitly |
+| `data-issue-body` | recommended | Multi-sentence description used as the GitHub issue body. Falls back to the `.oq-label` text when missing — that is usually too terse for a tracked issue. Always populate this with the concept-context the user would need to act on the issue cold (repro steps for bugs, motivation for refactors, etc.) |
+| `data-issue-role` | optional | Project-specific role label hint (`backend`, `frontend`, `infra`, …). Picked up when the project's `devops-new-issue` extension defines `role:*` labels; silently ignored otherwise |
+| `data-issue-module` | optional | Project-specific module label hint (`auth`, `ingest`, `ui-core`, …). Same gating as `role` |
+| `data-issue-milestone` | optional | Milestone name to attach. Claude will only honor this if the milestone already exists; never auto-creates one from this attribute |
+| `checked` | default `true` | User opts out, not in |
+| `disabled` | set by Claude | Added after the item has been routed (becomes `[Issue #NNN]`) so the gating logic in `updateCreateIssuesPanel()` ignores it on the next reload |
 
 ### After issues are created — HTML rewrite pattern
 

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.86.1",
+  "version": "0.86.2",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

Final-Report "Issues erstellen" landet `gh issue create` jetzt vollautomatisch — kein JSON-Copy aus der Browser-Console, keine Rückfrage je Item. Drei verkettete Doc/JS-Änderungen im `/devops-concept` Skill schließen die Lücke, durch die der Pfad bisher in den interaktiven `devops-new-issue` Step 1 fiel.

- **`submitCreateIssues` payload** trägt jetzt `description` (aus `data-issue-body` mit `.oq-label`-Fallback) plus optionale `role` / `module` / `milestone` Hints — damit hat Claude im Cron-Pickup alle Felder die `gh issue create` braucht.
- **SKILL.md Step 5b · create-issues** komplett umgeschrieben mit hartem "Zero-prompt invariant" Block: direkter `gh`-Aufruf statt `devops-new-issue`, 3-stufige Label-Auflösung (Payload → Projekt-Extension → silent omit), verpflichtender Concept-Backlink im Issue-Body, partial-success über mehrere Items.
- **bridge-server.md Cron-Prompt** zählt alle 4 `action`-Werte (`iterate` / `implement` / `create-issues` / `dispose-concept`) explizit auf, mit dediziertem Zero-prompt-Callout für die beiden Final-Report-Aktionen.
- HTML-Template + Attribute-Tabelle dokumentieren `data-issue-body` / `-role` / `-module` / `-milestone` mit Required/Recommended/Optional-Markern, sodass beim Generieren der Final-Report klar ist welche Felder zu setzen sind.

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` — 166/166 across 11 files
- [ ] Manual end-to-end: nächste Concept-Session bis Final-Report durchziehen, "Issues erstellen" klicken, prüfen dass GH-Issues ohne Rückfrage angelegt werden mit Backlink im Body