### PR TITLE
fix(concept): gate concept browser-open on HTTP 200 (0.86.5)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.86.4"
+    "version": "0.86.5"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.86.4",
+      "version": "0.86.5",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.86.4",
+      "version": "0.86.5",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.86.5] — 2026-05-29
+
+### Fixed
+
+- **plugins/devops/skills/devops-concept/SKILL.md** + **deep-knowledge/bridge-server.md** — hardened the concept browser-open against a second, independent cause of the "concept url not found" symptom that the #173 basename fix did not cover. The open command used `$PORT`/`$HTML_PATH` shell variables, but each Bash tool call is a fresh shell with no inherited state — if the server was launched in an earlier call, the variables were empty here and the URL collapsed to `http://localhost:/`. The open step now builds the URL once and **gates on a real HTTP 200 check** before opening a tab: any 404 cause (wrong path, empty variables, or a worktree/main-root cwd mismatch) now aborts loudly with the offending URL instead of silently opening a broken tab. Both docs also state explicitly that the variables must be set in the same shell or substituted with concrete literals. Closes #177 follow-up.
+
 ## [0.86.4] — 2026-05-28
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.86.4**
+**Version: 0.86.5**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.86.4",
+  "version": "0.86.5",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/skills/devops-concept/SKILL.md
+++ b/plugins/devops/skills/devops-concept/SKILL.md
@@ -414,14 +414,30 @@ that hands the URL to the user's default Edge window, which then opens
 a new tab. The exact command per platform:
 
 ```bash
+# Build the URL ONCE. $PORT and $HTML_PATH must be set in THIS SAME Bash
+# call — shell state does NOT survive across separate tool calls, so if you
+# launched the server in an earlier call these are empty here and the URL
+# collapses to "http://localhost:/" (the "concept url not found" symptom).
+# Either re-set them in this call or inline the concrete port + path. The
+# path is project-root-relative (the server's cwd), e.g.
+# docs/concepts/{date}-{slug}.html — it MUST equal the --html value exactly.
+URL="http://localhost:$PORT/$HTML_PATH"
+
+# Gate the open on a real 200 — NEVER open a tab on a 404. This single check
+# catches every cause of "concept url not found": wrong path (bare filename
+# vs full relative path), a server cwd that does not contain the file
+# (worktree/main-root mismatch), and empty $PORT/$HTML_PATH.
+CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 3 "$URL")
+[ "$CODE" = "200" ] || { echo "Concept URL $URL -> HTTP $CODE (expected 200) - aborting open. Check the server cwd contains $HTML_PATH and that \$PORT/\$HTML_PATH are set in this shell."; exit 1; }
+
 # Windows (this project's primary target)
-start "" msedge "http://localhost:$PORT/$HTML_PATH"
+start "" msedge "$URL"
 
 # macOS
-open -a "Microsoft Edge" "http://localhost:$PORT/$HTML_PATH"
+open -a "Microsoft Edge" "$URL"
 
 # Linux
-microsoft-edge "http://localhost:$PORT/$HTML_PATH" &
+microsoft-edge "$URL" &
 ```
 
 The empty `""` on Windows is required — without it, `cmd.exe` interprets

--- a/plugins/devops/skills/devops-concept/deep-knowledge/bridge-server.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/bridge-server.md
@@ -237,14 +237,40 @@ AND provides HTTP endpoints for heartbeat and decision exchange.
    self-pulse keeps `server_ts` fresh even when the request-handling
    thread is wedged.
 
-6. **Open the page in the user's real Edge browser** (reuses the running
-   instance, adds a tab). This step is non-negotiable:
+6. **Verify the concept URL serves 200, THEN open it in the user's real
+   Edge browser** (reuses the running instance, adds a tab). Both halves are
+   non-negotiable. The 200-gate exists because opening a tab on a 404 IS the
+   "concept url not found" the user sees, and that 404 has three independent
+   causes the bare open command cannot tell apart:
+   - wrong URL path — a bare filename instead of the full project-relative
+     `{html_path}` (`SimpleHTTPRequestHandler` serves from the server's cwd,
+     so `/foo.html` 404s when the file is at `docs/concepts/foo.html`);
+   - the server's cwd does not contain `{html_path}` — e.g. the bridge was
+     started in the worktree root while the HTML was written to the main
+     project tree, or vice-versa;
+   - empty `{port}`/`{html_path}` — the values were left as shell vars that
+     did not survive into this command, collapsing the URL to
+     `http://localhost:/`.
+
+   Gate the open on a real 200 so any of these aborts loudly with the
+   offending URL instead of opening a silent broken tab:
 
    ```bash
+   # Substitute {port} and {html_path} with CONCRETE literal values — do NOT
+   # rely on $PORT/$HTML_PATH surviving from an earlier command; each Bash
+   # tool call is a fresh shell with no inherited state.
+   URL="http://localhost:{port}/{html_path}"
+   CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 3 "$URL")
+   if [ "$CODE" != "200" ]; then
+     echo "Concept URL $URL -> HTTP $CODE (expected 200) - NOT opening a tab."
+     echo "Fix: ensure the bridge server's cwd is the project root holding {html_path}, and that {port}/{html_path} are concrete values."
+     exit 1
+   fi
+
    # Windows (primary target)
-   start "" msedge "http://localhost:{port}/{html_path}"
+   start "" msedge "$URL"
    ```
-   On macOS: `open -a "Microsoft Edge" "http://…"`, on Linux: `microsoft-edge "http://…"`.
+   On macOS: `open -a "Microsoft Edge" "$URL"`, on Linux: `microsoft-edge "$URL" &`.
 
    The empty `""` is required on Windows — without it, `cmd.exe` interprets
    the first quoted argument as a window title.

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.86.4",
+  "version": "0.86.5",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary
Hardens the `devops-concept` browser-open against a second, independent cause of the "concept url not found" symptom that the #173 basename fix did not cover.

The open command relied on `$PORT`/`$HTML_PATH` shell variables, but each Bash tool call is a fresh shell with no inherited state — if the server was launched in an earlier call, the variables were empty and the URL collapsed to `http://localhost:/`. The open step now builds the URL once and **gates on a real HTTP 200 check**: any 404 cause (wrong path, empty variables, worktree/main-root cwd mismatch) aborts loudly with the offending URL instead of opening a silent broken tab.

## Changes
- **SKILL.md** Step 3 + **bridge-server.md** Step 6 — 200-gate before browser-open + explicit shell-variable-persistence warning
- **CHANGELOG.md** — 0.86.5 entry

## Verification
- Empirical server test: full path → 200, basename → 404, empty vars → 000 (gate aborts on all failure modes)
- `npm test` → 166 passed

Follow-up to #177 / #173.

🤖 Generated with [Claude Code](https://claude.com/claude-code)