### PR TITLE
feat(devops): browser-test gate + Edge-primary test tool-chain

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.93.5"
+    "version": "0.94.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.93.5",
+      "version": "0.94.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.93.5",
+      "version": "0.94.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.94.0] — 2026-06-05
+
+### Added
+
+- **Browser-test enforcement gate (`stop.flow.browsertest`)** — closes the gap where a web-renderable change could ship unverified: previously the only Stop-time gate enforced the completion card, never the *test itself*, so Claude could finish a UI change without ever opening a browser. The new Stop hook blocks the turn when a browser-renderable file changed this session but no browser tool ran and no verification subagent was delegated, instructing verification via the Claude-in-Chrome extension in Edge (incl. mandatory console + network reads). Decision logic lives in unit-tested `hooks/lib/browsertest-guard.js` (26 tests); flags (`web-change-pending` / `browser-verified`) are written by `post.flow.completion` and read+reset by the gate. The gate yields after one block (`stop_hook_active`) so it can never loop, and `docs/concepts/*.html` (devops-concept artifacts) are carved out — they never trigger it. New hook `stop.flow.browsertest` 0.1.0; `post.flow.completion` 0.15.0→0.16.0.
+
+### Changed
+
+- **Test tool-chain now prefers the Edge extension over Preview** — the Edge Credo names the Claude-in-Chrome extension in Edge as the primary browser tool, but the deterministic `devops-test-plan` profile tool-chains (`web-vite`, `web-angular`, `electron-ow`) hardcoded the Preview MCP (waterfall priority 3) and the QA agent lacked the extension tools entirely — so the machine-readable instruction contradicted the doctrine. Profiles now resolve `$BROWSER_TOOL` via the waterfall (Chrome-MCP in Edge primary → Playwright → Preview) and add a mandatory console + network error read step (a clean snapshot does not prove the absence of runtime errors). The `qa` agent gains the Claude-in-Chrome read/verify tools and Edge-first guidance; the `post.flow.completion` first-edit reminder now names the Edge extension + console reads explicitly.
+
 ## [0.93.5] — 2026-06-04
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ For the full extension guide with examples per skill, see `deep-knowledge/skill-
 
 ## Features
 
-- **<!--devops:count:hooks-->29<!--/devops:count:hooks--> Hooks** — automated guards and triggers across the full session lifecycle
+- **<!--devops:count:hooks-->30<!--/devops:count:hooks--> Hooks** — automated guards and triggers across the full session lifecycle
 - **<!--devops:count:skills-->19<!--/devops:count:skills--> Skills** — devops-ship, devops-commit, devops-flow, devops-new-issue, devops-project-setup, devops-readme, devops-refresh-usage, devops-extend-skill, devops-repo-health, devops-claude-md-lint, devops-concept, devops-agents, devops-plugin-update, devops-autonomous, devops-burn, devops-learn, devops-harden, devops-polish, devops-test-plan
 - **<!--devops:count:agents-->11<!--/devops:count:agents--> Agents** — AI, Core, Designer, Feature, Frontend, Gamer, PO, QA, Redteam, Research, Windows
 - **Completion Flow** — mandatory card after every task (8 variants), visual verification, ship recommendation
@@ -178,7 +178,7 @@ For the full extension guide with examples per skill, see `deep-knowledge/skill-
 
 ### Hooks (automatic, no user action needed)
 
-<!--devops:count:hooks-->29<!--/devops:count:hooks--> hooks fire automatically across the session lifecycle — no user action needed.
+<!--devops:count:hooks-->30<!--/devops:count:hooks--> hooks fire automatically across the session lifecycle — no user action needed.
 
 <details>
 <summary><strong>By session lifecycle</strong> — when does it fire?</summary>
@@ -229,6 +229,7 @@ SessionStart  ──>  UserPromptSubmit  ──>  PreToolUse  ──>  PostToolU
 
 #### Stop — runs when Claude finishes responding
 
+- `stop.flow.browsertest` — Browser-test enforcement gate.
 - `stop.flow.guard` — Per-turn completion card enforcement.
 - `stop.flow.selfcalibration` — Run self-calibration when Claude finishes a response turn.
 <!--/devops:block:hook-lifecycle-->
@@ -641,7 +642,7 @@ Wk  ━━──╏─────────   15% +1%   · 4d 22h left
 devops/
 ├── .claude-plugin/plugin.json     ← Plugin manifest
 ├── CONVENTIONS.md                 ← Naming, versioning, extension rules
-├── hooks/                         ← <!--devops:count:hooks-->29<!--/devops:count:hooks--> hooks (JS) registered in hooks.json
+├── hooks/                         ← <!--devops:count:hooks-->30<!--/devops:count:hooks--> hooks (JS) registered in hooks.json
 ├── skills/                        ← <!--devops:count:skills-->19<!--/devops:count:skills--> skill definitions (SKILL.md)
 ├── agents/                        ← <!--devops:count:agents-->11<!--/devops:count:agents--> agent definitions
 ├── deep-knowledge/                ← Cross-cutting reference docs

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.93.5**
+**Version: 0.94.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.93.5",
+  "version": "0.94.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/agents/qa.md
+++ b/plugins/devops/agents/qa.md
@@ -8,7 +8,7 @@ description: >-
 model: sonnet
 effort: medium
 color: green
-tools: ["Bash", "Read", "Glob", "Grep", "preview_screenshot", "preview_snapshot", "preview_console_logs"]
+tools: ["Bash", "Read", "Glob", "Grep", "navigate", "read_page", "get_page_text", "read_console_messages", "read_network_requests", "javascript_tool", "tabs_context_mcp", "tabs_create_mcp", "preview_screenshot", "preview_snapshot", "preview_console_logs"]
 ---
 
 # QA Agent
@@ -26,8 +26,15 @@ Before starting, read `{PLUGIN_ROOT}/deep-knowledge/codex-integration.md` §4 (Q
 - **Browser-verify web tech changes** (see `{PLUGIN_ROOT}/deep-knowledge/test-strategy.md`
   § Web Tech → Always Browser-Test). Mandatory when HTML/CSS/JS framework files
   changed — mocks for missing backends are expected. No "browser not needed" exit.
+  Use the **Claude-in-Chrome extension in Edge as the primary tool** (`navigate`,
+  `read_page`, `javascript_tool`); fall back to Preview (`preview_snapshot`,
+  `preview_screenshot`) only when the extension is not connected. Never plain
+  Chrome, never computer-use for browser work
+  (see `{PLUGIN_ROOT}/deep-knowledge/browser-tool-strategy.md`).
 - Take screenshots of UI changes
-- Check console logs for errors
+- **Read console + network errors** alongside the snapshot — `read_console_messages`
+  + `read_network_requests` (Chrome-MCP) or `preview_console_logs` (Preview). A
+  clean snapshot does not prove the absence of runtime JS errors or failed requests.
 - Generate build-ID after successful build
 - **Flag User-Final-Tests** in output when automation cannot cover the final step:
   - Packaged Electron/Tauri without desktop takeover → `🔬 TESTE bitte noch:`

--- a/plugins/devops/docs/architecture.html
+++ b/plugins/devops/docs/architecture.html
@@ -169,7 +169,7 @@
 <section id="overview">
 <h1>Architecture Documentation <small>devops v0.87.0</small></h1>
 <p class="lead">
-  A comprehensive DevOps automation plugin for Claude Code &mdash; <!--devops:count:hooks-->29<!--/devops:count:hooks--> hooks, <!--devops:count:skills-->19<!--/devops:count:skills--> skills, <!--devops:count:agents-->11<!--/devops:count:agents--> agents,
+  A comprehensive DevOps automation plugin for Claude Code &mdash; <!--devops:count:hooks-->30<!--/devops:count:hooks--> hooks, <!--devops:count:skills-->19<!--/devops:count:skills--> skills, <!--devops:count:agents-->11<!--/devops:count:agents--> agents,
   2 MCP servers, a deterministic completion card engine, and a 3-layer extension system.
 </p>
 <div role="note" style="margin:.4rem 0 1.4rem;padding:.6rem .9rem;background:var(--bg2);border-left:3px solid var(--warn);border-radius:4px;color:var(--text2);font-size:.85rem;">
@@ -180,13 +180,13 @@
 
 <div class="card-grid">
   <div class="card">
-    <h4><!--devops:count:hooks-->29<!--/devops:count:hooks--> Hooks</h4>
+    <h4><!--devops:count:hooks-->30<!--/devops:count:hooks--> Hooks</h4>
     <p style="color:var(--text2);font-size:.85rem">Lifecycle guards across SessionStart, UserPromptSubmit, PreToolUse, PostToolUse, Stop</p>
     <span class="badge b-hook">SessionStart &times;<!--devops:count:hooks:ss-->12<!--/devops:count:hooks:ss--></span>
     <span class="badge b-hook">Prompt &times;<!--devops:count:hooks:prompt-->7<!--/devops:count:hooks:prompt--></span>
     <span class="badge b-hook">Pre &times;<!--devops:count:hooks:pre-->6<!--/devops:count:hooks:pre--></span>
     <span class="badge b-hook">Post &times;<!--devops:count:hooks:post-->2<!--/devops:count:hooks:post--></span>
-    <span class="badge b-hook">Stop &times;<!--devops:count:hooks:stop-->2<!--/devops:count:hooks:stop--></span>
+    <span class="badge b-hook">Stop &times;<!--devops:count:hooks:stop-->3<!--/devops:count:hooks:stop--></span>
   </div>
   <div class="card">
     <h4><!--devops:count:skills-->19<!--/devops:count:skills--> Skills</h4>
@@ -221,7 +221,7 @@
 │   ├── user-prompt-submit/    <span style="color:var(--purple)"># <!--devops:count:hooks:prompt-->7<!--/devops:count:hooks:prompt--> hooks (prompt.*)</span>
 │   ├── pre-tool-use/          <span style="color:var(--purple)"># <!--devops:count:hooks:pre-->6<!--/devops:count:hooks:pre--> hooks (pre.*)</span>
 │   ├── post-tool-use/         <span style="color:var(--purple)"># <!--devops:count:hooks:post-->2<!--/devops:count:hooks:post--> hooks (post.*)</span>
-│   └── stop/                  <span style="color:var(--purple)"># <!--devops:count:hooks:stop-->2<!--/devops:count:hooks:stop--> hooks (stop.*)</span>
+│   └── stop/                  <span style="color:var(--purple)"># <!--devops:count:hooks:stop-->3<!--/devops:count:hooks:stop--> hooks (stop.*)</span>
 ├── mcp-server/
 │   ├── index.js               <span style="color:var(--orange)"># dotclaude-completion MCP</span>
 │   └── ship/

--- a/plugins/devops/hooks/hooks.json
+++ b/plugins/devops/hooks/hooks.json
@@ -64,6 +64,7 @@
     "Stop": [
       {
         "hooks": [
+          { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/stop/stop.flow.browsertest.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/stop/stop.flow.guard.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/stop/stop.flow.selfcalibration.js" }
         ]

--- a/plugins/devops/hooks/lib/browsertest-guard.js
+++ b/plugins/devops/hooks/lib/browsertest-guard.js
@@ -1,0 +1,156 @@
+/**
+ * @module browsertest-guard
+ * @version 0.1.0
+ * @description Pure decision logic for the browser-test enforcement gate.
+ *   Split out of stop.flow.browsertest.js so the rules can be unit-tested
+ *   without mocking stdin or temp files.
+ *
+ *   The gate forces a browser verification whenever browser-renderable files
+ *   changed in a session but no browser tool ran and no verification subagent
+ *   was delegated. It mirrors card-guard's block/pass/reset contract.
+ *
+ *   Inputs: flag state (web-change-pending / browser-verified) + stop_hook_active
+ *           + silent.
+ *   Output: { action: 'block' | 'pass', reason?, resetFlags }.
+ */
+
+// ---------------------------------------------------------------------------
+// Web-renderable change detection
+// ---------------------------------------------------------------------------
+
+// Markup / style / framework-component files are ALWAYS browser-renderable.
+const ALWAYS_WEB_RE = /\.(html?|css|scss|sass|less|vue|svelte|astro|tsx|jsx)$/i;
+// Bare scripts count only when they live under a UI source directory.
+const SCRIPT_RE = /\.(ts|js|mjs|cjs)$/i;
+const UI_DIR_RE = /(^|\/)(src|app|components|pages|views|renderer)\//i;
+// Unit/spec files are logic, not a rendered view.
+const TEST_FILE_RE = /\.(test|spec)\.[tj]sx?$/i;
+// devops-concept artifacts — generated analysis pages, NOT product UI.
+// Carve-out per project decision: concept pages never trigger the gate.
+const CONCEPT_RE = /(^|\/)docs\/concepts\//i;
+
+/**
+ * Does a changed file require browser verification?
+ * Normalizes Windows backslashes so a single forward-slash regex set works.
+ *
+ * @param {string} filePath — path from the Edit/Write tool_input.file_path
+ * @returns {boolean}
+ */
+function isWebRenderableChange(filePath) {
+  if (!filePath) return false;
+  const p = String(filePath).replace(/\\/g, '/');
+  if (CONCEPT_RE.test(p)) return false;     // devops-concept carve-out
+  if (TEST_FILE_RE.test(p)) return false;   // *.test / *.spec — not a view
+  if (ALWAYS_WEB_RE.test(p)) return true;   // html/css/vue/svelte/astro/tsx/jsx
+  if (SCRIPT_RE.test(p) && UI_DIR_RE.test(p)) return true; // src/-scoped ts/js
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Browser-tool detection (tool_name as reported by PostToolUse)
+// ---------------------------------------------------------------------------
+
+const BROWSER_MCP_RE =
+  /^mcp__(Claude_in_Chrome__|Claude_Preview__preview_|plugin_playwright_playwright__browser_)/;
+// Short-name fallbacks, in case the runtime ever reports the suffix form.
+const BROWSER_SHORT_RE =
+  /^(preview_(snapshot|screenshot|eval|click|fill|console_logs|inspect|navigate|start|logs|network)|browser_(navigate|snapshot|take_screenshot|click|evaluate|console_messages|network_requests|type|fill_form|wait_for))/;
+
+/**
+ * Did a browser tool run? Any Chrome-MCP / Playwright / Preview call counts —
+ * if Claude touched the page at all, it verified in a real browser engine.
+ *
+ * @param {string} toolName
+ * @returns {boolean}
+ */
+function isBrowserTool(toolName) {
+  if (!toolName) return false;
+  const t = String(toolName);
+  return BROWSER_MCP_RE.test(t) || BROWSER_SHORT_RE.test(t);
+}
+
+// Subagents that perform their own browser verification. When one is delegated
+// we assume the browser check is covered (the main thread cannot observe the
+// subagent's inner tool calls).
+const VERIFY_AGENTS = new Set(['qa', 'frontend', 'feature', 'gamer', 'designer']);
+
+/**
+ * Was browser verification delegated to a verification-capable subagent?
+ *
+ * @param {string} toolName     — 'Agent' for a subagent spawn
+ * @param {string} subagentType — opts.subagent_type from the Agent call
+ * @returns {boolean}
+ */
+function isVerificationDelegation(toolName, subagentType) {
+  return toolName === 'Agent' && VERIFY_AGENTS.has(String(subagentType || '').toLowerCase());
+}
+
+// ---------------------------------------------------------------------------
+// Decision
+// ---------------------------------------------------------------------------
+
+/**
+ * Decide whether the Stop hook should block to force a browser verification.
+ *
+ * @param {object} s
+ * @param {boolean} s.webChangePending — a web-renderable file changed, unverified
+ * @param {boolean} s.browserVerified  — a browser tool ran / verify subagent ran
+ * @param {boolean} s.stopHookActive   — prior Stop hook already blocked this cycle
+ * @param {boolean} [s.silent]         — background tick (cron / autonomous loop)
+ * @returns {{ action: 'block' | 'pass', resetFlags: boolean, reason?: string }}
+ */
+function decideBrowserTest({ webChangePending, browserVerified, stopHookActive, silent }) {
+  if (silent) {
+    // Background tick — never enforce. Clear our own flags so the next real
+    // turn starts clean. (The silent flag itself is owned by stop.flow.guard.)
+    return { action: 'pass', resetFlags: true };
+  }
+
+  if (stopHookActive) {
+    // One-time bypass: if Claude stops again after being blocked, yield and
+    // clear the pending flag so we never loop. Mirrors card-guard.
+    return { action: 'pass', resetFlags: true };
+  }
+
+  if (webChangePending && !browserVerified) {
+    return { action: 'block', resetFlags: false, reason: buildBrowserTestReason() };
+  }
+
+  return { action: 'pass', resetFlags: true };
+}
+
+function buildBrowserTestReason() {
+  return [
+    '[stop.flow.browsertest] Web-renderable changes were made but no browser verification ran this session.',
+    '',
+    'Per deep-knowledge/test-strategy.md (Web Tech → Always Browser-Test) this is',
+    'mandatory — there is no "browser not needed" exit for web tech. Do this FIRST,',
+    'before rendering the completion card:',
+    '',
+    '1. Make the changed view reachable: dev server (npm run dev) or open the',
+    '   file:// URL in Edge for a static page.',
+    '2. Verify it via the Claude-in-Chrome extension in Edge (PRIMARY). Fall back to',
+    '   Playwright → Preview only if the extension is not connected. Never plain',
+    '   Chrome, never computer-use for browser work (see browser-tool-strategy.md).',
+    '3. Snapshot the DOM (read_page / browser_snapshot / preview_snapshot) AND read',
+    '   console + network errors (read_console_messages + read_network_requests /',
+    '   browser_console_messages + browser_network_requests / preview_console_logs).',
+    '4. Mocks for missing backends are expected — exercise the changed view, do not',
+    '   hit production services.',
+    '',
+    'Then render the completion card as the LAST action.',
+    '',
+    'devops-concept pages under docs/concepts/*.html are auto-excluded and never',
+    'trigger this gate. To intentionally skip (e.g. non-runtime change with no',
+    'startable view): stop again — this gate yields after one block.',
+  ].join('\n');
+}
+
+module.exports = {
+  isWebRenderableChange,
+  isBrowserTool,
+  isVerificationDelegation,
+  decideBrowserTest,
+  buildBrowserTestReason,
+  VERIFY_AGENTS,
+};

--- a/plugins/devops/hooks/lib/browsertest-guard.test.js
+++ b/plugins/devops/hooks/lib/browsertest-guard.test.js
@@ -1,0 +1,240 @@
+import { describe, test, expect } from "vitest";
+import {
+  isWebRenderableChange,
+  isBrowserTool,
+  isVerificationDelegation,
+  decideBrowserTest,
+  buildBrowserTestReason,
+} from "./browsertest-guard.js";
+
+// ---------------------------------------------------------------------------
+// isWebRenderableChange
+// ---------------------------------------------------------------------------
+
+describe("isWebRenderableChange", () => {
+  test("markup / style / framework files always count", () => {
+    for (const p of [
+      "index.html",
+      "src/App.vue",
+      "lib/Button.svelte",
+      "pages/about.astro",
+      "components/Card.tsx",
+      "views/list.jsx",
+      "styles/main.css",
+      "theme/_vars.scss",
+    ]) {
+      expect(isWebRenderableChange(p)).toBe(true);
+    }
+  });
+
+  test("bare .ts/.js count only under a UI source directory", () => {
+    expect(isWebRenderableChange("src/store.ts")).toBe(true);
+    expect(isWebRenderableChange("app/router.js")).toBe(true);
+    expect(isWebRenderableChange("renderer/main.ts")).toBe(true);
+    // Outside a UI dir → not a renderable change
+    expect(isWebRenderableChange("scripts/build.js")).toBe(false);
+    expect(isWebRenderableChange("mcp-server/index.js")).toBe(false);
+    expect(isWebRenderableChange("hooks/lib/foo.ts")).toBe(false);
+  });
+
+  test("Windows backslash paths are normalized", () => {
+    expect(isWebRenderableChange("src\\components\\Nav.tsx")).toBe(true);
+    expect(isWebRenderableChange("C:\\proj\\src\\store.ts")).toBe(true);
+    expect(isWebRenderableChange("C:\\proj\\docs\\concepts\\plan.html")).toBe(false);
+  });
+
+  test("devops-concept pages are carved out", () => {
+    expect(isWebRenderableChange("docs/concepts/2026-06-05-plan.html")).toBe(false);
+    expect(isWebRenderableChange("./docs/concepts/x.html")).toBe(false);
+    // A normal docs html still counts
+    expect(isWebRenderableChange("docs/guide.html")).toBe(true);
+  });
+
+  test("test / spec files do not count", () => {
+    expect(isWebRenderableChange("src/App.test.tsx")).toBe(false);
+    expect(isWebRenderableChange("src/util.spec.ts")).toBe(false);
+    expect(isWebRenderableChange("components/Card.test.jsx")).toBe(false);
+  });
+
+  test("non-web files never count", () => {
+    for (const p of [
+      "README.md",
+      "package.json",
+      "CLAUDE.md",
+      "data.csv",
+      "config.yaml",
+      "Dockerfile",
+    ]) {
+      expect(isWebRenderableChange(p)).toBe(false);
+    }
+  });
+
+  test("empty / missing input → false", () => {
+    expect(isWebRenderableChange("")).toBe(false);
+    expect(isWebRenderableChange(null)).toBe(false);
+    expect(isWebRenderableChange(undefined)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isBrowserTool
+// ---------------------------------------------------------------------------
+
+describe("isBrowserTool", () => {
+  test("Chrome-MCP (Claude extension in Edge) tools count", () => {
+    expect(isBrowserTool("mcp__Claude_in_Chrome__navigate")).toBe(true);
+    expect(isBrowserTool("mcp__Claude_in_Chrome__read_page")).toBe(true);
+    expect(isBrowserTool("mcp__Claude_in_Chrome__read_console_messages")).toBe(true);
+    expect(isBrowserTool("mcp__Claude_in_Chrome__javascript_tool")).toBe(true);
+  });
+
+  test("Preview MCP tools count", () => {
+    expect(isBrowserTool("mcp__Claude_Preview__preview_snapshot")).toBe(true);
+    expect(isBrowserTool("mcp__Claude_Preview__preview_screenshot")).toBe(true);
+  });
+
+  test("Playwright MCP browser tools count", () => {
+    expect(isBrowserTool("mcp__plugin_playwright_playwright__browser_navigate")).toBe(true);
+    expect(isBrowserTool("mcp__plugin_playwright_playwright__browser_snapshot")).toBe(true);
+  });
+
+  test("short-name fallbacks count", () => {
+    expect(isBrowserTool("preview_snapshot")).toBe(true);
+    expect(isBrowserTool("browser_take_screenshot")).toBe(true);
+  });
+
+  test("non-browser tools do not count", () => {
+    for (const t of ["Edit", "Write", "Bash", "Read", "Grep", "Agent", "WebFetch", ""]) {
+      expect(isBrowserTool(t)).toBe(false);
+    }
+  });
+
+  test("null / undefined → false", () => {
+    expect(isBrowserTool(null)).toBe(false);
+    expect(isBrowserTool(undefined)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isVerificationDelegation
+// ---------------------------------------------------------------------------
+
+describe("isVerificationDelegation", () => {
+  test("Agent spawn of a verification subagent counts", () => {
+    expect(isVerificationDelegation("Agent", "qa")).toBe(true);
+    expect(isVerificationDelegation("Agent", "frontend")).toBe(true);
+    expect(isVerificationDelegation("Agent", "gamer")).toBe(true);
+    expect(isVerificationDelegation("Agent", "QA")).toBe(true); // case-insensitive
+  });
+
+  test("Agent spawn of a non-verifying subagent does NOT count", () => {
+    expect(isVerificationDelegation("Agent", "research")).toBe(false);
+    expect(isVerificationDelegation("Agent", "redteam")).toBe(false);
+    expect(isVerificationDelegation("Agent", "core")).toBe(false);
+  });
+
+  test("non-Agent tools never count, even with a verify name", () => {
+    expect(isVerificationDelegation("Edit", "qa")).toBe(false);
+    expect(isVerificationDelegation("Bash", "frontend")).toBe(false);
+  });
+
+  test("missing subagent type → false", () => {
+    expect(isVerificationDelegation("Agent", undefined)).toBe(false);
+    expect(isVerificationDelegation("Agent", "")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// decideBrowserTest — decision matrix
+// ---------------------------------------------------------------------------
+
+describe("decideBrowserTest", () => {
+  test("web change + not verified → BLOCK, keep flags", () => {
+    const d = decideBrowserTest({
+      webChangePending: true,
+      browserVerified: false,
+      stopHookActive: false,
+    });
+    expect(d.action).toBe("block");
+    expect(d.resetFlags).toBe(false);
+    expect(d.reason).toMatch(/Web Tech/);
+    expect(d.reason).toMatch(/Claude-in-Chrome extension in Edge/);
+  });
+
+  test("web change + verified → pass, reset", () => {
+    const d = decideBrowserTest({
+      webChangePending: true,
+      browserVerified: true,
+      stopHookActive: false,
+    });
+    expect(d.action).toBe("pass");
+    expect(d.resetFlags).toBe(true);
+  });
+
+  test("no web change → pass, reset", () => {
+    const d = decideBrowserTest({
+      webChangePending: false,
+      browserVerified: false,
+      stopHookActive: false,
+    });
+    expect(d.action).toBe("pass");
+    expect(d.resetFlags).toBe(true);
+  });
+
+  test("stop_hook_active short-circuits — one-time bypass, reset", () => {
+    const d = decideBrowserTest({
+      webChangePending: true,
+      browserVerified: false,
+      stopHookActive: true,
+    });
+    expect(d.action).toBe("pass");
+    expect(d.resetFlags).toBe(true);
+  });
+
+  test("silent turn → pass + reset regardless of pending state", () => {
+    const d = decideBrowserTest({
+      webChangePending: true,
+      browserVerified: false,
+      stopHookActive: false,
+      silent: true,
+    });
+    expect(d.action).toBe("pass");
+    expect(d.resetFlags).toBe(true);
+  });
+
+  test("silent short-circuits before stop_hook_active check", () => {
+    const d = decideBrowserTest({
+      webChangePending: true,
+      browserVerified: false,
+      stopHookActive: true,
+      silent: true,
+    });
+    expect(d.action).toBe("pass");
+    expect(d.resetFlags).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildBrowserTestReason — output contract
+// ---------------------------------------------------------------------------
+
+describe("buildBrowserTestReason", () => {
+  test("names the Edge extension as primary and the fallback order", () => {
+    const r = buildBrowserTestReason();
+    expect(r).toMatch(/Claude-in-Chrome extension in Edge \(PRIMARY\)/);
+    expect(r).toMatch(/Playwright → Preview/);
+    expect(r).toMatch(/Never plain\s+Chrome/);
+  });
+
+  test("requires console + network reads", () => {
+    const r = buildBrowserTestReason();
+    expect(r).toMatch(/read_console_messages/);
+    expect(r).toMatch(/read_network_requests/);
+  });
+
+  test("documents the concept carve-out and the one-block escape", () => {
+    const r = buildBrowserTestReason();
+    expect(r).toMatch(/docs\/concepts/);
+    expect(r).toMatch(/yields after one block/);
+  });
+});

--- a/plugins/devops/hooks/post-tool-use/post.flow.completion.js
+++ b/plugins/devops/hooks/post-tool-use/post.flow.completion.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * @hook post.flow.completion
- * @version 0.15.0
+ * @version 0.16.0
  * @event PostToolUse
  * @plugin devops
  * @description After EVERY tool call: inject the completion-card reminder so
@@ -9,7 +9,9 @@
  *   of whether the last tool was Edit, Read, Bash, Grep, or anything else.
  *   Edit/Write calls additionally increment the session edit counter.
  *   At 5+ edits, injects desktop-testing prompt for UI projects.
- *   Writes a per-turn "work-happened" flag consumed by stop.flow.guard.
+ *   Writes a per-turn "work-happened" flag consumed by stop.flow.guard, plus
+ *   the browser-test gate flags (web-change-pending / browser-verified)
+ *   consumed by stop.flow.browsertest.
  */
 
 require('../lib/plugin-guard');
@@ -17,6 +19,11 @@ require('../lib/plugin-guard');
 const fs = require('fs');
 const { sessionFile, readSessionFile, writeSessionFile } = require('../lib/session-id');
 const { getLocale, t } = require('../lib/locale');
+const {
+  isWebRenderableChange,
+  isBrowserTool,
+  isVerificationDelegation,
+} = require('../lib/browsertest-guard');
 
 // Bilingual strings for the desktop-test AskUserQuestion prompt.
 // Keys correspond to fields the user sees in Claude Code's question UI.
@@ -98,6 +105,31 @@ process.stdin.on('end', () => {
     writeSessionFile(activityFile, Date.now().toString());
   } catch {}
 
+  // --- 1e. Browser-test gate flags (consumed by stop.flow.browsertest) ---
+  //   web-change-pending → a browser-renderable file changed and still needs
+  //     verification (devops-concept pages under docs/concepts/*.html are
+  //     excluded by isWebRenderableChange).
+  //   browser-verified → a browser tool ran, or a verification subagent was
+  //     delegated, somewhere this session.
+  try {
+    if (isCodeEdit) {
+      const editedPath = hook.tool_input && hook.tool_input.file_path;
+      if (isWebRenderableChange(editedPath)) {
+        writeSessionFile(
+          sessionFile('dotclaude-devops-web-change-pending', hook.session_id),
+          String(editedPath),
+        );
+      }
+    }
+    const subagentType = hook.tool_input && hook.tool_input.subagent_type;
+    if (isBrowserTool(toolName) || isVerificationDelegation(toolName, subagentType)) {
+      writeSessionFile(
+        sessionFile('dotclaude-devops-browser-verified', hook.session_id),
+        toolName,
+      );
+    }
+  } catch {}
+
   // --- 2. Emit completion-card instruction (MCP tool call) ---
 
   const lines = [];
@@ -133,6 +165,12 @@ process.stdin.on('end', () => {
       '[test-autonomy] First code edit this session.',
       'Before any test action: invoke /devops-test-plan to pin $TEST_PROFILE.',
       'Then follow the profile tool_chain — do NOT default to computer-use.',
+      'For web/renderer changes the PRIMARY browser tool is the Claude-in-Chrome',
+      'extension running in Edge (Chrome-MCP); Preview is only the fallback when the',
+      'extension is not connected (see deep-knowledge/browser-tool-strategy.md).',
+      'Always read console + network errors (read_console_messages +',
+      'read_network_requests, or preview_console_logs) alongside the snapshot — a',
+      'clean DOM does not prove the absence of runtime errors.',
       'Ask user ONLY at the must-ask triggers listed in $TEST_PROFILE.must_ask_triggers',
       '(see deep-knowledge/test-autonomy.md for the canonical list — 3 triggers total).',
     );

--- a/plugins/devops/hooks/stop/stop.flow.browsertest.js
+++ b/plugins/devops/hooks/stop/stop.flow.browsertest.js
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+/**
+ * @hook stop.flow.browsertest
+ * @version 0.1.0
+ * @event Stop
+ * @plugin devops
+ * @description Browser-test enforcement gate. Blocks the turn when a
+ *   browser-renderable file changed this session but no browser tool ran
+ *   (Claude-in-Chrome in Edge / Playwright / Preview) and no verification
+ *   subagent was delegated. Flags are written by post.flow.completion;
+ *   devops-concept pages (docs/concepts/*.html) are excluded there. Decision
+ *   logic lives in lib/browsertest-guard.js (pure, unit-tested).
+ *
+ *   Runs BEFORE stop.flow.guard so the "verify in the browser" instruction is
+ *   delivered before the completion-card gate. Yields after one block
+ *   (stop_hook_active) so it can never loop.
+ */
+
+require('../lib/plugin-guard');
+
+const fs = require('fs');
+const { readSessionFile } = require('../lib/session-id');
+const { decideBrowserTest } = require('../lib/browsertest-guard');
+
+let inputData = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', d => { inputData += d; });
+process.stdin.on('end', () => {
+  let hook;
+  try { hook = JSON.parse(inputData); }
+  catch { process.exit(0); }
+
+  const sessionId = hook.session_id;
+
+  const pendingResult = readSessionFile('dotclaude-devops-web-change-pending', sessionId);
+  const verifiedResult = readSessionFile('dotclaude-devops-browser-verified', sessionId);
+  const silentResult = readSessionFile('dotclaude-devops-silent-turn', sessionId);
+
+  const decision = decideBrowserTest({
+    webChangePending: pendingResult !== null,
+    browserVerified: verifiedResult !== null,
+    stopHookActive: hook.stop_hook_active === true,
+    silent: silentResult !== null,
+  });
+
+  if (decision.resetFlags) {
+    // Only clear our own gate flags. The silent flag is owned by
+    // stop.flow.guard — never delete it here, or the card gate would treat a
+    // background tick as a real turn.
+    if (pendingResult) try { fs.unlinkSync(pendingResult.filePath); } catch {}
+    if (verifiedResult) try { fs.unlinkSync(verifiedResult.filePath); } catch {}
+  }
+
+  if (decision.action === 'block') {
+    // Claude Code interprets JSON stdout for Stop hooks:
+    //   { decision: "block", reason: "..." } → blocks stop, feeds reason to Claude
+    process.stdout.write(JSON.stringify({
+      decision: 'block',
+      reason: decision.reason,
+    }));
+  }
+  // else: pass silently
+
+  process.exit(0);
+});

--- a/plugins/devops/skills/devops-test-plan/SKILL.md
+++ b/plugins/devops/skills/devops-test-plan/SKILL.md
@@ -168,16 +168,25 @@ $TEST_PROFILE = web-vite
 Detection: marker: vite.config.ts
 
 Tool chain (in order):
-  1. preview_snapshot → element and text verification
-  2. javascript_tool → set viewport iPhone SE (375×667), preview_screenshot
-  3. javascript_tool → set viewport iPad (768×1024), preview_screenshot
-  4. javascript_tool → set viewport Desktop (1280×800), preview_screenshot
+  1. Bash(npm run dev -- --port 5173) → start dev server
+  2. $BROWSER_TOOL probe → Chrome-MCP (Claude extension in Edge) PRIMARY → Playwright → Preview
+  3. $BROWSER_TOOL snapshot → element and text verification
+  4. $BROWSER_TOOL console + network read → runtime JS errors + failed requests
+  5. $BROWSER_TOOL set viewport iPhone SE (375×667) + screenshot
+  6. $BROWSER_TOOL set viewport iPad (768×1024) + screenshot
+  7. $BROWSER_TOOL set viewport Desktop (1280×800) + screenshot
 
 Viewports: mobile, tablet, desktop
 Allowed: read, write_via_dom
 Blocked: computer-use
 Must-ask triggers: none
 ```
+
+`$BROWSER_TOOL` resolves via the waterfall in
+`deep-knowledge/browser-tool-strategy.md` — the Claude-in-Chrome extension
+running in Edge is the primary tool; Preview is the last fallback, never the
+default. The console + network read step is mandatory: a clean snapshot does
+not prove the absence of runtime errors.
 
 ## Step 6 — Cache Result
 

--- a/plugins/devops/skills/devops-test-plan/profiles/electron-ow.json
+++ b/plugins/devops/skills/devops-test-plan/profiles/electron-ow.json
@@ -1,6 +1,6 @@
 {
   "profile": "electron-ow",
-  "description": "Electron app (OverwolfElectron or standard). Renderer tested via Chrome-MCP (no computer-use). Packaged-app final test requires Must-Ask trigger 'packaged_electron_final_test' — only then is computer-use authorized for that specific final step.",
+  "description": "Electron app (OverwolfElectron or standard). Renderer tested via Chrome-MCP in Edge (no computer-use). Packaged-app final test requires Must-Ask trigger 'packaged_electron_final_test' — only then is computer-use authorized for that specific final step.",
   "detection": {
     "files_required": [],
     "files_optional": ["electron-builder.json", "electron-builder.yml", "package.json"],
@@ -10,20 +10,30 @@
     {
       "step": 1,
       "tool": "Bash(npm run dev)",
-      "purpose": "Start Electron in dev mode so renderer is reachable via Chrome-MCP"
+      "purpose": "Start Electron in dev mode so the renderer is reachable via the browser tool"
     },
     {
       "step": 2,
-      "tool": "preview_snapshot",
-      "purpose": "Verify renderer DOM content and element presence"
+      "tool": "$BROWSER_TOOL probe — Chrome-MCP (Claude extension in Edge) → Playwright → Preview",
+      "purpose": "Resolve the active browser tool. Chrome-MCP in Edge is PRIMARY — do NOT default to Preview when the Edge extension is connected (see deep-knowledge/browser-tool-strategy.md). Never computer-use for the renderer."
     },
     {
       "step": 3,
-      "tool": "preview_screenshot",
-      "purpose": "Capture rendered visual layout of the renderer window"
+      "tool": "$BROWSER_TOOL snapshot (read_page / browser_snapshot / preview_snapshot)",
+      "purpose": "Verify renderer DOM content and element presence"
     },
     {
       "step": 4,
+      "tool": "$BROWSER_TOOL console + network read (read_console_messages + read_network_requests / browser_console_messages + browser_network_requests / preview_console_logs)",
+      "purpose": "Catch renderer runtime JS errors and failed requests"
+    },
+    {
+      "step": 5,
+      "tool": "$BROWSER_TOOL screenshot",
+      "purpose": "Capture rendered visual layout of the renderer window"
+    },
+    {
+      "step": 6,
       "tool": "NOTE — packaged app test",
       "purpose": "Testing the packaged (built) binary requires computer-use. Only proceed after must-ask trigger 'packaged_electron_final_test' is confirmed by user."
     }

--- a/plugins/devops/skills/devops-test-plan/profiles/web-angular.json
+++ b/plugins/devops/skills/devops-test-plan/profiles/web-angular.json
@@ -14,33 +14,43 @@
     },
     {
       "step": 2,
-      "tool": "preview_snapshot",
-      "purpose": "Verify DOM content, element presence, and ARIA state"
+      "tool": "$BROWSER_TOOL probe — Chrome-MCP (Claude extension in Edge) → Playwright → Preview",
+      "purpose": "Resolve the active browser tool. Chrome-MCP in Edge is PRIMARY — do NOT default to Preview when the Edge extension is connected (see deep-knowledge/browser-tool-strategy.md). Never computer-use, never plain Chrome."
     },
     {
       "step": 3,
-      "tool": "javascript_tool + preview_screenshot",
-      "purpose": "Set viewport to iPhone SE (375x667) and capture visual layout"
+      "tool": "$BROWSER_TOOL snapshot (read_page / browser_snapshot / preview_snapshot)",
+      "purpose": "Verify DOM content, element presence, and ARIA state"
     },
     {
       "step": 4,
-      "tool": "javascript_tool + preview_screenshot",
-      "purpose": "Set viewport to Pixel 7 / Android phone (393x851) and capture visual layout"
+      "tool": "$BROWSER_TOOL console + network read (read_console_messages + read_network_requests / browser_console_messages + browser_network_requests / preview_console_logs)",
+      "purpose": "Catch runtime JS errors and failed/4xx/5xx requests the snapshot cannot reveal"
     },
     {
       "step": 5,
-      "tool": "javascript_tool + preview_screenshot",
-      "purpose": "Set viewport to iPad (768x1024) and capture visual layout"
+      "tool": "$BROWSER_TOOL set viewport + screenshot (javascript_tool / browser_evaluate / preview_eval, then screenshot)",
+      "purpose": "iPhone SE (375x667) — visual layout, mobile iOS"
     },
     {
       "step": 6,
-      "tool": "javascript_tool + preview_screenshot",
-      "purpose": "Set viewport to Galaxy Tab S9 / Android tablet (800x1280) and capture visual layout"
+      "tool": "$BROWSER_TOOL set viewport + screenshot",
+      "purpose": "Pixel 7 / Android phone (393x851) — visual layout"
     },
     {
       "step": 7,
-      "tool": "javascript_tool + preview_screenshot",
-      "purpose": "Set viewport to Desktop (1280x800) and capture visual layout"
+      "tool": "$BROWSER_TOOL set viewport + screenshot",
+      "purpose": "iPad (768x1024) — visual layout, tablet iOS"
+    },
+    {
+      "step": 8,
+      "tool": "$BROWSER_TOOL set viewport + screenshot",
+      "purpose": "Galaxy Tab S9 / Android tablet (800x1280) — visual layout"
+    },
+    {
+      "step": 9,
+      "tool": "$BROWSER_TOOL set viewport + screenshot",
+      "purpose": "Desktop (1280x800) — visual layout"
     }
   ],
   "viewports": ["mobile-ios", "mobile-android", "tablet-ios", "tablet-android", "desktop"],

--- a/plugins/devops/skills/devops-test-plan/profiles/web-vite.json
+++ b/plugins/devops/skills/devops-test-plan/profiles/web-vite.json
@@ -14,33 +14,43 @@
     },
     {
       "step": 2,
-      "tool": "preview_snapshot",
-      "purpose": "Verify DOM content, element presence, and ARIA state"
+      "tool": "$BROWSER_TOOL probe — Chrome-MCP (Claude extension in Edge) → Playwright → Preview",
+      "purpose": "Resolve the active browser tool. Chrome-MCP in Edge is PRIMARY — do NOT default to Preview when the Edge extension is connected (see deep-knowledge/browser-tool-strategy.md). Never computer-use, never plain Chrome."
     },
     {
       "step": 3,
-      "tool": "javascript_tool + preview_screenshot",
-      "purpose": "Set viewport to iPhone SE (375x667) and capture visual layout"
+      "tool": "$BROWSER_TOOL snapshot (read_page / browser_snapshot / preview_snapshot)",
+      "purpose": "Verify DOM content, element presence, and ARIA state"
     },
     {
       "step": 4,
-      "tool": "javascript_tool + preview_screenshot",
-      "purpose": "Set viewport to Pixel 7 / Android phone (393x851) and capture visual layout"
+      "tool": "$BROWSER_TOOL console + network read (read_console_messages + read_network_requests / browser_console_messages + browser_network_requests / preview_console_logs)",
+      "purpose": "Catch runtime JS errors and failed/4xx/5xx requests the snapshot cannot reveal"
     },
     {
       "step": 5,
-      "tool": "javascript_tool + preview_screenshot",
-      "purpose": "Set viewport to iPad (768x1024) and capture visual layout"
+      "tool": "$BROWSER_TOOL set viewport + screenshot (javascript_tool / browser_evaluate / preview_eval, then screenshot)",
+      "purpose": "iPhone SE (375x667) — visual layout, mobile iOS"
     },
     {
       "step": 6,
-      "tool": "javascript_tool + preview_screenshot",
-      "purpose": "Set viewport to Galaxy Tab S9 / Android tablet (800x1280) and capture visual layout"
+      "tool": "$BROWSER_TOOL set viewport + screenshot",
+      "purpose": "Pixel 7 / Android phone (393x851) — visual layout"
     },
     {
       "step": 7,
-      "tool": "javascript_tool + preview_screenshot",
-      "purpose": "Set viewport to Desktop (1280x800) and capture visual layout"
+      "tool": "$BROWSER_TOOL set viewport + screenshot",
+      "purpose": "iPad (768x1024) — visual layout, tablet iOS"
+    },
+    {
+      "step": 8,
+      "tool": "$BROWSER_TOOL set viewport + screenshot",
+      "purpose": "Galaxy Tab S9 / Android tablet (800x1280) — visual layout"
+    },
+    {
+      "step": 9,
+      "tool": "$BROWSER_TOOL set viewport + screenshot",
+      "purpose": "Desktop (1280x800) — visual layout"
     }
   ],
   "viewports": ["mobile-ios", "mobile-android", "tablet-ios", "tablet-android", "desktop"],

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.93.5",
+  "version": "0.94.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary
Forces browser verification after web-renderable changes and aligns the deterministic test tool-chain with the Edge Credo (which the profile JSON previously contradicted).

- **Browser-test gate** (`stop.flow.browsertest` + unit-tested `lib/browsertest-guard`): blocks a turn when a web-renderable file changed this session but no browser tool ran and no verification subagent was delegated → instructs verification via the Claude-in-Chrome extension in Edge, incl. mandatory console + network reads. One-time bypass via `stop_hook_active` (never loops); `docs/concepts/*.html` (devops-concept artifacts) carved out.
- **Edge-primary tool-chain**: `web-vite` / `web-angular` / `electron-ow` profiles resolve `$BROWSER_TOOL` via the waterfall (Chrome-MCP in Edge primary → Playwright → Preview) instead of hardcoding the Preview MCP, and add a mandatory console + network error read step. The `qa` agent gains the extension read/verify tools.

## Tests
- vitest: 266 passed (26 new — `browsertest-guard`)
- eslint clean; hook smoke-test 4/4 (block / concept carve-out / verified-pass / non-web ignored)
- Codex review hit the 5-min hard timeout (rc=124) → proceeded per the ship gate's timeout protocol

🤖 Generated with [Claude Code](https://claude.com/claude-code)