### PR TITLE
fix(concept): bridge-server URL docs + watchdog default (0.86.3)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.86.2"
+    "version": "0.86.3"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.86.2",
+      "version": "0.86.3",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.86.2",
+      "version": "0.86.3",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.86.3] — 2026-05-28
+
+### Fixed
+
+- **plugins/devops/skills/devops-concept/SKILL.md** + **deep-knowledge/bridge-server.md** — bridge-server is `SimpleHTTPRequestHandler`-based and `os.chdir()`s into the project root, so URLs must include the full relative path. Docs incorrectly used basename routing (`{filename}` / `$(basename $HTML_PATH)`) which returns 404. Replaced with `{html_path}` / `$HTML_PATH` across all three platform invocations (Windows `start "" msedge`, macOS `open -a`, Linux `microsoft-edge`). Closes #173.
+
+### Changed
+
+- **plugins/devops/scripts/concept-server.py** — `--heartbeat-timeout-ms` default bumped from `300000` (5 min) to `1800000` (30 min). The original 5-minute window was calibrated for active coding sessions; concept-review flows have long user-idle phases (reading variants, comparing options) that exceeded the threshold and triggered spurious `[watchdog] claude_ts stale` shutdowns. **deep-knowledge/bridge-server.md** documents the new default and the rationale for the higher value, plus how to override for active coding sessions. Closes #174.
+
 ## [0.86.2] — 2026-05-28
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.86.2**
+**Version: 0.86.3**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.86.2",
+  "version": "0.86.3",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/scripts/concept-server.py
+++ b/plugins/devops/scripts/concept-server.py
@@ -42,7 +42,7 @@ A background **watchdog daemon** terminates the process when:
   (10 s grace covers the brief window during which Claude rewrites the
   file in-place for the next iteration). This catches "concept HTML was
   manually deleted / moved / never persisted" without needing the cron.
-- `_claude_ts` is older than `--heartbeat-timeout-ms` (default 5 min)
+- `_claude_ts` is older than `--heartbeat-timeout-ms` (default 30 min)
   AND non-zero. A claude_ts of 0 means Claude has never pinged — that
   is the bootstrap window before the first cron tick lands, NOT a dead
   cron, so the watchdog tolerates it indefinitely until the first POST.
@@ -464,9 +464,11 @@ if __name__ == '__main__':
                         help='Relative path to the concept HTML inside <directory>. '
                              'When set, the watchdog terminates the server if this '
                              'file disappears for more than 10 s.')
-    parser.add_argument('--heartbeat-timeout-ms', type=int, default=5 * 60 * 1000,
+    parser.add_argument('--heartbeat-timeout-ms', type=int, default=30 * 60 * 1000,
                         help='Max age of _claude_ts before the watchdog terminates. '
-                             'Default 300000 (5 min).')
+                             'Default 1800000 (30 min). Calibrated for concept-review '
+                             'flows with long user-idle phases. Pass a lower value '
+                             '(e.g. 300000) for active coding sessions.')
     args = parser.parse_args()
 
     port = int(args.port)

--- a/plugins/devops/skills/devops-concept/SKILL.md
+++ b/plugins/devops/skills/devops-concept/SKILL.md
@@ -415,13 +415,13 @@ a new tab. The exact command per platform:
 
 ```bash
 # Windows (this project's primary target)
-start "" msedge "http://localhost:$PORT/$(basename $HTML_PATH)"
+start "" msedge "http://localhost:$PORT/$HTML_PATH"
 
 # macOS
-open -a "Microsoft Edge" "http://localhost:$PORT/$(basename $HTML_PATH)"
+open -a "Microsoft Edge" "http://localhost:$PORT/$HTML_PATH"
 
 # Linux
-microsoft-edge "http://localhost:$PORT/$(basename $HTML_PATH)" &
+microsoft-edge "http://localhost:$PORT/$HTML_PATH" &
 ```
 
 The empty `""` on Windows is required — without it, `cmd.exe` interprets

--- a/plugins/devops/skills/devops-concept/deep-knowledge/bridge-server.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/bridge-server.md
@@ -45,10 +45,16 @@ AND provides HTTP endpoints for heartbeat and decision exchange.
    if the concept HTML file disappears for > 10 s, the watchdog terminates
    the bridge automatically — no orphan server can survive a manual
    `rm docs/concepts/…`, a failed disposition step, or a worktree wipe.
-   The watchdog ALSO terminates if Claude's heartbeat goes stale for > 5
-   min (`--heartbeat-timeout-ms` default `300000`), catching the dead-cron
+   The watchdog ALSO terminates if Claude's heartbeat goes stale for > 30
+   min (`--heartbeat-timeout-ms` default `1800000`), catching the dead-cron
    case (session closed without /shutdown, cron prompt loop dropped). Both
    conditions independently guarantee the server cannot become a ghost.
+
+   The 30 min default is calibrated for concept-review flows where the user
+   may read, think, and annotate for an extended period before submitting —
+   short idle pauses are expected and should not kill the server. Active
+   coding sessions with a tighter watchdog requirement can pass a lower value
+   (e.g. `--heartbeat-timeout-ms 300000` for 5 min) explicitly.
 
 3. Set up the **combined heartbeat + auto-poll cron**. This single cron keeps
    the connection indicator green AND automatically picks up user submissions
@@ -236,7 +242,7 @@ AND provides HTTP endpoints for heartbeat and decision exchange.
 
    ```bash
    # Windows (primary target)
-   start "" msedge "http://localhost:{port}/{filename}"
+   start "" msedge "http://localhost:{port}/{html_path}"
    ```
    On macOS: `open -a "Microsoft Edge" "http://…"`, on Linux: `microsoft-edge "http://…"`.
 

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.86.2",
+  "version": "0.86.3",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

Two coupled fixes around the concept-bridge server.

- **#173** — `SimpleHTTPRequestHandler` requires the full relative path from the chdir'd root. Docs used basename-only URLs (`{filename}` / `$(basename $HTML_PATH)`) which 404'd. Replaced with `{html_path}` / `$HTML_PATH` across `SKILL.md` (all three platform invocations) and `bridge-server.md`.
- **#174** — Default `--heartbeat-timeout-ms` was 5 min, calibrated for active coding. Concept-review flows have long user-idle phases (reading variants, comparing options) and the watchdog killed the bridge mid-review. Bumped default to 30 min in `concept-server.py` and documented the trade-off + override in `bridge-server.md`.

Closes #173, #174.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm test` — 166/166 passed
- [ ] Manual: start concept-server with new default, observe no spurious shutdown across ≥6 min idle
- [ ] Manual: verify `http://localhost:$PORT/docs/concepts/...html` returns 200

## Files changed
- `plugins/devops/scripts/concept-server.py` — default 300000 → 1800000, help text + docstring updated
- `plugins/devops/skills/devops-concept/SKILL.md` — basename → full path (3 lines)
- `plugins/devops/skills/devops-concept/deep-knowledge/bridge-server.md` — full-path docs + watchdog rationale
- `CHANGELOG.md` — 0.86.3 entry
- Version files bumped to 0.86.3