### PR TITLE
feat(docs): self-maintaining README roster + drift guards

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.87.3"
+    "version": "0.88.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.87.3",
+      "version": "0.88.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.87.3",
+      "version": "0.88.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.88.0] — 2026-05-30
+
+### Added
+
+- **plugins/devops/scripts/gen-readme-sections.js** — new generator that keeps the roster facts in `README.md` and `docs/architecture.html` permanently in sync with reality. It reads the canonical source (`hooks/hooks.json`, `skills/*/SKILL.md`, `agents/*.md`, `deep-knowledge/*.md`) and rewrites every value inside `<!--devops:count:*-->` inline markers and the `<!--devops:block:hook-lifecycle-->` block — so counts and the full hook lifecycle list can never drift again. Wired into `ship_build` alongside `gen-dk-index` / `gen-project-map`; no-ops outside the plugin source repo. Supports `--check` (exit 1 if any marker is stale), used as both a vitest regression guard (`gen-readme-sections.test.js`) and a ship gate.
+- **plugins/devops/mcp-server/ship/tools/preflight.js** — `ship_preflight` now runs a non-blocking doc-sync check (plugin source repo only): warns when the auto-markers are stale **and** when any skill/agent on disk is missing its curated row in the README tables — the one thing the generator deliberately does not auto-write.
+- **plugins/devops/hooks/session-start/ss.git.check.js** — emits a gentle once-per-8h nudge when `README.md` is older than the `skills/`/`hooks/`/`agents/` roster it documents, reusing the already-running SessionStart hook (no new per-session token overhead).
+- **plugins/devops/CONVENTIONS.md** — new "Auto-Maintained Documentation" section describing the marker system and the three-layer drift defense (generate → preflight verify → session nudge).
+
+### Fixed
+
+- **README.md + docs/architecture.html** — corrected stale roster facts that had drifted across several releases: hook/skill/agent counts (`13/16/10` → real `27/19/11`), the missing `harden`/`polish`/`test-plan` skills and `redteam` agent, the incomplete hook lifecycle list, the `architecture.html` version header (`v0.76.0` → current), and a factual error in the token-guard threshold prose (claimed a flat `2%` of a "session window"; the real gate is a plan-scaled share of the ~200K context window — 5%/8%/10% on Pro/Max5×/Max20×).
+- **plugins/devops/hooks/session-start/ss.permissions.ensure.js**, **ss.mcp.deps.js** — given the standard `@hook`/`@version`/`@event`/`@plugin`/`@description` JSDoc header used by every other hook, so the generator extracts clean descriptions and the roster is uniform.
+
 ## [0.87.3] — 2026-05-30
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Based on ~0.7M tokens/week plugin overhead:
 | Debugging the same error 4 times | /devops-flow kicks in after the second failure |
 | Writing commit messages by hand | Conventional commits, auto-staged, one command |
 
-**Token guard payoff:** The token guard blocks any single operation above 2% of your session window (~20K tokens). In a typical session, Claude attempts 5–15 broad searches or large-file reads that would each burn 20–80K tokens — that's 100–400K tokens/session evaporating into context you never asked for. Across ~10 sessions/week, the guard saves roughly **1–4M tokens/week** in prevented waste. The plugin's own overhead (~0.7M tokens/week for hooks, startup checks, and skill prompts) pays for itself 1.5–6x over just by keeping Claude from reading files it doesn't need.
+**Token guard payoff:** The token guard blocks any single operation above your plan's per-operation share of the ~200K context window — **5% (~10K tokens) on Pro, 8% (~16K) on Max 5×, 10% (~20K) on Max 20×**. In a typical session, Claude attempts 5–15 broad searches or large-file reads that would each burn 20–80K tokens — that's 100–400K tokens/session evaporating into context you never asked for. Across ~10 sessions/week, the guard saves roughly **1–4M tokens/week** in prevented waste. The plugin's own overhead (~0.7M tokens/week for hooks, startup checks, and skill prompts) pays for itself 1.5–6x over just by keeping Claude from reading files it doesn't need.
 
 Your mileage may vary. Your sanity will not.
 
@@ -167,9 +167,9 @@ For the full extension guide with examples per skill, see `deep-knowledge/skill-
 
 ## Features
 
-- **13 Hooks** — automated guards and triggers across the full session lifecycle
-- **16 Skills** — devops-ship, devops-commit, devops-flow, devops-new-issue, devops-project-setup, devops-readme, devops-refresh-usage, devops-extend-skill, devops-repo-health, devops-claude-md-lint, devops-concept, devops-agents, devops-plugin-update, devops-autonomous, devops-burn, devops-learn
-- **10 Agents** — AI, Core, Designer, Feature, Frontend, Gamer, PO, QA, Research, Windows
+- **<!--devops:count:hooks-->27<!--/devops:count:hooks--> Hooks** — automated guards and triggers across the full session lifecycle
+- **<!--devops:count:skills-->19<!--/devops:count:skills--> Skills** — devops-ship, devops-commit, devops-flow, devops-new-issue, devops-project-setup, devops-readme, devops-refresh-usage, devops-extend-skill, devops-repo-health, devops-claude-md-lint, devops-concept, devops-agents, devops-plugin-update, devops-autonomous, devops-burn, devops-learn, devops-harden, devops-polish, devops-test-plan
+- **<!--devops:count:agents-->11<!--/devops:count:agents--> Agents** — AI, Core, Designer, Feature, Frontend, Gamer, PO, QA, Redteam, Research, Windows
 - **Completion Flow** — mandatory card after every task (8 variants), visual verification, ship recommendation
 - **Ship Enforcement** — intent detection, PR command blocking, automatic /devops-ship skill routing
 - **3-Layer Extension Model** — customize any skill or agent per-project without forking
@@ -178,42 +178,58 @@ For the full extension guide with examples per skill, see `deep-knowledge/skill-
 
 ### Hooks (automatic, no user action needed)
 
-13 hooks fire automatically across the session lifecycle — no user action needed.
+<!--devops:count:hooks-->27<!--/devops:count:hooks--> hooks fire automatically across the session lifecycle — no user action needed.
 
 <details>
 <summary><strong>By session lifecycle</strong> — when does it fire?</summary>
 
 ```
-SessionStart  ──>  PreToolUse  ──>  PostToolUse  ──>  UserPromptSubmit  ──>  Stop
+SessionStart  ──>  UserPromptSubmit  ──>  PreToolUse  ──>  PostToolUse  ──>  Stop
 ```
 
+<!--devops:block:hook-lifecycle-->
 #### SessionStart — runs once when a session begins
 
-- `ss.plugin.update` — Check for plugin updates
-- `ss.mcp.deps` — Auto-install MCP server dependencies
-- `ss.tokens.scan` — Scan project for expensive files
-- `ss.git.check` — Check for uncommitted/unpushed changes
-
-#### PreToolUse — runs before each tool call
-
-- `pre.tokens.guard` — Block operations exceeding token budget
-
-#### PostToolUse — runs after each tool call
-
-- `post.flow.completion` — Track code edits for completion flow
-- `post.flow.debug` — Recommend /devops-flow after repeated failures
+- `ss.plugin.update` — Auto-update plugin marketplace clones, rebuild cache, and update registry.
+- `ss.permissions.ensure` — Ensure required plugin permissions exist so devops skills that write ephemeral review…
+- `ss.knowledge.index` — Inject deep-knowledge INDEX.md into context at session start.
+- `ss.mcp.deps` — Auto-install MCP server dependencies into CLAUDE_PLUGIN_DATA.
+- `ss.mcp.envcheck` — Detect enabled plugins whose .mcp.json references env vars that are not set.
+- `ss.tokens.scan` — Scan project for expensive files and update config for the pre.tokens.guard hook.
+- `ss.git.check` — Check for stale changes AND workspace setup issues at session start.
+- `ss.git.sync` — Registers a recurring git sync cron job (every 10 minutes).
+- `ss.ship.verify` — Surface results from the post-merge watcher (post-ship CI + optional deploy verify).
+- `ss.concept.resume` — Recover an open concept session after a Claude restart.
+- `ss.team.changelog` — Show a summary of changes made by other contributors on remote main since the last ti…
 
 #### UserPromptSubmit — runs when the user sends a message
 
-- `prompt.git.sync` — Periodic pull/merge main (every 15 min)
-- `prompt.issue.detect` — Track GitHub issues automatically
-- `prompt.ship.detect` — Detect ship intent, enforce /devops-ship skill
-- `prompt.flow.selfcalibration` — Register self-calibration cron (once per session)
-- `prompt.flow.appstart` — Detect app start intent, enforce completion card
+- `prompt.flow.silent-turn` — Detects background/cron-injected prompts and marks the turn as "silent" so post.flow.…
+- `prompt.knowledge.dispatch` — On-demand deep-knowledge injection based on prompt keywords.
+- `prompt.git.sync` — Throttled git sync on user prompt — delegates to scripts/git-sync.js.
+- `prompt.issue.detect` — Detect issue references in user messages.
+- `prompt.ship.detect` — Detect ship intent in user prompts and inject Skill('devops-ship') instruction.
+- `prompt.flow.appstart` — Detect app start intent in user prompts.
+- `prompt.worktree.branch-guard` — Prevents working on main/master inside a linked worktree.
+
+#### PreToolUse — runs before each tool call
+
+- `pre.tokens.guard` — Block Read/Bash/Glob/Grep operations that would consume a significant percentage of t…
+- `pre.ship.guard` — Block manual PR creation/merging via Bash.
+- `pre.main.guard` — Prevent accidental writes on local main/master.
+- `pre.edit.branch` — Prevent Edit/Write tool calls while HEAD is on local main/master.
+- `pre.mcp.health` — Detects dead or stale MCP servers before tool calls fail cryptically.
+
+#### PostToolUse — runs after each tool call
+
+- `post.flow.completion` — After EVERY tool call: inject the completion-card reminder so Claude always has the i…
+- `post.flow.debug` — After 2+ consecutive Bash failures: recommend the flow skill.
 
 #### Stop — runs when Claude finishes responding
 
-- `stop.flow.guard` — Enforce completion flow before response ends
+- `stop.flow.guard` — Per-turn completion card enforcement.
+- `stop.flow.selfcalibration` — Run self-calibration when Claude finishes a response turn.
+<!--/devops:block:hook-lifecycle-->
 
 </details>
 
@@ -228,31 +244,48 @@ SessionStart  ──>  PreToolUse  ──>  PostToolUse  ──>  UserPromptSubm
 #### git — keep the working tree in sync
 
 - `ss.git.check` — Check for uncommitted/unpushed changes *(SessionStart)*
-- `prompt.git.sync` — Periodic pull/merge main, every 15 min *(UserPromptSubmit)*
+- `ss.git.sync` — Register recurring git-sync cron, every 10 min *(SessionStart)*
+- `prompt.git.sync` — Throttled pull/merge main, every 15 min *(UserPromptSubmit)*
 
 #### ship — enforce the shipping pipeline
 
+- `pre.ship.guard` — Block manual PR/merge via Bash *(PreToolUse)*
 - `prompt.ship.detect` — Detect ship intent, enforce /devops-ship skill *(UserPromptSubmit)*
+- `ss.ship.verify` — Surface post-merge watcher results *(SessionStart)*
 
 #### flow — track progress toward completion
 
-- `post.flow.completion` — Track code edits for completion flow *(PostToolUse)*
+- `post.flow.completion` — Track code edits, inject completion reminder *(PostToolUse)*
 - `post.flow.debug` — Recommend /devops-flow after repeated failures *(PostToolUse)*
 - `prompt.flow.appstart` — Detect app start intent, enforce completion card *(UserPromptSubmit)*
+- `prompt.flow.silent-turn` — Mark background/cron-injected turns *(UserPromptSubmit)*
+- `stop.flow.guard` — Enforce completion card before response ends *(Stop)*
+- `stop.flow.selfcalibration` — Run self-calibration at end of turn *(Stop)*
 
-#### flow — self-calibration
+#### branch — protect main and worktrees
 
-- `prompt.flow.selfcalibration` — Register self-calibration cron, once per session *(UserPromptSubmit)*
-- `stop.flow.guard` — Enforce completion flow before response ends *(Stop)*
+- `pre.main.guard` — Prevent accidental writes on local main *(PreToolUse)*
+- `pre.edit.branch` — Block Edit/Write while HEAD is on main *(PreToolUse)*
+- `prompt.worktree.branch-guard` — Prevent working on main inside a worktree *(UserPromptSubmit)*
 
-#### plugin — updates and dependencies
+#### plugin — updates, dependencies, and health
 
 - `ss.plugin.update` — Check for plugin updates *(SessionStart)*
+- `ss.permissions.ensure` — Ensure required plugin permissions *(SessionStart)*
 - `ss.mcp.deps` — Auto-install MCP server dependencies *(SessionStart)*
+- `ss.mcp.envcheck` — Warn on MCP servers missing env vars *(SessionStart)*
+- `pre.mcp.health` — Detect dead/stale MCP servers before calls *(PreToolUse)*
 
-#### issues — automatic issue tracking
+#### knowledge — deep-knowledge injection
+
+- `ss.knowledge.index` — Inject deep-knowledge index into context *(SessionStart)*
+- `prompt.knowledge.dispatch` — Inject deep-knowledge by prompt keywords *(UserPromptSubmit)*
+
+#### issues & team — tracking and collaboration
 
 - `prompt.issue.detect` — Track GitHub issues automatically *(UserPromptSubmit)*
+- `ss.concept.resume` — Recover an open concept session after restart *(SessionStart)*
+- `ss.team.changelog` — Summarize teammates' changes on remote main *(SessionStart)*
 
 </details>
 
@@ -276,6 +309,9 @@ SessionStart  ──>  PreToolUse  ──>  PostToolUse  ──>  UserPromptSubm
 | `/devops-autonomous` | Explicit | Fully autonomous agent orchestration while user is AFK |
 | `/devops-burn` | Explicit | High-throughput autonomous task runner with aggressive parallelization |
 | `/devops-learn` | Explicit | Capture long-term learnings and route to project-specific instructions |
+| `/devops-harden` | Explicit | Stabilization pass: full test suite, autonomous bug fixes, regression + consistency |
+| `/devops-polish` | Explicit | UI refinement: visual consistency, state-visuals, UI-side functionality checks |
+| `/devops-test-plan` | Explicit + Hook | Detect test profile, deterministic tool-chain recommendations per test request |
 
 ### Agents (spawned for parallel work)
 
@@ -289,6 +325,7 @@ SessionStart  ──>  PreToolUse  ──>  PostToolUse  ──>  UserPromptSubm
 | **gamer** | Player perspective and UX |
 | **po** | Requirements and validation |
 | **qa** | Test, verify, screenshot |
+| **redteam** | Adversarial review: failure modes, blind spots, hidden risks |
 | **research** | Deep-dive investigations |
 | **windows** | Platform-specific features |
 
@@ -602,9 +639,9 @@ Wk  ━━──╏─────────   15% +1%   · 4d 22h left
 devops/
 ├── .claude-plugin/plugin.json     ← Plugin manifest
 ├── CONVENTIONS.md                 ← Naming, versioning, extension rules
-├── hooks/                         ← 13 hook scripts (JS)
-├── skills/                        ← 16 skill definitions (SKILL.md)
-├── agents/                        ← 10 agent definitions
+├── hooks/                         ← <!--devops:count:hooks-->27<!--/devops:count:hooks--> hooks (JS) registered in hooks.json
+├── skills/                        ← <!--devops:count:skills-->19<!--/devops:count:skills--> skill definitions (SKILL.md)
+├── agents/                        ← <!--devops:count:agents-->11<!--/devops:count:agents--> agent definitions
 ├── deep-knowledge/                ← Cross-cutting reference docs
 ├── templates/                     ← Output format templates
 └── scripts/                       ← Utility scripts (build-id, usage)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.87.3**
+**Version: 0.88.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.87.3",
+  "version": "0.88.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/CONVENTIONS.md
+++ b/plugins/devops/CONVENTIONS.md
@@ -216,6 +216,35 @@ templates/
 └── github-release.md
 ```
 
+## Auto-Maintained Documentation
+
+`README.md` and `docs/architecture.html` carry roster facts (hook/skill/agent
+counts, the full hook lifecycle list) that drift the moment someone adds a hook
+or skill. These live inside HTML-comment markers and are regenerated from the
+canonical source — **never hand-edit the text between markers:**
+
+```
+<!--devops:count:hooks-->27<!--/devops:count:hooks-->        ← inline count
+<!--devops:block:hook-lifecycle--> … <!--/devops:block:hook-lifecycle-->   ← block
+```
+
+- **Generator:** `scripts/gen-readme-sections.js` reads `hooks/hooks.json`,
+  `skills/*/SKILL.md`, `agents/*.md`, `deep-knowledge/*.md` and rewrites every
+  marker. Counts and the lifecycle roster can therefore never go stale.
+  No-ops outside the plugin source repo. Run standalone, or with `--check`
+  (exit 1 if any marker is stale — used as a regression test + ship gate).
+- **When it runs:** `ship_build` regenerates automatically (alongside
+  `gen-dk-index` / `gen-project-map`); `ship_preflight` warns on stale markers
+  **and** on any skill/agent missing its curated README table row;
+  `ss.git.check` nudges (once per 8h) when README is older than the roster.
+- **What stays manual:** curated prose — token math, and the per-skill /
+  per-agent **table descriptions**. The generator never touches those; preflight
+  only enforces that every skill/agent *has* a row, not what it says.
+
+Three layers, three failure windows covered: generate (can't drift) →
+preflight verify (catches the un-generated tables) → session nudge (catches
+"forgot to refresh entirely").
+
 ## General Rules
 
 - All code is JavaScript (Node.js), no Bash scripts

--- a/plugins/devops/docs/architecture.html
+++ b/plugins/devops/docs/architecture.html
@@ -121,7 +121,7 @@
 <!-- ==================== SIDEBAR NAV ==================== -->
 <nav role="navigation" aria-label="Main navigation">
   <span class="nav-brand">devops</span>
-  <span class="nav-version">v0.76.0 &middot; MIT &middot; Jerry0022</span>
+  <span class="nav-version">v0.87.0 &middot; MIT &middot; Jerry0022</span>
 
   <h2>Overview</h2>
   <a href="#overview">Architecture Overview</a>
@@ -167,33 +167,34 @@
 
 <!-- ===== OVERVIEW ===== -->
 <section id="overview">
-<h1>Architecture Documentation <small>devops v0.76.0</small></h1>
+<h1>Architecture Documentation <small>devops v0.87.0</small></h1>
 <p class="lead">
-  A comprehensive DevOps automation plugin for Claude Code &mdash; 29 hooks, 20 skills, 11 agents,
+  A comprehensive DevOps automation plugin for Claude Code &mdash; <!--devops:count:hooks-->27<!--/devops:count:hooks--> hooks, <!--devops:count:skills-->19<!--/devops:count:skills--> skills, <!--devops:count:agents-->11<!--/devops:count:agents--> agents,
   2 MCP servers, a deterministic completion card engine, and a 3-layer extension system.
 </p>
 <div role="note" style="margin:.4rem 0 1.4rem;padding:.6rem .9rem;background:var(--bg2);border-left:3px solid var(--warn);border-radius:4px;color:var(--text2);font-size:.85rem;">
-  &#9888; Content below mirrors the v0.18.2 baseline. Skill/hook/agent listings are not auto-regenerated yet &mdash;
+  &#9888; The summary cards and project structure below reflect the current roster. The detailed per-hook and
+  per-skill walkthroughs further down are a v0.18.2 snapshot and are not auto-regenerated &mdash;
   see <code>plugins/devops/skills/</code>, <code>hooks/hooks.json</code>, and <code>agents/</code> for the canonical roster.
 </div>
 
 <div class="card-grid">
   <div class="card">
-    <h4>10 Hooks</h4>
-    <p style="color:var(--text2);font-size:.85rem">Lifecycle guards across SessionStart, PreToolUse, PostToolUse, UserPromptSubmit, Stop</p>
-    <span class="badge b-hook">SessionStart &times;3</span>
-    <span class="badge b-hook">Pre &times;1</span>
-    <span class="badge b-hook">Post &times;2</span>
-    <span class="badge b-hook">Prompt &times;4</span>
-    <span class="badge b-hook">Stop &times;1</span>
+    <h4><!--devops:count:hooks-->27<!--/devops:count:hooks--> Hooks</h4>
+    <p style="color:var(--text2);font-size:.85rem">Lifecycle guards across SessionStart, UserPromptSubmit, PreToolUse, PostToolUse, Stop</p>
+    <span class="badge b-hook">SessionStart &times;<!--devops:count:hooks:ss-->11<!--/devops:count:hooks:ss--></span>
+    <span class="badge b-hook">Prompt &times;<!--devops:count:hooks:prompt-->7<!--/devops:count:hooks:prompt--></span>
+    <span class="badge b-hook">Pre &times;<!--devops:count:hooks:pre-->5<!--/devops:count:hooks:pre--></span>
+    <span class="badge b-hook">Post &times;<!--devops:count:hooks:post-->2<!--/devops:count:hooks:post--></span>
+    <span class="badge b-hook">Stop &times;<!--devops:count:hooks:stop-->2<!--/devops:count:hooks:stop--></span>
   </div>
   <div class="card">
-    <h4>10 Skills</h4>
-    <p style="color:var(--text2);font-size:.85rem">Slash commands: ship, commit, flow, new-issue, explain, project-setup, readme, refresh-usage, extend-skill</p>
+    <h4><!--devops:count:skills-->19<!--/devops:count:skills--> Skills</h4>
+    <p style="color:var(--text2);font-size:.85rem">Slash commands: ship, commit, flow, new-issue, project-setup, readme, refresh-usage, extend-skill, repo-health, claude-md-lint, concept, agents, plugin-update, autonomous, burn, learn, harden, polish, test-plan</p>
   </div>
   <div class="card">
-    <h4>10 Agents</h4>
-    <p style="color:var(--text2);font-size:.85rem">Specialized subagents: ai, core, designer, feature, frontend, gamer, po, qa, research, windows</p>
+    <h4><!--devops:count:agents-->11<!--/devops:count:agents--> Agents</h4>
+    <p style="color:var(--text2);font-size:.85rem">Specialized subagents: ai, core, designer, feature, frontend, gamer, po, qa, redteam, research, windows</p>
   </div>
   <div class="card">
     <h4>2 MCP Servers</h4>
@@ -211,16 +212,16 @@
 ├── .claude-plugin/
 │   ├── plugin.json            <span style="color:var(--text2)"># Plugin manifest (name, version, mcpServers, hooks)</span>
 │   └── marketplace.json       <span style="color:var(--text2)"># Marketplace registration</span>
-├── agents/                    <span style="color:var(--accent2)"># 10 agent definitions (*.md with YAML frontmatter)</span>
-├── deep-knowledge/            <span style="color:var(--warn)"># 13 cross-cutting reference docs</span>
+├── agents/                    <span style="color:var(--accent2)"># <!--devops:count:agents-->11<!--/devops:count:agents--> agent definitions (*.md with YAML frontmatter)</span>
+├── deep-knowledge/            <span style="color:var(--warn)"># <!--devops:count:dk-->29<!--/devops:count:dk--> cross-cutting reference docs</span>
 ├── hooks/
 │   ├── hooks.json             <span style="color:var(--purple)"># Hook registry (event &rarr; command mapping)</span>
 │   ├── lib/                   <span style="color:var(--text2)"># plugin-guard, run-once, session-id</span>
-│   ├── session-start/         <span style="color:var(--purple)"># 3 hooks (ss.*)</span>
-│   ├── pre-tool-use/          <span style="color:var(--purple)"># 1 hook  (pre.*)</span>
-│   ├── post-tool-use/         <span style="color:var(--purple)"># 2 hooks (post.*)</span>
-│   ├── user-prompt-submit/    <span style="color:var(--purple)"># 4 hooks (prompt.*)</span>
-│   └── stop/                  <span style="color:var(--purple)"># 1 hook  (stop.*)</span>
+│   ├── session-start/         <span style="color:var(--purple)"># <!--devops:count:hooks:ss-->11<!--/devops:count:hooks:ss--> hooks (ss.*)</span>
+│   ├── user-prompt-submit/    <span style="color:var(--purple)"># <!--devops:count:hooks:prompt-->7<!--/devops:count:hooks:prompt--> hooks (prompt.*)</span>
+│   ├── pre-tool-use/          <span style="color:var(--purple)"># <!--devops:count:hooks:pre-->5<!--/devops:count:hooks:pre--> hooks (pre.*)</span>
+│   ├── post-tool-use/         <span style="color:var(--purple)"># <!--devops:count:hooks:post-->2<!--/devops:count:hooks:post--> hooks (post.*)</span>
+│   └── stop/                  <span style="color:var(--purple)"># <!--devops:count:hooks:stop-->2<!--/devops:count:hooks:stop--> hooks (stop.*)</span>
 ├── mcp-server/
 │   ├── index.js               <span style="color:var(--orange)"># dotclaude-completion MCP</span>
 │   └── ship/
@@ -234,10 +235,11 @@
 │   ├── render-card.js         <span style="color:var(--warn)"># Completion card template engine</span>
 │   ├── build-id.js            <span style="color:var(--text2)"># Deterministic content hash</span>
 │   └── lib/usage-meter.js     <span style="color:var(--text2)"># Usage bar renderer</span>
-├── skills/                    <span style="color:var(--accent)"># 10 skill definitions (SKILL.md + deep-knowledge/)</span>
-│   ├── ship/  commit/  flow/  new-issue/
-│   ├── explain/  project-setup/  readme/  refresh-usage/
-│   └── extend-skill/
+├── skills/                    <span style="color:var(--accent)"># <!--devops:count:skills-->19<!--/devops:count:skills--> skill definitions (SKILL.md + deep-knowledge/)</span>
+│   ├── ship/  commit/  flow/  new-issue/  project-setup/  readme/
+│   ├── refresh-usage/  extend-skill/  repo-health/  claude-md-lint/
+│   ├── concept/  agents/  plugin-update/  autonomous/  burn/  learn/
+│   └── harden/  polish/  test-plan/
 ├── templates/                 <span style="color:var(--warn)"># Output format templates</span>
 │   ├── completion-card.md     changelog-entry.md
 │   ├── buildlog-entry.md      github-release.md
@@ -1083,7 +1085,7 @@
 <hr>
 
 <footer style="text-align:center;color:var(--text2);font-size:.8rem;padding:2rem 0">
-  devops v0.76.0 &middot; MIT License &middot; Jerry0022<br>
+  devops v0.87.0 &middot; MIT License &middot; Jerry0022<br>
   Generated 2026-04-01
 </footer>
 

--- a/plugins/devops/hooks/session-start/ss.git.check.js
+++ b/plugins/devops/hooks/session-start/ss.git.check.js
@@ -24,6 +24,7 @@
 
 require('../lib/plugin-guard');
 const { isActive: sentinelActive } = require('../lib/ship-sentinel');
+const { runOnce } = require('../lib/run-once');
 
 const { execSync } = require('child_process');
 const fs = require('fs');
@@ -65,6 +66,25 @@ function isLinkedWorktree(dir) {
   const commonDir = run('git rev-parse --git-common-dir', dir);
   if (!gitDir || !commonDir) return false;
   return path.resolve(dir, gitDir) !== path.resolve(dir, commonDir);
+}
+
+/**
+ * Plugin-source-repo only: warn (at most once per cooldown) when README.md is
+ * older than the skill/hook/agent roster it documents — a sign the docs were
+ * not refreshed after roster changes. Returns a note string or null.
+ */
+function readmeStaleness(dir) {
+  if (!fs.existsSync(path.join(dir, 'plugins', 'devops', 'skills'))) return null;
+  const lastCommit = (paths) => {
+    const ts = run(`git log -1 --format=%ct -- ${paths}`, dir);
+    return ts ? parseInt(ts, 10) : 0;
+  };
+  const readmeTime = lastCommit('README.md');
+  const rosterTime = lastCommit('plugins/devops/skills plugins/devops/hooks plugins/devops/agents');
+  if (!readmeTime || !rosterTime || rosterTime <= readmeTime) return null;
+  // Throttle to once per 8h so it nudges during active dev without nagging.
+  if (!runOnce('ss-git-readme-stale', null, { cooldownMs: 8 * 60 * 60 * 1000 })) return null;
+  return '📝 README.md is older than the skills/hooks/agents roster — run `/devops-readme` or `node plugins/devops/scripts/gen-readme-sections.js` to refresh counts & lists.';
 }
 
 function checkRepo(dir) {
@@ -217,8 +237,9 @@ for (const repo of repos) {
 }
 
 const workspace = checkWorkspace(cwd);
+const staleNote = readmeStaleness(cwd);
 
-if (dirty.length === 0 && !workspace) {
+if (dirty.length === 0 && !workspace && !staleNote) {
   process.exit(0);
 }
 
@@ -307,6 +328,11 @@ for (const r of dirty) {
     out.push(...lines);
     out.push('');
   }
+}
+
+if (staleNote) {
+  if (out.length > 0) out.push('');
+  out.push(staleNote);
 }
 
 if (out.length === 0) process.exit(0);

--- a/plugins/devops/hooks/session-start/ss.mcp.deps.js
+++ b/plugins/devops/hooks/session-start/ss.mcp.deps.js
@@ -1,16 +1,20 @@
 #!/usr/bin/env node
 /**
- * SessionStart hook: install MCP server dependencies into CLAUDE_PLUGIN_DATA.
+ * @hook ss.mcp.deps
+ * @version 0.1.0
+ * @event SessionStart
+ * @plugin devops
+ * @description Auto-install MCP server dependencies into CLAUDE_PLUGIN_DATA.
  *
- * Follows the official Claude Code plugin pattern:
- *   1. Compare mcp-server/package.json against the cached copy in PLUGIN_DATA
- *   2. If they differ (first run or dependency update), run `npm install`
- *   3. Symlink PLUGIN_DATA/node_modules into mcp-server/ dirs for ESM resolution
- *   4. On failure, remove the cached package.json so next session retries
+ *   Follows the official Claude Code plugin pattern:
+ *     1. Compare mcp-server/package.json against the cached copy in PLUGIN_DATA
+ *     2. If they differ (first run or dependency update), run `npm install`
+ *     3. Symlink PLUGIN_DATA/node_modules into mcp-server/ dirs for ESM resolution
+ *     4. On failure, remove the cached package.json so next session retries
  *
- * Why symlink instead of NODE_PATH?
- *   Node.js ESM resolver ignores NODE_PATH for package imports (import ... from "pkg").
- *   A symlink in the mcp-server directory lets the standard ESM resolver find packages.
+ *   Why symlink instead of NODE_PATH?
+ *     Node.js ESM resolver ignores NODE_PATH for package imports (import ... from "pkg").
+ *     A symlink in the mcp-server directory lets the standard ESM resolver find packages.
  */
 
 import { execSync } from "node:child_process";

--- a/plugins/devops/hooks/session-start/ss.permissions.ensure.js
+++ b/plugins/devops/hooks/session-start/ss.permissions.ensure.js
@@ -1,15 +1,16 @@
 #!/usr/bin/env node
 /**
- * SessionStart hook: ensure user-global permission rules exist so devops
- * skills that write ephemeral review artifacts don't trigger permission
- * prompts on every run.
+ * @hook ss.permissions.ensure
+ * @version 0.1.0
+ * @event SessionStart
+ * @plugin devops
+ * @description Ensure required plugin permissions exist so devops skills that
+ *   write ephemeral review artifacts don't trigger permission prompts.
  *
- * Idempotent: only adds rules that are missing. Never removes anything.
- * Scope: user-global settings at ~/.claude/settings.json — the rules apply
- * to all projects for this user.
- *
- * Also ensures the target directory exists so skills can Write without
- * first running mkdir.
+ *   Idempotent: only adds rules that are missing. Never removes anything.
+ *   Scope: user-global settings at ~/.claude/settings.json — the rules apply
+ *   to all projects for this user. Also ensures the target directory exists
+ *   so skills can Write without first running mkdir.
  */
 
 const { readFileSync, writeFileSync, mkdirSync, existsSync } = require("node:fs");

--- a/plugins/devops/mcp-server/ship/tools/build.js
+++ b/plugins/devops/mcp-server/ship/tools/build.js
@@ -57,6 +57,7 @@ function scriptPath(name) { return join(pluginRoot(), "scripts", name); }
 const BUILD_ID_SCRIPT = () => scriptPath("build-id.js");
 const DK_INDEX_SCRIPT = () => scriptPath("gen-dk-index.js");
 const PROJECT_MAP_SCRIPT = () => scriptPath("gen-project-map.js");
+const README_SECTIONS_SCRIPT = () => scriptPath("gen-readme-sections.js");
 
 export const schema = z.object({
   buildCmd: z.string().nullable().default(null).describe("Build command (null = auto-detect from package.json)"),
@@ -139,6 +140,9 @@ export async function handler(params) {
   }
   // 3. Project map (full codebase index)
   run(`"${process.execPath}" "${PROJECT_MAP_SCRIPT()}" "${cwd}"`, cwd);
+  // 4. README + architecture.html auto-marker sections (no-ops outside the
+  //    plugin source repo, i.e. when cwd/plugins/devops is absent)
+  run(`"${process.execPath}" "${README_SECTIONS_SCRIPT()}" "${cwd}"`, cwd);
 
   // Build (skip if no build script detected/provided)
   if (buildCmd) {

--- a/plugins/devops/mcp-server/ship/tools/preflight.js
+++ b/plugins/devops/mcp-server/ship/tools/preflight.js
@@ -5,7 +5,8 @@
 
 import { z } from "zod";
 import { createHash } from "node:crypto";
-import { readdirSync, statSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { readdirSync, statSync, readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { git, currentBranch, dirtyState, commitsAhead, unpushedCommits, isWorktree, detectParentBranch, detectDefaultBranch, branchExists, fileOverlap, getConfig } from "../lib/git.js";
 import { readVersion, verifyVersionFiles } from "../lib/version.js";
@@ -40,6 +41,62 @@ function latestMtime(dir, depth) {
 function pseudoCommit(mtimeMs) {
   const ts = Math.floor(mtimeMs / 1000)
   return createHash("sha1").update("mtime-" + ts).digest("hex").slice(0, 7)
+}
+
+// Doc-sync check (plugin source repo only). Two guarantees:
+//   1. Auto-marker counts/roster in README.md + architecture.html are current.
+//   2. Every skill/agent on disk has a (manually curated) row in the README
+//      tables — the one thing the generator deliberately does NOT auto-write.
+// Returns check objects (with `.warning` so they flow into the warnings list).
+// Never produces errors — doc drift warns, it does not block a ship.
+function docSyncChecks(cwd) {
+  const pluginDir = join(cwd, "plugins", "devops");
+  if (!existsSync(pluginDir)) return []; // consumer repo — nothing to verify
+  const out = [];
+
+  // 1. Marker staleness via the generator's --check mode
+  const genScript = join(pluginDir, "scripts", "gen-readme-sections.js");
+  if (existsSync(genScript)) {
+    try {
+      execFileSync(process.execPath, [genScript, "--check", cwd], { stdio: "pipe" });
+      out.push({ name: "doc-markers", ok: true });
+    } catch {
+      out.push({
+        name: "doc-markers",
+        ok: false,
+        warning: "README/architecture.html auto-markers are stale — ship_build regenerates them automatically",
+      });
+    }
+  }
+
+  // 2. Skill/agent table completeness (curated rows, not auto-generated)
+  try {
+    const readme = readFileSync(join(cwd, "README.md"), "utf8");
+    const skills = readdirSync(join(pluginDir, "skills"), { withFileTypes: true })
+      .filter((d) => d.isDirectory() && existsSync(join(pluginDir, "skills", d.name, "SKILL.md")))
+      .map((d) => d.name);
+    const agents = readdirSync(join(pluginDir, "agents"))
+      .filter((f) => f.endsWith(".md"))
+      .map((f) => f.replace(/\.md$/, ""));
+
+    const missingSkills = skills.filter((s) => !readme.includes(`/${s}`));
+    const missingAgents = agents.filter((a) => !readme.includes(`**${a}**`));
+
+    if (missingSkills.length || missingAgents.length) {
+      const parts = [];
+      if (missingSkills.length) parts.push(`skills: ${missingSkills.join(", ")}`);
+      if (missingAgents.length) parts.push(`agents: ${missingAgents.join(", ")}`);
+      out.push({
+        name: "doc-tables",
+        ok: false,
+        warning: `README tables missing rows for ${parts.join(" · ")} — add a curated description`,
+      });
+    } else {
+      out.push({ name: "doc-tables", ok: true });
+    }
+  } catch { /* README or dirs unreadable — skip silently */ }
+
+  return out;
 }
 
 export async function handler(params) {
@@ -221,6 +278,9 @@ export async function handler(params) {
   // Worktree detection
   const inWorktree = isWorktree(opts);
   checks.push({ name: "worktree", value: inWorktree });
+
+  // Doc-sync (plugin source repo only — no-op elsewhere). Non-blocking.
+  checks.push(...docSyncChecks(cwd));
 
   // Collect warnings from checks (non-blocking issues resolved autonomously)
   const warnings = checks.filter(c => c.warning).map(c => c.warning);

--- a/plugins/devops/scripts/gen-readme-sections.js
+++ b/plugins/devops/scripts/gen-readme-sections.js
@@ -1,0 +1,201 @@
+#!/usr/bin/env node
+/**
+ * @script gen-readme-sections
+ * @version 0.1.0
+ * @plugin devops
+ * @description Regenerates the auto-maintained marker blocks in README.md and
+ *   docs/architecture.html from the canonical plugin roster (hooks.json,
+ *   skills/, agents/, deep-knowledge/). Keeps every COUNT and the hook
+ *   lifecycle roster in sync with reality so they can never drift again.
+ *   Called automatically by ship_build; can also be run standalone.
+ *
+ *   Curated prose (token math, skill/agent table descriptions) stays manual —
+ *   only content between <!--devops:count:*--> and <!--devops:block:*-->
+ *   markers is rewritten. Files without markers are left untouched.
+ *
+ *   Usage:
+ *     node scripts/gen-readme-sections.js [project-root]   # rewrite in place
+ *     node scripts/gen-readme-sections.js --check [root]    # exit 1 if stale
+ *
+ *   No-ops silently when [project-root]/plugins/devops/ is absent (i.e. this
+ *   is a consumer repo, not the plugin source repo).
+ */
+
+import { readdirSync, readFileSync, writeFileSync, existsSync } from "node:fs";
+import { join, resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const args = process.argv.slice(2);
+const checkOnly = args.includes("--check");
+const rootArg = args.find((a) => !a.startsWith("--"));
+// Default: repo root is two levels above plugins/devops/scripts/
+const projectRoot = resolve(rootArg || join(__dirname, "..", "..", ".."));
+const pluginDir = join(projectRoot, "plugins", "devops");
+
+// ── Turn-order event metadata ───────────────────────────────────────────────
+
+const EVENTS = [
+  { name: "SessionStart", key: "ss", header: "SessionStart — runs once when a session begins" },
+  { name: "UserPromptSubmit", key: "prompt", header: "UserPromptSubmit — runs when the user sends a message" },
+  { name: "PreToolUse", key: "pre", header: "PreToolUse — runs before each tool call" },
+  { name: "PostToolUse", key: "post", header: "PostToolUse — runs after each tool call" },
+  { name: "Stop", key: "stop", header: "Stop — runs when Claude finishes responding" },
+];
+
+// ── Roster extraction ───────────────────────────────────────────────────────
+
+/** First sentence (or ~80-char slice) of a hook file's @description. */
+function hookDescription(file) {
+  let content;
+  try { content = readFileSync(file, "utf8"); } catch { return ""; }
+
+  const m = content.match(/@description\s+([\s\S]*?)(?:\n\s*\*\s*@|\n\s*\*\/)/);
+  let raw;
+  if (m) {
+    raw = m[1];
+  } else {
+    // Fallback: first non-tag JSDoc prose line
+    const line = content
+      .split("\n")
+      .map((l) => l.replace(/^\s*\*\s?/, "").trim())
+      .find((l) => l && !l.startsWith("@") && !l.startsWith("/**") && !l.startsWith("#!"));
+    raw = line || "";
+  }
+
+  const flat = raw
+    .split("\n")
+    .map((l) => l.replace(/^\s*\*\s?/, "").trim())
+    .join(" ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  const sentence = flat.match(/^(.*?\.)(?:\s|$)/);
+  const text = sentence ? sentence[1] : flat;
+  return text.length > 88 ? text.slice(0, 85).trimEnd() + "…" : text;
+}
+
+/** Parse hooks.json → { SessionStart: [{id, desc}], ... } excluding deprecated. */
+function readHooks() {
+  const hooksJson = JSON.parse(readFileSync(join(pluginDir, "hooks", "hooks.json"), "utf8"));
+  const byEvent = {};
+  for (const ev of EVENTS) byEvent[ev.name] = [];
+
+  for (const [event, groups] of Object.entries(hooksJson.hooks || {})) {
+    if (!byEvent[event]) continue;
+    for (const group of groups) {
+      for (const entry of group.hooks || []) {
+        if (entry._deprecated) continue;
+        const rel = (entry.command || "").match(/hooks\/[\w./-]+\.js/);
+        if (!rel) continue;
+        const file = join(pluginDir, rel[0]);
+        const id = rel[0].split("/").pop().replace(/\.js$/, "");
+        byEvent[event].push({ id, desc: hookDescription(file) });
+      }
+    }
+  }
+  return byEvent;
+}
+
+function countSkills() {
+  const dir = join(pluginDir, "skills");
+  return readdirSync(dir, { withFileTypes: true })
+    .filter((d) => d.isDirectory() && existsSync(join(dir, d.name, "SKILL.md")))
+    .length;
+}
+
+function countAgents() {
+  return readdirSync(join(pluginDir, "agents")).filter((f) => f.endsWith(".md")).length;
+}
+
+function countDeepKnowledge() {
+  return readdirSync(join(pluginDir, "deep-knowledge"))
+    .filter((f) => f.endsWith(".md") && f !== "INDEX.md").length;
+}
+
+// ── Marker rewriting ────────────────────────────────────────────────────────
+
+function replaceCount(content, key, value) {
+  const re = new RegExp(`(<!--devops:count:${key}-->)([\\s\\S]*?)(<!--/devops:count:${key}-->)`, "g");
+  return content.replace(re, `$1${value}$3`);
+}
+
+function replaceBlock(content, key, inner) {
+  const re = new RegExp(`(<!--devops:block:${key}-->)([\\s\\S]*?)(<!--/devops:block:${key}-->)`, "g");
+  return content.replace(re, `$1\n${inner}\n$3`);
+}
+
+function buildLifecycle(hooks) {
+  const parts = [];
+  for (const ev of EVENTS) {
+    const list = hooks[ev.name];
+    if (!list.length) continue;
+    parts.push(`#### ${ev.header}`, "");
+    for (const h of list) parts.push(`- \`${h.id}\` — ${h.desc}`);
+    parts.push("");
+  }
+  return parts.join("\n").trimEnd();
+}
+
+// ── Main ────────────────────────────────────────────────────────────────────
+
+function applyMarkers(content, counts, lifecycle) {
+  let out = content;
+  for (const [key, value] of Object.entries(counts)) out = replaceCount(out, key, value);
+  if (lifecycle != null) out = replaceBlock(out, "hook-lifecycle", lifecycle);
+  return out;
+}
+
+function processFile(path, counts, lifecycle, stale) {
+  if (!existsSync(path)) return;
+  const existing = readFileSync(path, "utf8");
+  const updated = applyMarkers(existing, counts, lifecycle);
+  if (updated === existing) return;
+  if (checkOnly) {
+    stale.push(path);
+  } else {
+    writeFileSync(path, updated, "utf8");
+    console.error(`[gen-readme-sections] updated ${path.replace(projectRoot, ".")}`);
+  }
+}
+
+function generate() {
+  if (!existsSync(pluginDir)) {
+    // Not the plugin source repo — nothing to maintain.
+    return false;
+  }
+
+  const hooks = readHooks();
+  const perEvent = {};
+  let hookTotal = 0;
+  for (const ev of EVENTS) {
+    perEvent[`hooks:${ev.key}`] = hooks[ev.name].length;
+    hookTotal += hooks[ev.name].length;
+  }
+
+  const counts = {
+    hooks: hookTotal,
+    skills: countSkills(),
+    agents: countAgents(),
+    dk: countDeepKnowledge(),
+    ...perEvent,
+  };
+  const lifecycle = buildLifecycle(hooks);
+
+  const stale = [];
+  processFile(join(projectRoot, "README.md"), counts, lifecycle, stale);
+  processFile(join(pluginDir, "docs", "architecture.html"), counts, null, stale);
+
+  if (checkOnly && stale.length) {
+    console.error(
+      "[gen-readme-sections] STALE — run `node plugins/devops/scripts/gen-readme-sections.js` to refresh:\n  " +
+        stale.map((p) => p.replace(projectRoot, ".")).join("\n  "),
+    );
+    process.exit(1);
+  }
+  if (checkOnly) console.error("[gen-readme-sections] markers up-to-date");
+  return true;
+}
+
+generate();

--- a/plugins/devops/scripts/gen-readme-sections.test.js
+++ b/plugins/devops/scripts/gen-readme-sections.test.js
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, join, resolve } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SCRIPT = join(__dirname, "gen-readme-sections.js");
+const REPO_ROOT = resolve(__dirname, "..", "..", "..");
+
+describe("gen-readme-sections", () => {
+  it("keeps README.md + architecture.html auto-markers in sync with the roster", () => {
+    // --check exits non-zero (throws) when any marker is stale. Committed docs
+    // must always be in sync — this is the regression guard the generator exists for.
+    expect(() =>
+      execFileSync(process.execPath, [SCRIPT, "--check", REPO_ROOT], { stdio: "pipe" }),
+    ).not.toThrow();
+  });
+});

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.87.3",
+  "version": "0.88.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## What

Make the README/architecture roster self-maintaining so counts and lists can never silently drift again, and fix the drift that had already accumulated.

### Drift guards (A·B·C)
- **A — Generator** `scripts/gen-readme-sections.js`: regenerates all `<!--devops:count:*-->` markers and the `<!--devops:block:hook-lifecycle-->` block from the canonical source (`hooks.json`, `skills/`, `agents/`, `deep-knowledge/`). Wired into `ship_build`; no-op outside the plugin source repo; `--check` mode used as a vitest guard + ship gate.
- **B — `ship_preflight`**: non-blocking warning on stale markers **and** on any skill/agent missing its curated README table row.
- **C — `ss.git.check`**: once-per-8h nudge when README is older than the roster.

### Fixes
- Corrected stale counts (`13/16/10` → `27/19/11`), missing `harden`/`polish`/`test-plan` skills + `redteam` agent, incomplete hook lifecycle list, `architecture.html` version header, and the factual token-guard threshold error (`2%` → real plan-scaled `5/8/10%`).
- `ss.permissions.ensure` / `ss.mcp.deps` given the standard JSDoc header.

## Test
- lint clean · 167/167 vitest passed (incl. new `gen-readme-sections.test.js`)
- generator `--check` in-sync (exit 0)