### PR TITLE
fix(completion): move state line below build ID, above CTA (0.87.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.87.0"
+    "version": "0.87.1"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.87.0",
+      "version": "0.87.1",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.87.0",
+      "version": "0.87.1",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.87.1] — 2026-05-30
+
+### Changed
+
+- **Completion card layout** — the git-state line (merge target / PR / commit / branch) now renders in the footer block, between the build-ID line (`📌 …`) and the final CTA, instead of at the top of the content block under Changes/Tests. Status info now clusters at the foot of the card next to the CTA, which already references the merge target / branch. Affects every card variant that shows state (`render_completion_card` in `plugins/devops/mcp-server/index.js`).
+
 ## [0.87.0] — 2026-05-30
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.87.0**
+**Version: 0.87.1**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.87.0",
+  "version": "0.87.1",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/mcp-server/index.js
+++ b/plugins/devops/mcp-server/index.js
@@ -454,22 +454,6 @@ function renderCard(input, meterText, buildId) {
     }
   }
 
-  // Block B — End state (with extra blank line above for visual separation)
-  if (config.state) {
-    const repoUrl = getRepoUrl(input.cwd);
-    if (!repoUrl && input.state && (input.state.pr || input.state.merged || input.state.commit || input.state.branch)) {
-      console.warn(
-        '[dotclaude-completion-mcp] repoUrl empty — card will render without clickable links. ' +
-        'Pass cwd set to the target repo to fix.'
-      );
-    }
-    const stateLine = renderState(input.state, variant, repoUrl);
-    if (stateLine) {
-      parts.push(stateLine);
-      parts.push('');
-    }
-  }
-
   // User test steps (test variant)
   if (config.userTest) {
     const testBlock = renderUserTest(input.userTest);
@@ -506,6 +490,23 @@ function renderCard(input, meterText, buildId) {
   // Footer: 📌 version bump + build ID (build ID in backticks for visibility)
   parts.push(renderFooter(buildId, input.cta, variant));
   parts.push('');
+
+  // End state — placed between build ID and CTA, since the CTA often
+  // references this state (merge target / branch). Clusters status near the foot.
+  if (config.state) {
+    const repoUrl = getRepoUrl(input.cwd);
+    if (!repoUrl && input.state && (input.state.pr || input.state.merged || input.state.commit || input.state.branch)) {
+      console.warn(
+        '[dotclaude-completion-mcp] repoUrl empty — card will render without clickable links. ' +
+        'Pass cwd set to the target repo to fix.'
+      );
+    }
+    const stateLine = renderState(input.state, variant, repoUrl);
+    if (stateLine) {
+      parts.push(stateLine);
+      parts.push('');
+    }
+  }
 
   parts.push(renderCTA(variant, input.cta, lang, input.state));
   parts.push('');

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.87.0",
+  "version": "0.87.1",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary
The git-state line (merge target / PR / commit / branch) in the completion card was rendered at the top of the content block, under Changes/Tests. It now renders in the footer block — between the build-ID line (`📌 …`) and the final CTA — so status info clusters at the foot next to the CTA, which already references the merge target / branch.

## Changes
- `render_completion_card` (`plugins/devops/mcp-server/index.js`): state-line block moved from Block B to Block C, repoUrl resolution moved with it.

## Tests
- Lint clean, 166 vitest tests pass. `node --check` clean.