### PR TITLE
feat: plugin cache self-healing (#190) + upstream learn routing

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.89.4"
+    "version": "0.90.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.89.4",
+      "version": "0.90.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.89.4",
+      "version": "0.90.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.90.0] — 2026-06-01
+
+### Fixed
+
+- **Plugin cache self-healing** — an incomplete marketplace→cache sync (issue #190) left the devops plugin's MCP servers unregistered, so `/devops-ship` could not find its `ship_*` tools and the failure recurred every session. `ss.plugin.update` now verifies the full `mcp-server/` tree + `.mcp.json` after a rebuild and treats an existing cache as stale when those files are missing despite a matching version/sha — healing it from the (complete) marketplace clone. `ss.mcp.deps` now reinstalls when the shared `node_modules` is partial and replaces a partial real `node_modules` with a junction to the healed copy, instead of trusting any pre-existing directory.
+
+### Changed
+
+- **devops-learn routing** — a plugin-topic learning found in a consumer project now defaults to an upstream issue in the plugin source repo (route 5b) instead of a local skill-extension; a local override (5b′) requires a deliberate, justifiable reason to keep the rule off upstream. Adds a hard boundary: in a consumer project the learn skill must never fix a plugin defect directly and never hand-edit installed copies under `~/.claude/plugins/cache/**` or `~/.claude/plugins/marketplaces/**`. The plugin source repo is the explicit exception — direct fixes expected, cache edits optional.
+
 ## [0.89.4] — 2026-05-31
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.89.4**
+**Version: 0.90.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 
@@ -193,7 +193,7 @@ SessionStart  ──>  UserPromptSubmit  ──>  PreToolUse  ──>  PostToolU
 - `ss.plugin.update` — Auto-update plugin marketplace clones, rebuild cache, and update registry.
 - `ss.permissions.ensure` — Ensure required plugin permissions exist so devops skills that write ephemeral review…
 - `ss.knowledge.index` — Inject deep-knowledge INDEX.md into context at session start.
-- `ss.mcp.deps` — Auto-install MCP server dependencies into CLAUDE_PLUGIN_DATA.
+- `ss.mcp.deps` — Auto-install MCP server dependencies into CLAUDE_PLUGIN_DATA, and self-heal partial i…
 - `ss.mcp.envcheck` — Detect enabled plugins whose .mcp.json references env vars that are not set.
 - `ss.tokens.scan` — Scan project for expensive files and update config for the pre.tokens.guard hook.
 - `ss.git.check` — Check for stale changes AND workspace setup issues at session start.

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.89.4",
+  "version": "0.90.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/hooks/session-start/ss.mcp.deps.js
+++ b/plugins/devops/hooks/session-start/ss.mcp.deps.js
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 /**
  * @hook ss.mcp.deps
- * @version 0.1.0
+ * @version 0.2.0
  * @event SessionStart
  * @plugin devops
- * @description Auto-install MCP server dependencies into CLAUDE_PLUGIN_DATA.
+ * @description Auto-install MCP server dependencies into CLAUDE_PLUGIN_DATA,
+ *   and self-heal partial installs left by an incomplete cache sync (#190).
  *
  *   Follows the official Claude Code plugin pattern:
  *     1. Compare mcp-server/package.json against the cached copy in PLUGIN_DATA
@@ -18,7 +19,7 @@
  */
 
 import { execSync } from "node:child_process";
-import { readFileSync, writeFileSync, symlinkSync, mkdirSync, existsSync, unlinkSync, lstatSync } from "node:fs";
+import { readFileSync, writeFileSync, symlinkSync, mkdirSync, existsSync, unlinkSync, lstatSync, rmSync } from "node:fs";
 import { join, resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -35,8 +36,21 @@ const SOURCE_PKG = join(PLUGIN_ROOT, "mcp-server", "package.json");
 const CACHED_PKG = join(PLUGIN_DATA, "package.json");
 const DATA_MODULES = join(PLUGIN_DATA, "node_modules");
 
+// Top-level runtime deps every MCP server needs (from mcp-server/package.json).
+// Their presence is the completeness signal: a partial node_modules (the
+// failure mode in issue #190) lacks these even when the directory exists.
+const REQUIRED_PKGS = ["@modelcontextprotocol/sdk", "zod"];
+
+function hasAllDeps(modulesDir) {
+  if (!existsSync(modulesDir)) return false;
+  return REQUIRED_PKGS.every((pkg) => existsSync(join(modulesDir, ...pkg.split("/"))));
+}
+
 function needsInstall() {
   if (!existsSync(CACHED_PKG) || !existsSync(DATA_MODULES)) return true;
+  // Heal partial installs: a node_modules missing the required packages
+  // (interrupted/incomplete cache sync) must be reinstalled, not trusted.
+  if (!hasAllDeps(DATA_MODULES)) return true;
   try {
     const source = readFileSync(SOURCE_PKG, "utf8");
     const cached = readFileSync(CACHED_PKG, "utf8");
@@ -76,12 +90,17 @@ const symlinkTargets = [
 
 for (const target of symlinkTargets) {
   try {
-    // Skip if already correctly linked
     if (existsSync(target)) {
       const stat = lstatSync(target);
       if (stat.isSymbolicLink()) continue;
-      // Real directory from dev environment — skip, don't overwrite
-      if (stat.isDirectory()) continue;
+      if (stat.isDirectory()) {
+        // Real directory: keep it only if it is a complete install (a dev
+        // checkout or a healthy cache). A partial real dir (issue #190 — the
+        // cache sync dropped deps) shadows the shared node_modules and makes
+        // the server crash; replace it with a junction to the healed copy.
+        if (hasAllDeps(target)) continue;
+        rmSync(target, { recursive: true, force: true });
+      }
     }
     symlinkSync(DATA_MODULES, target, "junction");
   } catch {

--- a/plugins/devops/hooks/session-start/ss.plugin.update.js
+++ b/plugins/devops/hooks/session-start/ss.plugin.update.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * @hook ss.plugin.update
- * @version 0.6.0
+ * @version 0.7.0
  * @event SessionStart
  * @plugin devops
  * @description Auto-update plugin marketplace clones, rebuild cache, and update registry.
@@ -49,6 +49,33 @@ const marketplacesDir = path.join(home, '.claude', 'plugins', 'marketplaces');
 const cacheDir = path.join(home, '.claude', 'plugins', 'cache');
 const registryFile = path.join(home, '.claude', 'plugins', 'installed_plugins.json');
 const sentinelFile = path.join(home, '.claude', 'plugins', '.mcp-stale.json');
+
+// Files whose absence means a cache is functionally broken even when its
+// version/sha look correct (issue #190 — sync dropped mcp-server files and
+// .mcp.json, so the MCP servers never registered). Checked both to flag an
+// existing cache for rebuild and to verify a freshly-built one. Paths are
+// relative to a plugin root; only assert files that exist in every plugin
+// that ships an .mcp.json — guarded by hasMcpServer() below.
+const MCP_CRITICAL_FILES = [
+  '.mcp.json',
+  path.join('mcp-server', 'index.js'),
+  path.join('mcp-server', 'lib', 'heartbeat.js'),
+  path.join('mcp-server', 'ship', 'index.js'),
+  path.join('mcp-server', 'issues', 'index.js'),
+];
+
+function hasMcpServer(root) {
+  return fs.existsSync(path.join(root, '.mcp.json'));
+}
+
+// Returns the MCP-critical files missing from `targetRoot`. `expectMcp` must be
+// derived from the SOURCE plugin dir, not the target — otherwise a target whose
+// own .mcp.json was dropped would report "nothing to assert" and mask the very
+// breakage we are checking for (issue #190).
+function missingMcpFiles(targetRoot, expectMcp) {
+  if (!expectMcp) return [];
+  return MCP_CRITICAL_FILES.filter((rel) => !fs.existsSync(path.join(targetRoot, rel)));
+}
 
 function run(cmd, cwd) {
   try {
@@ -154,6 +181,15 @@ function rebuildCache(marketplace, pluginName, pluginDir, version, sha) {
     if (!fs.existsSync(check)) {
       return { ok: false, missing: check };
     }
+  }
+
+  // If the source ships an MCP server, the copy must include the full
+  // mcp-server tree + .mcp.json — otherwise the servers never register
+  // (issue #190). Fail the rebuild so the registry is not pointed at a
+  // broken cache; the next session retries from the (complete) marketplace.
+  const mcpMissing = missingMcpFiles(newCache, hasMcpServer(pluginDir));
+  if (mcpMissing.length) {
+    return { ok: false, missing: `mcp-server files: ${mcpMissing.join(', ')}` };
   }
 
   // Verify version alignment
@@ -276,6 +312,12 @@ for (const marketplace of fs.readdirSync(marketplacesDir)) {
             // SHA mismatch: same version string but different commit (files may have changed)
             const cachedSha = entry.gitCommitSha || '';
             if (cachedSha && cachedSha !== newHead && cachedSha !== newSha) {
+              cacheStale = true;
+            }
+            // Completeness guard: version/sha can match while the MCP server
+            // files were dropped by an incomplete sync (issue #190). Rebuild
+            // from the marketplace clone to heal the cache in place.
+            if (!cacheStale && missingMcpFiles(entry.installPath, hasMcpServer(dir)).length) {
               cacheStale = true;
             }
           }

--- a/plugins/devops/skills/devops-learn/SKILL.md
+++ b/plugins/devops/skills/devops-learn/SKILL.md
@@ -87,21 +87,56 @@ rules, business logic conventions, file layout for that project, etc.).
 
 Store as `{topic}` ∈ {`plugin`, `project`}.
 
+## Step 4b — Plugin topic in a consumer project: upstream fix or local override?
+
+When `{topic} == plugin` AND the current project is a **consumer** (not the
+plugin source repo), the root cause of the learning lives in the plugin source,
+not here. Decide `{plugin_disposition}`:
+
+- `upstream` (**DEFAULT**) — the learning is a plugin defect, gap, or
+  improvement that would benefit any consumer of devops dotclaude. The fix
+  belongs in the plugin source repo. A local extension here would only paper
+  over the real cause and drift from upstream.
+- `local-override` — the learning is a deliberate, project-specific deviation
+  from the plugin default that would be wrong or meaningless to push upstream
+  (e.g. *this* project's ship pipeline must skip a step every other project
+  needs). Only this disposition justifies a local skill-extension.
+
+Bias hard toward `upstream`. Choose `local-override` ONLY when you can name why
+the rule must NOT become the plugin's default behavior. If unsure, treat it as
+`upstream` and create the issue. This is not set for plugin-repo or
+project-topic learnings.
+
+**Hard boundary in a consumer project:** this skill must NOT apply a plugin fix
+directly — not into the consumer's own tree, and **never** into the installed
+plugin copy under `~/.claude/plugins/cache/**` or
+`~/.claude/plugins/marketplaces/**`. Those are managed install artifacts; a
+hand-edit masks the real defect and is overwritten on the next sync. A plugin
+defect always leaves this skill as an **upstream issue** (5b). The only writes
+allowed here are a deliberate `local-override` extension (5b′). **Exception —
+plugin source repo:** when the current project IS the plugin's own repo, direct
+fixes are expected (5a) and touching the local cache is *optional* (e.g.
+repairing or testing the installed copy).
+
 ## Step 5 — Route by target × topic
 
-Use this decision table. **In every branch: prefer deep-knowledge over skill
-over CLAUDE.md** — see the Conventions section below for soft caps, re-route
-triggers, and the self-reference rule. Single source:
-`deep-knowledge/content-conventions.md` (CLAUDE.md target ~20 lines, re-route
-above ~25).
+Use this decision table. **Root cause first: fix the learning where it lives.**
+A plugin defect/gap found in a consumer project belongs upstream (an issue in
+the plugin source repo), NOT in a local extension — localize only for a
+deliberate project-specific override (see Step 4b). Within whatever container
+you land in: **prefer deep-knowledge over skill over CLAUDE.md** — see the
+Conventions section below for soft caps, re-route triggers, and the
+self-reference rule. Single source: `deep-knowledge/content-conventions.md`
+(CLAUDE.md target ~20 lines, re-route above ~25).
 
-| `{target_project}`     | `{topic}`  | Action                                           |
-|------------------------|------------|--------------------------------------------------|
-| current = plugin repo  | plugin     | **5a.** Edit plugin files directly               |
-| current (consumer)     | plugin     | **5b.** Skill-extension if it fits; else 5c      |
-| current (consumer)     | project    | **5c.** Project-specific skill or deep-knowledge |
-| other project (any)    | any        | **5d.** Cross-project — issue or prompt          |
-| global / ambiguous     | any        | **5e.** ASK FIRST — do not auto-write            |
+| `{target_project}`     | `{topic}`                | Action                                           |
+|------------------------|--------------------------|--------------------------------------------------|
+| current = plugin repo  | plugin                   | **5a.** Edit plugin files directly               |
+| current (consumer)     | plugin → upstream        | **5b.** Issue in plugin source repo (root-cause) |
+| current (consumer)     | plugin → local-override  | **5b′.** Skill-extension if it fits; else 5c     |
+| current (consumer)     | project                  | **5c.** Project-specific skill or deep-knowledge |
+| other project (any)    | any                      | **5d.** Cross-project — issue or prompt          |
+| global / ambiguous     | any                      | **5e.** ASK FIRST — do not auto-write            |
 
 ### 5a — Plugin repo, plugin topic
 
@@ -122,7 +157,33 @@ deep-knowledge fits and the rule is a one-liner. Bias: keep CLAUDE.md at
 ~20 lines (target). After any CLAUDE.md edit, invoke `/devops-claude-md-lint`
 via the **Skill** tool to verify size and structure — do not eyeball line counts.
 
-### 5b — Consumer project, plugin topic, fits a skill
+### 5b — Consumer project, plugin topic, upstream fix (DEFAULT)
+
+Fires when Step 4b resolved `{plugin_disposition} == upstream`. The root cause
+lives in the plugin source repo, not in this project — create an issue there
+instead of localizing a workaround.
+
+1. Resolve the plugin source repo. Its canonical GitHub slug is
+   `Jerry0022/dotclaude` (derivable from the installed plugin's
+   `marketplace.json`: `{owner.name}/{name}`). Do NOT assume a local checkout
+   of it exists — pass the slug straight to the issue skill.
+2. Delegate to `/devops-new-issue` via the **Skill** tool — never call
+   `gh issue create` directly. Hand off a self-contained prompt containing:
+   - `title`: `[BUG] <short>` for a defect, `[FEAT] <short>` for a gap or
+     improvement (imperative, sentence case, no trailing period)
+   - `body`: full learning text + "Captured from a session in
+     {current-project}." + which plugin part it concerns (skill / hook / agent
+     / MCP / convention)
+   - target repo: `Jerry0022/dotclaude` (so the issue lands upstream, not in
+     the consumer repo)
+   - issue type: `bug` or `feature` accordingly
+3. This branch persists NOTHING locally — skip Step 6, go to Step 7.
+
+### 5b′ — Consumer project, plugin topic, local override
+
+Fires only when Step 4b resolved `{plugin_disposition} == local-override`: the
+project deliberately customizes plugin behavior and the rule must NOT become
+the plugin default.
 
 Determine which plugin skill the learning belongs to (use the topic keywords
 to match against the skill list — `ship`, `commit`, `flow`, `concept`, etc.).
@@ -214,8 +275,9 @@ The canonical rule now lives in its proper file. Any pre-existing entry in
 — auto-memory is for personal style/tone preferences, not project rules, so
 the duplicate should be removed once the sorted Claude instructions own it.
 
-Skip this step entirely for 5d (cross-project): the feedback memory belongs
-to *this* session, not the target project — leave it alone.
+Skip this step entirely for 5b and 5d (issue created upstream / cross-project):
+nothing was persisted locally, so there is no canonical file to supersede a
+feedback entry — leave auto-memory alone.
 
 1. **Resolve the project memory dir.** The path is
    `~/.claude/projects/<encoded-cwd>/memory/` where `<encoded-cwd>` replaces
@@ -271,7 +333,7 @@ After persisting, show the user:
   (don't re-count lines manually — relay the lint output)
 - If Step 6 deleted any feedback memories: list the removed file names
 
-For 5d issue creation: show the issue URL.
+For 5b / 5d issue creation: show the issue URL.
 For 5d prompt: show the copy-pastable block.
 
 ## Step 8 — Completion Card
@@ -281,7 +343,7 @@ Call `mcp__plugin_devops_dotclaude-completion__render_completion_card`:
 | Situation                                | Variant     |
 |------------------------------------------|-------------|
 | Files written in current/plugin repo     | `ready`     |
-| GitHub issue created in other repo       | `fallback`  |
+| GitHub issue created upstream/other repo  | `fallback`  |
 | Copy-pastable prompt generated only      | `fallback`  |
 | User aborted at 5e                       | `analysis`  |
 
@@ -302,6 +364,18 @@ write this skill performs.
   — auto-memory owns that channel. The **only** permitted writes are Step 6
   duplicate-cleanup: deleting matched `feedback_*.md` files and removing
   their bullets from `MEMORY.md`, both requiring user confirmation per match.
+- **Default to the root cause's home.** A plugin defect/gap found in a consumer
+  project becomes an issue in the plugin source repo (5b), NOT a local
+  extension. Localize (5b′ / local dotclaude change) only for a deliberate
+  project-specific override you can justify keeping off upstream — and only when
+  it makes sense to implement in the current project at all.
+- **Never hand-edit installed plugin copies.** In a consumer project this skill
+  must not fix a plugin defect directly — not in the consumer's tree, and never
+  under `~/.claude/plugins/cache/**` or `~/.claude/plugins/marketplaces/**`
+  (managed artifacts, overwritten on the next sync). Route it upstream (5b);
+  the only local write allowed is a deliberate `local-override` extension (5b′).
+  **Exception:** when the current project IS the plugin source repo, direct
+  fixes are expected and touching the local cache is optional.
 - **Always** prefer deep-knowledge > skill/extension > CLAUDE.md.
 - **Respect the soft caps** above; re-route to the next-larger container
   before busting CLAUDE.md or SKILL.md targets.

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.89.4",
+  "version": "0.90.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
Closes #190

## Summary
- **Plugin cache self-healing** — fixes the incomplete marketplace→cache sync that left the devops MCP servers unregistered (`/devops-ship` could not find `ship_*` tools, recurring every session).
- **devops-learn routing** — plugin-topic learnings in a consumer project default to an upstream issue (5b) instead of a local extension, with a hard boundary against hand-editing installed plugin copies.

## Changes
- `ss.plugin.update`: verify full `mcp-server/` tree + `.mcp.json` after rebuild; flag an existing cache stale when those files are missing despite matching version/sha → heal from the marketplace clone.
- `ss.mcp.deps`: reinstall on partial shared `node_modules`; replace a partial real `node_modules` with a junction to the healed copy.
- `devops-learn/SKILL.md`: default-upstream routing + install-copy boundary (Step 4b + Rules); plugin source repo is the explicit exception.

## Verification
- `npm run lint` clean · `npm test` 167/167 green.
- Integration-tested both hooks against a simulated broken cache (detection + heal) and partial/complete/absent `node_modules`.