### PR TITLE
feat(completion): grey usage meter to match Changes block (0.89.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.89.0"
+    "version": "0.89.1"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.89.0",
+      "version": "0.89.1",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.89.0",
+      "version": "0.89.1",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.89.1] — 2026-05-31
+
+### Changed
+
+- **Completion card usage meter** — now rendered as a dimmed blockquote (matching the **Changes** block above) instead of a white code fence, so the battery line reads as subinfo. Column alignment is held by non-breaking spaces (a blockquote folds runs of regular spaces, a code fence did not), and the pace warning stays white via bold `**Pace!**` plus the font-rendered `⚠` icon. `renderUsageMeterForCard` in `plugins/devops/mcp-server/index.js`; template + Rule 10 in `plugins/devops/templates/completion-card.md` updated to match.
+
 ## [0.89.0] — 2026-05-30
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.89.0**
+**Version: 0.89.1**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.89.0",
+  "version": "0.89.1",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/mcp-server/index.js
+++ b/plugins/devops/mcp-server/index.js
@@ -125,21 +125,33 @@ function renderUsageMeter(usageData, delta5h, deltaWk) {
 // Usage-meter variant for completion card (with deltas + code fences)
 // ---------------------------------------------------------------------------
 
+// Dim a meter line to the muted blockquote grey while preserving column
+// alignment. Markdown folds runs of regular spaces, so the padding columns
+// would collapse inside a blockquote \u2014 non-breaking spaces hold the
+// layout the way a code fence used to. The pace icon is font-rendered (keeps
+// its color), and **Pace!** is bolded so it pops white instead of dimming with
+// the rest of the text.
+function dimMeterLine(line) {
+  return line
+    .replace(/ /g, '\u00a0')
+    .replace('Pace!', '**Pace!**');
+}
+
 function renderUsageMeterForCard(usageData, delta5h, deltaWk, healthLine) {
   if (!usageData || !usageData.session) {
-    return '```\n\u26a0 Usage data unavailable\n```';
+    return blockquote('\u26a0 Usage data unavailable');
   }
 
   const s = usageData.session;
   const w = usageData.weekly;
-  const lines = ['```'];
+  const lines = [];
 
   const elapsed5hPct = s.resetInMinutes != null ? ((WINDOW_5H_MIN - s.resetInMinutes) / WINDOW_5H_MIN) * 100 : 0;
-  lines.push(renderUsageLine('5h', s.pct, elapsed5hPct, delta5h, s.resetInMinutes));
+  lines.push(dimMeterLine(renderUsageLine('5h', s.pct, elapsed5hPct, delta5h, s.resetInMinutes)));
 
   if (w) {
     const elapsedWkPct = ((WINDOW_WK_MIN - w.resetInMinutes) / WINDOW_WK_MIN) * 100;
-    lines.push(renderUsageLine('Wk', w.pct, elapsedWkPct, deltaWk, w.resetInMinutes));
+    lines.push(dimMeterLine(renderUsageLine('Wk', w.pct, elapsedWkPct, deltaWk, w.resetInMinutes)));
   }
 
   // Failure indicator — login required is always shown prominently regardless
@@ -156,16 +168,14 @@ function renderUsageMeterForCard(usageData, delta5h, deltaWk, healthLine) {
     lines.push(`cached \u00b7 ${ageLabel}${suffix}`);
   }
 
-  lines.push('```');
-
-  // Health line is the first line inside the code fence, above bars
-  // Add blank line after health line to visually separate it from the bars
+  // Health line sits above the bars, separated by a blank line.
   if (healthLine) {
-    const idx = 1; // after opening ```
-    lines.splice(idx, 0, healthLine, '');
+    lines.unshift(healthLine, '');
   }
 
-  return lines.join('\n');
+  // Whole block is greyed as subinfo (matching the Changes block above); the
+  // pace icon and **Pace!** keep their own color inside the quote.
+  return blockquote(lines.join('\n'));
 }
 
 // ---------------------------------------------------------------------------

--- a/plugins/devops/templates/completion-card.md
+++ b/plugins/devops/templates/completion-card.md
@@ -64,13 +64,10 @@ All variables in `{{...}}`. Sections wrapped in `{{#if}}` are conditional per va
 {{/if}}
 
 {{#if usage}}
-{{context-health-line}}
-
-```
-5h  {{bar-5h}}  {{pct-5h}}{{delta-5h}}  · {{reset-5h}} left{{pace-warn-5h}}
-
-Wk  {{bar-wk}}  {{pct-wk}}{{delta-wk}}  · {{reset-wk}} left{{pace-warn-wk}}
-```
+> {{context-health-line}}
+>
+> 5h  {{bar-5h}}  {{pct-5h}}{{delta-5h}}  · {{reset-5h}} left{{pace-warn-5h}}
+> Wk  {{bar-wk}}  {{pct-wk}}{{delta-wk}}  · {{reset-wk}} left{{pace-warn-wk}}
 {{/if}}
 
 ---
@@ -101,7 +98,10 @@ Wk  {{bar-wk}}  {{pct-wk}}{{delta-wk}}  · {{reset-wk}} left{{pace-warn-wk}}
 
 ### Usage meter
 
-Directly under the title. Two usage bars with inline elapsed-time marker, in a code block.
+Directly under the title. Two usage bars with inline elapsed-time marker, greyed
+as subinfo (blockquote) to match the Changes block. Column alignment is held by
+non-breaking spaces (a blockquote folds runs of regular spaces); only `⚠` and
+**Pace!** keep their white color.
 If `usage-live.json` is missing: show error message instead of bars.
 
 **Example rendering:**
@@ -501,7 +501,7 @@ else                                             → fallback (8)
 7. Content in user's language. Status words (SHIPPED, READY, etc.) stay English.
 8. Factual — no commentary, praise, or filler.
 9. Omit sections that don't apply (don't render empty).
-10. Usage meter always in code block, never as plain text.
+10. Usage meter is greyed as subinfo (blockquote), matching the Changes block — column alignment held by non-breaking spaces; only `⚠` and **Pace!** stay white.
 11. If `usage-live.json` is missing: show `⚠ Usage data unavailable — monitoring issue`.
 12. Build-ID always included — even for pure docs/config changes.
 13. State line always with all fields (merge, pr, push, commit, branch) — most important first.

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.89.0",
+  "version": "0.89.1",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

Render the completion-card usage meter as a dimmed blockquote (matching the **Changes** block above) instead of a white code fence, so the battery line reads as subinfo. Column alignment is preserved with non-breaking spaces; the pace warning stays white via bold `**Pace!**` plus the font-rendered `⚠` icon.

## Changes

- `renderUsageMeterForCard` in `plugins/devops/mcp-server/index.js` — blockquote + NBSP + bold-Pace, new `dimMeterLine` helper.
- `plugins/devops/templates/completion-card.md` — rendered template, meter description, and Rule 10 updated to match.
- CHANGELOG + version bump 0.89.0 → 0.89.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)