### PR TITLE
fix(devops): ship_release includes new files; complete #198

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.93.2"
+    "version": "0.93.3"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.93.2",
+      "version": "0.93.3",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.93.2",
+      "version": "0.93.3",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.93.3] — 2026-06-04
+
+### Fixed
+
+- **`ship_release` silently dropped new untracked files (caused a half-merged 0.93.2)** — when committing via `commitMessage`, the release tool staged tracked modifications (`git add -u`) plus only `CHANGELOG.md`, and recorded every other untracked file in a `skippedFiles` field that nothing acted on. The #198 ship therefore merged its *modified* files (`pre.ship.guard.js`, `hooks.json`) while silently omitting the **new** module files they require (`hooks/lib/ship-guard-match.js`, `hooks/lib/mcp-status.js`, `hooks/session-start/ss.mcp.verify.js`) — leaving `main` referencing modules that were never committed. `ship_release` now stages all untracked files (`git status --porcelain` already excludes gitignored paths, so the list is intentional repo content) and reports them as `includedUntracked` instead of dropping them.
+- **Completes #198** — re-adds the three module files dropped by the 0.93.2 ship so `pre.ship.guard` and `ss.mcp.verify` actually resolve their dependencies on `main`.
+
 ## [0.93.2] — 2026-06-04
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.93.2**
+**Version: 0.93.3**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.93.2",
+  "version": "0.93.3",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/hooks/lib/mcp-status.js
+++ b/plugins/devops/hooks/lib/mcp-status.js
@@ -1,0 +1,97 @@
+/**
+ * @module mcp-status
+ * @version 0.1.0
+ * @description Shared helpers for inspecting devops MCP server health, used by
+ *   ss.mcp.verify (cache-file presence at session start) and pre.ship.guard
+ *   (heartbeat liveness when deciding between "deferred" vs "genuinely absent").
+ *
+ *   Two independent signals:
+ *     - expectedServers()/serverEntryExists(): does the server's entry file exist
+ *       in the active install root? Deterministic — predicts whether a server CAN
+ *       register. The right signal at SessionStart (servers may not have spawned
+ *       yet, so liveness would be racy).
+ *     - isServerAlive(): is the heartbeat PID (written by mcp-server/lib/heartbeat.js)
+ *       referencing a live process? The right signal mid-session (PreToolUse),
+ *       when a server has had the whole session to start.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const PID_PREFIX = 'dotclaude-mcp-';
+
+function pidFileFor(serverName) {
+  return path.join(os.tmpdir(), `${PID_PREFIX}${serverName}.pid`);
+}
+
+function isProcessAlive(pid) {
+  try {
+    process.kill(pid, 0); // signal 0 = existence check, no kill
+    return true;
+  } catch (err) {
+    // EPERM = process exists but we lack permission → alive
+    return err.code === 'EPERM';
+  }
+}
+
+/**
+ * Is the named MCP server reporting alive via its heartbeat PID file?
+ * Returns false when the PID file is absent, unreadable, or the PID is dead.
+ * @param {string} serverName  e.g. "dotclaude-ship"
+ * @returns {boolean}
+ */
+function isServerAlive(serverName) {
+  let pid;
+  try {
+    pid = parseInt(fs.readFileSync(pidFileFor(serverName), 'utf8').trim(), 10);
+  } catch {
+    return false;
+  }
+  if (!pid || Number.isNaN(pid)) return false;
+  return isProcessAlive(pid);
+}
+
+/**
+ * Substitute ${CLAUDE_PLUGIN_ROOT} and ${ENV_VARS} in an .mcp.json arg.
+ * Unset env vars are left as-is so the caller can still report a usable path.
+ */
+function resolveVars(str, pluginRoot) {
+  return str
+    .replace(/\$\{CLAUDE_PLUGIN_ROOT\}/g, pluginRoot)
+    .replace(/\$\{([A-Z_][A-Z0-9_]*)\}/g, (m, v) => process.env[v] || m);
+}
+
+/**
+ * Parse the plugin's .mcp.json and return the declared servers with their
+ * resolved entry-file paths.
+ * @param {string} pluginRoot  CLAUDE_PLUGIN_ROOT (the active install dir)
+ * @returns {Array<{name: string, entry: string|null}>}
+ */
+function expectedServers(pluginRoot) {
+  let cfg;
+  try {
+    cfg = JSON.parse(fs.readFileSync(path.join(pluginRoot, '.mcp.json'), 'utf8'));
+  } catch {
+    return [];
+  }
+  const servers = cfg.mcpServers || {};
+  return Object.entries(servers).map(([name, def]) => {
+    const args = Array.isArray(def?.args) ? def.args : [];
+    const rawEntry = args.find((a) => typeof a === 'string' && a.endsWith('.js'));
+    return { name, entry: rawEntry ? resolveVars(rawEntry, pluginRoot) : null };
+  });
+}
+
+function serverEntryExists(entry) {
+  return !!entry && fs.existsSync(entry);
+}
+
+module.exports = {
+  pidFileFor,
+  isProcessAlive,
+  isServerAlive,
+  resolveVars,
+  expectedServers,
+  serverEntryExists,
+};

--- a/plugins/devops/hooks/lib/mcp-status.test.js
+++ b/plugins/devops/hooks/lib/mcp-status.test.js
@@ -1,0 +1,94 @@
+import { describe, test, expect, afterEach } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import {
+  expectedServers,
+  serverEntryExists,
+  isServerAlive,
+  pidFileFor,
+  resolveVars,
+} from "./mcp-status.js";
+
+const tmpDirs = [];
+const tmpFiles = [];
+
+function mkTmpDir() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "mcp-status-test-"));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const f of tmpFiles.splice(0)) { try { fs.unlinkSync(f); } catch {} }
+  for (const d of tmpDirs.splice(0)) { try { fs.rmSync(d, { recursive: true, force: true }); } catch {} }
+});
+
+// ---------------------------------------------------------------------------
+// expectedServers / serverEntryExists
+// ---------------------------------------------------------------------------
+
+describe("expectedServers", () => {
+  test("parses .mcp.json and resolves ${CLAUDE_PLUGIN_ROOT}", () => {
+    const root = mkTmpDir();
+    fs.writeFileSync(path.join(root, ".mcp.json"), JSON.stringify({
+      mcpServers: {
+        "dotclaude-ship": { command: "node", args: ["${CLAUDE_PLUGIN_ROOT}/mcp-server/ship/index.js"] },
+        "dotclaude-completion": { command: "node", args: ["${CLAUDE_PLUGIN_ROOT}/mcp-server/index.js"] },
+      },
+    }));
+    const servers = expectedServers(root);
+    expect(servers).toHaveLength(2);
+    const ship = servers.find((s) => s.name === "dotclaude-ship");
+    expect(ship.entry.startsWith(root)).toBe(true);
+    expect(ship.entry.endsWith("ship/index.js")).toBe(true);
+  });
+
+  test("missing .mcp.json → empty list", () => {
+    expect(expectedServers(mkTmpDir())).toEqual([]);
+  });
+});
+
+describe("serverEntryExists", () => {
+  test("true for an existing file, false for missing / null", () => {
+    const root = mkTmpDir();
+    const entry = path.join(root, "index.js");
+    fs.writeFileSync(entry, "// stub");
+    expect(serverEntryExists(entry)).toBe(true);
+    expect(serverEntryExists(path.join(root, "nope.js"))).toBe(false);
+    expect(serverEntryExists(null)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isServerAlive — heartbeat PID liveness
+// ---------------------------------------------------------------------------
+
+describe("isServerAlive", () => {
+  const NAME = "vitest-fake-server-" + process.pid;
+
+  test("alive when PID file points at this process", () => {
+    const pidFile = pidFileFor(NAME);
+    tmpFiles.push(pidFile);
+    fs.writeFileSync(pidFile, String(process.pid));
+    expect(isServerAlive(NAME)).toBe(true);
+  });
+
+  test("dead when PID file points at a non-existent process", () => {
+    const pidFile = pidFileFor(NAME);
+    tmpFiles.push(pidFile);
+    fs.writeFileSync(pidFile, "999999999");
+    expect(isServerAlive(NAME)).toBe(false);
+  });
+
+  test("false when no PID file exists", () => {
+    expect(isServerAlive("vitest-no-such-server-" + Date.now())).toBe(false);
+  });
+});
+
+describe("resolveVars", () => {
+  test("substitutes plugin root and leaves unset env vars intact", () => {
+    expect(resolveVars("${CLAUDE_PLUGIN_ROOT}/x.js", "/root")).toBe("/root/x.js");
+    expect(resolveVars("${DEFINITELY_UNSET_VAR_XYZ}", "/root")).toBe("${DEFINITELY_UNSET_VAR_XYZ}");
+  });
+});

--- a/plugins/devops/hooks/lib/ship-guard-match.js
+++ b/plugins/devops/hooks/lib/ship-guard-match.js
@@ -1,0 +1,66 @@
+/**
+ * @module ship-guard-match
+ * @version 0.1.0
+ * @description Pure matcher for pre.ship.guard — decides whether a Bash command
+ *   is a REAL manual PR create/merge invocation that must go through /devops-ship.
+ *
+ *   Split out of pre.ship.guard.js so the logic is unit-testable, and to fix the
+ *   #198 bonus defect: the old guard tested its patterns against the entire
+ *   command string, so it false-positived when "gh pr create" merely appeared
+ *   inside quoted text (an issue body, a commit message, a here-string) rather
+ *   than as an actual invocation.
+ *
+ *   Two-stage match:
+ *     1. stripQuoted() removes quoted spans (single/double quotes, PowerShell
+ *        here-strings, bash heredoc bodies) so embedded prose can't trip it.
+ *     2. The patterns are anchored to a command position (start of command or
+ *        right after a shell separator) so only real command tokens match, not
+ *        arbitrary substrings.
+ *
+ *   This is a nudge, not a security boundary — over-stripping quotes is fine; the
+ *   goal is zero false positives on documentation/quoted text while still
+ *   catching the direct `gh pr create …` invocations Claude actually issues.
+ */
+
+// A command position: start of string, or immediately after a shell separator
+// (newline, ; & | ( ) { }). `&&` / `||` are covered by the single & / | chars.
+const BOUNDARY = String.raw`(?:^|[\n;&|(){}])\s*`;
+
+const PATTERNS = [
+  new RegExp(BOUNDARY + String.raw`gh\s+pr\s+create\b`),
+  new RegExp(BOUNDARY + String.raw`gh\s+pr\s+merge\b`),
+  new RegExp(BOUNDARY + String.raw`gh\s+api\s+.*pulls.*\/merge`),
+];
+
+/**
+ * Remove quoted / here-doc spans so command words inside prose don't match.
+ * Order matters: multi-line here-strings and heredocs first (they contain
+ * quotes), then plain double- then single-quoted spans.
+ *
+ * @param {string} s
+ * @returns {string}
+ */
+function stripQuoted(s) {
+  let out = s;
+  // PowerShell here-strings: @"..."@ and @'...'@ (may span lines)
+  out = out.replace(/@"[\s\S]*?"@/g, ' ');
+  out = out.replace(/@'[\s\S]*?'@/g, ' ');
+  // Bash heredocs: <<['"]?TAG ... \n TAG  (optional <<- dash, quoted/unquoted tag)
+  out = out.replace(/<<-?\s*(['"]?)([A-Za-z_]\w*)\1[\s\S]*?\n[ \t]*\2\b/g, ' ');
+  // Remaining double- then single-quoted spans
+  out = out.replace(/"[^"]*"/g, ' ');
+  out = out.replace(/'[^']*'/g, ' ');
+  return out;
+}
+
+/**
+ * @param {string} cmd  Raw Bash command string from the tool input.
+ * @returns {boolean}   true only for a real manual PR create/merge invocation.
+ */
+function isManualShipCommand(cmd) {
+  if (!cmd || typeof cmd !== 'string') return false;
+  const stripped = stripQuoted(cmd);
+  return PATTERNS.some((re) => re.test(stripped));
+}
+
+module.exports = { isManualShipCommand, stripQuoted };

--- a/plugins/devops/hooks/lib/ship-guard-match.test.js
+++ b/plugins/devops/hooks/lib/ship-guard-match.test.js
@@ -1,0 +1,81 @@
+import { describe, test, expect } from "vitest";
+import { isManualShipCommand, stripQuoted } from "./ship-guard-match.js";
+
+// ---------------------------------------------------------------------------
+// isManualShipCommand — real invocations match, quoted/prose text does not
+// ---------------------------------------------------------------------------
+
+describe("isManualShipCommand — real invocations", () => {
+  test("gh pr create at start", () => {
+    expect(isManualShipCommand('gh pr create --title x --body y')).toBe(true);
+  });
+
+  test("gh pr merge", () => {
+    expect(isManualShipCommand('gh pr merge 5 --squash')).toBe(true);
+  });
+
+  test("gh api pulls merge", () => {
+    expect(isManualShipCommand('gh api repos/o/r/pulls/5/merge -X PUT')).toBe(true);
+  });
+
+  test("chained after &&", () => {
+    expect(isManualShipCommand('git push origin main && gh pr create --fill')).toBe(true);
+  });
+
+  test("chained after ;", () => {
+    expect(isManualShipCommand('git push; gh pr merge 5')).toBe(true);
+  });
+
+  test("extra whitespace", () => {
+    expect(isManualShipCommand('gh   pr   create')).toBe(true);
+  });
+});
+
+describe("isManualShipCommand — no false positives (the #198 bonus defect)", () => {
+  test("gh pr create inside a double-quoted issue body", () => {
+    expect(isManualShipCommand(
+      'gh issue create --title "[BUG]" --body "use gh pr create to ship"'
+    )).toBe(false);
+  });
+
+  test("gh pr create inside a commit message", () => {
+    expect(isManualShipCommand('git commit -m "docs: explain gh pr create"')).toBe(false);
+  });
+
+  test("gh pr create inside a PowerShell here-string", () => {
+    const cmd = "git commit -m @'\nbody mentions gh pr create here\n'@";
+    expect(isManualShipCommand(cmd)).toBe(false);
+  });
+
+  test("gh pr create inside a bash heredoc", () => {
+    const cmd = "gh issue create --body-file - <<'EOF'\nrun gh pr create manually\nEOF";
+    expect(isManualShipCommand(cmd)).toBe(false);
+  });
+
+  test("unrelated gh subcommands", () => {
+    expect(isManualShipCommand('gh pr list')).toBe(false);
+    expect(isManualShipCommand('gh pr view 5')).toBe(false);
+  });
+
+  test("plain git push is allowed", () => {
+    expect(isManualShipCommand('git push origin feature')).toBe(false);
+  });
+
+  test("empty / non-string input", () => {
+    expect(isManualShipCommand('')).toBe(false);
+    expect(isManualShipCommand(undefined)).toBe(false);
+    expect(isManualShipCommand(null)).toBe(false);
+  });
+});
+
+describe("stripQuoted", () => {
+  test("removes double-quoted spans", () => {
+    expect(stripQuoted('a "b c" d')).not.toContain('b c');
+  });
+  test("removes single-quoted spans", () => {
+    expect(stripQuoted("a 'b c' d")).not.toContain('b c');
+  });
+  test("keeps unquoted tokens", () => {
+    expect(stripQuoted('gh pr create')).toContain('gh pr create');
+  });
+});

--- a/plugins/devops/hooks/session-start/ss.mcp.verify.js
+++ b/plugins/devops/hooks/session-start/ss.mcp.verify.js
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+/**
+ * @hook ss.mcp.verify
+ * @version 0.1.0
+ * @event SessionStart
+ * @plugin devops
+ * @description Verify every MCP server declared in this plugin's .mcp.json has
+ *   its entry file present in the active install root, and surface a per-server
+ *   diagnostic when one is missing.
+ *
+ *   Closes the visibility gap from issue #198: the dotclaude-ship server was
+ *   silently absent (an incomplete cache sync dropped mcp-server/ship/index.js)
+ *   while its sibling dotclaude-completion was fine, so /devops-ship deadlocked
+ *   with no signal that the server never registered.
+ *
+ *   Signal choice — file presence, not live PID:
+ *     MCP servers are spawned by the Claude Code runtime and may not have started
+ *     yet when SessionStart hooks run, so a heartbeat-liveness probe here would be
+ *     racy. Entry-file presence under CLAUDE_PLUGIN_ROOT (the exact copy the
+ *     runtime reads .mcp.json from) deterministically predicts whether a server
+ *     CAN register. A missing file ⇒ that server will not appear this session.
+ *
+ *   Output: silent (exit 0, no output) when all servers are intact — no green-tick
+ *   noise every session. When one is missing, writes a per-server block to stdout
+ *   for Claude to relay verbatim. A machine-readable last-run status is always
+ *   written to a temp file for post-hoc debugging.
+ */
+
+require('../lib/plugin-guard');
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { expectedServers, serverEntryExists } = require('../lib/mcp-status');
+
+const PLUGIN_ROOT = process.env.CLAUDE_PLUGIN_ROOT || path.resolve(__dirname, '..', '..');
+
+const servers = expectedServers(PLUGIN_ROOT);
+if (servers.length === 0) process.exit(0); // no .mcp.json / no servers declared
+
+const results = servers.map((s) => ({
+  name: s.name,
+  entry: s.entry,
+  rel: s.entry ? path.relative(PLUGIN_ROOT, s.entry) : '(no entry in .mcp.json)',
+  ok: serverEntryExists(s.entry),
+}));
+
+// Always write a last-run status file — cheap, silent, inspectable when a user
+// later asks "why was the ship server missing?".
+try {
+  fs.writeFileSync(
+    path.join(os.tmpdir(), 'dotclaude-mcp-verify.json'),
+    JSON.stringify({ pluginRoot: PLUGIN_ROOT, servers: results }, null, 2),
+  );
+} catch {
+  // Non-fatal — diagnostics only.
+}
+
+const broken = results.filter((r) => !r.ok);
+if (broken.length === 0) process.exit(0);
+
+const out = [];
+out.push('MCP server verification (devops) — show the user this block as-is:');
+out.push('');
+out.push('⚠️  **MCP server(s) missing from this session**');
+out.push('');
+out.push('Declared in the plugin but the entry file is absent from the active install');
+out.push('— these servers will NOT register, so their tools are unavailable:');
+out.push('');
+for (const r of broken) {
+  const note = r.name === 'dotclaude-ship' ? '  (/devops-ship pipeline unavailable)' : '';
+  out.push(`- **${r.name}** → missing \`${r.rel}\`${note}`);
+}
+out.push('');
+out.push('Likely cause: an incomplete plugin-cache sync dropped the file (claude-code#14061 / #190).');
+out.push('Fix: **restart Claude Code** — ss.plugin.update self-heals the cache on the next session');
+out.push('start. If it persists after a restart, run `/devops-plugin-update` to rebuild the cache.');
+
+process.stdout.write(out.join('\n'));

--- a/plugins/devops/mcp-server/ship/tools/release.js
+++ b/plugins/devops/mcp-server/ship/tools/release.js
@@ -54,17 +54,18 @@ export async function handler(params) {
         git(`add -u :/`, opts);
       }
       if (state.untracked.length > 0) {
-        const safePatterns = ["CHANGELOG.md", "changelog.md"];
+        // Stage NEW files too, not just CHANGELOG. `git status --porcelain`
+        // already excludes gitignored paths, so everything listed here is
+        // intentional repo content. The previous behaviour silently skipped
+        // every untracked file except CHANGELOG (recorded in `skippedFiles`),
+        // which dropped new source files from the ship — a feature that added
+        // files (e.g. a new hook + its lib module) landed half-merged on main,
+        // leaving callers referencing modules that never got committed.
         for (const file of state.untracked) {
-          if (safePatterns.some(p => file.endsWith(p))) {
-            // `:/${file}` resolves against repo root regardless of cwd.
-            git(`add -- :/${file}`, opts);
-          }
+          // `:/${file}` resolves against repo root regardless of cwd.
+          git(`add -- :/${file}`, opts);
         }
-        const skipped = state.untracked.filter(f => !safePatterns.some(p => f.endsWith(p)));
-        if (skipped.length > 0) {
-          result.skippedFiles = skipped;
-        }
+        result.includedUntracked = [...state.untracked];
       }
       execFileSync("git", ["commit", "-m", commitMessage], {
         cwd,

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.93.2",
+  "version": "0.93.3",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
Hotfix for the half-merged 0.93.2 (#199).

## Problem
The #198 ship merged its *modified* files (`pre.ship.guard.js`, `hooks.json`) but `ship_release` silently dropped the **new** module files they require — `hooks/lib/ship-guard-match.js`, `hooks/lib/mcp-status.js`, `hooks/session-start/ss.mcp.verify.js` (+ tests). `main` was left referencing modules that were never committed, so the guard hook and the new SessionStart hook would crash.

## Root cause
When committing via `commitMessage`, `ship_release` staged tracked modifications (`git add -u`) plus only `CHANGELOG.md`, and recorded every other untracked file in a `skippedFiles` field that nothing acted on.

## Fix
- `ship_release` now stages **all** untracked files (`git status --porcelain` already excludes gitignored paths, so the list is intentional repo content) and reports them as `includedUntracked` instead of dropping them.
- Re-adds the three dropped module files + their tests so `main` resolves its dependencies again.

## Tests
- 238 passing; lint clean.

Refs #198, #199.