### PR TITLE
fix(completion): pop headline, grey subinfo text, spacer above card

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.87.1"
+    "version": "0.87.2"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.87.1",
+      "version": "0.87.2",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.87.1",
+      "version": "0.87.2",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.87.2] — 2026-05-30
+
+### Changed
+
+- **Completion card emphasis** — the card now builds a clearer visual hierarchy via Markdown constructs (the renderer only picks constructs; the terminal theme colors them). The headline renders as `# ` H1 **bold** so it stands out instead of muted heading-grey; a forced `&nbsp;` spacer line above the opening `---` detaches the card from the preceding response text; and the subinfo blocks (Changes, Tests, git-state, build-ID footer) are wrapped in blockquotes to grey their text baseline. Icons, `code`, links (merge target / PR / commit) and bold keep their own color, so the merge target and the CTA still pop. The `✨✨✨` card-detection marker stays intact. `render_completion_card` in `plugins/devops/mcp-server/index.js`.
+
 ## [0.87.1] — 2026-05-30
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.87.1**
+**Version: 0.87.2**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.87.1",
+  "version": "0.87.2",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/mcp-server/index.js
+++ b/plugins/devops/mcp-server/index.js
@@ -254,7 +254,17 @@ function getBuildId(overrideCwd) {
 }
 
 function renderTitle(summary) {
-  return '## \u2728\u2728\u2728 ' + summary + ' \u2728\u2728\u2728';
+  // H1 + bold so the headline stands out instead of rendering in the muted
+  // heading-grey. Stays OUTSIDE any blockquote \u2014 it must pop, not dim.
+  return '# **\u2728\u2728\u2728 ' + summary + ' \u2728\u2728\u2728**';
+}
+
+// Dim a text block to the muted blockquote color. Only the plain-text baseline
+// is affected \u2014 emojis (font-rendered), `code`, links, and **bold** keep their
+// own color inside the quote, so icons and merge/PR/commit links still pop.
+function blockquote(block) {
+  if (!block) return block;
+  return block.split('\n').map(l => (l.length ? '> ' + l : '>')).join('\n');
 }
 
 function renderFooter(buildId, cta, variant) {
@@ -431,6 +441,13 @@ function renderCard(input, meterText, buildId) {
 
   const parts = [];
 
+  // Spacer above the card — one forced blank line (&nbsp; survives the
+  // renderer's blank-line collapsing) detaches the card from the preceding
+  // response text. The trailing '' keeps the opening --- a thematic break
+  // rather than turning &nbsp; into a setext heading.
+  parts.push('&nbsp;');
+  parts.push('');
+
   // Block A — Title + Content (no build ID in title)
   parts.push('---');
   parts.push('');
@@ -441,7 +458,7 @@ function renderCard(input, meterText, buildId) {
   if (config.changes) {
     const changesBlock = renderChanges(input.changes);
     if (changesBlock) {
-      parts.push(changesBlock);
+      parts.push(blockquote(changesBlock));
       parts.push('');
     }
   }
@@ -449,7 +466,7 @@ function renderCard(input, meterText, buildId) {
   if (config.tests) {
     const testsBlock = renderTests(input.tests);
     if (testsBlock) {
-      parts.push(testsBlock);
+      parts.push(blockquote(testsBlock));
       parts.push('');
     }
   }
@@ -488,7 +505,8 @@ function renderCard(input, meterText, buildId) {
   }
 
   // Footer: 📌 version bump + build ID (build ID in backticks for visibility)
-  parts.push(renderFooter(buildId, input.cta, variant));
+  // Greyed as meta/subinfo — the 📌 icon and `build-id` code stay colored.
+  parts.push(blockquote(renderFooter(buildId, input.cta, variant)));
   parts.push('');
 
   // End state — placed between build ID and CTA, since the CTA often
@@ -503,7 +521,9 @@ function renderCard(input, meterText, buildId) {
     }
     const stateLine = renderState(input.state, variant, repoUrl);
     if (stateLine) {
-      parts.push(stateLine);
+      // Greyed text baseline; the merge/PR/commit links inside keep their
+      // link color, so the merge target still pops as the user wanted.
+      parts.push(blockquote(stateLine));
       parts.push('');
     }
   }

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.87.1",
+  "version": "0.87.2",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

Sharper visual hierarchy for the completion card, driven entirely by Markdown construct choice (the terminal theme colors the constructs):

- **Headline pops** — now `# ` H1 + **bold** instead of the muted `##` heading-grey.
- **Spacer above card** — a forced `&nbsp;` line above the opening `---` detaches the card from the preceding response text.
- **Subinfos greyed** — Changes, Tests, git-state and the build-ID footer are wrapped in blockquotes so their text baseline dims. Icons, `code`, links (merge target / PR / commit) and **bold** keep their color, so the merge target and the CTA still stand out.

The `✨✨✨` card-detection marker stays contiguous, so the stop-hook card guard is unaffected.

## Tests

- `npm run lint` — clean
- `npm test` — 166 passed