### PR TITLE
chore(gitignore): ignore ship post-merge-watcher runtime dir (0.89.3)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.89.2"
+    "version": "0.89.3"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.89.2",
+      "version": "0.89.3",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.89.2",
+      "version": "0.89.3",
       "author": {
         "name": "Jerry0022"
       },

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ node_modules/
 .claude/scheduled_tasks.lock
 .claude/usage-live.json
 .claude/.ship-in-progress
+.claude/.ship-watcher/
 .claude/concept-active.json
 .claude/session-opened-files.json
 # Plugin-managed runtime dirs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.89.3] — 2026-05-31
+
+### Fixed
+
+- **.gitignore** — ignore `.claude/.ship-watcher/`. The ship pipeline's post-merge watcher (Step 4b) writes status JSON to `.claude/.ship-watcher/<sha>.json`; that runtime output is not source and was surfacing as an untracked `.claude/` entry after every ship.
+
 ## [0.89.2] — 2026-05-31
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.89.2**
+**Version: 0.89.3**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.89.2",
+  "version": "0.89.3",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.89.2",
+  "version": "0.89.3",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

Ignore `.claude/.ship-watcher/`. The ship pipeline's post-merge watcher (Step 4b) writes status JSON to `.claude/.ship-watcher/<sha>.json` — runtime output, not source — which surfaced as an untracked `.claude/` entry after every ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)