### PR TITLE
fix(ship): guarantee local main == origin/main after every ship

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.93.3"
+    "version": "0.93.4"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.93.3",
+      "version": "0.93.4",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.93.3",
+      "version": "0.93.4",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.93.4] — 2026-06-04
+
+### Fixed
+
+- **`/devops-ship` left local `main` stale ("ship succeeded but main not updated locally")** — the PR merge runs remote-side, so `origin/main` advances but the local `main` ref does not move on its own. `ship_cleanup` only synced local base as a *side effect* of `checkout base`; when the repo was already on base (the normal post-`ExitWorktree` case, `current === base`), the pull was skipped entirely. Cleanup now unconditionally runs `pull --ff-only origin <base>` and asserts the hard post-condition `local base == origin/base`, warning loudly otherwise. Side branches stay a working vehicle — the terminal state of every ship to `main` is `main` updated **remote AND local**. Documented in `deep-knowledge/cleanup.md §2` with a worktree-robust recipe (`update-ref` / `-C <wt> merge --ff-only`).
+- **devops-concept: single-threaded bridge server could wedge** — `concept-server.py` used `http.server.HTTPServer`, which serves one request at a time; a slow or hung client could block heartbeat/decision polling. Switched to `ThreadingHTTPServer` and hardened the bridge keepalive documentation against drop-outs.
+
+### Changed
+
+- **Worktree read-path discipline for version verification** — `deep-knowledge/merge-safety.md` now codifies that verification reads (version/cache/file-presence) must resolve against the worktree, `main`, or a tag — never the bare main-repo cwd, which may sit on a stale branch and report a false version conflict.
+
 ## [0.93.3] — 2026-06-04
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.93.3**
+**Version: 0.93.4**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.93.3",
+  "version": "0.93.4",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/deep-knowledge/merge-safety.md
+++ b/plugins/devops/deep-knowledge/merge-safety.md
@@ -24,6 +24,15 @@ success, you see confusing "file modified since read" races, and the change is
 gone. Edits in your own worktree are isolated and survive. If a path during a
 worktree session lacks the `worktrees/<name>/` segment, it is wrong.
 
+The same discipline applies to **reads during verification** (version checks,
+cache-integrity diffs, file-presence audits). The main-repo working directory
+may sit on a stale or unrelated branch — reading `plugin.json` (or any file)
+from the bare main-repo root then reports *that* branch's state, not the
+session's, and surfaces as a false version conflict. Source of truth for the
+current version is the worktree, `main`, or the relevant tag — never the
+main-repo cwd. Resolve version/source comparisons against `git show main:<path>`
+or `git show <tag>:<path>`, not an absolute main-repo path.
+
 This discipline extends to git-mutating commands (commit, checkout -b, merge,
 rebase). See [git-hygiene.md § Session-worktree hygiene](git-hygiene.md#session-worktree-hygiene)
 for the full tracked-or-gitignored invariant and enforcement points.

--- a/plugins/devops/mcp-server/ship/tools/cleanup.js
+++ b/plugins/devops/mcp-server/ship/tools/cleanup.js
@@ -69,7 +69,6 @@ export async function handler(params) {
   if (current !== base) {
     try {
       gitStrict(`checkout ${base}`, opts);
-      gitStrict(`pull origin ${base}`, opts);
       cleaned.push(`checkout:${base}`);
     } catch (e) {
       clearSentinel(cwd);
@@ -80,6 +79,30 @@ export async function handler(params) {
         warnings,
       };
     }
+  }
+
+  // Sync local base to origin/base. The PR merged remote-side, so origin/${base}
+  // advanced but the local ref does NOT move on its own. This MUST run even when
+  // we are already on ${base} — otherwise a ship that ends on main leaves local
+  // main stale ("ship succeeded but main not updated locally").
+  // See skills/devops-ship/deep-knowledge/cleanup.md §2.
+  try {
+    gitStrict(`pull --ff-only origin ${base}`, opts);
+    cleaned.push(`sync:${base}`);
+  } catch (e) {
+    warnings.push(
+      `Could not fast-forward local '${base}' to origin/${base}: ${e.message}. ` +
+        `Local '${base}' may be stale — run: git pull --ff-only origin ${base}`
+    );
+  }
+  // Hard post-condition: local base must equal origin/base after a ship.
+  const localBase = git(`rev-parse ${base}`, opts);
+  const remoteBase = git(`rev-parse origin/${base}`, opts);
+  if (localBase && remoteBase && localBase !== remoteBase) {
+    warnings.push(
+      `Local '${base}' (${localBase.slice(0, 7)}) != origin/${base} (${remoteBase.slice(0, 7)}) ` +
+        `after ship — main not fully landed locally.`
+    );
   }
 
   // Verify remote branch is gone (merge step should have deleted it)

--- a/plugins/devops/mcp-server/ship/tools/cleanup.test.js
+++ b/plugins/devops/mcp-server/ship/tools/cleanup.test.js
@@ -24,7 +24,7 @@ vi.mock("../lib/sentinel.js", () => ({
 }));
 
 import { handler } from "./cleanup.js";
-import { git, isWorktree, getWorktreeBranches } from "../lib/git.js";
+import { git, gitStrict, isWorktree, getWorktreeBranches } from "../lib/git.js";
 import { dirtySessionWorktrees } from "../lib/worktree.js";
 
 const CWD = "/fake/consumer-repo";
@@ -68,5 +68,24 @@ describe("ship_cleanup — session-worktree final-gate invariant", () => {
     const result = await handler({ branch: "feat/topic", base: "main", cwd: CWD, keep: true });
     expect(result.kept).toBe(true);
     expect(dirtySessionWorktrees).not.toHaveBeenCalled();
+  });
+
+  test("local main sync: fast-forwards local base even when already on base", async () => {
+    // current === base ("main"), so the legacy checkout path is skipped — the
+    // unconditional sync must still fast-forward local main to origin/main.
+    await handler({ branch: "feat/topic", base: "main", cwd: CWD, keep: false });
+    expect(gitStrict).toHaveBeenCalledWith("pull --ff-only origin main", expect.objectContaining({ cwd: CWD }));
+  });
+
+  test("local main sync: warns when local base stays behind origin after sync", async () => {
+    git.mockImplementation((cmd) => {
+      if (cmd.includes("rev-parse --abbrev-ref HEAD")) return "main";
+      if (cmd.includes("rev-parse origin/main")) return "bbbbbbbbbbbb";
+      if (cmd.includes("rev-parse main")) return "aaaaaaaaaaaa";
+      if (cmd.includes("ls-remote")) return "";
+      return "";
+    });
+    const result = await handler({ branch: "feat/topic", base: "main", cwd: CWD, keep: false });
+    expect(result.warnings.some((w) => /not fully landed locally/i.test(w))).toBe(true);
   });
 });

--- a/plugins/devops/scripts/concept-server.py
+++ b/plugins/devops/scripts/concept-server.py
@@ -494,7 +494,7 @@ if __name__ == '__main__':
         daemon=True,
     ).start()
 
-    with http.server.HTTPServer(('', port), ConceptBridgeHandler) as httpd:
+    with http.server.ThreadingHTTPServer(('', port), ConceptBridgeHandler) as httpd:
         print(f"Concept bridge server on http://localhost:{port}/")
         print(f"Serving: {os.getcwd()}")
         if html_path:

--- a/plugins/devops/skills/devops-concept/deep-knowledge/bridge-server.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/bridge-server.md
@@ -35,15 +35,41 @@ AND provides HTTP endpoints for heartbeat and decision exchange.
 2. Start the bridge server in the **project root** (NOT the worktree root —
    the watchdog resolves `--html` against the cwd, and concept HTML lives in
    the main project tree):
+   **Launch it via the Bash tool's `run_in_background: true`** — NOT
+   `nohup … &` (or any `&`-backgrounded child) inside a single foreground
+   Bash call. A child backgrounded inside one tool call is reaped when that
+   call's shell is torn down, so the server dies a few calls later, mid-
+   session, with no error — the page then silently loses its bridge. Only a
+   detached background task survives across turns:
    ```bash
+   # Bash tool, run_in_background: true  (no trailing &, no nohup)
    python "$PLUGIN_ROOT" {random-port} "{project-root}" \
-       --html "docs/concepts/{date}-{slug}.html" &
+       --html "docs/concepts/{date}-{slug}.html"
    ```
-   Use a random port (8700-8999) to avoid conflicts. Store the port as `$PORT`
-   and the spawned background PID as `$SERVER_PID` (`echo $!` immediately
-   after the `&`-launch). Both are written to `.claude/concept-active.json`
-   in step 6 so the SessionStart resume hook can find this server again
-   after a Claude restart.
+   Use a random port (8700-8999). Record the port as `$PORT`; an exact OS PID
+   is not reliably knowable from a detached task, so `server_pid` in the state
+   file is best-effort (resolve it later via `Get-NetTCPConnection -LocalPort
+   {port}` if you need it) — cleanup targets the server by **port** via
+   `/shutdown`, never by PID, so the precise PID is not required.
+
+   **Sweep the port BEFORE launching — exactly one instance must own it.**
+   A prior instance that did not fully die (its listening socket lingers in
+   TIME_WAIT/CLOSE_WAIT) plus a fresh launch leaves **two** servers bound to
+   the same port (Windows permits this via `SO_REUSEADDR`). `curl` then hits
+   whichever accepts the connection — sometimes the healthy one (200),
+   sometimes the wedged one (HTTP 000 / timeout). The symptom is a connection
+   indicator that flickers between connected and "Claude nicht verbunden" for
+   no apparent reason, plus a watcher (step 3) that trips on the wedged
+   replies. Kill every listener on the port first, then start exactly one:
+   ```bash
+   # PowerShell tool
+   Get-NetTCPConnection -LocalPort {port} -State Listen -EA SilentlyContinue |
+     ForEach-Object { Stop-Process -Id $_.OwningProcess -Force -EA SilentlyContinue }
+   ```
+   After launch, assert a **single** listener (`netstat -ano | grep
+   "0.0.0.0:{port}"` → exactly one LISTENING row) before opening the browser.
+   `$PORT` is written to `.claude/concept-active.json` in step 6 so the
+   SessionStart resume hook can find this server again after a Claude restart.
 
    **The `--html` flag is mandatory.** It arms the server-side watchdog:
    if the concept HTML file disappears for > 10 s, the watchdog terminates
@@ -156,6 +182,47 @@ AND provides HTTP endpoints for heartbeat and decision exchange.
    **Why combined, not two crons?** One cron minimizes race conditions and makes
    the contract explicit: every tick does both. Minimum cron resolution is 1 min,
    so the max submit-to-process lag is ~60 s — acceptable for interactive flows.
+
+   **The cron alone does NOT keep the indicator green — add a background
+   watcher.** The page flips to "Claude nicht verbunden" as soon as Claude's
+   last `/heartbeat` POST is older than `HEARTBEAT_STALE_MS` (90 s). The
+   once-a-minute cron is the documented keepalive, but session-only crons
+   fire ONLY while the REPL is idle and have multi-minute gaps in practice
+   (observed: a 638 s gap with the cron registered and the session idle) — so
+   during normal reading/thinking the indicator goes red, and because the SAME
+   cron is the only pickup path, submissions are also picked up late.
+
+   Alongside the cron, launch a **detached background watcher** (Bash tool,
+   `run_in_background: true`) that both keeps the heartbeat warm AND wakes
+   Claude the instant a submission lands — its `exit 0` re-invokes the model
+   immediately, instead of waiting up to 60 s for the next cron tick:
+   ```bash
+   fails=0
+   while true; do
+     [ -f .claude/concept-active.json ] || { echo "WATCHER_EXIT reason=STATE_GONE"; exit 0; }
+     grep -q '"port": {port}' .claude/concept-active.json 2>/dev/null || { echo "WATCHER_EXIT reason=PORT_CHANGED"; exit 0; }
+     if curl -s -X POST --max-time 8 http://localhost:{port}/heartbeat >/dev/null 2>&1; then
+       fails=0
+       p=$(curl -s --max-time 8 http://localhost:{port}/pending | python -c "import sys,json;print('yes' if json.load(sys.stdin).get('pending') else 'no')" 2>/dev/null)
+       [ "$p" = "yes" ] && { echo "WATCHER_EXIT reason=PENDING_SUBMISSION"; exit 0; }
+     else
+       fails=$((fails+1))
+       [ "$fails" -ge 4 ] && { echo "WATCHER_EXIT reason=SERVER_DEAD"; exit 0; }
+     fi
+     sleep 20
+   done
+   ```
+   Pulse every ~20 s (well under the 90 s threshold). **Tolerate transient
+   blips:** declare `SERVER_DEAD` only after ≥4 consecutive failed POSTs — a
+   single failed `curl` (server busy, a competing request, a duplicate-instance
+   wedge per step 2) must NOT tear the watcher down, or the page goes stale
+   again on every hiccup. The loop self-terminates when the state file is gone,
+   its port changed, or the server is truly unreachable, so it cannot become a
+   ghost (the `--html` watchdog still backs it up). On `PENDING_SUBMISSION`
+   Claude processes the payload, then **re-launches the watcher** for the next
+   round. Keep the cron too: it is the backup pickup path during the brief
+   window when the watcher has exited for processing and not yet been
+   re-launched.
 
 4. **Persist active-concept state.** Write `.claude/concept-active.json` in
    the project root with the metadata the SessionStart resume hook

--- a/plugins/devops/skills/devops-concept/deep-knowledge/bridge-server.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/bridge-server.md
@@ -68,6 +68,18 @@ AND provides HTTP endpoints for heartbeat and decision exchange.
    ```
    After launch, assert a **single** listener (`netstat -ano | grep
    "0.0.0.0:{port}"` → exactly one LISTENING row) before opening the browser.
+
+   **The server must be threaded.** `concept-server.py` uses
+   `http.server.ThreadingHTTPServer` (not the single-threaded `HTTPServer`).
+   A single-threaded server serves one request at a time, so the browser's
+   own poll loops (it hits `/heartbeat`, `/decisions`, `/reload` every few
+   seconds) plus the background watcher plus any manual `curl` collide: one
+   slow or held connection blocks the serve loop and **every** subsequent
+   request times out — the socket still accepts (LISTENING) but returns
+   nothing, so `curl` reports HTTP 000 for 15 s+ and the page reads
+   "Claude nicht verbunden" even though the process is alive. This is a
+   distinct cause of HTTP 000 from the duplicate-instance case above; both
+   present identically. If you ever fork the script, keep it threaded.
    `$PORT` is written to `.claude/concept-active.json` in step 6 so the
    SessionStart resume hook can find this server again after a Claude restart.
 

--- a/plugins/devops/skills/devops-ship/deep-knowledge/cleanup.md
+++ b/plugins/devops/skills/devops-ship/deep-knowledge/cleanup.md
@@ -29,15 +29,45 @@ If `ExitWorktree` reports uncommitted changes and refuses to remove, use
 
 If `ExitWorktree` is not applicable (no worktree session active), skip to step 2.
 
-### 2. Sync local main
+### 2. Sync local main — hard invariant
+
+**A ship to `main` is not complete until local `main` == `origin/main` == the
+shipped commits.** Side branches and worktrees are working vehicles — the
+*terminal* state of every ship to `main` is `main` updated **both remote and
+local**. The PR merge runs remote-side, so `origin/main` advances on its own;
+**the local `main` ref does not move.** A ship that leaves local `main` behind
+has NOT finished, even though the GitHub merge succeeded.
+
+Do **not** rely on a bare `git checkout main && git pull`. It fails outright
+when `main` is already checked out in another worktree (the normal case during
+a worktree ship — Git forbids a second checkout), and it does nothing for the
+main repo when that repo sits on an unrelated branch. In both cases the merge
+reports success while local `main` silently stays stale.
+
+Robust sequence (works regardless of worktree layout):
 
 ```bash
-git checkout main
-git pull origin main
+git fetch origin main                  # advance the remote-tracking ref
+git worktree list --porcelain          # find any tree with "branch refs/heads/main"
 ```
 
-If a worktree was active, the main repo may already be on the correct branch
-after ExitWorktree — verify with `git branch --show-current` before checkout.
+- **No working tree holds `main`** → move the ref directly, no checkout needed:
+  ```bash
+  git update-ref refs/heads/main origin/main
+  ```
+- **A working tree holds `main`** → fast-forward that one in place:
+  ```bash
+  git -C <that-worktree> merge --ff-only origin/main
+  ```
+
+Then assert the post-condition (not optional):
+
+```bash
+[ "$(git rev-parse main)" = "$(git rev-parse origin/main)" ] || echo "✗ local main stale — ship NOT done"
+```
+
+If the refs differ, resolve before reporting success. See
+[git-hygiene.md § Session-worktree hygiene](../../../deep-knowledge/git-hygiene.md#session-worktree-hygiene).
 
 ### 3. Verify remote branch is gone
 

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.93.3",
+  "version": "0.93.4",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
Ships the local-main ship invariant plus two devops-concept fixes and a verification-discipline doc.

- **fix(ship):** `ship_cleanup` now unconditionally fast-forwards local `<base>` to `origin/<base>` and asserts `local == origin` as a hard post-condition. Fixes "ship succeeded remotely but local main stayed stale" when the repo was already on base after `ExitWorktree` (`current === base` skipped the pull). Side branches stay a working vehicle; the terminal state of every ship to `main` is `main` updated remote AND local.
- **fix(concept):** `concept-server.py` uses `ThreadingHTTPServer` (was single-threaded `HTTPServer` that could wedge on a slow client); bridge keepalive docs hardened.
- **docs(deep-knowledge):** worktree read-path discipline — version/cache/file-presence verification must resolve against the worktree, `main`, or a tag, never the bare main-repo cwd (which may sit on a stale branch and report a false version conflict).

240 tests pass; lint clean.