### PR TITLE
feat(autonomous): fail-safe OS shutdown timer at run start

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.92.0"
+    "version": "0.93.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.92.0",
+      "version": "0.93.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.92.0",
+      "version": "0.93.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.93.0] — 2026-06-04
+
+### Added
+
+- **Fail-safe shutdown timer for autonomous runs** — when the user chooses "Ja, herunterfahren", `devops-autonomous` now arms a hard OS-level `shutdown.exe /s /t` timer as the *first* action of Step 5, before any task work. This closes the gap the user hit in practice: an autonomous run that exhausts its token budget (or hits an Anthropic API hang) wedges before reaching Step 8's in-session shutdown and leaves the PC powered on indefinitely — the frozen session can no longer fire the shutdown itself. The new `scripts/autonomous-shutdown-timer.js` sizes the timer to the remaining 5h token period (`session.resetInMinutes` from `usage-live.json`, age-corrected) clamped to [90 min, 5 h], falling back to 5 h when usage data is missing or stale. It invokes `shutdown.exe` directly with an absolute path and a guaranteed-local CWD (UNC-safe). Because the timer is unconditional, the new Step 8.0 cancels it the moment finalization runs — so a BLOCKED run stays powered on (the data-integrity rule is preserved) and the graceful 60 s shutdown replaces the longer fail-safe window on the happy path. The existing 8 h scheduled-task watchdog remains the outermost net. Skill `devops-autonomous` 0.2.0→0.3.0.
+
 ## [0.92.0] — 2026-06-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.92.0**
+**Version: 0.93.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.92.0",
+  "version": "0.93.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/scripts/autonomous-shutdown-timer.js
+++ b/plugins/devops/scripts/autonomous-shutdown-timer.js
@@ -1,0 +1,183 @@
+#!/usr/bin/env node
+/**
+ * autonomous-shutdown-timer.js — Fail-safe OS shutdown timer for devops-autonomous.
+ *
+ * Armed at the START of an autonomous run (Step 5) whenever the user chose
+ * "Ja, herunterfahren". It shells out to Windows `shutdown.exe /s /t <seconds>`
+ * IMMEDIATELY, so the PC powers off even if the session later wedges (token
+ * exhaustion, Anthropic API hang, stuck subagent) and never reaches Step 8's
+ * in-session shutdown. This is the inner, early safety net; the 8h Scheduled-Task
+ * watchdog (autonomous-watchdog.js) remains the outer net for the case where even
+ * this `shutdown.exe` call could not be placed.
+ *
+ * Timer length — "remaining 5h-period + floor" (user choice):
+ *   - Read `session.resetInMinutes` from ~/.claude/usage-live.json (last scrape),
+ *     age-correct it against the snapshot `timestamp`.
+ *   - Clamp to [90 min, 5 h]. The 90-min FLOOR stops a near-empty token window
+ *     from cutting off still-running work; the 5 h CAP is one full token period.
+ *   - Fall back to 5 h if usage data is missing, stale (>5 h old), or the period
+ *     already reset — "5h passt im Zweifelsfall immer".
+ *
+ * Because the timer is UNCONDITIONAL, Step 8 must `cancel` it the moment it runs:
+ *   - COMPLETED / INTERRUPTED → cancel, then place the graceful 60s shutdown.
+ *   - BLOCKED                 → cancel, place NO shutdown (user must intervene).
+ *   - reaching Step 8 at all proves the session is alive, so the deliberate
+ *     Step 8 decision always supersedes this blind timer.
+ *
+ * Subcommands (stdout: JSON):
+ *   arm [resetMinutesOverride]   Place `shutdown /s /t <seconds>`. Optional numeric
+ *                                override skips the usage-file read (testing / when
+ *                                the caller already knows resetInMinutes).
+ *                                → { ok, armed, seconds, minutes, source }
+ *   cancel                       Run `shutdown /a`. A "nothing scheduled" result is
+ *                                treated as success (idempotent).
+ *                                → { ok, cancelled, noPending }
+ *
+ * Platform: Windows-only (uses shutdown.exe). No-op on other platforms.
+ */
+
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const USAGE_JSON_PATH = path.join(os.homedir(), '.claude', 'usage-live.json');
+
+const FIVE_HOURS_SEC = 5 * 60 * 60; // 18000 — fallback & hard cap (one token period)
+const FLOOR_SEC = 90 * 60;          // 5400  — min, guards against cutting off live work
+const MAX_STALE_MIN = 300;          // usage older than a full window → unreliable → fallback
+
+function fail(msg) {
+  process.stdout.write(JSON.stringify({ ok: false, error: msg }) + '\n');
+  process.exit(1);
+}
+
+function ok(extra) {
+  process.stdout.write(JSON.stringify({ ok: true, ...extra }) + '\n');
+  process.exit(0);
+}
+
+/**
+ * Pure timer-length resolver — no I/O, exported for tests.
+ * @param {object|null} usageData  Parsed usage-live.json (or null/garbage).
+ * @param {number} nowMs           Current epoch ms (injected for determinism).
+ * @returns {{seconds:number, minutes:number, source:string, effectiveMin?:number}}
+ */
+function computeShutdownDelaySeconds(usageData, nowMs) {
+  const fallback = {
+    seconds: FIVE_HOURS_SEC,
+    minutes: FIVE_HOURS_SEC / 60,
+    source: 'fallback-5h',
+  };
+
+  const resetMin = usageData && usageData.session && usageData.session.resetInMinutes;
+  const ts = usageData && usageData.timestamp;
+  if (typeof resetMin !== 'number' || !Number.isFinite(resetMin) || resetMin <= 0) {
+    return fallback;
+  }
+  if (!ts) return fallback;
+
+  const ageMin = (nowMs - new Date(ts).getTime()) / 60000;
+  if (!Number.isFinite(ageMin) || ageMin < 0 || ageMin > MAX_STALE_MIN) {
+    return fallback; // stale or future-dated snapshot → unreliable
+  }
+
+  const effectiveMin = resetMin - ageMin;
+  if (effectiveMin <= 0) return fallback; // period already reset → assume a fresh 5h
+
+  const rawSec = Math.round(effectiveMin * 60);
+  const seconds = Math.min(Math.max(rawSec, FLOOR_SEC), FIVE_HOURS_SEC);
+  let source = 'reset-window';
+  if (rawSec < FLOOR_SEC) source = 'reset-window-floored';
+  else if (rawSec > FIVE_HOURS_SEC) source = 'reset-window-capped';
+
+  return {
+    seconds,
+    minutes: Math.round(seconds / 60),
+    source,
+    effectiveMin: Math.round(effectiveMin),
+  };
+}
+
+function readUsageJson() {
+  try {
+    return JSON.parse(fs.readFileSync(USAGE_JSON_PATH, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function shutdownExe() {
+  const root = process.env.SystemRoot || process.env.windir || 'C:\\Windows';
+  return path.join(root, 'System32', 'shutdown.exe');
+}
+
+// Force a guaranteed-local CWD so a UNC working directory (e.g. session running
+// from \\nas\share\...) can't break the native shutdown.exe invocation.
+function safeCwd() {
+  const home = os.homedir();
+  return home && !home.startsWith('\\\\') ? home : os.tmpdir();
+}
+
+function runArm(argv) {
+  const override = argv[0];
+  let plan;
+  if (override !== undefined) {
+    const m = Number(override);
+    if (!Number.isFinite(m)) fail(`arm: resetMinutesOverride must be numeric, got "${override}"`);
+    plan = computeShutdownDelaySeconds(
+      { session: { resetInMinutes: m }, timestamp: new Date(0).toISOString() },
+      0, // age 0 → use override verbatim (clamped)
+    );
+  } else {
+    plan = computeShutdownDelaySeconds(readUsageJson(), Date.now());
+  }
+
+  const exe = shutdownExe();
+  const cwd = safeCwd();
+
+  // Idempotent re-arm: clear any pre-existing scheduled shutdown first.
+  spawnSync(exe, ['/a'], { encoding: 'utf8', cwd });
+
+  const msg =
+    `Claude autonomous fail-safe — PC shuts down in ${plan.minutes} min unless the ` +
+    `task finishes first. Run 'shutdown /a' to abort.`;
+  const res = spawnSync(exe, ['/s', '/t', String(plan.seconds), '/c', msg],
+    { encoding: 'utf8', cwd });
+
+  if (res.status !== 0) {
+    fail(`shutdown /s failed (status ${res.status}): ` +
+      `${(res.stderr || res.stdout || '').trim()}`);
+  }
+  ok({ armed: true, seconds: plan.seconds, minutes: plan.minutes, source: plan.source });
+}
+
+function runCancel() {
+  const res = spawnSync(shutdownExe(), ['/a'], { encoding: 'utf8', cwd: safeCwd() });
+  if (res.status === 0) ok({ cancelled: true, noPending: false });
+  // /a returns non-zero (error 1116) when no shutdown was scheduled — that's the
+  // benign "nothing to cancel" case, not a failure.
+  const noPending = /1116|no shutdown|kein Herunterfahren|wurde nicht|not in progress/i
+    .test((res.stderr || '') + (res.stdout || ''));
+  if (noPending) ok({ cancelled: false, noPending: true });
+  fail(`shutdown /a failed (status ${res.status}): ` +
+    `${(res.stderr || res.stdout || '').trim()}`);
+}
+
+// --- CLI entry (skipped when require()'d by tests) ---
+if (require.main === module) {
+  if (process.platform !== 'win32') {
+    ok({ skipped: true, reason: 'non-windows platform' });
+  }
+  const [, , subcmd, ...args] = process.argv;
+  if (subcmd === 'arm') runArm(args);
+  else if (subcmd === 'cancel') runCancel();
+  else fail(`Unknown subcommand: ${subcmd || '(empty)'}. Use: arm | cancel`);
+}
+
+module.exports = {
+  computeShutdownDelaySeconds,
+  FIVE_HOURS_SEC,
+  FLOOR_SEC,
+  MAX_STALE_MIN,
+};

--- a/plugins/devops/scripts/autonomous-shutdown-timer.test.js
+++ b/plugins/devops/scripts/autonomous-shutdown-timer.test.js
@@ -1,0 +1,100 @@
+import { describe, test, expect } from "vitest";
+import {
+  computeShutdownDelaySeconds,
+  FIVE_HOURS_SEC,
+  FLOOR_SEC,
+} from "./autonomous-shutdown-timer.js";
+
+// Fixed "now" so age-correction is deterministic.
+const NOW = Date.parse("2026-06-04T12:00:00.000Z");
+const atNow = (resetInMinutes, ageMin = 0) => ({
+  timestamp: new Date(NOW - ageMin * 60000).toISOString(),
+  session: { pct: 30, resetInMinutes },
+});
+
+describe("computeShutdownDelaySeconds — reset-window mapping", () => {
+  test("fresh snapshot, full window → ~5h, capped exactly at 5h", () => {
+    const r = computeShutdownDelaySeconds(atNow(300), NOW);
+    expect(r.seconds).toBe(FIVE_HOURS_SEC);
+    expect(r.source).toBe("reset-window"); // 300min == cap, not over → not 'capped'
+  });
+
+  test("mid window (180 min remaining) → 180 min timer", () => {
+    const r = computeShutdownDelaySeconds(atNow(180), NOW);
+    expect(r.seconds).toBe(180 * 60);
+    expect(r.minutes).toBe(180);
+    expect(r.source).toBe("reset-window");
+  });
+
+  test("just above floor (120 min) → unchanged", () => {
+    const r = computeShutdownDelaySeconds(atNow(120), NOW);
+    expect(r.seconds).toBe(120 * 60);
+    expect(r.source).toBe("reset-window");
+  });
+});
+
+describe("computeShutdownDelaySeconds — floor guards short windows", () => {
+  test("20 min remaining → floored to 90 min", () => {
+    const r = computeShutdownDelaySeconds(atNow(20), NOW);
+    expect(r.seconds).toBe(FLOOR_SEC);
+    expect(r.minutes).toBe(90);
+    expect(r.source).toBe("reset-window-floored");
+  });
+
+  test("exactly at floor boundary (90 min) → not flagged floored", () => {
+    const r = computeShutdownDelaySeconds(atNow(90), NOW);
+    expect(r.seconds).toBe(FLOOR_SEC);
+    expect(r.source).toBe("reset-window");
+  });
+});
+
+describe("computeShutdownDelaySeconds — cap guards long/over windows", () => {
+  test("override-style >5h is capped", () => {
+    const r = computeShutdownDelaySeconds(atNow(600), NOW);
+    expect(r.seconds).toBe(FIVE_HOURS_SEC);
+    expect(r.source).toBe("reset-window-capped");
+  });
+});
+
+describe("computeShutdownDelaySeconds — age correction", () => {
+  test("200 min remaining but snapshot 60 min old → 140 min effective", () => {
+    const r = computeShutdownDelaySeconds(atNow(200, 60), NOW);
+    expect(r.minutes).toBe(140);
+    expect(r.source).toBe("reset-window");
+  });
+
+  test("window already elapsed after age correction → fallback 5h", () => {
+    // 30 min remaining at snapshot, but 45 min have passed → period reset.
+    const r = computeShutdownDelaySeconds(atNow(30, 45), NOW);
+    expect(r.seconds).toBe(FIVE_HOURS_SEC);
+    expect(r.source).toBe("fallback-5h");
+  });
+});
+
+describe("computeShutdownDelaySeconds — fallback to 5h", () => {
+  test.each([
+    ["null usage", null],
+    ["empty object", {}],
+    ["missing session", { timestamp: new Date(NOW).toISOString() }],
+    ["missing timestamp", { session: { resetInMinutes: 120 } }],
+    ["non-numeric resetInMinutes", atNow("nope")],
+    ["zero resetInMinutes", atNow(0)],
+    ["negative resetInMinutes", atNow(-10)],
+  ])("%s → fallback 5h", (_label, usage) => {
+    const r = computeShutdownDelaySeconds(usage, NOW);
+    expect(r.seconds).toBe(FIVE_HOURS_SEC);
+    expect(r.source).toBe("fallback-5h");
+  });
+
+  test("stale snapshot (>5h old) → fallback 5h", () => {
+    const r = computeShutdownDelaySeconds(atNow(180, 6 * 60), NOW);
+    expect(r.seconds).toBe(FIVE_HOURS_SEC);
+    expect(r.source).toBe("fallback-5h");
+  });
+
+  test("future-dated snapshot (clock skew) → fallback 5h", () => {
+    const r = computeShutdownDelaySeconds(atNow(180, -30), NOW);
+    expect(r.seconds).toBe(FIVE_HOURS_SEC);
+    expect(r.source).toBe("fallback-5h");
+  });
+});

--- a/plugins/devops/skills/devops-autonomous/SKILL.md
+++ b/plugins/devops/skills/devops-autonomous/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: devops-autonomous
-version: 0.2.0
+version: 0.3.0
 description: >-
   Fully autonomous agent orchestration for when the user is away from the PC.
   Runs agents without supervision (implementation, desktop interaction, live
@@ -317,6 +317,33 @@ after confirmation is the next session (via Resume Detection in Step 0.5).
 
 ## Step 5 — Autonomous Execution
 
+### 5.0 — Arm Fail-Safe Shutdown Timer (shutdown mode only)
+
+**FIRST action, before any other work — only if shutdown=yes.** The 8h external
+watchdog (Step 4d) is the *outer* net; this is the *inner, early* one. It places a
+hard OS-level shutdown timer the instant the run begins, so the PC powers off even
+if this session later wedges (token exhaustion, Anthropic API hang, stuck subagent)
+and never reaches Step 8 — the exact "tokens ran out, PC stayed on all night" case.
+
+```bash
+node "$CLAUDE_PLUGIN_ROOT/scripts/autonomous-shutdown-timer.js" arm
+```
+
+The script reads `~/.claude/usage-live.json`, sets the timer to the remaining
+5h-period (`session.resetInMinutes`, age-corrected) **clamped to [90 min, 5 h]**,
+and falls back to **5 h** if usage data is missing/stale. It calls
+`shutdown.exe /s /t <seconds>` directly with an absolute path and a guaranteed-local
+CWD (UNC-safe). Parse the JSON: on `ok:true` log the armed window
+(`{minutes} min, source={source}`) to `AUTONOMOUS-LOG.md`; on `ok:false` or
+`skipped:true` (non-Windows) log a one-line warning and continue — the 8h watchdog
+still covers the gap.
+
+Because this timer is **unconditional**, Step 8 cancels it the moment it runs (the
+deliberate Step 8 decision supersedes the blind timer). Full rationale and the
+Step 8 interaction: `deep-knowledge/shutdown-watchdog.md` § Fail-Safe Shutdown Timer.
+
+### Execution Gate
+
 Behavior depends on `$EXEC_MODE` from Step 2. The full execution gate, safety
 guardrails, and late-permission protocol live in
 `deep-knowledge/autonomous-execution.md` — read that file at the start of Step 5.
@@ -457,11 +484,23 @@ the CLI card is the quick confirmation.
 
 ## Step 8 — Shutdown / Finalization
 
-Full mechanics (8a wait-loop, 8b PowerShell shutdown, 8c flag decision matrix)
-live in `deep-knowledge/shutdown-watchdog.md` § Step 8. Behavior by
-`$WATCHDOG_ACTION`:
+Full mechanics (8.0 fail-safe cancel, 8a wait-loop, 8b PowerShell shutdown, 8c
+flag decision matrix) live in `deep-knowledge/shutdown-watchdog.md` § Step 8.
 
-- **notify mode** (shutdown=no): the PC stays on. Skip 8a/8b; run only **8c** —
+**8.0 — Cancel the fail-safe timer FIRST (shutdown mode only).** If Step 5.0 armed
+the early timer, cancel it now — reaching Step 8 proves the session is alive, so the
+deliberate decision below supersedes the blind timer. Without this, a BLOCKED run
+would still power off, or the long fail-safe window would override the graceful 60s
+shutdown:
+
+```bash
+node "$CLAUDE_PLUGIN_ROOT/scripts/autonomous-shutdown-timer.js" cancel
+```
+
+Harmless no-op if nothing was scheduled. Then proceed by `$WATCHDOG_ACTION`:
+
+- **notify mode** (shutdown=no): the PC stays on. No fail-safe was armed; skip
+  8.0/8a/8b; run only **8c** —
   write `AUTONOMOUS-DONE.flag` for every terminal status (COMPLETED / INTERRUPTED
   / BLOCKED). Reaching Step 8 proves the run is not wedged, so the health-watchdog
   finds the flag and stands down (no `AUTONOMOUS-STALLED.txt`).

--- a/plugins/devops/skills/devops-autonomous/deep-knowledge/shutdown-watchdog.md
+++ b/plugins/devops/skills/devops-autonomous/deep-knowledge/shutdown-watchdog.md
@@ -1,9 +1,26 @@
 # Watchdog Arming & Shutdown — Full Mechanics
 
-Low-level mechanics for `devops-autonomous` Step 4d (arm watchdog) and Step 8
-(finalization / shutdown). Read this when you reach Step 4d. It is split out of
-SKILL.md so the trigger-time body stays lean (progressive disclosure) — the Bash
-below is only needed at run time.
+Low-level mechanics for `devops-autonomous` Step 4d (arm watchdog), Step 5.0 (arm
+fail-safe shutdown timer) and Step 8 (finalization / shutdown). Read this when you
+reach Step 4d. It is split out of SKILL.md so the trigger-time body stays lean
+(progressive disclosure) — the Bash below is only needed at run time.
+
+## Three Shutdown Layers (shutdown mode)
+
+When the user chose "Ja, herunterfahren", three independent layers guarantee the PC
+powers off — each covers a failure the others can't:
+
+| Layer | Armed at | Fires | Covers |
+|-------|----------|-------|--------|
+| **Fail-safe timer** (`autonomous-shutdown-timer.js`) | Step 5.0, run start | `shutdown /s /t` after 90 min–5 h | Session wedges before Step 8 (token exhaustion, API hang) — early & OS-level |
+| **In-session shutdown** (Step 8b) | Step 8, after work | `shutdown /s /t 60`, 60 s after completion | The normal happy path; cancels the fail-safe first |
+| **External watchdog** (`autonomous-watchdog.js`) | Step 4d | Scheduled Task after 8 h | Even the fail-safe `shutdown.exe` call could not be placed |
+
+The fail-safe timer is the answer to "tokens ran out mid-run, the session froze, and
+the PC stayed on all night". It is armed **unconditionally** and **early**, so it does
+not depend on Claude reaching any later step. Step 8 cancels it the instant it runs,
+because by then the session has proven it is alive and the deliberate Step 8 decision
+(graceful 60 s shutdown, or *no* shutdown for BLOCKED) supersedes the blind timer.
 
 ## External Watchdog — Always Armed
 
@@ -58,15 +75,90 @@ without crowding the firing window. Override only if the user declared an
 explicitly long task during intake ("12h migration", "run overnight benchmark")
 — bump to `12` or `24` (script enforces ≤ 24h).
 
+## Fail-Safe Shutdown Timer (Step 5.0)
+
+Armed as the **first action** of Step 5 when shutdown=yes, before any task work.
+It is the inner, early net (the watchdog above is the outer one): a hard OS-level
+`shutdown.exe /s /t <seconds>` placed immediately, so the PC powers off even if the
+session later wedges and never reaches Step 8.
+
+### Arming
+
+```bash
+node "$CLAUDE_PLUGIN_ROOT/scripts/autonomous-shutdown-timer.js" arm
+```
+
+Parse the JSON:
+- `ok:true` → log `armed {minutes} min (source={source})` to `AUTONOMOUS-LOG.md`.
+  `source` is `reset-window` | `reset-window-floored` | `reset-window-capped` |
+  `fallback-5h` — useful when the user asks on return why the timer was that length.
+- `ok:false` → log `⚠ Fail-safe-Timer konnte nicht gesetzt werden — 8h-Watchdog ist
+  alleinige Absicherung` and continue. Never abort the run over it.
+- `skipped:true` (non-Windows) → silent, continue.
+
+### Timer length — "remaining 5h-period + floor"
+
+The script reads `~/.claude/usage-live.json` (last usage scrape) and resolves the
+delay purely (`computeShutdownDelaySeconds`, unit-tested):
+
+1. Take `session.resetInMinutes`, **age-correct** it by the snapshot `timestamp`
+   (`effective = resetInMinutes − minutesSinceSnapshot`).
+2. **Clamp to [90 min, 5 h].** The 90-min FLOOR stops a near-empty token window from
+   cutting off still-running work; the 5 h CAP is one full token period.
+3. **Fall back to 5 h** when usage data is missing, unparsable, stale (>5 h old),
+   future-dated (clock skew), or the period already elapsed — *"5h passt im
+   Zweifelsfall immer"*.
+
+Why a live scrape is **not** triggered here: it would cost ~60 s and spin up the Edge
+scraper at run start. The cached snapshot is precise enough for a coarse fail-safe,
+and the 5 h fallback is safe when it is absent.
+
+### Robustness
+
+`shutdown.exe` is invoked directly (not through cmd/PowerShell) with an absolute path
+(`%SystemRoot%\System32\shutdown.exe`) and a guaranteed-local CWD — a UNC working
+directory (session on `\\nas\share\...`) cannot break it. `arm` runs `/a` first, so a
+re-arm is idempotent.
+
+### Cancellation (Step 8.0)
+
+Because the timer is unconditional, **Step 8 cancels it before deciding anything**:
+
+```bash
+node "$CLAUDE_PLUGIN_ROOT/scripts/autonomous-shutdown-timer.js" cancel
+```
+
+`cancel` runs `shutdown /a`; a "nothing scheduled" result (error 1116) is treated as
+success. This is what lets a **BLOCKED** run stay powered on (the fail-safe would
+otherwise force it off) and lets the graceful 60 s shutdown replace the longer
+fail-safe window on the happy path.
+
 ## Step 8 — Finalization & Shutdown
 
 Runs after Step 7 (Report). Behavior depends on `$WATCHDOG_ACTION`:
 
-- **notify mode** (shutdown=no): the PC stays on. Skip 8a and 8b entirely — go
-  straight to 8c and write the done-flag so the health-watchdog stands down. The
-  flag here simply means "the session reached completion and is not wedged".
-- **shutdown mode** (shutdown=yes): run 8a → 8b → 8c, but only when status is
-  COMPLETED or INTERRUPTED. BLOCKED skips 8b (see below).
+- **notify mode** (shutdown=no): the PC stays on. No fail-safe timer was armed, so
+  skip 8.0/8a/8b entirely — go straight to 8c and write the done-flag so the
+  health-watchdog stands down. The flag here simply means "the session reached
+  completion and is not wedged".
+- **shutdown mode** (shutdown=yes): run 8.0 → 8a → 8b → 8c, but 8a/8b only when
+  status is COMPLETED or INTERRUPTED. BLOCKED still runs 8.0, then skips to 8c.
+
+### 8.0 — Cancel the Fail-Safe Timer (shutdown mode only)
+
+Always the first finalization step in shutdown mode — for **every** status,
+including BLOCKED. Reaching Step 8 proves the session is alive, so the Step 5.0
+fail-safe must hand control back to the deliberate decision here:
+
+```bash
+node "$CLAUDE_PLUGIN_ROOT/scripts/autonomous-shutdown-timer.js" cancel
+```
+
+Skipping this for BLOCKED would force the very power-off that BLOCKED forbids;
+skipping it for COMPLETED/INTERRUPTED would leave the long fail-safe countdown
+racing the graceful 60 s shutdown (whichever Windows scheduled first wins, and a
+second `shutdown /s` errors with "a shutdown is already scheduled"). A
+"nothing scheduled" result is benign — the script reports `noPending:true`.
 
 ### 8a — Wait for Other Active Claude Sessions (shutdown mode only)
 

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.92.0",
+  "version": "0.93.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary
Arms a hard OS-level shutdown timer at the start of every `devops-autonomous` run with shutdown=yes, so the PC powers off even if the session wedges (token exhaustion, Anthropic API hang) before reaching the in-session shutdown. Addresses the real-world case where an autonomous run that runs out of tokens left the PC on indefinitely.

## How it works
- **Step 5.0** (first action, shutdown mode): `autonomous-shutdown-timer.js arm` places `shutdown.exe /s /t <T>`. `T` = remaining 5h token period (`session.resetInMinutes` from `usage-live.json`, age-corrected), clamped to **[90 min, 5 h]**, with a **5 h fallback** when usage data is missing/stale.
- **Step 8.0** (first finalization action): cancels the timer the moment the deliberate decision takes over — so a **BLOCKED** run stays powered on (data-integrity rule preserved) and the graceful 60 s shutdown replaces the longer fail-safe window on success.
- The existing **8 h scheduled-task watchdog** remains the outermost net → three-layer defense.

## Tests
- New `autonomous-shutdown-timer.test.js` (17 cases): clamp, floor, cap, age-correction, all fallbacks.
- Full suite **215 green**, lint clean.
- `arm` / `cancel` / no-pending verified end-to-end on Windows (timer scheduled, cancelled, nothing left scheduled).

## Notes
- Codex review gate timed out (300 s ceiling) — proceeded without findings per the fail-tolerance protocol.