### PR TITLE
fix(devops): branch-guard also blocks detached HEAD in worktrees

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.93.4"
+    "version": "0.93.5"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.93.4",
+      "version": "0.93.5",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.93.4",
+      "version": "0.93.5",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.93.5] — 2026-06-04
+
+### Fixed
+
+- **`prompt.worktree.branch-guard` left detached HEAD unguarded** — the worktree branch-guard only blocked work when the linked worktree sat on `main`/`master`, so a worktree checked out on a bare commit or tag (detached HEAD) slipped through. Any commits made there become unreachable once `HEAD` moves, silently losing work. The guard now also treats a detached HEAD (`git rev-parse --abbrev-ref HEAD` == `"HEAD"`) as an unsafe state and emits a BLOCKING instruction to create a dedicated branch first, with a message tailored to the detached case. Hook `prompt.worktree.branch-guard` 0.1.0→0.2.0.
+
 ## [0.93.4] — 2026-06-04
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ SessionStart  ──>  UserPromptSubmit  ──>  PreToolUse  ──>  PostToolU
 - `prompt.issue.detect` — Detect issue references in user messages.
 - `prompt.ship.detect` — Detect ship intent in user prompts and inject Skill('devops-ship') instruction.
 - `prompt.flow.appstart` — Detect app start intent in user prompts.
-- `prompt.worktree.branch-guard` — Prevents working on main/master inside a linked worktree.
+- `prompt.worktree.branch-guard` — Prevents working without a dedicated branch inside a linked worktree.
 
 #### PreToolUse — runs before each tool call
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.93.4**
+**Version: 0.93.5**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.93.4",
+  "version": "0.93.5",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/hooks/user-prompt-submit/prompt.worktree.branch-guard.js
+++ b/plugins/devops/hooks/user-prompt-submit/prompt.worktree.branch-guard.js
@@ -1,13 +1,15 @@
 #!/usr/bin/env node
 /**
  * @hook prompt.worktree.branch-guard
- * @version 0.1.0
+ * @version 0.2.0
  * @event UserPromptSubmit
  * @plugin devops
- * @description Prevents working on main/master inside a linked worktree.
- *   Only fires when the session is inside a git worktree (.git is a file,
- *   not a directory). If the current branch is main or master, outputs a
- *   BLOCKING instruction telling Claude to create a new branch first.
+ * @description Prevents working without a dedicated branch inside a linked
+ *   worktree. Only fires when the session is inside a git worktree (.git is a
+ *   file, not a directory). Outputs a BLOCKING instruction telling Claude to
+ *   create a new branch first when the worktree sits on:
+ *     - main or master (shared mainline), OR
+ *     - a detached HEAD (no branch at all — `--abbrev-ref HEAD` returns "HEAD").
  *   Does nothing if not in a worktree — the user intentionally works on main.
  */
 
@@ -54,10 +56,18 @@ if (!isLinkedWorktree) {
 const branch = git('rev-parse --abbrev-ref HEAD');
 if (!branch) process.exit(0);
 
-if (branch === 'main' || branch === 'master') {
+// "HEAD" from --abbrev-ref means a detached HEAD: the worktree is on a
+// commit/tag, not a branch — so commits would be unreachable once HEAD moves.
+const isDetached = branch === 'HEAD';
+const isMainline = branch === 'main' || branch === 'master';
+
+if (isMainline || isDetached) {
   const worktreeName = path.basename(cwd);
+  const where = isDetached
+    ? 'in a detached HEAD (no branch)'
+    : `on branch "${branch}"`;
   process.stdout.write(
-    `BLOCKING — You are in a worktree but on branch "${branch}". ` +
+    `BLOCKING — You are in a worktree but ${where}. ` +
     `Create a new branch BEFORE doing any work: ` +
     `git checkout -b claude/${worktreeName}`
   );

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.93.4",
+  "version": "0.93.5",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary
Closes a gap in the worktree branch-guard: a linked worktree on a detached HEAD (a bare commit or tag, not a branch) previously slipped through and allowed work whose commits become unreachable once `HEAD` moves. The guard now treats detached HEAD as an unsafe state and blocks with a tailored message instructing a dedicated branch.

## Changes
- `prompt.worktree.branch-guard` 0.1.0→0.2.0 — also blocks detached HEAD (`git rev-parse --abbrev-ref HEAD` == `"HEAD"`), distinct message vs. main/master
- README hook description regenerated to match
- CHANGELOG + version bump 0.93.4→0.93.5

## Tests
- eslint clean, `node -c` OK
- vitest 240/240 passed