### PR TITLE
fix(completion): single test section + neutral icon (0.89.4)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.89.3"
+    "version": "0.89.4"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.89.3",
+      "version": "0.89.4",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.89.3",
+      "version": "0.89.4",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.89.4] — 2026-05-31
+
+### Fixed
+
+- **Completion card** — the `test` variant no longer renders two stacked test sections. It was the only variant with both `userTest` and `userFinalTest` enabled, so a card could show *Please test* **and** *TESTE bitte noch:* back-to-back. `userFinalTest` is now disabled for the `test` variant — all manual steps route through `userTest` — establishing the invariant that no card ever shows two test sections. `VARIANTS.test` + schema/comment in `plugins/devops/mcp-server/index.js`; template + variant tables in `plugins/devops/templates/completion-card.md`.
+
+### Changed
+
+- **Completion card** — the manual-test icon changed from 🧑 (reads as a male person) to a neutral 🔬 across all variants, and `userTest` now renders under a `🔬 **Bitte testen:**` / `🔬 **Please test:**` header instead of a plain `**Please test**`. Icon updated in `qa.md`, `agent-orchestration.md`, `test-strategy.md`, `devops-autonomous/SKILL.md` to match.
+- **deep-knowledge/merge-safety.md** — new *Worktree Path Discipline* section: in a worktree session, always edit files under the worktree root, never the main-repo root, since a parallel ship/reset in the main checkout silently wipes uncommitted edits there.
+
 ## [0.89.3] — 2026-05-31
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.89.3**
+**Version: 0.89.4**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.89.3",
+  "version": "0.89.4",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/agents/qa.md
+++ b/plugins/devops/agents/qa.md
@@ -30,9 +30,9 @@ Before starting, read `{PLUGIN_ROOT}/deep-knowledge/codex-integration.md` §4 (Q
 - Check console logs for errors
 - Generate build-ID after successful build
 - **Flag User-Final-Tests** in output when automation cannot cover the final step:
-  - Packaged Electron/Tauri without desktop takeover → `🧑 TESTE bitte noch:`
+  - Packaged Electron/Tauri without desktop takeover → `🔬 TESTE bitte noch:`
   - Third-party integrations (OAuth, payments, webhooks, external APIs) →
-    `🧑 TESTE bitte noch:` + bullet with `— nach Deployment` suffix
+    `🔬 TESTE bitte noch:` + bullet with `— nach Deployment` suffix
   - Always include concrete action (what to open, what to click, what to verify).
 - **Automatically run** Codex review via Bash: `bash "${CLAUDE_PLUGIN_ROOT}/scripts/codex-safe.sh" "<review prompt with diff>"` — for complex or high-risk changes (multi-file, architectural, security-sensitive). Skip for trivial single-file fixes. Handle exit codes per codex-integration.md: rc=124 → log timeout and continue without findings; rc=126/127 → skip silently; other non-zero → note and continue. **Never** invoke `/codex:rescue` via the Agent tool.
 - Report findings in structured format

--- a/plugins/devops/deep-knowledge/agent-orchestration.md
+++ b/plugins/devops/deep-knowledge/agent-orchestration.md
@@ -206,7 +206,7 @@ See `deep-knowledge/test-strategy.md` § Electron / Native UI.
 Renderer-level verification happens via rule 3 (mount renderer HTML in Edge, mock
 main-process calls). Final integration test on the packaged app requires
 `computer-use` — **only** if the user chose "Desktop übernehmen", otherwise QA
-flags the completion card with `🧑 TESTE bitte noch:` plus concrete
+flags the completion card with `🔬 TESTE bitte noch:` plus concrete
 steps. Never claim an Electron/Tauri change "verified" based on dev-browser mocks
 alone.
 
@@ -217,7 +217,7 @@ Any code calling external services (OAuth, payments, social APIs, webhooks,
 analytics, LLM APIs) follows two mandatory steps:
 1. Automated mock test (MSW/nock/fixtures) — verifies integration shape.
 2. Real test — flagged in completion card as
-   `🧑 TESTE bitte noch:` + bullet with `— nach Deployment` suffix.
+   `🔬 TESTE bitte noch:` + bullet with `— nach Deployment` suffix.
 
 The mock step is **not** a substitute for step 2. Both are required.
 
@@ -251,7 +251,7 @@ Test the changes (follow deep-knowledge/test-strategy.md):
 
 **Orchestrator handoff:** When the QA agent returns `userFinalTest` items, pass
 them through to `render_completion_card` as the `userFinalTest` input so the
-completion card displays the unified `🧑 TESTE bitte noch:` block.
+completion card displays the unified `🔬 TESTE bitte noch:` block.
 Never drop this field — it's the only signal the user sees about work that
 automation couldn't cover.
 

--- a/plugins/devops/deep-knowledge/merge-safety.md
+++ b/plugins/devops/deep-knowledge/merge-safety.md
@@ -10,6 +10,20 @@ and agent collaboration flows.
 changed the same area. Both changes may be valid. Strategies that blindly pick one
 side (`--ours`, `--theirs`) destroy information and must never be used.
 
+## Worktree Path Discipline
+
+When the session runs in a git worktree (cwd is `…/.claude/worktrees/<name>/`),
+resolve **every** file edit against the worktree root — never the bare main-repo
+root (`…/<repo>/plugins/…`). They are separate working directories on separate
+branches.
+
+**Why:** the main checkout may run a parallel `/devops-ship` or `git-sync` that
+does `git reset --hard` / `git checkout`. Uncommitted edits made to the main
+checkout's files are silently wiped by that reset — the Edit tool reports
+success, you see confusing "file modified since read" races, and the change is
+gone. Edits in your own worktree are isolated and survive. If a path during a
+worktree session lacks the `worktrees/<name>/` segment, it is wrong.
+
 ## Why Squash Merges Cause Data Loss
 
 Squash merges sever Git's ancestry chain. When Dev B squash-merges to main, the new

--- a/plugins/devops/deep-knowledge/test-strategy.md
+++ b/plugins/devops/deep-knowledge/test-strategy.md
@@ -59,7 +59,7 @@ browser instance, not inside the app's own webview. Testing therefore splits:
   when the user explicitly chose "Desktop übernehmen" (see
   `desktop-testing.md`).
 - If desktop-takeover was not chosen → flag in completion card:
-  `🧑 TESTE bitte noch:` with concrete steps (what to open, what to verify).
+  `🔬 TESTE bitte noch:` with concrete steps (what to open, what to verify).
 
 Never claim an Electron/Tauri change is "verified" based on dev-browser mocks alone
 — the mocked renderer is not the production runtime.
@@ -77,7 +77,7 @@ protocol:
 - Never send real requests to production 3rd-party endpoints during automated tests.
 
 **Step 2 — Real integration test (cannot be automated):**
-- Flag in completion card: `🧑 TESTE bitte noch:` + bullet with `— nach Deployment` suffix
+- Flag in completion card: `🔬 TESTE bitte noch:` + bullet with `— nach Deployment` suffix
   with the concrete action (e.g. "Login mit Google in Prod-Umgebung testen",
   "Test-Zahlung mit Stripe Live-Key durchführen").
 - Never declare the integration "verified" based on the mock step alone — credentials,
@@ -106,7 +106,7 @@ userFinalTest: [
 ]
 ```
 
-The card renders a unified `🧑 TESTE bitte noch:` (DE) / `🧑 Please TEST:` (EN)
+The card renders a unified `🔬 TESTE bitte noch:` (DE) / `🔬 Please TEST:` (EN)
 block with the bullets. Never summarize away — this is the only signal the user
 sees about work automation could not cover.
 

--- a/plugins/devops/mcp-server/index.js
+++ b/plugins/devops/mcp-server/index.js
@@ -187,7 +187,7 @@ const VARIANTS = {
   ready:             { usage: true,  changes: true,  tests: true,  state: true,  userTest: false, userFinalTest: true  },
   'ready-files':     { usage: true,  changes: true,  tests: true,  state: true,  userTest: false, userFinalTest: true  },
   'ship-blocked':    { usage: true,  changes: true,  tests: true,  state: true,  userTest: false, userFinalTest: true  },
-  test:              { usage: true,  changes: true,  tests: true,  state: true,  userTest: true,  userFinalTest: true  },
+  test:              { usage: true,  changes: true,  tests: true,  state: true,  userTest: true,  userFinalTest: false },
   'test-minimal':    { usage: false, changes: false, tests: false, state: false, userTest: false, userFinalTest: false },
   analysis:          { usage: true,  changes: true,  tests: false, state: true,  userTest: false, userFinalTest: true  },
   aborted:           { usage: true,  changes: true,  tests: false, state: true,  userTest: false, userFinalTest: true  },
@@ -409,15 +409,21 @@ function renderState(state, variant, repoUrl) {
   return line;
 }
 
-function renderUserTest(steps) {
+const USER_TEST_LABEL = {
+  de: '\uD83D\uDD2C **Bitte testen:**',
+  en: '\uD83D\uDD2C **Please test:**',
+};
+
+function renderUserTest(steps, lang) {
   if (!steps || steps.length === 0) return '';
+  const header = USER_TEST_LABEL[lang] || USER_TEST_LABEL.de;
   const items = steps.map((s, i) => (i + 1) + '. ' + s);
-  return '**Please test**\n' + items.join('\n');
+  return header + '\n' + items.join('\n');
 }
 
 const USER_FINAL_TEST_LABEL = {
-  de: { header: '\uD83E\uDDD1 **TESTE bitte noch:**', suffix: ' \u2014 nach Deployment' },
-  en: { header: '\uD83E\uDDD1 **Please TEST:**',      suffix: ' \u2014 after deployment' },
+  de: { header: '\uD83D\uDD2C **TESTE bitte noch:**', suffix: ' \u2014 nach Deployment' },
+  en: { header: '\uD83D\uDD2C **Please TEST:**',      suffix: ' \u2014 after deployment' },
 };
 
 function renderUserFinalTest(items, lang) {
@@ -518,7 +524,7 @@ function renderCard(input, meterText, buildId) {
 
   // User test steps (test variant)
   if (config.userTest) {
-    const testBlock = renderUserTest(input.userTest);
+    const testBlock = renderUserTest(input.userTest, lang);
     if (testBlock) {
       parts.push(testBlock);
       parts.push('');
@@ -526,8 +532,10 @@ function renderCard(input, meterText, buildId) {
   }
 
   // User-final-test flag (Electron without takeover, 3rd-party integrations)
-  // Available in all variants except test-minimal — so e.g. a ship-successful
-  // card can still flag "test the real Stripe integration in prod".
+  // Available in all variants except test-minimal and test — so e.g. a
+  // ship-successful card can still flag "test the real Stripe integration in
+  // prod". The test variant routes all manual steps through userTest instead,
+  // so a card never shows two stacked test sections.
   if (config.userFinalTest) {
     const finalBlock = renderUserFinalTest(input.userFinalTest, lang);
     if (finalBlock) {
@@ -802,7 +810,7 @@ server.registerTool(
             afterDeployment: z.boolean().optional(),
           }),
         ])).optional(),
-      ).describe("User-final-test items — for changes where automation cannot cover the last step (packaged Electron/Tauri without desktop takeover, 3rd-party integrations). Pass strings for local final tests; pass { action, afterDeployment: true } for 3rd-party items that require deployment first. Available in all variants except test-minimal."),
+      ).describe("User-final-test items — for changes where automation cannot cover the last step (packaged Electron/Tauri without desktop takeover, 3rd-party integrations). Pass strings for local final tests; pass { action, afterDeployment: true } for 3rd-party items that require deployment first. Available in all variants except test-minimal and test — in the test variant all manual steps go into userTest (single test section, no duplicate)."),
     }),
   },
   async (params) => {

--- a/plugins/devops/skills/devops-autonomous/SKILL.md
+++ b/plugins/devops/skills/devops-autonomous/SKILL.md
@@ -378,10 +378,10 @@ Use `$BROWSER_TOOL` (from Step 3b) for all browser-based visual verification.
 - **Packaged Electron/Tauri**: renderer tested via `$BROWSER_TOOL` with mocks
   (rule 4). If user chose "Desktop übernehmen", run the packaged-app final test
   via computer-use. Otherwise add a `userFinalTest` item (string form) for the
-  completion card — renders as `🧑 TESTE bitte noch:`.
+  completion card — renders as `🔬 TESTE bitte noch:`.
 - **3rd-party integrations**: mock automated tests (rule 5). Always add a
   `userFinalTest` item with `afterDeployment: true` — renders under the same
-  `🧑 TESTE bitte noch:` block with `— nach Deployment` suffix. Never mark the
+  `🔬 TESTE bitte noch:` block with `— nach Deployment` suffix. Never mark the
   integration "verified" on mocks alone.
 - Track progress via TodoWrite.
 
@@ -421,7 +421,7 @@ Call `render_completion_card` (variant per status: "ship-successful" for COMPLET
 
 **Always forward `userFinalTest` items** collected during Step 5 Live Testing
 (packaged Electron/Tauri without takeover, 3rd-party integrations). The card
-renders a unified `🧑 TESTE bitte noch:` block — this is the only signal the
+renders a unified `🔬 TESTE bitte noch:` block — this is the only signal the
 user sees about work that automation couldn't cover, so never drop or summarize
 these items away.
 

--- a/plugins/devops/templates/completion-card.md
+++ b/plugins/devops/templates/completion-card.md
@@ -54,12 +54,12 @@ All variables in `{{...}}`. Sections wrapped in `{{#if}}` are conditional per va
 {{state-icon}} {{state-text}}
 
 {{#if user-test}}
-**Please test**
+🔬 **Bitte testen:**
 1. {{each: test-step}}
 {{/if}}
 
 {{#if user-final-test}}
-🧑 **TESTE bitte noch:**
+🔬 **TESTE bitte noch:**
 * {{each: action}}{{#if afterDeployment}} — nach Deployment{{/if}}
 {{/if}}
 
@@ -321,7 +321,10 @@ Falls back to plain text when no GitHub remote is detected.
 
 ### User test
 
-Numbered steps the user must perform manually.
+Numbered steps the user must perform manually, under the header `🔬 **Bitte
+testen:**` / `🔬 **Please test:**`. In the `test` variant this is the **single**
+test section — all manual steps (including anything that would otherwise land in
+user-final-test) go here, so a card never shows two stacked test sections.
 
 | Variants | Behavior |
 |----------|----------|
@@ -343,13 +346,13 @@ Wording is identical across both cases — only the `— nach Deployment` / `—
 deployment` suffix distinguishes the 3rd-party case:
 
 ```
-🧑 **TESTE bitte noch:**
+🔬 **TESTE bitte noch:**
 * Electron-App öffnen → Settings-Dialog testen
 * Login mit Google in Prod-Umgebung testen — nach Deployment
 ```
 
 ```
-🧑 **Please TEST:**
+🔬 **Please TEST:**
 * Open Electron app → test Settings dialog
 * Test Google login in prod environment — after deployment
 ```
@@ -360,7 +363,8 @@ The header is always rendered once; the suffix is attached per bullet.
 
 | Variants | Behavior |
 |----------|----------|
-| ship-successful, ready, ship-blocked, test, analysis, aborted, fallback | **If QA flagged one** — otherwise omit |
+| ship-successful, ready, ship-blocked, analysis, aborted, fallback | **If QA flagged one** — otherwise omit |
+| test | **Omit** — manual steps go into user-test instead (single test section) |
 | test-minimal | **Omit** (session greeting, no QA context) |
 
 Rendered between state/user-test and the usage meter so it sits in Block A's
@@ -429,7 +433,7 @@ The footer line sits between the separator and the CTA. It contains:
 | 1 | ship-successful | 🚀 | yes | yes | — | if flagged | final | yes |
 | 2 | ready | 📦 | yes | if ran | — | if flagged | branch | yes |
 | 3 | ship-blocked | ⛔ | yes | if ran | — | if flagged | branch | yes |
-| 4 | test | 🧪 | yes | if ran | yes | if flagged | app-status | yes |
+| 4 | test | 🧪 | yes | if ran | yes | — | app-status | yes |
 | 5 | test-minimal | ▶️ | — | — | — | — | — | — |
 | 6 | analysis | 📋 | yes | — | — | if flagged | none | yes |
 | 7 | aborted | 🚫 | opt. | — | — | if flagged | dep. | yes |

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.89.3",
+  "version": "0.89.4",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary
The `test` completion-card variant was the only variant with both `userTest` and `userFinalTest` enabled, so a card could render two stacked test sections (*Please test* + *TESTE bitte noch:*). This disables `userFinalTest` for the `test` variant — all manual steps route through `userTest` — establishing the invariant that no card ever shows two test sections.

## Changes
- **test variant**: `userFinalTest` off → one test section, ever
- **manual-test icon** 🧑 → neutral 🔬 across all variants; `userTest` renders under `🔬 **Bitte testen:**`
- **deep-knowledge/merge-safety.md**: new *Worktree Path Discipline* note (edit worktree paths, not the main checkout)

## Tests
- vitest: 167 passed
- eslint: clean
- render smoke test: no variant renders two test sections; test→`🔬 Bitte testen:`, ready→`🔬 TESTE bitte noch:`