### PR TITLE
feat(hooks): proactive project-map injection on first broad search

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.88.1"
+    "version": "0.89.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.88.1",
+      "version": "0.89.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.88.1",
+      "version": "0.89.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.89.0] — 2026-05-30
+
+### Changed
+
+- **plugins/devops/hooks/pre-tool-use/pre.tokens.guard.js** (`0.2.0` → `0.3.0`) — proactive project-map injection. On the **first** broad `Grep`/`Glob` (no `path`) of a session, the hook now attaches `.claude/project-map.md` as `additionalContext` and **allows** the search, instead of only nagging after a block. Closes the gap found in a 30-session audit across all local projects: the map was read proactively in **0/30** sessions — only reactively, after the token-guard blocked a broad search. Injected at most once per session (md5 session+cwd flag in tmp); later broad searches still hit the normal token-cost block. Measured effect of the map being in context: blind full-repo greps drop from 11% → 4%.
+- **plugins/devops/deep-knowledge/tool-selection.md** — documents that the guard now supplies the project map automatically on the first broad search.
+
 ## [0.88.1] — 2026-05-30
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.88.1**
+**Version: 0.89.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.88.1",
+  "version": "0.89.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/deep-knowledge/tool-selection.md
+++ b/plugins/devops/deep-knowledge/tool-selection.md
@@ -22,6 +22,10 @@ Before running a full-repo Grep or Glob (no `path` parameter), **always** read
 codebase structure — it tells you which directories and files exist and what they
 contain.
 
+> **Note:** The `pre.tokens.guard` hook also injects the project map automatically
+> on the *first* broad Grep/Glob of a session (no `path`), so you usually receive
+> the structure without an explicit read. Use it to scope every following search.
+
 Use it to derive the correct `path` parameter:
 
 1. Read `.claude/project-map.md` (cheap — small file)

--- a/plugins/devops/hooks/pre-tool-use/pre.tokens.guard.js
+++ b/plugins/devops/hooks/pre-tool-use/pre.tokens.guard.js
@@ -1,13 +1,19 @@
 #!/usr/bin/env node
 /**
  * @hook pre.tokens.guard
- * @version 0.2.0
+ * @version 0.3.0
  * @event PreToolUse
  * @plugin devops
  * @description Block Read/Bash/Glob/Grep operations that would consume a
  *   significant percentage of the ~200K context window. Threshold scales
  *   with the user's Claude plan (pro/max_5/max_20). Uses a flag-file
  *   mechanism: first call blocks with warning, retry allows through.
+ *
+ *   Project-map injection: on the FIRST broad Grep/Glob (no `path`) of a
+ *   session, attaches `.claude/project-map.md` as additionalContext and
+ *   ALLOWS the search, so Claude can scope subsequent calls with a `path`
+ *   instead of only being nagged after a block. Injected at most once per
+ *   session (temp flag); later broad searches still hit the normal block.
  */
 
 require('../lib/plugin-guard');
@@ -175,6 +181,40 @@ process.stdin.on('end', () => {
 
   else {
     process.exit(0);
+  }
+
+  // ── Proactive project-map injection (once per session) ──────────────
+  // Audit finding: the map was never read proactively (0/30 sessions) — only
+  // reactively, after this guard blocked a broad search. Fix: on the FIRST
+  // broad Grep/Glob of a session, attach the project structure as
+  // additionalContext and ALLOW the search, so Claude can scope the next
+  // calls with a `path`. Falls through to the normal block on later broad
+  // searches (map already in context by then).
+  if ((toolName === 'Grep' || toolName === 'Glob') && !toolInput.path) {
+    const projectMap = path.join(cwd, '.claude', 'project-map.md');
+    const sid = hook.session_id || hook.sessionId || 'nosid';
+    const mapKey = crypto.createHash('md5').update(`${sid}:${cwd}`).digest('hex').slice(0, 12);
+    const mapFlag = path.join(os.tmpdir(), `devops_mapinject_${mapKey}.flag`);
+    if (fs.existsSync(projectMap) && !fs.existsSync(mapFlag)) {
+      try {
+        const mapBody = fs.readFileSync(projectMap, 'utf8').trim();
+        fs.writeFileSync(mapFlag, Date.now().toString());
+        const ctx = [
+          `[project-map] Before this broad ${toolName} (no \`path\` set), here is the project's file structure.`,
+          'Use it to re-scope: pick the directory that contains your target and pass it as the `path`',
+          'parameter on this and future Grep/Glob calls instead of scanning the whole repo.',
+          '',
+          mapBody,
+        ].join('\n');
+        process.stdout.write(JSON.stringify({
+          hookSpecificOutput: {
+            hookEventName: 'PreToolUse',
+            additionalContext: ctx,
+          },
+        }));
+        process.exit(0); // allow the search; map is now in context for the next one
+      } catch {}
+    }
   }
 
   // Check threshold

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.88.1",
+  "version": "0.89.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary
A 30-session audit across all local projects found the project map was read proactively in **0/30** sessions — only reactively, after `pre.tokens.guard` blocked a broad search. This wires the map into the first broad `Grep`/`Glob` of a session so Claude can scope subsequent calls.

## Changes
- `pre.tokens.guard.js` (0.2.0 → 0.3.0): on the first broad Grep/Glob (no `path`), attach `.claude/project-map.md` as `additionalContext` and allow the search. Once per session (md5 session+cwd flag); later broad searches still hit the normal token block.
- `tool-selection.md`: documents the new automatic behavior.

## Testing
- Hook simulation: 1st broad grep → inject+allow, 2nd → block, scoped → allow.
- vitest: 167 passed. eslint: clean.