### PR TITLE
fix(ship): card variant = merge state, not downstream verify

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.89.1"
+    "version": "0.89.2"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.89.1",
+      "version": "0.89.2",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.89.1",
+      "version": "0.89.2",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [0.89.2] — 2026-05-31
+
+### Fixed
+
+- **plugins/devops/skills/devops-ship/SKILL.md** — Step 6 now states explicitly
+  that the completion-card variant reflects what the pipeline *did*, not what is
+  verified downstream. After `ship_release` reports merged (+ tag/release),
+  render `ship-successful`; an unverified downstream auto-deploy (Vercel on
+  main-push, a tag-triggered build, the Step 4b watcher still running) is
+  surfaced as a `userFinalTest` item, never a downgrade to the pre-ship `ready`
+  variant (whose "SHIP or CHANGE?" CTA falsely reads as "nothing shipped" after
+  a merge). The gap let a consumer ship-extension encode the wrong "downgrade to
+  ready" instruction; the base now owns the rule so extensions only carry
+  project-specific downstream surfaces.
+
 ## [0.89.1] — 2026-05-31
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.89.1**
+**Version: 0.89.2**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.89.1",
+  "version": "0.89.2",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/skills/devops-ship/SKILL.md
+++ b/plugins/devops/skills/devops-ship/SKILL.md
@@ -484,6 +484,21 @@ render_completion_card({
 })
 ```
 
+**Variant reflects what the pipeline DID, not what's verified downstream.**
+Once `ship_release` reports `merged` + (where applicable) `tag` + `release`,
+the ship **has happened** → render `ship-successful`. Do NOT downgrade to
+`ready` just because a downstream auto-deploy isn't confirmed yet (Vercel on
+main-push, a tag-triggered build, the Step 4b watcher still running). `ready`
+is the PRE-ship variant — its CTA is "SHIP or CHANGE?" — so using it after a
+merge is self-contradictory and reads as "nothing shipped". Surface any
+pending/unverified downstream as an explicit `userFinalTest` item instead
+(e.g. "Vercel-Deploy live verifizieren", "Build run #N läuft — `gh run view N`").
+The MCP variant guard already auto-corrects `ship-successful`→`ready` when
+`state.merged`/`state.pushed` are falsy, so the only judgement call left to you
+is: merged ⇒ `ship-successful`, downstream-still-pending ⇒ `userFinalTest`,
+never a variant downgrade. (Project ship-extensions: keep project-specific
+downstream surfaces, but don't re-encode this variant rule.)
+
 **Keep-mode variant** (Step 5a chose keep, Step 5c ran):
 ```
 render_completion_card({

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.89.1",
+  "version": "0.89.2",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Problem

`devops-ship` Step 6 never stated explicitly how to choose the completion-card variant after a merge. That gap let a consumer ship-extension (SC Companion) encode a wrong rule — "downgrade the card to `ready` until the downstream auto-deploy is verified". But `ready` is the **pre-ship** variant (CTA: "SHIP or CHANGE?"), so rendering it after `ship_release` already merged + tagged + released reads as "nothing shipped". Surfaced live: a v0.10.0 ship merged PR #47, yet the card said `ready`.

## Fix

Step 6 now owns the rule:
- merged (+ tag/release) ⇒ render `ship-successful`;
- an unverified downstream auto-deploy (Vercel on main-push, a tag-triggered build, the Step 4b watcher still running) ⇒ flag as an explicit `userFinalTest` item, **never** a variant downgrade.

This matches the existing MCP variant guard (auto-corrects `ship-successful`→`ready` only when `state.merged`/`pushed` are falsy) and the completion-card template's "STRICT variant rules". Project extensions now carry only project-specific downstream surfaces, not the variant logic.

Docs/skill-only change. Patch bump 0.89.1 → 0.89.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)