### PR TITLE
fix(completion): sync-status state line, merge on PR (0.88.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.88.0"
+    "version": "0.88.1"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.88.0",
+      "version": "0.88.1",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.88.0",
+      "version": "0.88.1",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.88.1] — 2026-05-30
+
+### Changed
+
+- **Completion card git-state line** — reworked so the lead segment states **sync status** (`up-to-date` / `updated` / `not updated` against `origin/<branch>`) instead of merge status. The merge fact now rides on the PR segment as an adjective — `merged PR #N` / `open PR #N` — and is shown only when a PR actually exists, so there is no more `no PR` noise. The commit segment renders `nothing to commit` when the tree is clean and synced, reserving `uncommitted` for genuinely pending work. This kills the contradictory `merged → origin/main · no PR · uncommitted`, which now reads `up-to-date origin/main · nothing to commit`. `render_completion_card` in `plugins/devops/mcp-server/index.js`.
+
 ## [0.88.0] — 2026-05-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.88.0**
+**Version: 0.88.1**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.88.0",
+  "version": "0.88.1",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/mcp-server/index.js
+++ b/plugins/devops/mcp-server/index.js
@@ -322,40 +322,75 @@ function renderState(state, variant, repoUrl) {
     ? '[`' + branchLabel + '`](' + repoUrl + '/tree/' + branch + ')'
     : '`' + branchLabel + '`';
 
-  const commitStr = state.commit
-    ? (repoUrl
+  // No commit hash + synced/landed → clean working tree → "nothing to commit".
+  // No commit hash + unsynced work → real pending changes → "uncommitted".
+  let commitStr;
+  if (state.commit) {
+    commitStr = repoUrl
       ? '[' + state.commit + '](' + repoUrl + '/commit/' + state.commit + ')'
-      : state.commit)
-    : 'uncommitted';
+      : state.commit;
+  } else if (state.pushed || state.merged) {
+    commitStr = 'nothing to commit';
+  } else {
+    commitStr = 'uncommitted';
+  }
 
-  const pushStr = state.pushed ? 'pushed' : 'not pushed';
-
-  let prStr = 'no PR';
+  // PR segment carries the merge status as an adjective ("merged"/"open").
+  // Rendered only when a PR exists — no PR means no "no PR" noise.
+  let prStr = '';
   if (state.pr) {
-    const prLabel = 'PR #' + state.pr.number + ' "' + state.pr.title + '"';
+    const mergeWord = state.merged ? 'merged ' : 'open ';
+    const prLabel = mergeWord + 'PR #' + state.pr.number + ' "' + state.pr.title + '"';
     prStr = repoUrl
       ? '[' + prLabel + '](' + repoUrl + '/pull/' + state.pr.number + ')'
       : prLabel;
   }
 
-  let mergeStr = 'not merged';
-  if (state.merged) {
-    const target = 'origin/' + state.merged;
-    mergeStr = repoUrl
-      ? 'merged \u2192 [' + target + '](' + repoUrl + '/tree/' + state.merged + ')'
-      : 'merged \u2192 ' + target;
+  // Helper: clickable origin/<name> ref, or plain text without a repo URL.
+  const originRef = (name) => {
+    const target = 'origin/' + name;
+    return repoUrl ? '[' + target + '](' + repoUrl + '/tree/' + name + ')' : target;
+  };
+
+  // Lead segment = sync status (NOT merge status). The merge fact moved onto the
+  // PR segment above. The lead states whether origin reflects the work:
+  //   PR merged \u2192 "updated origin/<base>";  PR open \u2192 "not updated";
+  //   no PR     \u2192 branch sync vs origin/<branch> (merged-without-PR = clean/landed).
+  let syncStr;
+  let syncRefBranch = null; // branch the ref points at, for trailing-branch dedupe
+  if (state.pr) {
+    if (state.merged) {
+      syncStr = 'updated ' + originRef(state.merged);
+      syncRefBranch = state.merged;
+    } else {
+      syncStr = 'not updated';
+    }
+  } else {
+    const b = state.merged || branch || 'main';
+    if (state.merged) {
+      syncStr = 'up-to-date ' + originRef(b);
+      syncRefBranch = b;
+    } else if (state.pushed) {
+      syncStr = (state.commit ? 'updated ' : 'up-to-date ') + originRef(b);
+      syncRefBranch = b;
+    } else if (state.commit) {
+      syncStr = 'not updated'; // committed locally, origin not updated yet
+    } else {
+      syncStr = 'up-to-date ' + originRef(b);
+      syncRefBranch = b;
+    }
   }
 
-  // Order: most important first — merge · PR · push · commit · branch
-  // When merged, "pushed" is redundant (you can't merge without pushing)
-  // When branch equals the merge target, the trailing branch is also redundant
-  // (use raw state.branch — do NOT use the 'main' fallback, or a card with
-  // unknown branch would silently drop the segment when merged === 'main')
+  // Order: sync · PR(+merge status) · commit · branch
+  // Drop the trailing branch when the sync segment already references origin/<branch>
+  // (use raw state.branch — do NOT use the 'main' fallback, or a card with an
+  // unknown branch would silently drop the segment).
   const rawBranch = state.branch;
-  const segments = [mergeStr, prStr];
-  if (!state.merged) segments.push(pushStr);
+  const branchRedundant = syncRefBranch && rawBranch && syncRefBranch === rawBranch;
+  const segments = [syncStr];
+  if (prStr) segments.push(prStr);
   segments.push(commitStr);
-  if (branch && !(state.merged && rawBranch && state.merged === rawBranch)) segments.push(branchStr);
+  if (branch && !branchRedundant) segments.push(branchStr);
   let line = icon + ' ' + segments.join(' \u00b7 ');
 
   if (state.appStatus === 'running')     line += ' \u00b7 app running';

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.88.0",
+  "version": "0.88.1",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

Reworks the completion card git-state line so it stops contradicting itself.

**Before:** `✅ merged → origin/main · no PR · uncommitted` — the lead claimed a merge while saying there was no PR, and "uncommitted" alarmed even when the tree was clean.

**After:**
- Lead segment = **sync status**: `up-to-date` / `updated` / `not updated` (against `origin/<branch>`).
- Merge status moved onto the PR segment as an adjective: `merged PR #N` / `open PR #N`, rendered **only when a PR exists** (no more `no PR` noise).
- Commit segment: `nothing to commit` when clean+synced; `uncommitted` reserved for genuinely pending work.

The confusing case now renders `✅ up-to-date origin/main · nothing to commit`.

## Verification
- `renderState` extracted + exercised against 6 scenarios → all match the approved previews
- eslint clean · 167 vitest tests pass