### PR TITLE
feat: session-worktree invariant + Windows MCP cache crash fix

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.90.1"
+    "version": "0.91.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.90.1",
+      "version": "0.91.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.90.1",
+      "version": "0.91.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.91.0] — 2026-06-03
+
+### Fixed
+
+- **MCP servers crashed on Windows (issue #190, root cause)** — `ss.plugin.update`'s `copyDir` shelled out to `cp -a` / `cp -r` to rebuild the plugin cache. `cp` is not a cmd.exe builtin and Git's coreutils are usually off the PATH that Node's `execSync` sees, so on a fresh Windows install the copy silently failed and left a partial cache (missing `mcp-server/*.js`, `.mcp.json`, hooks) — every MCP server then crashed with `ERR_MODULE_NOT_FOUND`. The 0.90.0 completeness guard detected the breakage but the copy itself kept failing; `copyDir` now uses cross-platform `fs.cpSync` (Node 16.7+), keeping the `cp` shellout only as a last-resort fallback.
+
+### Added
+
+- **Session-worktree "tracked-or-gitignored" invariant (issue #193)** — the ship pipeline could report success while leaving the session's worktree in a dirty "limbo" state (work driven from the main repo while a sibling `.claude/worktrees/*` worktree was left untouched), triggering a scary "archive N uncommitted changes" prompt even though the work shipped. Now: `ship_preflight` hard-blocks when the dirty session worktree is on the shipped branch or base (this ship's own worktree) and warns for unrelated concurrent sessions; `ship_cleanup` warns post-merge if a session worktree is still dirty; a new warn-only `pre.worktree.split-guard` hook nudges when a git-mutating command runs from the main repo while a session worktree is active. New `ship/lib/worktree.js` helper.
+
+### Changed
+
+- **Agent orchestration sub-branch naming** — the collaboration protocol prescribed `<parent>/<role>` sub-branches, but git stores refs as files and refuses `refs/heads/foo/bar` while branch `foo` exists, so a slash-nested child always collided with the checked-out integration branch. Switched to the flat `<parent>-<role>` form (with the git reason documented), fixed the self-inconsistent diagram, and clarified that the orchestrator merges sub-branches back and ships the integration branch once (slash-based hierarchical ship stays documented as a separate opt-in with its on-origin-only precondition).
+
 ## [0.90.1] — 2026-06-01
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ For the full extension guide with examples per skill, see `deep-knowledge/skill-
 
 ## Features
 
-- **<!--devops:count:hooks-->27<!--/devops:count:hooks--> Hooks** — automated guards and triggers across the full session lifecycle
+- **<!--devops:count:hooks-->28<!--/devops:count:hooks--> Hooks** — automated guards and triggers across the full session lifecycle
 - **<!--devops:count:skills-->19<!--/devops:count:skills--> Skills** — devops-ship, devops-commit, devops-flow, devops-new-issue, devops-project-setup, devops-readme, devops-refresh-usage, devops-extend-skill, devops-repo-health, devops-claude-md-lint, devops-concept, devops-agents, devops-plugin-update, devops-autonomous, devops-burn, devops-learn, devops-harden, devops-polish, devops-test-plan
 - **<!--devops:count:agents-->11<!--/devops:count:agents--> Agents** — AI, Core, Designer, Feature, Frontend, Gamer, PO, QA, Redteam, Research, Windows
 - **Completion Flow** — mandatory card after every task (8 variants), visual verification, ship recommendation
@@ -178,7 +178,7 @@ For the full extension guide with examples per skill, see `deep-knowledge/skill-
 
 ### Hooks (automatic, no user action needed)
 
-<!--devops:count:hooks-->27<!--/devops:count:hooks--> hooks fire automatically across the session lifecycle — no user action needed.
+<!--devops:count:hooks-->28<!--/devops:count:hooks--> hooks fire automatically across the session lifecycle — no user action needed.
 
 <details>
 <summary><strong>By session lifecycle</strong> — when does it fire?</summary>
@@ -217,6 +217,7 @@ SessionStart  ──>  UserPromptSubmit  ──>  PreToolUse  ──>  PostToolU
 - `pre.tokens.guard` — Block Read/Bash/Glob/Grep operations that would consume a significant percentage of t…
 - `pre.ship.guard` — Block manual PR creation/merging via Bash.
 - `pre.main.guard` — Prevent accidental writes on local main/master.
+- `pre.worktree.split-guard` — WARN (never block) on git-mutating work driven from the main repo root while an agent…
 - `pre.edit.branch` — Prevent Edit/Write tool calls while HEAD is on local main/master.
 - `pre.mcp.health` — Detects dead or stale MCP servers before tool calls fail cryptically.
 
@@ -639,7 +640,7 @@ Wk  ━━──╏─────────   15% +1%   · 4d 22h left
 devops/
 ├── .claude-plugin/plugin.json     ← Plugin manifest
 ├── CONVENTIONS.md                 ← Naming, versioning, extension rules
-├── hooks/                         ← <!--devops:count:hooks-->27<!--/devops:count:hooks--> hooks (JS) registered in hooks.json
+├── hooks/                         ← <!--devops:count:hooks-->28<!--/devops:count:hooks--> hooks (JS) registered in hooks.json
 ├── skills/                        ← <!--devops:count:skills-->19<!--/devops:count:skills--> skill definitions (SKILL.md)
 ├── agents/                        ← <!--devops:count:agents-->11<!--/devops:count:agents--> agent definitions
 ├── deep-knowledge/                ← Cross-cutting reference docs

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.90.1**
+**Version: 0.91.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.90.1",
+  "version": "0.91.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/deep-knowledge/agent-collaboration.md
+++ b/plugins/devops/deep-knowledge/agent-collaboration.md
@@ -88,19 +88,21 @@ Workaround: <temporary solution if any>
 
 ## Sub-Branch Strategy
 
-When the Feature agent delegates to domain agents:
+When the Feature agent delegates to domain agents, each sub-agent works on its own
+branch off the integration branch:
 
 ```
-feat/42-video-filters          ← Feature agent (integration branch)
-├── feat/42/core               ← Core agent worktree
-├── feat/42/frontend           ← Frontend agent worktree
-├── feat/42/windows            ← Windows agent worktree
-└── feat/42/ai                 ← AI agent worktree
+feat/42-video-filters               ← Feature agent (integration branch)
+├── feat/42-video-filters-core      ← Core agent worktree
+├── feat/42-video-filters-frontend  ← Frontend agent worktree
+├── feat/42-video-filters-windows   ← Windows agent worktree
+└── feat/42-video-filters-ai        ← AI agent worktree
 ```
 
-Merge order follows wave order: Core → Frontend/Windows/AI → integration branch.
-
-Each sub-agent ships via `/devops-ship` — the pipeline auto-detects the parent branch from naming convention. See `skills/devops-ship/SKILL.md` → "Hierarchical Merge Workflow".
+The orchestrator merges each sub-branch back into the integration branch (merge order
+follows wave order: Core → Frontend/Windows/AI → integration). The integration branch is
+shipped to `main` **once**, at the end, via `/devops-ship` — sub-branches are NOT shipped
+individually.
 
 ## Branch Inheritance Protocol
 
@@ -111,56 +113,53 @@ To ensure agents work on the correct branch, every isolated agent MUST follow th
 
 1. **Push the integration branch to origin before spawning any sub-agent:**
    `git push -u origin <integration-branch>`
-   This is mandatory — sub-agents need the branch on origin to auto-detect it as their parent.
+   Mandatory — sub-agents reset to `origin/<integration-branch>` so they start from the
+   integration tip rather than from main.
 2. Before spawning any sub-agent, capture the current branch:
    `PARENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)`
-3. Include in EVERY agent prompt:
-   `Parent branch: <branch-name>`
-4. After each sub-agent completes, merge their branch back:
+3. Include in EVERY agent prompt: `Parent branch: <branch-name>` plus the exact
+   sub-branch name to use (see § Branch naming).
+4. After each sub-agent completes, merge its branch back:
    `git merge --no-ff <sub-agent-branch>`
 
 ### For every isolated Sub-Agent (first action after spawn)
 
-1. Fetch and reset to parent branch:
+1. Fetch and start your branch from the parent tip. Use `checkout -B` (not `-b`) so it
+   works whether or not the fresh worktree already sits on a branch of that name:
    ```bash
    git fetch origin
-   git reset --hard origin/<parent-branch>  # or local ref if not pushed
+   git checkout -B <sub-branch-name> origin/<parent-branch>
    ```
-2. Create your working branch from there:
-   ```bash
-   git checkout -b <sub-branch-name>
-   ```
-3. Work, commit, push
-4. Report branch name in handoff
+2. Work, commit, push: `git push -u origin <sub-branch-name>`
+3. Report the exact branch name in the handoff.
 
 ### Branch naming
 
-Sub-branches follow: `<parent-branch>/<role>`
-Example: If parent is `feat/42-video-filters`, core agent works on `feat/42-video-filters/core`
+Sub-branches use a **flat, dash-joined** name: `<parent-branch>-<role>`
+Example: parent `feat/42-video-filters` → core agent works on `feat/42-video-filters-core`.
+
+**Never use a slash (`<parent-branch>/<role>`).** Git stores branches as files under
+`.git/refs/heads`, so it refuses to create `foo/bar` while a branch `foo` exists
+(`cannot lock ref 'refs/heads/foo/bar': 'refs/heads/foo' exists`). The orchestrator keeps
+the integration branch checked out locally, so a slash-nested child ALWAYS collides. The
+dash form never collides — every sub-agent must use it.
 
 ### Merge order
 
-Same as wave order. Feature agent merges each wave's branches before spawning the next wave.
+Same as wave order. The Feature agent merges each wave's sub-branches into the integration
+branch before spawning the next wave. Disjoint-file sub-branches merge cleanly; resolve any
+conflicts per `deep-knowledge/merge-safety.md`.
 
-### Shipping sub-branches
+### Hierarchical ship (separate, optional)
 
-Sub-agents call `/devops-ship` from their branch. The ship pipeline auto-detects the parent:
-- `feat/42-video-filters/core` → detects base `feat/42-video-filters` → intermediate merge
-- `feat/42-video-filters` → no parent detected → ships to `main` with full release
-
-Intermediate merges skip version bump, tag, and GitHub release. These only happen on the final ship to main.
-
-### Shipping order within a wave
-
-**Sub-agents within the same wave must ship sequentially, not in parallel.**
-The Feature agent orchestrates shipping one sub-branch at a time:
-
-1. Sub-agent A completes → Feature agent calls `/devops-ship` for A's branch → waits for merge
-2. Sub-agent B completes → Feature agent calls `/devops-ship` for B's branch → waits for merge
-3. Continue until all sub-branches in the wave are merged
-
-This prevents merge conflicts from concurrent PRs targeting the same feature branch.
-Parallel **work** within a wave is fine — only the **shipping** must be sequential.
+The ship pipeline can also auto-detect a parent from a **slash-nested** branch name
+(`detectParentBranch`: `feat/42/core` → base `feat/42` → intermediate merge; full release
+only on the final ship to main). This is a distinct capability for genuine multi-stage
+feature branches, with a hard precondition: the parent must exist **on origin only** and
+NOT be checked out as a local branch — otherwise the slash-nested child cannot be created
+(see § Branch naming). The agent-orchestration default does NOT use this; it uses dash
+sub-branches + orchestrator merge-back (above), which always works regardless of what is
+checked out locally.
 
 ### Conflict resolution during integration
 
@@ -201,8 +200,9 @@ All happens within the single `/devops-new-issue` execution.
 - **Handoff data is mandatory.** No agent starts without knowing what came before.
 - **Conflicts resolve at integration.** The Feature agent handles merge conflicts per `deep-knowledge/merge-safety.md`. Never use `--ours`/`--theirs`. Auto-resolve complementary changes; escalate design decisions to user.
 - **Parallel agents don't cross-depend.** Frontend and Windows never import from each other.
-- **Push integration branch before spawning sub-agents.** Sub-agents rely on the branch existing on origin for auto-detection.
-- **Ship sub-branches sequentially.** Parallel work is fine, but shipping must be one at a time to avoid merge conflicts.
+- **Push integration branch before spawning sub-agents.** Sub-agents reset to `origin/<integration-branch>` to start from the integration tip.
+- **Sub-branches use dash names, never slashes.** `<parent>-<role>` — a slash-nested child collides with the checked-out integration branch ref (see § Branch naming).
+- **Merge sub-branches back in wave order; ship the integration branch once.** Sub-branches are not shipped individually.
 
 ## Extension
 

--- a/plugins/devops/deep-knowledge/agent-orchestration.md
+++ b/plugins/devops/deep-knowledge/agent-orchestration.md
@@ -263,4 +263,4 @@ The orchestrator (calling skill) is responsible for:
 1. Creating the integration branch if not already on a feature branch
 2. Pushing it to origin before spawning sub-agents
 3. Merging each wave's branches back before spawning the next wave
-4. Sequential shipping within a wave (parallel work, sequential ship)
+4. Shipping the integration branch ONCE at the end — sub-branches are merged back (step 3), not shipped individually. Sub-branch names are dash-joined `<parent>-<role>`, never slash-nested (a slash collides with the checked-out integration branch's ref).

--- a/plugins/devops/deep-knowledge/git-hygiene.md
+++ b/plugins/devops/deep-knowledge/git-hygiene.md
@@ -55,3 +55,46 @@ See [merge-safety.md](merge-safety.md) for full details on preventing silent ove
 - **Rebase before merge** — mandatory when base has diverged (enforced by `ship_release`)
 - **diff3 conflict style** — required for all developers (`git config merge.conflictstyle diff3`)
 - **No auto-resolve** — `git-sync.js` never uses `--ours`; conflicts abort and warn
+
+## Session-worktree hygiene
+
+Enforced by the parallel-agent guard introduced in #193. See also
+[merge-safety.md § Worktree Path Discipline](merge-safety.md#worktree-path-discipline).
+
+### Work and commit inside the session worktree
+
+- **Always work inside the session worktree** — cwd is `.claude/worktrees/<name>/`,
+  branch is `claude/<name>`.
+- **Never run git-mutating commands from the main repo root** while a session
+  worktree is active. Mutating commands: `commit`, `checkout -b`, `merge`,
+  `rebase`, `cherry-pick`, `reset --hard`, `apply`, `am`.
+- **Why:** commits issued from the main repo root land on the main repo's
+  current branch, not on the session branch. The session worktree is left dirty
+  (untracked / modified files not staged to any branch). That split state is
+  silent — no error is raised.
+
+### Ship-end invariant: tracked-or-gitignored
+
+- At ship completion, every file created during the session must be either:
+  - **(a) tracked → committed → pushed → merged**, or
+  - **(b) explicitly gitignored**.
+- **Never leave a session worktree in a "limbo" state** — partially committed,
+  untracked, or staged but not pushed — when a ship reports success.
+- A ship pipeline must **not** declare success while the session worktree is
+  dirty. Dirty = any `git status` output other than "nothing to commit."
+
+### Why it matters
+
+- A success path that strands uncommitted work in the session worktree triggers
+  an "archive N uncommitted changes?" prompt on the next session start.
+- This undermines trust in the ship pipeline as a no-data-loss guarantee and
+  forces the user to manually rescue or discard work.
+
+### Enforcement points
+
+- **`ship_preflight`** — blocks shipping if the session worktree is dirty and
+  the working directory is detected as the main repo root.
+- **`ship_cleanup`** — warns when the session worktree still has uncommitted
+  changes after merge.
+- **Pre-tool-use guard** — warns when a git-mutating command is issued from the
+  main repo root while a worktree for the current session is active.

--- a/plugins/devops/deep-knowledge/git-hygiene.md
+++ b/plugins/devops/deep-knowledge/git-hygiene.md
@@ -92,8 +92,10 @@ Enforced by the parallel-agent guard introduced in #193. See also
 
 ### Enforcement points
 
-- **`ship_preflight`** — blocks shipping if the session worktree is dirty and
-  the working directory is detected as the main repo root.
+- **`ship_preflight`** — when the working directory is the main repo root,
+  hard-blocks if a dirty session worktree is on the shipped branch (or base) —
+  i.e. this ship's own worktree. Other dirty session worktrees (unrelated
+  concurrent sessions) are surfaced as non-blocking warnings, never a block.
 - **`ship_cleanup`** — warns when the session worktree still has uncommitted
   changes after merge.
 - **Pre-tool-use guard** — warns when a git-mutating command is issued from the

--- a/plugins/devops/deep-knowledge/merge-safety.md
+++ b/plugins/devops/deep-knowledge/merge-safety.md
@@ -24,6 +24,10 @@ success, you see confusing "file modified since read" races, and the change is
 gone. Edits in your own worktree are isolated and survive. If a path during a
 worktree session lacks the `worktrees/<name>/` segment, it is wrong.
 
+This discipline extends to git-mutating commands (commit, checkout -b, merge,
+rebase). See [git-hygiene.md § Session-worktree hygiene](git-hygiene.md#session-worktree-hygiene)
+for the full tracked-or-gitignored invariant and enforcement points.
+
 ## Why Squash Merges Cause Data Loss
 
 Squash merges sever Git's ancestry chain. When Dev B squash-merges to main, the new

--- a/plugins/devops/docs/architecture.html
+++ b/plugins/devops/docs/architecture.html
@@ -169,7 +169,7 @@
 <section id="overview">
 <h1>Architecture Documentation <small>devops v0.87.0</small></h1>
 <p class="lead">
-  A comprehensive DevOps automation plugin for Claude Code &mdash; <!--devops:count:hooks-->27<!--/devops:count:hooks--> hooks, <!--devops:count:skills-->19<!--/devops:count:skills--> skills, <!--devops:count:agents-->11<!--/devops:count:agents--> agents,
+  A comprehensive DevOps automation plugin for Claude Code &mdash; <!--devops:count:hooks-->28<!--/devops:count:hooks--> hooks, <!--devops:count:skills-->19<!--/devops:count:skills--> skills, <!--devops:count:agents-->11<!--/devops:count:agents--> agents,
   2 MCP servers, a deterministic completion card engine, and a 3-layer extension system.
 </p>
 <div role="note" style="margin:.4rem 0 1.4rem;padding:.6rem .9rem;background:var(--bg2);border-left:3px solid var(--warn);border-radius:4px;color:var(--text2);font-size:.85rem;">
@@ -180,11 +180,11 @@
 
 <div class="card-grid">
   <div class="card">
-    <h4><!--devops:count:hooks-->27<!--/devops:count:hooks--> Hooks</h4>
+    <h4><!--devops:count:hooks-->28<!--/devops:count:hooks--> Hooks</h4>
     <p style="color:var(--text2);font-size:.85rem">Lifecycle guards across SessionStart, UserPromptSubmit, PreToolUse, PostToolUse, Stop</p>
     <span class="badge b-hook">SessionStart &times;<!--devops:count:hooks:ss-->11<!--/devops:count:hooks:ss--></span>
     <span class="badge b-hook">Prompt &times;<!--devops:count:hooks:prompt-->7<!--/devops:count:hooks:prompt--></span>
-    <span class="badge b-hook">Pre &times;<!--devops:count:hooks:pre-->5<!--/devops:count:hooks:pre--></span>
+    <span class="badge b-hook">Pre &times;<!--devops:count:hooks:pre-->6<!--/devops:count:hooks:pre--></span>
     <span class="badge b-hook">Post &times;<!--devops:count:hooks:post-->2<!--/devops:count:hooks:post--></span>
     <span class="badge b-hook">Stop &times;<!--devops:count:hooks:stop-->2<!--/devops:count:hooks:stop--></span>
   </div>
@@ -219,7 +219,7 @@
 │   ├── lib/                   <span style="color:var(--text2)"># plugin-guard, run-once, session-id</span>
 │   ├── session-start/         <span style="color:var(--purple)"># <!--devops:count:hooks:ss-->11<!--/devops:count:hooks:ss--> hooks (ss.*)</span>
 │   ├── user-prompt-submit/    <span style="color:var(--purple)"># <!--devops:count:hooks:prompt-->7<!--/devops:count:hooks:prompt--> hooks (prompt.*)</span>
-│   ├── pre-tool-use/          <span style="color:var(--purple)"># <!--devops:count:hooks:pre-->5<!--/devops:count:hooks:pre--> hooks (pre.*)</span>
+│   ├── pre-tool-use/          <span style="color:var(--purple)"># <!--devops:count:hooks:pre-->6<!--/devops:count:hooks:pre--> hooks (pre.*)</span>
 │   ├── post-tool-use/         <span style="color:var(--purple)"># <!--devops:count:hooks:post-->2<!--/devops:count:hooks:post--> hooks (post.*)</span>
 │   └── stop/                  <span style="color:var(--purple)"># <!--devops:count:hooks:stop-->2<!--/devops:count:hooks:stop--> hooks (stop.*)</span>
 ├── mcp-server/

--- a/plugins/devops/hooks/hooks.json
+++ b/plugins/devops/hooks/hooks.json
@@ -29,7 +29,8 @@
       {
         "hooks": [
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/pre-tool-use/pre.ship.guard.js" },
-          { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/pre-tool-use/pre.main.guard.js" }
+          { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/pre-tool-use/pre.main.guard.js" },
+          { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/pre-tool-use/pre.worktree.split-guard.js" }
         ],
         "matcher": "Bash"
       },

--- a/plugins/devops/hooks/pre-tool-use/pre.worktree.split-guard.js
+++ b/plugins/devops/hooks/pre-tool-use/pre.worktree.split-guard.js
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+/**
+ * @hook pre.worktree.split-guard
+ * @version 0.1.0
+ * @event PreToolUse
+ * @plugin devops
+ * @matcher Bash
+ * @description WARN (never block) on git-mutating work driven from the main
+ *   repo root while an agent session worktree is active.
+ *
+ *   The split-state bug: an agent session has an isolated worktree at
+ *   `.claude/worktrees/<name>`, but git-mutating commands (and later the ship
+ *   pipeline) are run from the MAIN repo root instead of inside the worktree.
+ *   The branch/commits land on the main repo and can ship+merge fine — but the
+ *   session worktree is never inspected and is left dirty, so the harness later
+ *   warns "Archive session with N uncommitted changes". This hook nudges the
+ *   user toward the worktree before that limbo state is created.
+ *
+ *   Fires ONLY in that exact split-state:
+ *     - cwd is the MAIN working tree (NOT a linked worktree)
+ *     - the command is git commit / git checkout -b / git merge
+ *     - at least one `.claude/worktrees/*` session worktree is active
+ *
+ *   Always exits 0 (warn-only). Bypass conditions (→ silent exit 0):
+ *     - Not inside a git repo
+ *     - cwd IS a linked worktree (the intended place to work)
+ *     - Ship sentinel active (ship legitimately mutates from main)
+ *     - No session worktree present
+ */
+
+require('../lib/plugin-guard');
+
+const { execFileSync } = require('node:child_process');
+const path = require('node:path');
+const { isActive: sentinelActive } = require('../lib/ship-sentinel');
+
+// Mutating commands that create the limbo state when run from the main root.
+// Conservative set per spec: commit, checkout -b, merge.
+const SPLIT_PATTERNS = [
+  /^\s*git\s+commit(\s|$)/,
+  /^\s*git\s+merge(\s|$)/,
+  /^\s*git\s+checkout\s+-b(\s|$)/,
+  /^\s*git\s+checkout\s+-B(\s|$)/,
+  /^\s*git\s+switch\s+-c(\s|$)/,
+  /^\s*git\s+switch\s+-C(\s|$)/,
+];
+
+const SESSION_WORKTREE_MARKER = '/.claude/worktrees/';
+
+function gitOut(args, cwd) {
+  try {
+    return execFileSync('git', args, {
+      cwd, encoding: 'utf8', timeout: 5000, stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function isGitRepo(cwd) {
+  return gitOut(['rev-parse', '--is-inside-work-tree'], cwd) === 'true';
+}
+
+// True when cwd is a LINKED worktree (git-dir != git-common-dir).
+function isLinkedWorktree(cwd) {
+  const gitDir = gitOut(['rev-parse', '--git-dir'], cwd);
+  const commonDir = gitOut(['rev-parse', '--git-common-dir'], cwd);
+  if (!gitDir || !commonDir) return false;
+  return path.resolve(cwd, gitDir) !== path.resolve(cwd, commonDir);
+}
+
+// List active session worktree paths (under .claude/worktrees/), normalized.
+// `git worktree list --porcelain` emits forward-slash paths on all platforms.
+function activeSessionWorktrees(cwd) {
+  const out = gitOut(['worktree', 'list', '--porcelain'], cwd);
+  if (!out) return [];
+  const paths = [];
+  for (const line of out.split('\n')) {
+    if (line.startsWith('worktree ')) {
+      const p = line.slice('worktree '.length).trim().replace(/\\/g, '/');
+      if (p.includes(SESSION_WORKTREE_MARKER)) paths.push(p);
+    }
+  }
+  return paths;
+}
+
+let inputData = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', d => { inputData += d; });
+process.stdin.on('end', () => {
+  let hook;
+  try { hook = JSON.parse(inputData); } catch { process.exit(0); }
+
+  if ((hook.tool_name || '') !== 'Bash') process.exit(0);
+
+  const cmd = (hook.tool_input || {}).command || '';
+  if (!cmd) process.exit(0);
+  if (!SPLIT_PATTERNS.some(re => re.test(cmd))) process.exit(0);
+
+  const cwd = hook.cwd || process.cwd();
+
+  if (!isGitRepo(cwd)) process.exit(0);
+  // Ship runs git from main legitimately — its own gates cover the worktree.
+  if (sentinelActive(cwd)) process.exit(0);
+  // If we are inside the worktree already, this is exactly where work belongs.
+  if (isLinkedWorktree(cwd)) process.exit(0);
+
+  const worktrees = activeSessionWorktrees(cwd);
+  if (worktrees.length === 0) process.exit(0);
+
+  const list = worktrees.map(p => `  - ${p}`).join('\n');
+  process.stderr.write(
+    `[pre.worktree.split-guard] WARNING: git-mutating command in the MAIN repo while a session worktree is active:\n` +
+    `${list}\n` +
+    `[pre.worktree.split-guard] If this work belongs to the session, run it INSIDE the worktree instead — otherwise the worktree is left dirty and the session shows "uncommitted changes" even though the work shipped from main.\n` +
+    `[pre.worktree.split-guard] This is a warning only; the command will proceed.\n`
+  );
+  process.exit(0);
+});

--- a/plugins/devops/hooks/session-start/ss.plugin.update.copydir.test.js
+++ b/plugins/devops/hooks/session-start/ss.plugin.update.copydir.test.js
@@ -1,0 +1,136 @@
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+/**
+ * Characterization test for the copy primitive behind ss.plugin.update.js's
+ * copyDir() — issue #190.
+ *
+ * The bug: copyDir() shelled out to `cp -a` / `cp -r`, which silently fails on
+ * Windows (cp is not a cmd.exe builtin and Git's coreutils are usually off the
+ * PATH that Node's execSync sees). A failed copy left a partial plugin cache —
+ * missing mcp-server/*.js, .mcp.json, and hooks — that crashed every MCP server
+ * with ERR_MODULE_NOT_FOUND. The fix replaces the shell-out with
+ *   fs.cpSync(src, dst, { recursive: true, force: true })
+ *
+ * copyDir() is a non-exported internal of a SessionStart hook whose module body
+ * self-executes (reads ~/.claude/plugins, can process.exit) on import. Importing
+ * it would run that logic, and exporting copyDir purely to test it would contort
+ * production code. So this test exercises the EXACT primitive the fix relies on,
+ * with the EXACT options the production call passes, against a temp source tree
+ * that reproduces the structures the old `cp` shell-out dropped:
+ *   - dotfiles at the root (.mcp.json)
+ *   - dot-directories (.claude-plugin/plugin.json)
+ *   - a nested mcp-server/ tree (index.js + lib/ + ship/ + issues/)
+ *   - the hooks/ + skills/ dirs the completeness guard asserts
+ * and asserts the destination is a complete, byte-faithful mirror.
+ *
+ * This locks in the platform guarantee the fix depends on (fs.cpSync copies
+ * dotfiles + nested dirs recursively here) without touching production code.
+ */
+
+// Mirror of the production call site in copyDir().
+function copyTree(src, dst) {
+  fs.cpSync(src, dst, { recursive: true, force: true });
+}
+
+let tmpRoot;
+let src;
+let dst;
+
+// The MCP-critical files ss.plugin.update.js verifies post-copy (MCP_CRITICAL_FILES).
+// A dropped copy of any of these is exactly the #190 breakage.
+const MCP_CRITICAL_FILES = [
+  ".mcp.json",
+  path.join("mcp-server", "index.js"),
+  path.join("mcp-server", "lib", "heartbeat.js"),
+  path.join("mcp-server", "ship", "index.js"),
+  path.join("mcp-server", "issues", "index.js"),
+];
+
+function write(root, rel, content) {
+  const full = path.join(root, rel);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, content);
+}
+
+beforeEach(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "dotclaude-copydir-"));
+  src = path.join(tmpRoot, "src");
+  dst = path.join(tmpRoot, "dst");
+  fs.mkdirSync(src, { recursive: true });
+
+  // A realistic plugin source tree: dotfiles, dot-dirs, nested mcp-server,
+  // hooks, skills — the shapes the old `cp` shell-out silently dropped.
+  write(src, ".mcp.json", '{"mcpServers":{}}');
+  write(src, path.join(".claude-plugin", "plugin.json"), '{"version":"9.9.9"}');
+  write(src, path.join("mcp-server", "index.js"), "export const x = 1;");
+  write(src, path.join("mcp-server", "lib", "heartbeat.js"), "export const hb = 1;");
+  write(src, path.join("mcp-server", "ship", "index.js"), "export const ship = 1;");
+  write(src, path.join("mcp-server", "issues", "index.js"), "export const issues = 1;");
+  write(src, path.join("hooks", "hooks.json"), "{}");
+  write(src, path.join("hooks", "session-start", "ss.x.js"), "// hook");
+  write(src, path.join("skills", "devops-x", "SKILL.md"), "# skill");
+});
+
+afterEach(() => {
+  try {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  } catch { /* ignore */ }
+});
+
+describe("ss.plugin.update copyDir primitive (fs.cpSync) — issue #190", () => {
+  test("copies the .claude-plugin/plugin.json sentinel copyDir checks for", () => {
+    copyTree(src, dst);
+    // copyDir() returns true iff this file exists post-copy — its success signal.
+    expect(fs.existsSync(path.join(dst, ".claude-plugin", "plugin.json"))).toBe(true);
+    expect(fs.readFileSync(path.join(dst, ".claude-plugin", "plugin.json"), "utf8")).toBe('{"version":"9.9.9"}');
+  });
+
+  test("copies root-level dotfile (.mcp.json) — dropped by the old cp glob", () => {
+    copyTree(src, dst);
+    expect(fs.existsSync(path.join(dst, ".mcp.json"))).toBe(true);
+    expect(fs.readFileSync(path.join(dst, ".mcp.json"), "utf8")).toBe('{"mcpServers":{}}');
+  });
+
+  test("copies the full nested mcp-server tree (all MCP_CRITICAL_FILES present)", () => {
+    copyTree(src, dst);
+    const missing = MCP_CRITICAL_FILES.filter((rel) => !fs.existsSync(path.join(dst, rel)));
+    expect(missing).toEqual([]);
+  });
+
+  test("copies hooks/ and skills/ dirs the completeness guard asserts", () => {
+    copyTree(src, dst);
+    expect(fs.existsSync(path.join(dst, "hooks"))).toBe(true);
+    expect(fs.existsSync(path.join(dst, "skills"))).toBe(true);
+    expect(fs.existsSync(path.join(dst, "hooks", "session-start", "ss.x.js"))).toBe(true);
+    expect(fs.existsSync(path.join(dst, "skills", "devops-x", "SKILL.md"))).toBe(true);
+  });
+
+  test("destination mirrors the full source file set (no dropped paths)", () => {
+    copyTree(src, dst);
+    // Collect all file paths under `root`, relative to `base`, sorted.
+    const walk = (root, base) => {
+      const out = [];
+      for (const e of fs.readdirSync(root, { withFileTypes: true })) {
+        const full = path.join(root, e.name);
+        if (e.isDirectory()) out.push(...walk(full, base));
+        else out.push(path.relative(base, full));
+      }
+      return out.sort();
+    };
+    expect(walk(dst, dst)).toEqual(walk(src, src));
+  });
+
+  test("force:true overwrites a pre-existing partial cache (in-place repair path)", () => {
+    // Simulate a stale/partial cache already present at the destination.
+    write(dst, path.join(".claude-plugin", "plugin.json"), '{"version":"0.0.1-old"}');
+    write(dst, "stale-only.txt", "leftover");
+    copyTree(src, dst);
+    // Overwritten with the new content...
+    expect(fs.readFileSync(path.join(dst, ".claude-plugin", "plugin.json"), "utf8")).toBe('{"version":"9.9.9"}');
+    // ...and the new tree is complete.
+    expect(MCP_CRITICAL_FILES.every((rel) => fs.existsSync(path.join(dst, rel)))).toBe(true);
+  });
+});

--- a/plugins/devops/hooks/session-start/ss.plugin.update.js
+++ b/plugins/devops/hooks/session-start/ss.plugin.update.js
@@ -136,18 +136,21 @@ function getVersion(dir) {
 }
 
 function copyDir(src, dst) {
-  // Try cp -a (archive) to get dotfiles + new directories.
-  run(`cp -a "${src}/." "${dst}/"`, path.dirname(src));
-
-  // Verify copy worked by checking a known file — don't trust return value
-  // (cp returns empty string on both success and failure via run()).
-  if (!fs.existsSync(path.join(dst, '.claude-plugin', 'plugin.json'))) {
-    // Fallback: explicit copy for Windows where cp -a may not work
-    run(`cp -r "${src}/"* "${dst}/"`, path.dirname(src));
+  // Cross-platform recursive copy (Node 16.7+). The previous implementation
+  // shelled out to `cp -a` / `cp -r`, which silently fails on Windows: `cp` is
+  // not a cmd.exe builtin and Git's coreutils are usually not on the PATH that
+  // Node's execSync sees. A failed copy left a partial cache (missing
+  // mcp-server/*.js, .mcp.json, hooks) that crashed every MCP server — the
+  // exact breakage the #190 completeness guard was meant to prevent.
+  try {
+    fs.cpSync(src, dst, { recursive: true, force: true });
+  } catch {
+    // Last-resort fallback for environments where fs.cpSync is unavailable.
+    run(`cp -a "${src}/." "${dst}/"`, path.dirname(src));
     run(`cp -r "${src}/.claude-plugin" "${dst}/"`, path.dirname(src));
     const mcpSrc = path.join(src, '.mcp.json');
     if (fs.existsSync(mcpSrc)) {
-      fs.copyFileSync(mcpSrc, path.join(dst, '.mcp.json'));
+      try { fs.copyFileSync(mcpSrc, path.join(dst, '.mcp.json')); } catch { /* ignore */ }
     }
   }
 

--- a/plugins/devops/mcp-server/ship/lib/worktree.js
+++ b/plugins/devops/mcp-server/ship/lib/worktree.js
@@ -1,0 +1,123 @@
+/**
+ * @module ship/lib/worktree
+ * @description Detect sibling session worktrees and their dirty state.
+ *
+ *   A "session worktree" is a linked git worktree that lives under
+ *   `.claude/worktrees/<name>` (the convention agent sessions use). The ship
+ *   pipeline runs from a cwd that may be the MAIN repo root while such a
+ *   session worktree is active on the side. If git-mutating work + the ship
+ *   were driven from the main repo (instead of inside the worktree), the
+ *   feature branch + commits land on the main repo and merge to the default
+ *   branch successfully — but the session worktree itself is never inspected
+ *   and can be left in a dirty "limbo" state (uncommitted/partial changes).
+ *
+ *   This helper lets preflight (hard gate) and cleanup (post-merge warning)
+ *   enforce the invariant: at ship completion every file in a session worktree
+ *   must be tracked→committed→pushed→merged OR gitignored — never in-between.
+ *
+ *   Style mirrors ship/lib/git.js (thin execSync wrappers, null-on-failure).
+ */
+
+import { git } from "./git.js";
+
+// Path segment that marks a worktree as an agent session worktree.
+// `git worktree list --porcelain` always emits forward-slash paths, even on
+// Windows — match on the forward-slash form so the check is OS-agnostic.
+const SESSION_WORKTREE_MARKER = "/.claude/worktrees/";
+
+/**
+ * Normalize a filesystem path for comparison: forward slashes, no trailing
+ * slash, drive letter lower-cased (Windows paths from different sources differ
+ * only in drive-letter case). Mirrors what we need to reliably tell whether a
+ * porcelain worktree path is the same directory as `opts.cwd`.
+ */
+function normPath(p) {
+  if (!p) return "";
+  let n = p.replace(/\\/g, "/").replace(/\/+$/, "");
+  // Lower-case a leading "C:" style drive letter for case-insensitive match.
+  if (/^[A-Za-z]:/.test(n)) n = n[0].toLowerCase() + n.slice(1);
+  return n;
+}
+
+/**
+ * Parse `git worktree list --porcelain` into structured entries.
+ * Each entry: { path, branch|null, detached }.
+ *
+ * Porcelain format is record-per-worktree, blank-line separated:
+ *   worktree <abs-path>
+ *   HEAD <sha>
+ *   branch refs/heads/<name>   (omitted when detached; `detached` line instead)
+ */
+export function listWorktrees(opts) {
+  const output = git("worktree list --porcelain", opts);
+  if (!output) return [];
+  const entries = [];
+  let cur = null;
+  for (const line of output.split("\n")) {
+    if (line.startsWith("worktree ")) {
+      if (cur) entries.push(cur);
+      cur = { path: line.slice("worktree ".length).trim(), branch: null, detached: false };
+    } else if (line.startsWith("branch refs/heads/") && cur) {
+      cur.branch = line.slice("branch refs/heads/".length).trim();
+    } else if (line === "detached" && cur) {
+      cur.detached = true;
+    }
+  }
+  if (cur) entries.push(cur);
+  return entries;
+}
+
+/**
+ * Whether a worktree path is an agent session worktree (under
+ * `.claude/worktrees/`).
+ */
+export function isSessionWorktreePath(p) {
+  return normPath(p).includes(SESSION_WORKTREE_MARKER);
+}
+
+/**
+ * Report dirtiness of a single worktree at `path`.
+ * Returns { path, dirty, changes } where `changes` is the count of porcelain
+ * lines. `git status --porcelain` excludes gitignored files by default, so a
+ * non-empty result means uncommitted tracked changes OR non-gitignored
+ * untracked files — exactly the "limbo" state we must not ship past.
+ *
+ * On git failure (path gone, not a worktree) we report dirty:false — a path we
+ * cannot inspect must not manufacture a false-positive block.
+ */
+export function worktreeDirty(path, opts = {}) {
+  const status = git("status --porcelain", { ...opts, cwd: path });
+  if (status === null) return { path, dirty: false, changes: 0 };
+  const lines = status.split("\n").filter(Boolean);
+  return { path, dirty: lines.length > 0, changes: lines.length };
+}
+
+/**
+ * List sibling session worktrees (under `.claude/worktrees/`) and their dirty
+ * state, EXCLUDING the worktree at `opts.cwd` itself.
+ *
+ * Intended for use when shipping from the MAIN repo: it surfaces a session
+ * worktree that was never inspected because the git-mutating work + ship were
+ * driven from the main repo root instead of inside the worktree.
+ *
+ * Returns an array of { path, branch, dirty, changes }. Excluding `cwd` means
+ * the normal in-worktree ship (where the session worktree IS the cwd) does not
+ * flag itself — preflight's own clean-tree check already covers that case.
+ */
+export function sessionWorktrees(opts = {}) {
+  const cwdNorm = normPath(opts.cwd || process.cwd());
+  return listWorktrees(opts)
+    .filter((w) => isSessionWorktreePath(w.path) && normPath(w.path) !== cwdNorm)
+    .map((w) => {
+      const { dirty, changes } = worktreeDirty(w.path, opts);
+      return { path: w.path, branch: w.branch, dirty, changes };
+    });
+}
+
+/**
+ * Convenience: the subset of sessionWorktrees() that are dirty. Empty array
+ * means the invariant holds (no sibling session worktree in limbo).
+ */
+export function dirtySessionWorktrees(opts = {}) {
+  return sessionWorktrees(opts).filter((w) => w.dirty);
+}

--- a/plugins/devops/mcp-server/ship/lib/worktree.test.js
+++ b/plugins/devops/mcp-server/ship/lib/worktree.test.js
@@ -1,0 +1,222 @@
+import { describe, test, expect, vi, beforeEach } from "vitest";
+
+vi.mock("node:child_process", () => ({
+  execSync: vi.fn(),
+}));
+
+import { execSync } from "node:child_process";
+import {
+  listWorktrees,
+  isSessionWorktreePath,
+  worktreeDirty,
+  sessionWorktrees,
+  dirtySessionWorktrees,
+} from "./worktree.js";
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+// Porcelain `git worktree list --porcelain` output. Paths are forward-slash
+// even on Windows (matches real `git worktree list` behavior observed in repo).
+const MAIN = "C:/repo";
+const WT_DIRTY = "C:/repo/.claude/worktrees/awesome-haslett";
+const WT_CLEAN = "C:/repo/.claude/worktrees/clean-session";
+
+function porcelain(entries) {
+  // entries: [{ path, branch?, detached? }]
+  return entries
+    .map((e) => {
+      const lines = [`worktree ${e.path}`, "HEAD abc1234"];
+      if (e.detached) lines.push("detached");
+      else if (e.branch) lines.push(`branch refs/heads/${e.branch}`);
+      return lines.join("\n");
+    })
+    .join("\n\n");
+}
+
+/**
+ * Route execSync by the git subcommand embedded in the command string so a
+ * single mock can serve both the `worktree list` call and the per-path
+ * `status` calls (git.js builds `git ${cmd}` and passes cwd via options).
+ */
+function routeGit(map) {
+  execSync.mockImplementation((cmd, opts) => {
+    if (cmd.includes("worktree list")) {
+      if (map.worktreeList === undefined) throw new Error("no worktrees");
+      return map.worktreeList;
+    }
+    if (cmd.includes("status --porcelain")) {
+      const cwd = (opts && opts.cwd) || "";
+      if (Object.prototype.hasOwnProperty.call(map.status || {}, cwd)) {
+        const v = map.status[cwd];
+        if (v === null) throw new Error("git failure");
+        return v;
+      }
+      return ""; // unknown path → clean
+    }
+    throw new Error(`unexpected git command: ${cmd}`);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// listWorktrees — porcelain parsing
+// ---------------------------------------------------------------------------
+
+describe("listWorktrees", () => {
+  test("parses path + branch for each record", () => {
+    execSync.mockReturnValue(
+      porcelain([
+        { path: MAIN, branch: "main" },
+        { path: WT_DIRTY, branch: "claude/awesome-haslett" },
+      ]),
+    );
+    expect(listWorktrees()).toEqual([
+      { path: MAIN, branch: "main", detached: false },
+      { path: WT_DIRTY, branch: "claude/awesome-haslett", detached: false },
+    ]);
+  });
+
+  test("marks detached worktree with null branch", () => {
+    execSync.mockReturnValue(
+      porcelain([
+        { path: MAIN, branch: "main" },
+        { path: WT_DIRTY, detached: true },
+      ]),
+    );
+    const wts = listWorktrees();
+    expect(wts[1]).toEqual({ path: WT_DIRTY, branch: null, detached: true });
+  });
+
+  test("returns empty array on git failure", () => {
+    execSync.mockImplementation(() => {
+      throw new Error("fatal");
+    });
+    expect(listWorktrees()).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isSessionWorktreePath
+// ---------------------------------------------------------------------------
+
+describe("isSessionWorktreePath", () => {
+  test("true for .claude/worktrees path (forward slash)", () => {
+    expect(isSessionWorktreePath(WT_DIRTY)).toBe(true);
+  });
+
+  test("true for backslash path (Windows normalization)", () => {
+    expect(isSessionWorktreePath("C:\\repo\\.claude\\worktrees\\x")).toBe(true);
+  });
+
+  test("false for main repo path", () => {
+    expect(isSessionWorktreePath(MAIN)).toBe(false);
+  });
+
+  test("false for empty", () => {
+    expect(isSessionWorktreePath("")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// worktreeDirty
+// ---------------------------------------------------------------------------
+
+describe("worktreeDirty", () => {
+  test("dirty when status non-empty (counts lines)", () => {
+    execSync.mockReturnValue(" M a.js\n?? b.txt");
+    const r = worktreeDirty(WT_DIRTY);
+    expect(r).toEqual({ path: WT_DIRTY, dirty: true, changes: 2 });
+  });
+
+  test("clean when status empty", () => {
+    execSync.mockReturnValue("");
+    expect(worktreeDirty(WT_CLEAN)).toEqual({ path: WT_CLEAN, dirty: false, changes: 0 });
+  });
+
+  test("git failure reports not-dirty (no false positive)", () => {
+    execSync.mockImplementation(() => {
+      throw new Error("path gone");
+    });
+    expect(worktreeDirty(WT_DIRTY)).toEqual({ path: WT_DIRTY, dirty: false, changes: 0 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sessionWorktrees — filters to .claude/worktrees siblings, excludes cwd
+// ---------------------------------------------------------------------------
+
+describe("sessionWorktrees", () => {
+  test("reports sibling session worktrees with dirty state, excludes main", () => {
+    routeGit({
+      worktreeList: porcelain([
+        { path: MAIN, branch: "main" },
+        { path: WT_DIRTY, branch: "claude/awesome-haslett" },
+        { path: WT_CLEAN, branch: "claude/clean-session" },
+      ]),
+      status: { [WT_DIRTY]: " M x.js", [WT_CLEAN]: "" },
+    });
+    const result = sessionWorktrees({ cwd: MAIN });
+    expect(result).toEqual([
+      { path: WT_DIRTY, branch: "claude/awesome-haslett", dirty: true, changes: 1 },
+      { path: WT_CLEAN, branch: "claude/clean-session", dirty: false, changes: 0 },
+    ]);
+  });
+
+  test("excludes the cwd worktree itself (in-worktree ship does not self-flag)", () => {
+    routeGit({
+      worktreeList: porcelain([
+        { path: MAIN, branch: "main" },
+        { path: WT_DIRTY, branch: "claude/awesome-haslett" },
+      ]),
+      status: { [WT_DIRTY]: " M x.js" },
+    });
+    // cwd IS the dirty worktree → it must be excluded from the sibling list.
+    expect(sessionWorktrees({ cwd: WT_DIRTY })).toEqual([]);
+  });
+
+  test("cwd exclusion is case-insensitive on drive letter", () => {
+    routeGit({
+      worktreeList: porcelain([{ path: WT_DIRTY, branch: "claude/x" }]),
+      status: { [WT_DIRTY]: " M x.js" },
+    });
+    // Same path but lower-case drive letter in cwd — still excluded.
+    expect(sessionWorktrees({ cwd: "c:/repo/.claude/worktrees/awesome-haslett" })).toEqual([]);
+  });
+
+  test("returns empty when no worktrees", () => {
+    routeGit({ status: {} });
+    expect(sessionWorktrees({ cwd: MAIN })).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dirtySessionWorktrees — invariant check
+// ---------------------------------------------------------------------------
+
+describe("dirtySessionWorktrees", () => {
+  test("returns only dirty siblings (split-state detected)", () => {
+    routeGit({
+      worktreeList: porcelain([
+        { path: MAIN, branch: "main" },
+        { path: WT_DIRTY, branch: "claude/awesome-haslett" },
+        { path: WT_CLEAN, branch: "claude/clean-session" },
+      ]),
+      status: { [WT_DIRTY]: " M x.js\n?? y.txt", [WT_CLEAN]: "" },
+    });
+    expect(dirtySessionWorktrees({ cwd: MAIN })).toEqual([
+      { path: WT_DIRTY, branch: "claude/awesome-haslett", dirty: true, changes: 2 },
+    ]);
+  });
+
+  test("empty when all session worktrees are clean (no false positive)", () => {
+    routeGit({
+      worktreeList: porcelain([
+        { path: MAIN, branch: "main" },
+        { path: WT_CLEAN, branch: "claude/clean-session" },
+      ]),
+      status: { [WT_CLEAN]: "" },
+    });
+    expect(dirtySessionWorktrees({ cwd: MAIN })).toEqual([]);
+  });
+});

--- a/plugins/devops/mcp-server/ship/tools/cleanup.js
+++ b/plugins/devops/mcp-server/ship/tools/cleanup.js
@@ -6,6 +6,7 @@
 
 import { z } from "zod";
 import { git, gitStrict, isWorktree, getWorktreeBranches } from "../lib/git.js";
+import { dirtySessionWorktrees } from "../lib/worktree.js";
 import { clearSentinel } from "../lib/sentinel.js";
 
 export const schema = z.object({
@@ -110,6 +111,18 @@ export async function handler(params) {
   // For intermediate merges: note that the base (feature branch) stays alive
   if (intermediate) {
     warnings.push(`Intermediate merge: base branch '${base}' preserved for further sub-branch merges or final ship to main`);
+  }
+
+  // Final-gate invariant: every file in a session worktree must be
+  // tracked→committed→pushed→merged OR gitignored — never in limbo. The hard
+  // block lives in preflight; cleanup runs AFTER the merge, so we only warn
+  // loudly here (failing cleanup post-merge would strand the user). A dirty
+  // sibling session worktree means work was driven from the main repo while
+  // the worktree was left untouched — its changes are NOT on main.
+  for (const wt of dirtySessionWorktrees(opts)) {
+    warnings.push(
+      `WARNING: session worktree '${wt.path}' (branch '${wt.branch || "detached"}') still has ${wt.changes} uncommitted change(s) AFTER ship. These changes were NOT included in this ship — inspect the worktree and commit-or-discard before archiving the session.`
+    );
   }
 
   // Restore the original branch if we switched away from a non-base branch

--- a/plugins/devops/mcp-server/ship/tools/cleanup.test.js
+++ b/plugins/devops/mcp-server/ship/tools/cleanup.test.js
@@ -1,0 +1,72 @@
+import { describe, test, expect, vi, beforeEach } from "vitest";
+
+// zod is a runtime dep of the MCP server, not installed in the test env. The
+// handler never invokes the schema (only MCP registration does), so a minimal
+// chainable stub suffices to load the module.
+vi.mock("zod", () => {
+  const node = new Proxy(() => node, { get: () => () => node });
+  return { z: { object: () => node, string: () => node, boolean: () => node } };
+});
+
+vi.mock("../lib/git.js", () => ({
+  git: vi.fn(() => ""),
+  gitStrict: vi.fn(() => ""),
+  isWorktree: vi.fn(() => false),
+  getWorktreeBranches: vi.fn(() => new Set()),
+}));
+
+vi.mock("../lib/worktree.js", () => ({
+  dirtySessionWorktrees: vi.fn(() => []),
+}));
+
+vi.mock("../lib/sentinel.js", () => ({
+  clearSentinel: vi.fn(),
+}));
+
+import { handler } from "./cleanup.js";
+import { git, isWorktree, getWorktreeBranches } from "../lib/git.js";
+import { dirtySessionWorktrees } from "../lib/worktree.js";
+
+const CWD = "/fake/consumer-repo";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  isWorktree.mockReturnValue(false);
+  getWorktreeBranches.mockReturnValue(new Set());
+  dirtySessionWorktrees.mockReturnValue([]);
+  // On base branch already, no remote branch left → minimal happy path.
+  git.mockImplementation((cmd) => {
+    if (cmd.includes("rev-parse --abbrev-ref HEAD")) return "main";
+    if (cmd.includes("ls-remote")) return "";
+    return "";
+  });
+});
+
+describe("ship_cleanup — session-worktree final-gate invariant", () => {
+  test("clean case: no dirty session worktree → success, no worktree warning", async () => {
+    const result = await handler({ branch: "feat/topic", base: "main", cwd: CWD, keep: false });
+    expect(result.success).toBe(true);
+    expect(result.warnings.some((w) => /session worktree/i.test(w))).toBe(false);
+  });
+
+  test("split-state after merge: dirty session worktree → loud WARNING (cleanup still succeeds)", async () => {
+    dirtySessionWorktrees.mockReturnValue([
+      { path: "/fake/consumer-repo/.claude/worktrees/awesome-haslett", branch: "claude/awesome-haslett", dirty: true, changes: 4 },
+    ]);
+    const result = await handler({ branch: "feat/topic", base: "main", cwd: CWD, keep: false });
+
+    // Hard block lives in preflight — cleanup runs post-merge, so it warns only.
+    expect(result.success).toBe(true);
+    const warning = result.warnings.find((w) => /WARNING/.test(w) && /session worktree/i.test(w));
+    expect(warning).toBeTruthy();
+    expect(warning).toMatch(/awesome-haslett/);
+    expect(warning).toMatch(/4 uncommitted/);
+    expect(warning).toMatch(/NOT included/i);
+  });
+
+  test("keep-mode: invariant not asserted (early return)", async () => {
+    const result = await handler({ branch: "feat/topic", base: "main", cwd: CWD, keep: true });
+    expect(result.kept).toBe(true);
+    expect(dirtySessionWorktrees).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/devops/mcp-server/ship/tools/preflight.js
+++ b/plugins/devops/mcp-server/ship/tools/preflight.js
@@ -291,15 +291,24 @@ export async function handler(params) {
   // normal case) self-exclude — clean-tree already covers the cwd.
   if (!inWorktree) {
     const dirtyWts = dirtySessionWorktrees(opts);
-    if (dirtyWts.length > 0) {
-      for (const wt of dirtyWts) {
-        errors.push(
-          `Session worktree '${wt.path}' (branch '${wt.branch || "detached"}') has ${wt.changes} uncommitted change(s) — you shipped from the main repo while a session worktree was left dirty. Commit or discard those changes inside the worktree before shipping.`
-        );
-        checks.push({ name: "session-worktree-clean", ok: false, worktree: wt.path, branch: wt.branch, changes: wt.changes });
-      }
-    } else {
+    if (dirtyWts.length === 0) {
       checks.push({ name: "session-worktree-clean", ok: true });
+    } else {
+      for (const wt of dirtyWts) {
+        const desc = `Session worktree '${wt.path}' (branch '${wt.branch || "detached"}') has ${wt.changes} uncommitted change(s)`;
+        // Hard-block ONLY the worktree that belongs to THIS ship — its branch is
+        // the branch (or base) being shipped. An unrelated session worktree (a
+        // different concurrent session — common when several agents run in
+        // parallel) must NOT block this ship; surface it as a loud, non-blocking
+        // warning instead. Keeps the #193 guarantee for the ship's own worktree
+        // without over-reaching across unrelated sessions.
+        if (wt.branch && (wt.branch === branch || wt.branch === base)) {
+          errors.push(`${desc} — you shipped from the main repo while this ship's own worktree was left dirty. Commit or discard those changes inside the worktree before shipping.`);
+          checks.push({ name: "session-worktree-clean", ok: false, worktree: wt.path, branch: wt.branch, changes: wt.changes });
+        } else {
+          checks.push({ name: "session-worktree-clean", ok: true, worktree: wt.path, branch: wt.branch, changes: wt.changes, warning: `${desc} — unrelated to this ship; if that work isn't already on its target branch, commit it inside that worktree (not the main repo).` });
+        }
+      }
     }
   } else {
     checks.push({ name: "session-worktree-clean", ok: true });

--- a/plugins/devops/mcp-server/ship/tools/preflight.js
+++ b/plugins/devops/mcp-server/ship/tools/preflight.js
@@ -9,6 +9,7 @@ import { execFileSync } from "node:child_process";
 import { readdirSync, statSync, readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { git, currentBranch, dirtyState, commitsAhead, unpushedCommits, isWorktree, detectParentBranch, detectDefaultBranch, branchExists, fileOverlap, getConfig } from "../lib/git.js";
+import { dirtySessionWorktrees } from "../lib/worktree.js";
 import { readVersion, verifyVersionFiles } from "../lib/version.js";
 import { writeSentinel } from "../lib/sentinel.js";
 import { detectRepoMode } from "../lib/repo-mode.js";
@@ -278,6 +279,31 @@ export async function handler(params) {
   // Worktree detection
   const inWorktree = isWorktree(opts);
   checks.push({ name: "worktree", value: inWorktree });
+
+  // Session-worktree split-state gate. When shipping from the MAIN repo
+  // (inWorktree === false), a sibling agent session worktree under
+  // `.claude/worktrees/` may have been left dirty because the git-mutating
+  // work + ship were driven from the main repo instead of inside the worktree.
+  // The branch/commits land on main fine, but the session worktree is in a
+  // "limbo" state (uncommitted/partial changes) — and the harness later warns
+  // "Archive session with N uncommitted changes". Block the ship so the user
+  // commits-or-discards inside the worktree first. In-worktree ships (the
+  // normal case) self-exclude — clean-tree already covers the cwd.
+  if (!inWorktree) {
+    const dirtyWts = dirtySessionWorktrees(opts);
+    if (dirtyWts.length > 0) {
+      for (const wt of dirtyWts) {
+        errors.push(
+          `Session worktree '${wt.path}' (branch '${wt.branch || "detached"}') has ${wt.changes} uncommitted change(s) — you shipped from the main repo while a session worktree was left dirty. Commit or discard those changes inside the worktree before shipping.`
+        );
+        checks.push({ name: "session-worktree-clean", ok: false, worktree: wt.path, branch: wt.branch, changes: wt.changes });
+      }
+    } else {
+      checks.push({ name: "session-worktree-clean", ok: true });
+    }
+  } else {
+    checks.push({ name: "session-worktree-clean", ok: true });
+  }
 
   // Doc-sync (plugin source repo only — no-op elsewhere). Non-blocking.
   checks.push(...docSyncChecks(cwd));

--- a/plugins/devops/mcp-server/ship/tools/preflight.test.js
+++ b/plugins/devops/mcp-server/ship/tools/preflight.test.js
@@ -1,0 +1,112 @@
+import { describe, test, expect, vi, beforeEach } from "vitest";
+
+// zod is a runtime dependency of the MCP server (installed where the server
+// runs) but is not a devDependency of this repo, so the test environment can't
+// resolve it. The handler never invokes the schema — only the MCP registration
+// does — so a minimal chainable stub is enough to load the module.
+vi.mock("zod", () => {
+  const node = new Proxy(() => node, { get: () => () => node });
+  return { z: { object: () => node, string: () => node, boolean: () => node } };
+});
+
+// Mock every lib the handler touches so we can drive a deterministic "ready"
+// pipeline and isolate the session-worktree-clean gate. cwd is a synthetic
+// path that is NOT the plugin source repo, so docSyncChecks() no-ops.
+vi.mock("../lib/git.js", () => ({
+  git: vi.fn(() => ""),
+  currentBranch: vi.fn(() => "feat/topic"),
+  dirtyState: vi.fn(() => ({ dirty: false, untracked: [], modified: [], lines: [] })),
+  commitsAhead: vi.fn(() => 1),
+  unpushedCommits: vi.fn(() => 0),
+  isWorktree: vi.fn(() => false),
+  detectParentBranch: vi.fn(() => null),
+  detectDefaultBranch: vi.fn(() => "main"),
+  branchExists: vi.fn(() => "remote"),
+  fileOverlap: vi.fn(() => ({ mergeBase: "abc", branchFiles: [], baseFiles: [], overlap: [] })),
+  getConfig: vi.fn(() => "diff3"),
+}));
+
+vi.mock("../lib/version.js", () => ({
+  readVersion: vi.fn(() => ({ version: "1.0.0", type: "npm" })),
+  verifyVersionFiles: vi.fn(() => ({ consistent: true, mismatches: [] })),
+}));
+
+vi.mock("../lib/sentinel.js", () => ({
+  writeSentinel: vi.fn(),
+}));
+
+vi.mock("../lib/repo-mode.js", () => ({
+  detectRepoMode: vi.fn(() => "git"),
+}));
+
+vi.mock("../lib/worktree.js", () => ({
+  dirtySessionWorktrees: vi.fn(() => []),
+}));
+
+import { handler } from "./preflight.js";
+import { isWorktree } from "../lib/git.js";
+import { dirtySessionWorktrees } from "../lib/worktree.js";
+
+const CWD = "/fake/consumer-repo";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Re-apply defaults cleared by clearAllMocks.
+  isWorktree.mockReturnValue(false);
+  dirtySessionWorktrees.mockReturnValue([]);
+});
+
+function checkByName(result, name) {
+  return result.checks.find((c) => c.name === name);
+}
+
+describe("ship_preflight — session-worktree-clean gate", () => {
+  test("clean case: shipping from main with no dirty session worktree → ok, ready", async () => {
+    const result = await handler({ cwd: CWD });
+    const check = checkByName(result, "session-worktree-clean");
+    expect(check).toEqual({ name: "session-worktree-clean", ok: true });
+    expect(result.errors.some((e) => /session worktree/i.test(e))).toBe(false);
+    expect(result.ready).toBe(true);
+  });
+
+  test("split-state: main-repo ship + dirty session worktree → blocked", async () => {
+    dirtySessionWorktrees.mockReturnValue([
+      { path: "/fake/consumer-repo/.claude/worktrees/awesome-haslett", branch: "claude/awesome-haslett", dirty: true, changes: 3 },
+    ]);
+    const result = await handler({ cwd: CWD });
+
+    const check = checkByName(result, "session-worktree-clean");
+    expect(check).toMatchObject({
+      name: "session-worktree-clean",
+      ok: false,
+      worktree: "/fake/consumer-repo/.claude/worktrees/awesome-haslett",
+      branch: "claude/awesome-haslett",
+      changes: 3,
+    });
+    // Blocking: an error was pushed and the pipeline is not ready.
+    expect(result.errors.some((e) => /session worktree/i.test(e) && /uncommitted/i.test(e))).toBe(true);
+    expect(result.ready).toBe(false);
+  });
+
+  test("multiple dirty session worktrees → one error + check each", async () => {
+    dirtySessionWorktrees.mockReturnValue([
+      { path: "/r/.claude/worktrees/a", branch: "claude/a", dirty: true, changes: 1 },
+      { path: "/r/.claude/worktrees/b", branch: "claude/b", dirty: true, changes: 2 },
+    ]);
+    const result = await handler({ cwd: CWD });
+    const checks = result.checks.filter((c) => c.name === "session-worktree-clean");
+    expect(checks).toHaveLength(2);
+    expect(checks.every((c) => c.ok === false)).toBe(true);
+    expect(result.ready).toBe(false);
+  });
+
+  test("in-worktree ship (normal case): gate self-excludes → ok, helper not consulted", async () => {
+    isWorktree.mockReturnValue(true);
+    const result = await handler({ cwd: CWD });
+    const check = checkByName(result, "session-worktree-clean");
+    expect(check).toEqual({ name: "session-worktree-clean", ok: true });
+    // When in-worktree we must NOT scan siblings (clean-tree already covers cwd).
+    expect(dirtySessionWorktrees).not.toHaveBeenCalled();
+    expect(result.ready).toBe(true);
+  });
+});

--- a/plugins/devops/mcp-server/ship/tools/preflight.test.js
+++ b/plugins/devops/mcp-server/ship/tools/preflight.test.js
@@ -69,9 +69,11 @@ describe("ship_preflight — session-worktree-clean gate", () => {
     expect(result.ready).toBe(true);
   });
 
-  test("split-state: main-repo ship + dirty session worktree → blocked", async () => {
+  test("split-state: ship's OWN worktree dirty (branch === shipped branch) → blocked", async () => {
+    // currentBranch mock = "feat/topic" — a dirty worktree on that same branch
+    // is unambiguously this ship's own worktree, so it hard-blocks.
     dirtySessionWorktrees.mockReturnValue([
-      { path: "/fake/consumer-repo/.claude/worktrees/awesome-haslett", branch: "claude/awesome-haslett", dirty: true, changes: 3 },
+      { path: "/fake/consumer-repo/.claude/worktrees/topic-wt", branch: "feat/topic", dirty: true, changes: 3 },
     ]);
     const result = await handler({ cwd: CWD });
 
@@ -79,16 +81,39 @@ describe("ship_preflight — session-worktree-clean gate", () => {
     expect(check).toMatchObject({
       name: "session-worktree-clean",
       ok: false,
-      worktree: "/fake/consumer-repo/.claude/worktrees/awesome-haslett",
-      branch: "claude/awesome-haslett",
+      worktree: "/fake/consumer-repo/.claude/worktrees/topic-wt",
+      branch: "feat/topic",
       changes: 3,
     });
-    // Blocking: an error was pushed and the pipeline is not ready.
     expect(result.errors.some((e) => /session worktree/i.test(e) && /uncommitted/i.test(e))).toBe(true);
     expect(result.ready).toBe(false);
   });
 
-  test("multiple dirty session worktrees → one error + check each", async () => {
+  test("dirty worktree on the BASE branch → blocked (related to ship target)", async () => {
+    dirtySessionWorktrees.mockReturnValue([
+      { path: "/fake/consumer-repo/.claude/worktrees/main-wt", branch: "main", dirty: true, changes: 1 },
+    ]);
+    const result = await handler({ cwd: CWD });
+    expect(checkByName(result, "session-worktree-clean")).toMatchObject({ ok: false, branch: "main" });
+    expect(result.ready).toBe(false);
+  });
+
+  test("UNRELATED dirty session worktree → warns, does NOT block (no false positive)", async () => {
+    dirtySessionWorktrees.mockReturnValue([
+      { path: "/fake/consumer-repo/.claude/worktrees/other-session", branch: "claude/other-session", dirty: true, changes: 5 },
+    ]);
+    const result = await handler({ cwd: CWD });
+
+    const check = checkByName(result, "session-worktree-clean");
+    expect(check).toMatchObject({ name: "session-worktree-clean", ok: true, branch: "claude/other-session", changes: 5 });
+    expect(check.warning).toMatch(/unrelated to this ship/i);
+    // Surfaced as a warning, but the ship is NOT blocked.
+    expect(result.errors.some((e) => /session worktree/i.test(e))).toBe(false);
+    expect(result.warnings.some((w) => /session worktree/i.test(w))).toBe(true);
+    expect(result.ready).toBe(true);
+  });
+
+  test("multiple UNRELATED dirty worktrees → all warn, ship still ready (no false-positive block)", async () => {
     dirtySessionWorktrees.mockReturnValue([
       { path: "/r/.claude/worktrees/a", branch: "claude/a", dirty: true, changes: 1 },
       { path: "/r/.claude/worktrees/b", branch: "claude/b", dirty: true, changes: 2 },
@@ -96,8 +121,8 @@ describe("ship_preflight — session-worktree-clean gate", () => {
     const result = await handler({ cwd: CWD });
     const checks = result.checks.filter((c) => c.name === "session-worktree-clean");
     expect(checks).toHaveLength(2);
-    expect(checks.every((c) => c.ok === false)).toBe(true);
-    expect(result.ready).toBe(false);
+    expect(checks.every((c) => c.ok === true && c.warning)).toBe(true);
+    expect(result.ready).toBe(true);
   });
 
   test("in-worktree ship (normal case): gate self-excludes → ok, helper not consulted", async () => {

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.90.1",
+  "version": "0.91.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
Closes #193

## Summary
Three plugin-reliability fixes from a Windows debugging session.

## Fixed
- **MCP servers crashed on Windows (#190 root cause)** — `ss.plugin.update`'s `copyDir` shelled out to `cp` (not a cmd.exe builtin; Git coreutils off PATH), so a fresh-install copy silently failed → partial cache → all MCP servers `ERR_MODULE_NOT_FOUND`. The 0.90.0 completeness guard *detected* this but the copy kept failing; now uses cross-platform `fs.cpSync`.

## Added
- **Session-worktree tracked-or-gitignored invariant (#193)** — `ship_preflight` hard-blocks when the dirty session worktree is on the shipped branch/base (this ship's own worktree) and warns for unrelated concurrent sessions; `ship_cleanup` warns post-merge; new warn-only `pre.worktree.split-guard` hook. New `ship/lib/worktree.js`.

## Changed
- **Agent sub-branch naming** — flat `<parent>-<role>` instead of slash-nested (`<parent>/<role>` collides with the checked-out integration branch ref). Diagram + protocol corrected.

198 tests green · lint clean.