### PR TITLE
fix(devops): surface missing MCP servers + harden ship-guard (#198)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.93.1"
+    "version": "0.93.2"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.93.1",
+      "version": "0.93.2",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.93.1",
+      "version": "0.93.2",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.93.2] — 2026-06-04
+
+### Fixed
+
+- **MCP ship-server can be silently absent → `/devops-ship` deadlock (issue #198)** — when an incomplete plugin-cache sync dropped `mcp-server/ship/index.js` (sibling to the #190 failure mode), the `dotclaude-ship` server never registered while `dotclaude-completion` worked fine, so the ship pipeline was unavailable with **no signal** that the server was missing. A new `ss.mcp.verify` SessionStart hook now verifies every server declared in `.mcp.json` has its entry file present under the active install root and surfaces a per-server diagnostic (with restart/rebuild recovery steps) when one is missing — silent when all are intact, plus a machine-readable last-run status in tmp for post-hoc debugging. New shared `hooks/lib/mcp-status.js` (entry-file + heartbeat-liveness helpers).
+- **`pre.ship.guard` misleading "likely DEFERRED" guidance** — the block message asserted unconditionally that absent ship tools were merely deferred, dead-ending the user when the server was genuinely unregistered. The guard now probes the ship server's heartbeat PID: **alive** → confident "deferred, ToolSearch them"; **not alive** → dual guidance (try ToolSearch, and if it returns nothing, recover via restart / `/devops-plugin-update`). An opt-in `DOTCLAUDE_ALLOW_MANUAL_SHIP=1` escape allows a one-off manual ship — honored **only** when the server is confirmed absent, never when it is up — so a missing pipeline server can no longer hard-deadlock a session.
+- **`pre.ship.guard` false-positive on quoted text** — the matcher tested its `gh pr create` / `gh pr merge` / `gh api …/merge` patterns against the entire command string, so it blocked commands that merely *mentioned* those words inside an issue body, commit message, or here-string. Matching is now delegated to a unit-tested `hooks/lib/ship-guard-match.js` that strips quoted spans (single/double quotes, PowerShell here-strings, bash heredocs) and anchors patterns to a command position, so only real invocations match.
+
 ## [0.93.1] — 2026-06-04
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.93.1**
+**Version: 0.93.2**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 
@@ -167,7 +167,7 @@ For the full extension guide with examples per skill, see `deep-knowledge/skill-
 
 ## Features
 
-- **<!--devops:count:hooks-->28<!--/devops:count:hooks--> Hooks** — automated guards and triggers across the full session lifecycle
+- **<!--devops:count:hooks-->29<!--/devops:count:hooks--> Hooks** — automated guards and triggers across the full session lifecycle
 - **<!--devops:count:skills-->19<!--/devops:count:skills--> Skills** — devops-ship, devops-commit, devops-flow, devops-new-issue, devops-project-setup, devops-readme, devops-refresh-usage, devops-extend-skill, devops-repo-health, devops-claude-md-lint, devops-concept, devops-agents, devops-plugin-update, devops-autonomous, devops-burn, devops-learn, devops-harden, devops-polish, devops-test-plan
 - **<!--devops:count:agents-->11<!--/devops:count:agents--> Agents** — AI, Core, Designer, Feature, Frontend, Gamer, PO, QA, Redteam, Research, Windows
 - **Completion Flow** — mandatory card after every task (8 variants), visual verification, ship recommendation
@@ -178,7 +178,7 @@ For the full extension guide with examples per skill, see `deep-knowledge/skill-
 
 ### Hooks (automatic, no user action needed)
 
-<!--devops:count:hooks-->28<!--/devops:count:hooks--> hooks fire automatically across the session lifecycle — no user action needed.
+<!--devops:count:hooks-->29<!--/devops:count:hooks--> hooks fire automatically across the session lifecycle — no user action needed.
 
 <details>
 <summary><strong>By session lifecycle</strong> — when does it fire?</summary>
@@ -195,6 +195,7 @@ SessionStart  ──>  UserPromptSubmit  ──>  PreToolUse  ──>  PostToolU
 - `ss.knowledge.index` — Inject deep-knowledge INDEX.md into context at session start.
 - `ss.mcp.deps` — Auto-install MCP server dependencies into CLAUDE_PLUGIN_DATA, and self-heal partial i…
 - `ss.mcp.envcheck` — Detect enabled plugins whose .mcp.json references env vars that are not set.
+- `ss.mcp.verify` — Verify every MCP server declared in this plugin's .mcp.json has its entry file presen…
 - `ss.tokens.scan` — Scan project for expensive files and update config for the pre.tokens.guard hook.
 - `ss.git.check` — Check for stale changes AND workspace setup issues at session start.
 - `ss.git.sync` — Registers a recurring git sync cron job (every 10 minutes).
@@ -640,7 +641,7 @@ Wk  ━━──╏─────────   15% +1%   · 4d 22h left
 devops/
 ├── .claude-plugin/plugin.json     ← Plugin manifest
 ├── CONVENTIONS.md                 ← Naming, versioning, extension rules
-├── hooks/                         ← <!--devops:count:hooks-->28<!--/devops:count:hooks--> hooks (JS) registered in hooks.json
+├── hooks/                         ← <!--devops:count:hooks-->29<!--/devops:count:hooks--> hooks (JS) registered in hooks.json
 ├── skills/                        ← <!--devops:count:skills-->19<!--/devops:count:skills--> skill definitions (SKILL.md)
 ├── agents/                        ← <!--devops:count:agents-->11<!--/devops:count:agents--> agent definitions
 ├── deep-knowledge/                ← Cross-cutting reference docs

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.93.1",
+  "version": "0.93.2",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/docs/architecture.html
+++ b/plugins/devops/docs/architecture.html
@@ -169,7 +169,7 @@
 <section id="overview">
 <h1>Architecture Documentation <small>devops v0.87.0</small></h1>
 <p class="lead">
-  A comprehensive DevOps automation plugin for Claude Code &mdash; <!--devops:count:hooks-->28<!--/devops:count:hooks--> hooks, <!--devops:count:skills-->19<!--/devops:count:skills--> skills, <!--devops:count:agents-->11<!--/devops:count:agents--> agents,
+  A comprehensive DevOps automation plugin for Claude Code &mdash; <!--devops:count:hooks-->29<!--/devops:count:hooks--> hooks, <!--devops:count:skills-->19<!--/devops:count:skills--> skills, <!--devops:count:agents-->11<!--/devops:count:agents--> agents,
   2 MCP servers, a deterministic completion card engine, and a 3-layer extension system.
 </p>
 <div role="note" style="margin:.4rem 0 1.4rem;padding:.6rem .9rem;background:var(--bg2);border-left:3px solid var(--warn);border-radius:4px;color:var(--text2);font-size:.85rem;">
@@ -180,9 +180,9 @@
 
 <div class="card-grid">
   <div class="card">
-    <h4><!--devops:count:hooks-->28<!--/devops:count:hooks--> Hooks</h4>
+    <h4><!--devops:count:hooks-->29<!--/devops:count:hooks--> Hooks</h4>
     <p style="color:var(--text2);font-size:.85rem">Lifecycle guards across SessionStart, UserPromptSubmit, PreToolUse, PostToolUse, Stop</p>
-    <span class="badge b-hook">SessionStart &times;<!--devops:count:hooks:ss-->11<!--/devops:count:hooks:ss--></span>
+    <span class="badge b-hook">SessionStart &times;<!--devops:count:hooks:ss-->12<!--/devops:count:hooks:ss--></span>
     <span class="badge b-hook">Prompt &times;<!--devops:count:hooks:prompt-->7<!--/devops:count:hooks:prompt--></span>
     <span class="badge b-hook">Pre &times;<!--devops:count:hooks:pre-->6<!--/devops:count:hooks:pre--></span>
     <span class="badge b-hook">Post &times;<!--devops:count:hooks:post-->2<!--/devops:count:hooks:post--></span>
@@ -217,7 +217,7 @@
 ├── hooks/
 │   ├── hooks.json             <span style="color:var(--purple)"># Hook registry (event &rarr; command mapping)</span>
 │   ├── lib/                   <span style="color:var(--text2)"># plugin-guard, run-once, session-id</span>
-│   ├── session-start/         <span style="color:var(--purple)"># <!--devops:count:hooks:ss-->11<!--/devops:count:hooks:ss--> hooks (ss.*)</span>
+│   ├── session-start/         <span style="color:var(--purple)"># <!--devops:count:hooks:ss-->12<!--/devops:count:hooks:ss--> hooks (ss.*)</span>
 │   ├── user-prompt-submit/    <span style="color:var(--purple)"># <!--devops:count:hooks:prompt-->7<!--/devops:count:hooks:prompt--> hooks (prompt.*)</span>
 │   ├── pre-tool-use/          <span style="color:var(--purple)"># <!--devops:count:hooks:pre-->6<!--/devops:count:hooks:pre--> hooks (pre.*)</span>
 │   ├── post-tool-use/         <span style="color:var(--purple)"># <!--devops:count:hooks:post-->2<!--/devops:count:hooks:post--> hooks (post.*)</span>

--- a/plugins/devops/hooks/hooks.json
+++ b/plugins/devops/hooks/hooks.json
@@ -9,6 +9,7 @@
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-start/ss.knowledge.index.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-start/ss.mcp.deps.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-start/ss.mcp.envcheck.js" },
+          { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-start/ss.mcp.verify.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-start/ss.tokens.scan.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-start/ss.git.check.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-start/ss.git.sync.js" },

--- a/plugins/devops/hooks/pre-tool-use/pre.ship.guard.js
+++ b/plugins/devops/hooks/pre-tool-use/pre.ship.guard.js
@@ -1,26 +1,33 @@
 #!/usr/bin/env node
 /**
  * @hook pre.ship.guard
- * @version 0.3.0
+ * @version 0.4.0
  * @event PreToolUse
  * @plugin devops
  * @description Block manual PR creation/merging via Bash.
  *   These operations MUST go through /devops-ship MCP tools.
  *   Detects: gh pr create, gh pr merge, gh api .../pulls/.../merge
  *   Does NOT block: git push (needed for branch work before shipping).
- *   Does NOT block: MCP tool calls (tool_name !== "Bash") — the ship pipeline
- *   itself uses execFileSync which doesn't go through Bash hooks, but Claude
- *   may retry failed MCP calls via Bash as a fallback. This guard only fires
- *   on Bash tool invocations.
+ *   Does NOT block: MCP tool calls (tool_name !== "Bash").
+ *
+ *   #198 fixes:
+ *     - Matching is delegated to lib/ship-guard-match, which strips quoted text
+ *       and anchors to command position — so the guard no longer false-positives
+ *       on "gh pr create" appearing inside an issue body / commit message.
+ *     - The block message no longer unconditionally asserts "likely DEFERRED".
+ *       It probes the ship server's heartbeat: if alive → the tools are merely
+ *       deferred (ToolSearch them); if not alive → it may be genuinely
+ *       unregistered, so it points at the recovery path (restart / cache rebuild).
+ *     - Escape hatch: when the ship server is confirmed NOT alive, setting
+ *       DOTCLAUDE_ALLOW_MANUAL_SHIP=1 allows a one-off manual ship so a missing
+ *       server can no longer hard-deadlock the session. The escape is ignored
+ *       when the server IS alive (then there is no deadlock — use the tools).
  */
 
 require('../lib/plugin-guard');
 
-const BLOCKED_PATTERNS = [
-  /gh\s+pr\s+create/,
-  /gh\s+pr\s+merge/,
-  /gh\s+api\s+.*pulls.*\/merge/,
-];
+const { isManualShipCommand } = require('../lib/ship-guard-match');
+const { isServerAlive } = require('../lib/mcp-status');
 
 let inputData = '';
 process.stdin.setEncoding('utf8');
@@ -31,27 +38,62 @@ process.stdin.on('end', () => {
   catch { process.exit(0); }
 
   // Only guard Bash tool calls — MCP tools (ship_release etc.) are pipeline-internal
-  const toolName = hook.tool_name || '';
-  if (toolName !== 'Bash') process.exit(0);
+  if ((hook.tool_name || '') !== 'Bash') process.exit(0);
 
   const cmd = (hook.tool_input || {}).command || '';
+  if (!isManualShipCommand(cmd)) process.exit(0);
 
-  const blocked = BLOCKED_PATTERNS.some(re => re.test(cmd));
-  if (!blocked) process.exit(0);
+  const shipAlive = isServerAlive('dotclaude-ship');
 
-  process.stderr.write(
-    'BLOCKED: Manual PR creation/merging detected. ' +
-    'Use /devops-ship for shipping. ' +
-    'The ship pipeline ensures build-ID, safety checks, version bumps, and proper completion cards.\n' +
-    '\n' +
-    'If ship_* MCP tools appear missing: they are likely DEFERRED, not unregistered. ' +
-    'Load their schemas via ToolSearch before calling:\n' +
+  // Escape hatch — only when the pipeline server is confirmed absent. Never when
+  // it is up: then there is no deadlock to escape, the tools are simply deferred.
+  if (!shipAlive && process.env.DOTCLAUDE_ALLOW_MANUAL_SHIP === '1') {
+    process.stderr.write(
+      'NOTE: dotclaude-ship MCP server is not reporting alive and ' +
+      'DOTCLAUDE_ALLOW_MANUAL_SHIP=1 is set — allowing this manual PR command ' +
+      'as an explicit, user-authorized recovery escape.\n'
+    );
+    process.exit(0);
+  }
+
+  const lines = [
+    'BLOCKED: Manual PR creation/merging detected. Use /devops-ship for shipping.',
+    'The ship pipeline ensures build-ID, safety checks, version bumps, and proper completion cards.',
+    '',
+  ];
+
+  if (shipAlive) {
+    lines.push(
+      'The dotclaude-ship MCP server IS running — its tools are just DEFERRED, not unregistered.',
+      'Load their schemas via ToolSearch before calling:',
+    );
+  } else {
+    lines.push(
+      'The dotclaude-ship MCP server is NOT reporting alive (no heartbeat PID).',
+      'First try loading the tools via ToolSearch — if it returns matches, they were only deferred:',
+    );
+  }
+
+  lines.push(
     '  ToolSearch({ query: "select:mcp__plugin_devops_dotclaude-ship__ship_preflight,' +
     'mcp__plugin_devops_dotclaude-ship__ship_build,' +
     'mcp__plugin_devops_dotclaude-ship__ship_version_bump,' +
     'mcp__plugin_devops_dotclaude-ship__ship_release,' +
-    'mcp__plugin_devops_dotclaude-ship__ship_cleanup", max_results: 5 })\n' +
-    'See {PLUGIN_ROOT}/deep-knowledge/mcp-deferred-tools.md for details.\n'
+    'mcp__plugin_devops_dotclaude-ship__ship_cleanup", max_results: 5 })',
   );
+
+  if (!shipAlive) {
+    lines.push(
+      '',
+      'If ToolSearch returns NO matches, the ship server genuinely failed to register.',
+      'Recovery: restart Claude Code (MCP servers spawn only at session init; ss.plugin.update',
+      'self-heals the cache on the next start). If it persists, run /devops-plugin-update.',
+      'Last resort: set DOTCLAUDE_ALLOW_MANUAL_SHIP=1 to allow a one-off manual ship this session.',
+    );
+  }
+
+  lines.push('See {PLUGIN_ROOT}/deep-knowledge/mcp-deferred-tools.md for details.');
+
+  process.stderr.write(lines.join('\n') + '\n');
   process.exit(2);
 });

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.93.1",
+  "version": "0.93.2",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
Closes #198

## Summary
Hardens the `/devops-ship` path against the failure mode where the `dotclaude-ship` MCP server is silently absent (incomplete cache sync) and the guard's guidance dead-ends the user.

## Changes
- **`ss.mcp.verify` (new SessionStart hook)** — verifies every server in `.mcp.json` has its entry file present under the active install root; surfaces a per-server diagnostic with recovery steps when one is missing. Silent when all intact; always writes a last-run status to tmp for debugging.
- **`hooks/lib/mcp-status.js` (new, shared)** — entry-file presence + heartbeat-liveness helpers, unit-tested.
- **`pre.ship.guard` rewrite** — probes the ship server heartbeat to distinguish *deferred* (ToolSearch) from *genuinely absent* (restart / `/devops-plugin-update`); adds an opt-in `DOTCLAUDE_ALLOW_MANUAL_SHIP=1` escape honored only when the server is confirmed absent.
- **`hooks/lib/ship-guard-match.js` (new, unit-tested)** — quote-stripping + command-position-anchored matcher, fixing the false-positive where `gh pr create` inside quoted text (issue body / commit message / here-string) tripped the guard.

## Tests
- 238 passing (23 new across `ship-guard-match` + `mcp-status`); lint clean.

## Notes
- Codex review gate could not run (account/model config: `gpt-5.4 not supported`); proceeded per pipeline failure-tolerance rule.