### PR TITLE
fix(ship): ExitWorktree no-op → forced-keep, not keep (0.87.3)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.87.2"
+    "version": "0.87.3"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.87.2",
+      "version": "0.87.3",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.87.2",
+      "version": "0.87.3",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.87.3] — 2026-05-30
+
+### Fixed
+
+- **plugins/devops/skills/devops-ship/SKILL.md** — Step 5b now handles the case where `ExitWorktree` returns a No-op because the worktree was created externally (by the harness or `git worktree add`) rather than via `EnterWorktree` in the session. Previously this fell through to `ship_cleanup keep:true`, which set `state.kept:true` on the completion card and rendered the keep-mode CTA `WEITER in <branch>` — falsely signalling expected follow-up work. The skill now distinguishes **forced-keep** (cleanup blocked by an active worktree) from **deliberate keep-mode** (Step 5c, expected follow-up): forced-keep clears the sentinel but renders the normal DONE CTA plus a manual-cleanup note, and never passes `state.kept`.
+
 ## [0.87.2] — 2026-05-30
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.87.2**
+**Version: 0.87.3**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.87.2",
+  "version": "0.87.3",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/skills/devops-ship/SKILL.md
+++ b/plugins/devops/skills/devops-ship/SKILL.md
@@ -361,6 +361,20 @@ what was decided and can override (`"nein, doch räum auf"` for a follow-up clea
 If `ExitWorktree` **fails** (e.g. directory locked by another process): **STOP**. Do not proceed to cleanup.
 Report the error to the user. The merge already landed on GitHub — cleanup can be retried later.
 
+**If `ExitWorktree` returns a No-op** (the worktree was created externally — by the harness or
+`git worktree add` — not via `EnterWorktree` in this session): the tool cannot release the CWD
+lock and `ship_cleanup` will refuse (`"attached to an active worktree"`). Do **NOT** force-remove
+the directory the session lives in — that would break the session. This is **forced-keep**, NOT
+deliberate keep-mode:
+- Clear the sentinel with `ship_cleanup({ ..., keep: true })` (same call as Step 5c) so Edit/branch
+  guards reset — but treat it purely as sentinel cleanup.
+- In Step 6, render the **normal** DONE CTA — do **NOT** pass `state.kept: true`. Keep-mode's
+  `WEITER in <branch>` CTA is reserved for *deliberate* keep (expected follow-up work); a worktree
+  kept only because cleanup was blocked must not signal "keep coding here".
+- Instead, add a short manual-cleanup note **above** the card (close the session, then from the main
+  repo: `git worktree remove <path>` + `git branch -d <branch>`).
+- Skip the rest of Step 5b/5c.
+
 Then call `ship_cleanup` MCP tool with the `base` from Step 1 (always pass `cwd`):
 ```
 ship_cleanup({ branch: "claude/feature-branch", base: "main", cwd: "<cwd>" })

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.87.2",
+  "version": "0.87.3",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary
When the worktree was created externally (harness / `git worktree add`) rather than via `EnterWorktree`, `ExitWorktree` is a no-op and `ship_cleanup` refuses (`"attached to an active worktree"`). The ship flow fell through to `ship_cleanup keep:true`, which set `state.kept:true` and rendered the keep-mode CTA `WEITER in <branch>` — falsely signalling expected follow-up work.

## Changes
- `plugins/devops/skills/devops-ship/SKILL.md` Step 5b: new branch for the `ExitWorktree` no-op case. Distinguishes **forced-keep** (cleanup blocked by an active worktree → clear sentinel, render normal DONE CTA + manual-cleanup note, never pass `state.kept`) from **deliberate keep-mode** (Step 5c, expected follow-up).

## Tests
- Lint clean, 166 vitest tests pass.