### PR TITLE
fix(concept): scroll to top on Claude-driven reload (0.86.4)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.86.3"
+    "version": "0.86.4"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.86.3",
+      "version": "0.86.4",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.86.3",
+      "version": "0.86.4",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.86.4] — 2026-05-28
+
+### Fixed
+
+- **plugins/devops/skills/devops-concept/deep-knowledge/templates.md** — concept pages now scroll to the top when Claude triggers a reload for the next iteration or final-report append. The browser previously restored the previous scroll position, so the user submitted from the bottom of the decision panel, saw the page visually unchanged, and only noticed the new iteration because the active iteration tab moved. `pollReload` now stamps a `sessionStorage` flag (`_concept_jumpTop`) immediately before `location.reload()`, and a fresh IIFE on the next load consumes the flag, disables `history.scrollRestoration`, and forces `window.scrollTo(0, 0)` three times (sync at script eval, on `DOMContentLoaded`, on `load`) to win the race against late browser restorations. Manual F5 while reading does not set the flag and keeps the previous scroll position unchanged.
+
 ## [0.86.3] — 2026-05-28
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.86.3**
+**Version: 0.86.4**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.86.3",
+  "version": "0.86.4",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/skills/devops-concept/deep-knowledge/templates.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/templates.md
@@ -3354,6 +3354,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
 ### Reload Polling
 
+A Claude-driven reload (next iteration / final-report append) MUST land the
+user at the top of the page. Without this, the browser restores the previous
+scroll position — the user submitted from the bottom of the decision panel,
+sees the page "do nothing" visually, and only notices the change because the
+iteration tab moved. The sessionStorage flag scopes the jump to reloads we
+triggered, so manual F5 while reading still preserves scroll position.
+
 ```javascript
 let _bootReloadCounter = null;
 async function pollReload() {
@@ -3363,12 +3370,29 @@ async function pollReload() {
     const { counter } = await res.json();
     if (_bootReloadCounter === null) { _bootReloadCounter = counter; return; }
     if (counter > _bootReloadCounter) {
+      // Tag the reload as Claude-driven so the fresh load jumps to top.
+      try { sessionStorage.setItem('_concept_jumpTop', '1'); } catch (_) {}
       location.reload();
     }
   } catch (e) { /* bridge offline */ }
 }
 setInterval(pollReload, 3000);
 document.addEventListener('DOMContentLoaded', pollReload);
+
+// Disable the browser's scroll restoration for Claude-driven reloads and
+// force scroll to top. Runs before any layout-affecting init, and again on
+// `load` to win against late restorations on slower browsers.
+(function () {
+  let pending = false;
+  try { pending = sessionStorage.getItem('_concept_jumpTop') === '1'; } catch (_) {}
+  if (!pending) return;
+  try { sessionStorage.removeItem('_concept_jumpTop'); } catch (_) {}
+  if ('scrollRestoration' in history) history.scrollRestoration = 'manual';
+  const jump = () => window.scrollTo(0, 0);
+  jump();
+  document.addEventListener('DOMContentLoaded', jump);
+  window.addEventListener('load', jump);
+})();
 ```
 
 ## Final Report Panel

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.86.3",
+  "version": "0.86.4",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

Concept pages now jump back to the top whenever the bridge-server triggers `location.reload()` for a new iteration or final-report append. The browser previously restored the previous scroll position, so after submitting from the bottom of the decision panel the user saw the page visually unchanged and only noticed the new iteration because the active iteration tab moved.

## How

- `pollReload` stamps a `sessionStorage` flag (`_concept_jumpTop`) immediately before `location.reload()`.
- A fresh IIFE on the next load consumes the flag, disables `history.scrollRestoration`, and forces `window.scrollTo(0, 0)` three times (sync at script eval, `DOMContentLoaded`, `load`) to beat the browser's scroll-restore race on slower browsers.
- Manual F5 while reading does not set the flag → scroll position preserved.

## Scope

Generated concept pages copy the snippet from `deep-knowledge/templates.md` verbatim, so the fix applies to all future concept pages. Existing on-disk concept HTML files are not patched.

## Test plan

- [x] `npm run lint`
- [x] `npm run test` (166 tests)
- [ ] Manual: open a concept page, scroll to bottom of decision panel, submit iterate → new iteration loads scrolled to top
- [ ] Manual: scroll mid-page, hit F5 → scroll position preserved