### PR TITLE
feat(test): profile-aware Light gate + Surface×Depth model

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.95.0"
+    "version": "0.96.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.95.0",
+      "version": "0.96.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.95.0",
+      "version": "0.96.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.96.0] — 2026-06-06
+
+### Changed
+
+- **Test-tool selection is now a two-axis model, and the Stop-time test gate enforces it profile-wide.** `deep-knowledge/test-autonomy.md` replaces the single Snapshot→Screenshot→Computer-use ladder with two orthogonal axes — *surface* (DOM → text → a11y/UIA → pixels; pick the cheapest readable one) and *depth* (Light always-on/autonomous vs Full opt-in) — plus three application categories (pure web · DOM-in-a-non-web-shell incl. Electron/Tauri/Capacitor/Cordova · no-DOM native/canvas/TUI). Computer-use is reframed as the *no-DOM floor*, not a "no-browser" tool: it is the primary path for native/canvas frontends and only the last resort for an unreachable DOM (e.g. a packaged Electron build without a debug port). Category-B Light tests at the shell's real constraints (min window size + DPI scaling), not the web responsive breakpoints. Full verification (launching the packaged app, computer-use, desktop/device takeover) stays user- or extension-gated via a new standing `full_app_test` opt-in. `browser-tool-strategy.md` updates the computer-use section to match.
+- **`stop.flow.browsertest` generalized from web-only to `$TEST_PROFILE`-aware Light enforcement.** The gate previously fired only on browser-renderable file changes and was satisfied by *any* browser tool — or merely by delegating to a verification subagent. It now blocks whenever a **code** file changed and the matching Light check never ran: DOM profiles require a browser tool, runner profiles (cli/lib/generic/backend) require an observable test run (`npm test` / `vitest` / `jest` / `pytest` / `go test` / …), unknown/unpinned profiles accept either. Two correctness fixes fall out: (a) a **subagent delegation no longer satisfies the gate** — only an observable tool call in the main thread counts (closed loophole), and (b) test runs via the **PowerShell** tool are now recognised, not just `Bash` — without which the gate would have blocked every code edit on Windows. Pure docs/markdown/config edits, `*.test`/`*.spec` files, and `docs/concepts/*.html` never trigger it; the gate still yields after one block so it can never loop. New session flags `light-pending` / `light-kind` / `light-verified` replace `web-change-pending` / `browser-verified`. `browsertest-guard` 0.1.0→0.2.0, `stop.flow.browsertest` 0.1.0→0.2.0, `post.flow.completion` 0.16.0→0.17.0; 39 unit tests (was 26).
+
 ## [0.95.0] — 2026-06-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ SessionStart  ──>  UserPromptSubmit  ──>  PreToolUse  ──>  PostToolU
 
 #### Stop — runs when Claude finishes responding
 
-- `stop.flow.browsertest` — Browser-test enforcement gate.
+- `stop.flow.browsertest` — Light-verification enforcement gate.
 - `stop.flow.guard` — Per-turn completion card enforcement.
 - `stop.flow.selfcalibration` — Run self-calibration when Claude finishes a response turn.
 <!--/devops:block:hook-lifecycle-->

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.95.0**
+**Version: 0.96.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.95.0",
+  "version": "0.96.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/deep-knowledge/browser-tool-strategy.md
+++ b/plugins/devops/deep-knowledge/browser-tool-strategy.md
@@ -280,17 +280,26 @@ already succeeded), follow this recovery sequence:
 
 **NEVER silently stop monitoring** — always inform the user why monitoring ended.
 
-## Computer-Use: Native Apps Only
+## Computer-Use: No-DOM Floor, Not "No Browser"
 
-`computer-use` is **exclusively** for native desktop applications (file explorer,
-system settings, desktop apps). Never use it for:
+The precise rule is in [test-autonomy.md](test-autonomy.md) (Surface axis):
+computer-use is the **pixel floor**, reached only when no structured surface is
+readable. That makes it the *primary* tool for genuinely no-DOM frontends
+(native GUI, games, canvas) — and the *last resort* for a DOM frontend whose
+renderer is unreachable (e.g. a packaged Electron build with no debug port).
+
+For any reachable DOM surface it is **never** used:
 - Browser navigation or clicking
 - Web page interaction
 - Form filling in web apps
 - Reading web page content
 
-Browsers have read-only tier in computer-use — visible in screenshots but all
-interaction (clicks, typing) is blocked by the MCP server.
+A packaged desktop app still has a DOM — prefer attaching via
+`--remote-debugging-port` (then Chrome-MCP/Playwright/Preview) over driving it
+with pixels. Browsers have read-only tier in computer-use — visible in
+screenshots but all interaction (clicks, typing) is blocked by the MCP server.
+"No DOM" is not "no structured surface": a TUI's text output is readable via the
+terminal (Bash), which is cheaper than pixel control.
 
 ## Tool Mapping Reference
 

--- a/plugins/devops/deep-knowledge/test-autonomy.md
+++ b/plugins/devops/deep-knowledge/test-autonomy.md
@@ -8,38 +8,106 @@ defer to this file for autonomy and tool-selection decisions.
 
 ## Hard Rule
 
-Autonomy is the default. Do not ask the user which test tool to use. Follow the
-tier order Snapshot → Screenshot → Computer-use strictly — use the lowest tier
-that can verify the change. Ask the user only when a Must-Ask Trigger fires (see
-below). The `$TEST_PROFILE` variable (set by `/devops-test-plan`) pins the
-tool-chain for the session; if it is not set, invoke `/devops-test-plan` first.
+Autonomy is the default. Do not ask the user which test tool to use.
+
+- **Light verification ALWAYS runs** after a code change — automatically, at the
+  lowest surface tier that can verify it. It is not optional and not user-gated.
+- **Full verification** (launching the real app-as-shipped, computer-use,
+  desktop/device takeover) runs **only** on explicit user request OR when a
+  project skill extension demands it. Never autonomously.
+
+Ask the user only when a Must-Ask Trigger fires (see below). The `$TEST_PROFILE`
+variable (set by `/devops-test-plan`) pins the tool-chain for the session; if it
+is not set, invoke `/devops-test-plan` first.
+
+---
+
+## The Model — Two Orthogonal Axes
+
+Tool selection is the intersection of two independent questions, not one ladder.
+
+### Axis 1 — Surface: what can you read?
+
+Pick the cheapest readable surface that exists. Drop to pixels only when nothing
+structured is reachable.
+
+| Surface | Read via | Example targets |
+|---------|----------|-----------------|
+| **DOM** | Preview / Chrome-MCP (Edge) / Playwright — snapshot, then screenshot | web apps, Electron/Tauri/WebView renderers, PWAs |
+| **Text** | terminal / PTY capture (Bash) | CLI tools, TUIs (ncurses) |
+| **a11y / UIA tree** | *(no reader tool ships in this plugin today → falls through to pixels)* | native GUI: WPF, Qt, WinForms, Cocoa |
+| **Pixels** | computer-use (screenshot + click) | games, canvas/GPU UIs, native GUI without a reader |
+
+"No DOM" is **not** "no structured surface": a TUI's surface is its text output —
+read it via the terminal, not computer-use. Computer-use is the **floor**,
+reached only when no structured surface is available.
+
+Decision gate: **is any debug/structured surface reachable?** If yes → stay in
+structured tools. A *packaged* Electron app still has a DOM — attach via
+`--remote-debugging-port` and stay on the DOM surface. Drop to pixels only when
+there is genuinely no attach point or the frontend speaks no browser language.
+
+### Axis 2 — Depth: Light vs Full
+
+Orthogonal to surface. Applies wherever the frontend is separable from its shell.
+
+| Depth | Verifies | When | Driver |
+|-------|----------|------|--------|
+| **Light** | frontend correctness via the structured surface | **always, autonomous** | the surface tool (Axis 1), at the shell's real constraints |
+| **Full** | the app *as shipped*: shell, window chrome, installer, OS integration, tray, auto-update, multi-monitor | **opt-in only** — explicit user request OR project-extension flag | the shell's own driver (desktop binary → computer-use; mobile → emulator/device automation) |
+
+Light and Full test **different things**, not two quality levels. Light cannot
+see the native shell; Full exists precisely to test what the DOM never exposes.
+That is why Full is opt-in.
+
+---
+
+## Application Categories
+
+| Cat. | Frontend | Light (default, always) | Full (opt-in) |
+|------|----------|-------------------------|---------------|
+| **A — Pure web** | DOM, dev-server or deployed | snapshot + screenshot across the responsive viewports | n/a — the browser *is* the shell |
+| **B — DOM in a non-web shell** | DOM wrapped in a desktop / mobile / kiosk / embedded shell (Electron, Tauri, Capacitor, Cordova, RN-WebView…) | DOM tools at the **shell's** constraints (min window size + supported DPI/scaling, or device viewport) | launch the packaged app: desktop → computer-use · mobile → emulator window (computer-use) / real device (Appium, scrcpy) |
+| **C — No DOM** | native-UI / text / canvas | **none for native/canvas** — no readable structured surface, so computer-use is the *primary* path, not a fallback. **TUI exception:** read the text surface via the terminal | already the primary path |
+
+Category-B Light uses the **shell's** real constraints — `minWidth`/`minHeight`
+of the window plus the DPI/zoom steps the app permits (100/125/150 %) — **not**
+the web responsive breakpoints. An Electron window is never 375 px wide.
+
+---
+
+## Surface Tier Order (within Light)
+
+Always escalate from the cheapest read upward; never skip a tier without a
+documented reason. The capability matters, not the specific tool — these tier
+names are tool-agnostic so the same order holds for Preview, Chrome-MCP, and
+Playwright alike.
+
+| Tier | Capability | DOM tools (examples) | Text tools |
+|------|-----------|----------------------|------------|
+| 1 — Structured read | DOM/text + ARIA + console + network | `preview_snapshot` / `read_page` / `browser_snapshot` **+** console + network read | terminal stdout capture |
+| 2 — Rendered read | rendered pixels (layout, colour, icons) | `preview_screenshot` / `take_screenshot` — only when pixels matter | — |
+| 3 — Interaction | click / fill / eval | DOM click/fill/eval | scripted input |
+| 4 — Pixel control | full pixel drive | computer-use — **Full / no-DOM only**, never autonomous on a DOM surface | computer-use |
+
+Use Tier 1 for all content and logic checks. Escalate to Tier 2 only when
+pixel-level layout matters. A clean structured read does **not** prove the
+absence of runtime errors — always read console + network alongside a snapshot.
 
 ---
 
 ## Default Behavior
 
-1. Check whether `$TEST_PROFILE` is already set for this session
-   (read `~/.claude/cache/devops/test-profile-<session_id>.json`).
-2. If not set → invoke `/devops-test-plan` to detect the project profile and
-   populate the session cache.
-3. Default tool-chain: Chrome-MCP (running in Microsoft Edge — never Chrome).
-4. Use `preview_snapshot` before `preview_screenshot` before `javascript_tool`
-   viewport changes before computer-use.
-5. Never skip a tier without a documented reason.
-
----
-
-## Tier Order
-
-| Tier | Tool(s) | When to use | Why this tier first |
-|------|---------|-------------|---------------------|
-| 1 — Snapshot | `preview_snapshot`, `read_page` | DOM/text content verification, element presence, ARIA state | Zero visual overhead; fast; deterministic |
-| 2 — Screenshot | `preview_screenshot`, `take_screenshot` | Visual layout, colour, icon rendering, responsive breakpoints | Captures rendered output without browser control |
-| 3 — Computer-use | `mcp__computer-use__*` | Only when explicitly triggered by user or a packaged-app Must-Ask | Full desktop control; disruptive; slow |
-
-Use **Tier 1** for all content and logic checks. Escalate to **Tier 2** only
-when pixel-level layout matters (UI change in a web or Electron renderer). Use
-**Tier 3** only at Must-Ask triggers — never autonomously.
+1. Check whether `$TEST_PROFILE` is set
+   (`~/.claude/cache/devops/test-profile-<session_id>.json`).
+2. If not → invoke `/devops-test-plan` to detect the profile and populate cache.
+3. Run the **Light** verification for the profile's surface — automatically,
+   for every code change (enforced by the browser/light gate, not advisory).
+4. For a DOM surface, resolve the concrete browser tool via the waterfall in
+   [browser-tool-strategy.md](browser-tool-strategy.md). Computer-use is never a
+   DOM-surface tool.
+5. Escalate Light tiers Structured → Rendered → Interaction only as needed.
+6. **Full** verification only at an opt-in (user request or extension flag).
 
 ---
 
@@ -47,43 +115,54 @@ when pixel-level layout matters (UI change in a web or Electron renderer). Use
 
 Ask the user before proceeding in exactly these situations:
 
-1. **Native packaged desktop app** — packaged Electron, Tauri, or Win32
-   executable (not running in a dev-server renderer). Reason: the renderer is
-   not reachable via Chrome-MCP; computer-use may be the only option.
+1. **Full verification of a native packaged app** — launching a packaged
+   Electron/Tauri/Win32 binary (Category-B Full or Category-C). Reason: the real
+   shell needs computer-use/device control, which is disruptive. A project skill
+   extension MAY pre-authorize this as a **standing opt-in** (see below) so the
+   per-run question is skipped.
 2. **Real 3rd-party live call that changes state** — Stripe charge, OAuth login
    with a real user account, outbound webhook to a production system. Reason:
    irreversible side-effect outside the project boundary.
 3. **Explicit user instruction for desktop takeover** — user says "take the
    desktop", "desktop übernehmen", or "computer use". Reason: opt-in only.
 
-Everything else — including service calls in dev/test environments,
-form fills, and responsive-layout checks — is autonomous.
+Everything else — Light verification, service calls in dev/test environments,
+form fills, responsive-layout checks — is autonomous.
+
+**Standing opt-in (extension flag).** A project extension may set
+`full_app_test: true` (in its `devops-test-plan` profile) to declare that
+Full verification is always wanted for that project. This converts trigger #1
+from a per-run question into a pre-authorized autonomous Full run. Without the
+flag, Full stays user-gated.
 
 ---
 
 ## Decision Matrix
 
 Use the intersection of project profile and change scope to determine the
-tool-chain. "Chrome-MCP" means Chrome-MCP extension running in Edge.
+tool-chain. "DOM tools" resolves to the browser waterfall (Preview / Chrome-MCP
+in Edge / Playwright) per [browser-tool-strategy.md](browser-tool-strategy.md).
 
 | Profile \ Change scope | `style-only` | `component-logic` | `data-model` | `config` | `build/infra` |
 |------------------------|-------------|-------------------|--------------|----------|---------------|
-| `web-vite` | Snapshot + Screenshot × 5 viewports | Snapshot + Screenshot × 5 viewports | Snapshot | Snapshot | npm test only |
-| `web-angular` | Snapshot + Screenshot × 5 viewports | Snapshot + Screenshot × 5 viewports | Snapshot | Snapshot | npm test only |
-| `electron-ow` | Snapshot + Screenshot (renderer) | Snapshot + Screenshot (renderer) | Snapshot | Snapshot | Must-Ask (packaged) |
+| `web-vite` | Light: Snapshot + Screenshot × 5 viewports | Light: Snapshot + Screenshot × 5 viewports | Snapshot | Snapshot | npm test only |
+| `web-angular` | Light: Snapshot + Screenshot × 5 viewports | Light: Snapshot + Screenshot × 5 viewports | Snapshot | Snapshot | npm test only |
+| `electron-ow` | **Light**: Snapshot + Screenshot (renderer at app min-res/scaling, autonomous) | **Light**: Snapshot + Screenshot (renderer) | Snapshot | Snapshot | **Full**: packaged app via computer-use — opt-in (user or `full_app_test`) |
 | `cli-node` | — | npm test + CLI run | npm test | npm test | npm test |
 | `lib` | — | npm test | npm test | — | npm run build |
 | `generic` | Manual review | npm test or pytest | npm test or pytest | Manual review | Manual review |
 
-Viewports for web profiles (5 total): iPhone SE 375×667, Pixel 7 393×851
+Viewports for **web** profiles (5 total): iPhone SE 375×667, Pixel 7 393×851
 (Android phone), iPad 768×1024, Galaxy Tab S9 800×1280 (Android tablet),
 Desktop 1280×800 (see [responsive-testing.md](responsive-testing.md)).
+**Category-B** profiles (electron-ow and any mobile/kiosk shell) replace these
+with the shell's own constraints — never the web breakpoints.
 
 Project skill extensions can register additional profiles via
 `{project}/.claude/skills/devops-test-plan/` (see the
 [skill SKILL.md, Step 2a](../skills/devops-test-plan/SKILL.md)). The same tier
 order and must-ask rules apply — extension profiles inherit autonomy defaults
-unless their JSON sets `must_ask_triggers` explicitly.
+unless their JSON sets `must_ask_triggers` (or `full_app_test`) explicitly.
 
 ---
 

--- a/plugins/devops/hooks/lib/browsertest-guard.js
+++ b/plugins/devops/hooks/lib/browsertest-guard.js
@@ -1,39 +1,48 @@
 /**
  * @module browsertest-guard
- * @version 0.1.0
- * @description Pure decision logic for the browser-test enforcement gate.
+ * @version 0.2.0
+ * @description Pure decision logic for the Light-verification enforcement gate.
  *   Split out of stop.flow.browsertest.js so the rules can be unit-tested
  *   without mocking stdin or temp files.
  *
- *   The gate forces a browser verification whenever browser-renderable files
- *   changed in a session but no browser tool ran and no verification subagent
- *   was delegated. It mirrors card-guard's block/pass/reset contract.
+ *   The gate forces a Light verification whenever a CODE file changed in a
+ *   session but the matching Light check never ran:
+ *     - DOM-surface profiles (web-*, electron-ow, …) → a browser tool must run
+ *       (Claude-in-Chrome in Edge / Playwright / Preview).
+ *     - Runner profiles (cli-node, lib, generic, …) → a test runner must run
+ *       (npm test / vitest / jest / pytest / go test / …).
+ *     - Unknown / unpinned profile → either satisfies.
  *
- *   Inputs: flag state (web-change-pending / browser-verified) + stop_hook_active
+ *   Per deep-knowledge/test-autonomy.md the Light check is mandatory and
+ *   autonomous; Full (computer-use / packaged-app launch) stays opt-in and is
+ *   NOT enforced here. Delegating to a subagent does NOT satisfy the gate —
+ *   verification must be observable in the main thread (closed loophole).
+ *
+ *   Inputs: flag state (light-pending / light-verified / kind) + stop_hook_active
  *           + silent.
  *   Output: { action: 'block' | 'pass', reason?, resetFlags }.
  */
 
 // ---------------------------------------------------------------------------
-// Web-renderable change detection
+// Change detection
 // ---------------------------------------------------------------------------
 
 // Markup / style / framework-component files are ALWAYS browser-renderable.
 const ALWAYS_WEB_RE = /\.(html?|css|scss|sass|less|vue|svelte|astro|tsx|jsx)$/i;
-// Bare scripts count only when they live under a UI source directory.
+// Bare scripts count as renderable only when they live under a UI source dir.
 const SCRIPT_RE = /\.(ts|js|mjs|cjs)$/i;
 const UI_DIR_RE = /(^|\/)(src|app|components|pages|views|renderer)\//i;
-// Unit/spec files are logic, not a rendered view.
-const TEST_FILE_RE = /\.(test|spec)\.[tj]sx?$/i;
+// Any source-code file (broader than web) — what a runner profile must verify.
+const CODE_EXT_RE =
+  /\.(tsx?|jsx?|mjs|cjs|vue|svelte|astro|html?|css|scss|sass|less|py|go|rs|java|rb|php|cs|cpp|cc|c|h|hpp|swift|kt|kts|dart|ex|exs|scala|clj|lua|sh)$/i;
+// Unit/spec files are logic, not a rendered view — and they ARE the test.
+const TEST_FILE_RE = /\.(test|spec)\.[a-z]+$/i;
 // devops-concept artifacts — generated analysis pages, NOT product UI.
-// Carve-out per project decision: concept pages never trigger the gate.
 const CONCEPT_RE = /(^|\/)docs\/concepts\//i;
 
 /**
- * Does a changed file require browser verification?
- * Normalizes Windows backslashes so a single forward-slash regex set works.
- *
- * @param {string} filePath — path from the Edit/Write tool_input.file_path
+ * Does a changed file require BROWSER verification (DOM surface)?
+ * @param {string} filePath
  * @returns {boolean}
  */
 function isWebRenderableChange(filePath) {
@@ -46,20 +55,69 @@ function isWebRenderableChange(filePath) {
   return false;
 }
 
+/**
+ * Is the change a source-code file that warrants Light verification at all?
+ * Excludes docs, config, lockfiles, images (not in CODE_EXT), plus the concept
+ * carve-out and *.test/*.spec files. This is the Option-A scope: pure
+ * doc/markdown/config edits never trigger the gate.
+ *
+ * @param {string} filePath
+ * @returns {boolean}
+ */
+function isCodeChange(filePath) {
+  if (!filePath) return false;
+  const p = String(filePath).replace(/\\/g, '/');
+  if (CONCEPT_RE.test(p)) return false;
+  if (TEST_FILE_RE.test(p)) return false;
+  return CODE_EXT_RE.test(p);
+}
+
 // ---------------------------------------------------------------------------
-// Browser-tool detection (tool_name as reported by PostToolUse)
+// Profile classification — which Light check does this profile require?
+// ---------------------------------------------------------------------------
+
+/**
+ * Map a $TEST_PROFILE name to the kind of Light verification it needs.
+ *   'dom'    → browser snapshot (web / electron renderer / tauri / pwa)
+ *   'runner' → test suite (cli, lib, generic, backend, language runtimes)
+ *   'any'    → unknown / unpinned → either satisfies
+ * @param {string} name
+ * @returns {'dom'|'runner'|'any'}
+ */
+function classifyProfile(name) {
+  const p = String(name || '').toLowerCase();
+  if (!p) return 'any';
+  if (/(^|[-_])?(web|angular|vite|electron|tauri|renderer|pwa|svelte|nuxt|next|capacitor|cordova|ionic)/.test(p)) {
+    return 'dom';
+  }
+  if (/(^|[-_])?(cli|lib|node|generic|api|backend|service|worker|python|go|rust|java)/.test(p)) {
+    return 'runner';
+  }
+  return 'any';
+}
+
+/**
+ * Does this file change make a Light verification pending, given the profile?
+ * @param {'dom'|'runner'|'any'} profileClass
+ * @param {string} filePath
+ * @returns {boolean}
+ */
+function needsLightVerification(profileClass, filePath) {
+  if (profileClass === 'dom') return isWebRenderableChange(filePath);
+  return isCodeChange(filePath); // 'runner' and 'any' → any source file
+}
+
+// ---------------------------------------------------------------------------
+// Verification detection (tool_name / command as reported by PostToolUse)
 // ---------------------------------------------------------------------------
 
 const BROWSER_MCP_RE =
   /^mcp__(Claude_in_Chrome__|Claude_Preview__preview_|plugin_playwright_playwright__browser_)/;
-// Short-name fallbacks, in case the runtime ever reports the suffix form.
 const BROWSER_SHORT_RE =
   /^(preview_(snapshot|screenshot|eval|click|fill|console_logs|inspect|navigate|start|logs|network)|browser_(navigate|snapshot|take_screenshot|click|evaluate|console_messages|network_requests|type|fill_form|wait_for))/;
 
 /**
- * Did a browser tool run? Any Chrome-MCP / Playwright / Preview call counts —
- * if Claude touched the page at all, it verified in a real browser engine.
- *
+ * Did a browser tool run? Any Chrome-MCP / Playwright / Preview call counts.
  * @param {string} toolName
  * @returns {boolean}
  */
@@ -69,20 +127,37 @@ function isBrowserTool(toolName) {
   return BROWSER_MCP_RE.test(t) || BROWSER_SHORT_RE.test(t);
 }
 
-// Subagents that perform their own browser verification. When one is delegated
-// we assume the browser check is covered (the main thread cannot observe the
-// subagent's inner tool calls).
-const VERIFY_AGENTS = new Set(['qa', 'frontend', 'feature', 'gamer', 'designer']);
+// Test-runner invocations in a Bash command. Anchored so "npm install" etc. do
+// not match; "npm run test:unit" matches via the word boundary after "test".
+const TEST_RUNNER_RE =
+  /\b(npm|pnpm|yarn)\s+(run\s+)?test\b|\bnpm\s+t\b|\b(vitest|jest|mocha|ava|jasmine|pytest|rspec|phpunit|nose2)\b|\bpython\s+-m\s+(pytest|unittest)\b|\bgo\s+test\b|\bcargo\s+test\b|\bdotnet\s+test\b|\b(mvn|gradle|gradlew)\s+(test|verify|check)\b|\bnpx\s+(vitest|jest|mocha|playwright\s+test)\b|\bplaywright\s+test\b/i;
 
 /**
- * Was browser verification delegated to a verification-capable subagent?
- *
- * @param {string} toolName     — 'Agent' for a subagent spawn
- * @param {string} subagentType — opts.subagent_type from the Agent call
+ * Did a test runner run? Only shell tools count (Bash on *nix, PowerShell on
+ * Windows — this plugin targets Windows, so both must be recognised).
+ * @param {string} toolName
+ * @param {string} command — hook.tool_input.command
  * @returns {boolean}
  */
-function isVerificationDelegation(toolName, subagentType) {
-  return toolName === 'Agent' && VERIFY_AGENTS.has(String(subagentType || '').toLowerCase());
+function isTestRunnerTool(toolName, command) {
+  if (toolName !== 'Bash' && toolName !== 'PowerShell') return false;
+  if (!command) return false;
+  return TEST_RUNNER_RE.test(String(command));
+}
+
+/**
+ * Did an appropriate Light verification run for this profile class?
+ * @param {'dom'|'runner'|'any'} profileClass
+ * @param {string} toolName
+ * @param {string} [command]
+ * @returns {boolean}
+ */
+function isLightVerification(profileClass, toolName, command) {
+  const browser = isBrowserTool(toolName);
+  const runner = isTestRunnerTool(toolName, command);
+  if (profileClass === 'dom') return browser;
+  if (profileClass === 'runner') return runner;
+  return browser || runner; // 'any'
 }
 
 // ---------------------------------------------------------------------------
@@ -90,16 +165,17 @@ function isVerificationDelegation(toolName, subagentType) {
 // ---------------------------------------------------------------------------
 
 /**
- * Decide whether the Stop hook should block to force a browser verification.
+ * Decide whether the Stop hook should block to force a Light verification.
  *
  * @param {object} s
- * @param {boolean} s.webChangePending — a web-renderable file changed, unverified
- * @param {boolean} s.browserVerified  — a browser tool ran / verify subagent ran
- * @param {boolean} s.stopHookActive   — prior Stop hook already blocked this cycle
- * @param {boolean} [s.silent]         — background tick (cron / autonomous loop)
+ * @param {boolean} s.pending        — a code file changed, Light check still owed
+ * @param {boolean} s.verified       — a matching Light verification ran
+ * @param {boolean} s.stopHookActive — prior Stop hook already blocked this cycle
+ * @param {boolean} [s.silent]       — background tick (cron / autonomous loop)
+ * @param {'dom'|'runner'|'any'} [s.kind] — required verification kind (for reason)
  * @returns {{ action: 'block' | 'pass', resetFlags: boolean, reason?: string }}
  */
-function decideBrowserTest({ webChangePending, browserVerified, stopHookActive, silent }) {
+function decideLightTest({ pending, verified, stopHookActive, silent, kind }) {
   if (silent) {
     // Background tick — never enforce. Clear our own flags so the next real
     // turn starts clean. (The silent flag itself is owned by stop.flow.guard.)
@@ -108,49 +184,98 @@ function decideBrowserTest({ webChangePending, browserVerified, stopHookActive, 
 
   if (stopHookActive) {
     // One-time bypass: if Claude stops again after being blocked, yield and
-    // clear the pending flag so we never loop. Mirrors card-guard.
+    // clear the pending flag so we never loop.
     return { action: 'pass', resetFlags: true };
   }
 
-  if (webChangePending && !browserVerified) {
-    return { action: 'block', resetFlags: false, reason: buildBrowserTestReason() };
+  if (pending && !verified) {
+    return { action: 'block', resetFlags: false, reason: buildLightTestReason(kind) };
   }
 
   return { action: 'pass', resetFlags: true };
 }
 
-function buildBrowserTestReason() {
+// ---------------------------------------------------------------------------
+// Reason text
+// ---------------------------------------------------------------------------
+
+const FOOTER = [
+  '',
+  'A subagent delegation does NOT satisfy this gate — verification must be',
+  'observable in THIS thread (a browser or test-runner tool call). If a subagent',
+  'did the testing, re-run a quick observable check or surface its evidence.',
+  '',
+  'Auto-excluded: docs/markdown/config edits, *.test/*.spec files, and',
+  'devops-concept pages under docs/concepts/*.html. To intentionally skip',
+  '(non-runtime change, no startable surface): stop again — this gate yields',
+  'after one block.',
+];
+
+function domReason() {
   return [
     '[stop.flow.browsertest] Web-renderable changes were made but no browser verification ran this session.',
     '',
-    'Per deep-knowledge/test-strategy.md (Web Tech → Always Browser-Test) this is',
-    'mandatory — there is no "browser not needed" exit for web tech. Do this FIRST,',
-    'before rendering the completion card:',
+    'Per deep-knowledge/test-autonomy.md (DOM surface → Light = browser snapshot)',
+    'this is mandatory for web tech. Do this FIRST, before the completion card:',
     '',
-    '1. Make the changed view reachable: dev server (npm run dev) or open the',
-    '   file:// URL in Edge for a static page.',
-    '2. Verify it via the Claude-in-Chrome extension in Edge (PRIMARY). Fall back to',
-    '   Playwright → Preview only if the extension is not connected. Never plain',
-    '   Chrome, never computer-use for browser work (see browser-tool-strategy.md).',
+    '1. Make the changed view reachable: dev server (npm run dev) or a file:// URL in Edge.',
+    '2. Verify via the Claude-in-Chrome extension in Edge (PRIMARY). Fall back to',
+    '   Playwright → Preview only if the extension is not connected. Never plain Chrome,',
+    '   never computer-use for browser work (see browser-tool-strategy.md).',
     '3. Snapshot the DOM (read_page / browser_snapshot / preview_snapshot) AND read',
     '   console + network errors (read_console_messages + read_network_requests /',
     '   browser_console_messages + browser_network_requests / preview_console_logs).',
-    '4. Mocks for missing backends are expected — exercise the changed view, do not',
-    '   hit production services.',
+    '4. Mocks for missing backends are expected — exercise the changed view.',
+  ];
+}
+
+function runnerReason() {
+  return [
+    '[stop.flow.browsertest] Code changed but no test run was observed this session.',
     '',
-    'Then render the completion card as the LAST action.',
+    'Per deep-knowledge/test-autonomy.md (non-DOM surface → Light = run the test',
+    'suite) this is mandatory. Do this FIRST, before the completion card:',
     '',
-    'devops-concept pages under docs/concepts/*.html are auto-excluded and never',
-    'trigger this gate. To intentionally skip (e.g. non-runtime change with no',
-    'startable view): stop again — this gate yields after one block.',
-  ].join('\n');
+    '1. Run the project test suite: npm test (or vitest / jest / pytest / go test / …).',
+    '2. For a CLI, also exercise the changed command path once and read its output.',
+    '3. Fix failures before finishing.',
+  ];
+}
+
+function anyReason() {
+  return [
+    '[stop.flow.browsertest] Code changed but no Light verification ran this session,',
+    'and no $TEST_PROFILE is pinned.',
+    '',
+    'Do this FIRST, before the completion card:',
+    '',
+    '1. Invoke /devops-test-plan to pin the profile.',
+    '2. Then run the matching Light check: a browser snapshot for a web/DOM surface,',
+    '   or the test suite (npm test / pytest / …) otherwise.',
+  ];
+}
+
+/**
+ * Build the block reason for a given verification kind.
+ * @param {'dom'|'runner'|'any'} [kind]
+ * @returns {string}
+ */
+function buildLightTestReason(kind) {
+  let body;
+  if (kind === 'dom') body = domReason();
+  else if (kind === 'runner') body = runnerReason();
+  else body = anyReason();
+  return body.concat(['', 'Then render the completion card as the LAST action.'], FOOTER).join('\n');
 }
 
 module.exports = {
   isWebRenderableChange,
+  isCodeChange,
+  classifyProfile,
+  needsLightVerification,
   isBrowserTool,
-  isVerificationDelegation,
-  decideBrowserTest,
-  buildBrowserTestReason,
-  VERIFY_AGENTS,
+  isTestRunnerTool,
+  isLightVerification,
+  decideLightTest,
+  buildLightTestReason,
 };

--- a/plugins/devops/hooks/lib/browsertest-guard.test.js
+++ b/plugins/devops/hooks/lib/browsertest-guard.test.js
@@ -1,10 +1,14 @@
 import { describe, test, expect } from "vitest";
 import {
   isWebRenderableChange,
+  isCodeChange,
+  classifyProfile,
+  needsLightVerification,
   isBrowserTool,
-  isVerificationDelegation,
-  decideBrowserTest,
-  buildBrowserTestReason,
+  isTestRunnerTool,
+  isLightVerification,
+  decideLightTest,
+  buildLightTestReason,
 } from "./browsertest-guard.js";
 
 // ---------------------------------------------------------------------------
@@ -31,7 +35,6 @@ describe("isWebRenderableChange", () => {
     expect(isWebRenderableChange("src/store.ts")).toBe(true);
     expect(isWebRenderableChange("app/router.js")).toBe(true);
     expect(isWebRenderableChange("renderer/main.ts")).toBe(true);
-    // Outside a UI dir → not a renderable change
     expect(isWebRenderableChange("scripts/build.js")).toBe(false);
     expect(isWebRenderableChange("mcp-server/index.js")).toBe(false);
     expect(isWebRenderableChange("hooks/lib/foo.ts")).toBe(false);
@@ -45,26 +48,16 @@ describe("isWebRenderableChange", () => {
 
   test("devops-concept pages are carved out", () => {
     expect(isWebRenderableChange("docs/concepts/2026-06-05-plan.html")).toBe(false);
-    expect(isWebRenderableChange("./docs/concepts/x.html")).toBe(false);
-    // A normal docs html still counts
     expect(isWebRenderableChange("docs/guide.html")).toBe(true);
   });
 
   test("test / spec files do not count", () => {
     expect(isWebRenderableChange("src/App.test.tsx")).toBe(false);
     expect(isWebRenderableChange("src/util.spec.ts")).toBe(false);
-    expect(isWebRenderableChange("components/Card.test.jsx")).toBe(false);
   });
 
   test("non-web files never count", () => {
-    for (const p of [
-      "README.md",
-      "package.json",
-      "CLAUDE.md",
-      "data.csv",
-      "config.yaml",
-      "Dockerfile",
-    ]) {
+    for (const p of ["README.md", "package.json", "data.csv", "config.yaml"]) {
       expect(isWebRenderableChange(p)).toBe(false);
     }
   });
@@ -77,34 +70,113 @@ describe("isWebRenderableChange", () => {
 });
 
 // ---------------------------------------------------------------------------
+// isCodeChange
+// ---------------------------------------------------------------------------
+
+describe("isCodeChange", () => {
+  test("source files of many languages count", () => {
+    for (const p of [
+      "mcp-server/index.js",
+      "hooks/lib/foo.ts",
+      "src/app.py",
+      "cmd/main.go",
+      "lib/thing.rs",
+      "Service.java",
+      "styles/main.css",
+      "src/App.vue",
+    ]) {
+      expect(isCodeChange(p)).toBe(true);
+    }
+  });
+
+  test("docs / config / markdown never count (Option-A exclusion)", () => {
+    for (const p of [
+      "README.md",
+      "deep-knowledge/test-autonomy.md",
+      "package.json",
+      "tsconfig.json",
+      "config.yaml",
+      "settings.toml",
+      ".gitignore",
+      "pnpm-lock.yaml",
+      "logo.png",
+    ]) {
+      expect(isCodeChange(p)).toBe(false);
+    }
+  });
+
+  test("test / spec files and concept pages are excluded", () => {
+    expect(isCodeChange("src/util.spec.ts")).toBe(false);
+    expect(isCodeChange("hooks/lib/guard.test.js")).toBe(false);
+    expect(isCodeChange("docs/concepts/plan.html")).toBe(false);
+  });
+
+  test("empty / missing input → false", () => {
+    expect(isCodeChange("")).toBe(false);
+    expect(isCodeChange(null)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// classifyProfile
+// ---------------------------------------------------------------------------
+
+describe("classifyProfile", () => {
+  test("DOM profiles", () => {
+    for (const n of ["web-vite", "web-angular", "electron-ow", "tauri-app", "my-pwa"]) {
+      expect(classifyProfile(n)).toBe("dom");
+    }
+  });
+
+  test("runner profiles", () => {
+    for (const n of ["cli-node", "lib", "generic", "python-api", "go-service"]) {
+      expect(classifyProfile(n)).toBe("runner");
+    }
+  });
+
+  test("unknown / empty → any", () => {
+    expect(classifyProfile("")).toBe("any");
+    expect(classifyProfile(null)).toBe("any");
+    expect(classifyProfile("some-exotic-profile")).toBe("any");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// needsLightVerification
+// ---------------------------------------------------------------------------
+
+describe("needsLightVerification", () => {
+  test("dom profile → only web-renderable files are pending", () => {
+    expect(needsLightVerification("dom", "src/App.vue")).toBe(true);
+    expect(needsLightVerification("dom", "mcp-server/index.js")).toBe(false); // backend js, not renderable
+  });
+
+  test("runner profile → any source file is pending", () => {
+    expect(needsLightVerification("runner", "mcp-server/index.js")).toBe(true);
+    expect(needsLightVerification("runner", "src/app.py")).toBe(true);
+    expect(needsLightVerification("runner", "README.md")).toBe(false);
+  });
+
+  test("any profile → any source file is pending", () => {
+    expect(needsLightVerification("any", "scripts/build.js")).toBe(true);
+    expect(needsLightVerification("any", "config.json")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // isBrowserTool
 // ---------------------------------------------------------------------------
 
 describe("isBrowserTool", () => {
-  test("Chrome-MCP (Claude extension in Edge) tools count", () => {
+  test("Chrome-MCP / Preview / Playwright tools count", () => {
     expect(isBrowserTool("mcp__Claude_in_Chrome__navigate")).toBe(true);
-    expect(isBrowserTool("mcp__Claude_in_Chrome__read_page")).toBe(true);
-    expect(isBrowserTool("mcp__Claude_in_Chrome__read_console_messages")).toBe(true);
-    expect(isBrowserTool("mcp__Claude_in_Chrome__javascript_tool")).toBe(true);
-  });
-
-  test("Preview MCP tools count", () => {
     expect(isBrowserTool("mcp__Claude_Preview__preview_snapshot")).toBe(true);
-    expect(isBrowserTool("mcp__Claude_Preview__preview_screenshot")).toBe(true);
-  });
-
-  test("Playwright MCP browser tools count", () => {
-    expect(isBrowserTool("mcp__plugin_playwright_playwright__browser_navigate")).toBe(true);
     expect(isBrowserTool("mcp__plugin_playwright_playwright__browser_snapshot")).toBe(true);
-  });
-
-  test("short-name fallbacks count", () => {
     expect(isBrowserTool("preview_snapshot")).toBe(true);
-    expect(isBrowserTool("browser_take_screenshot")).toBe(true);
   });
 
   test("non-browser tools do not count", () => {
-    for (const t of ["Edit", "Write", "Bash", "Read", "Grep", "Agent", "WebFetch", ""]) {
+    for (const t of ["Edit", "Write", "Bash", "Read", "Agent", ""]) {
       expect(isBrowserTool(t)).toBe(false);
     }
   });
@@ -116,125 +188,160 @@ describe("isBrowserTool", () => {
 });
 
 // ---------------------------------------------------------------------------
-// isVerificationDelegation
+// isTestRunnerTool
 // ---------------------------------------------------------------------------
 
-describe("isVerificationDelegation", () => {
-  test("Agent spawn of a verification subagent counts", () => {
-    expect(isVerificationDelegation("Agent", "qa")).toBe(true);
-    expect(isVerificationDelegation("Agent", "frontend")).toBe(true);
-    expect(isVerificationDelegation("Agent", "gamer")).toBe(true);
-    expect(isVerificationDelegation("Agent", "QA")).toBe(true); // case-insensitive
+describe("isTestRunnerTool", () => {
+  test("common runners in a Bash command count", () => {
+    for (const c of [
+      "npm test",
+      "npm run test",
+      "npm run test:unit",
+      "pnpm test",
+      "yarn test",
+      "npx vitest run",
+      "vitest",
+      "jest --ci",
+      "python -m pytest",
+      "pytest -q",
+      "go test ./...",
+      "cargo test",
+      "dotnet test",
+      "./gradlew test",
+      "npx playwright test",
+    ]) {
+      expect(isTestRunnerTool("Bash", c)).toBe(true);
+    }
   });
 
-  test("Agent spawn of a non-verifying subagent does NOT count", () => {
-    expect(isVerificationDelegation("Agent", "research")).toBe(false);
-    expect(isVerificationDelegation("Agent", "redteam")).toBe(false);
-    expect(isVerificationDelegation("Agent", "core")).toBe(false);
+  test("non-test Bash commands do not count", () => {
+    for (const c of ["npm install", "npm run build", "git status", "node app.js", "ls"]) {
+      expect(isTestRunnerTool("Bash", c)).toBe(false);
+    }
   });
 
-  test("non-Agent tools never count, even with a verify name", () => {
-    expect(isVerificationDelegation("Edit", "qa")).toBe(false);
-    expect(isVerificationDelegation("Bash", "frontend")).toBe(false);
+  test("PowerShell counts too (Windows shell)", () => {
+    expect(isTestRunnerTool("PowerShell", "npm test")).toBe(true);
+    expect(isTestRunnerTool("PowerShell", "npm run build")).toBe(false);
   });
 
-  test("missing subagent type → false", () => {
-    expect(isVerificationDelegation("Agent", undefined)).toBe(false);
-    expect(isVerificationDelegation("Agent", "")).toBe(false);
+  test("only shell tools count; missing command → false", () => {
+    expect(isTestRunnerTool("Edit", "npm test")).toBe(false);
+    expect(isTestRunnerTool("Read", "pytest")).toBe(false);
+    expect(isTestRunnerTool("Bash", "")).toBe(false);
+    expect(isTestRunnerTool("Bash", null)).toBe(false);
   });
 });
 
 // ---------------------------------------------------------------------------
-// decideBrowserTest — decision matrix
+// isLightVerification
 // ---------------------------------------------------------------------------
 
-describe("decideBrowserTest", () => {
-  test("web change + not verified → BLOCK, keep flags", () => {
-    const d = decideBrowserTest({
-      webChangePending: true,
-      browserVerified: false,
-      stopHookActive: false,
-    });
-    expect(d.action).toBe("block");
-    expect(d.resetFlags).toBe(false);
-    expect(d.reason).toMatch(/Web Tech/);
-    expect(d.reason).toMatch(/Claude-in-Chrome extension in Edge/);
+describe("isLightVerification", () => {
+  test("dom → only a browser tool satisfies", () => {
+    expect(isLightVerification("dom", "mcp__Claude_in_Chrome__read_page")).toBe(true);
+    expect(isLightVerification("dom", "Bash", "npm test")).toBe(false);
   });
 
-  test("web change + verified → pass, reset", () => {
-    const d = decideBrowserTest({
-      webChangePending: true,
-      browserVerified: true,
-      stopHookActive: false,
-    });
+  test("runner → only a test run satisfies", () => {
+    expect(isLightVerification("runner", "Bash", "npm test")).toBe(true);
+    expect(isLightVerification("runner", "mcp__Claude_in_Chrome__read_page")).toBe(false);
+  });
+
+  test("any → browser OR test run satisfies", () => {
+    expect(isLightVerification("any", "mcp__Claude_Preview__preview_snapshot")).toBe(true);
+    expect(isLightVerification("any", "Bash", "pytest")).toBe(true);
+    expect(isLightVerification("any", "Bash", "npm run build")).toBe(false);
+  });
+
+  test("a subagent delegation never satisfies (closed loophole)", () => {
+    // Agent spawns are no longer special-cased — only observable tool calls count.
+    expect(isLightVerification("dom", "Agent")).toBe(false);
+    expect(isLightVerification("any", "Agent")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// decideLightTest — decision matrix
+// ---------------------------------------------------------------------------
+
+describe("decideLightTest", () => {
+  test("pending + not verified → BLOCK, keep flags", () => {
+    const d = decideLightTest({ pending: true, verified: false, stopHookActive: false, kind: "dom" });
+    expect(d.action).toBe("block");
+    expect(d.resetFlags).toBe(false);
+    expect(d.reason).toMatch(/browser verification/);
+  });
+
+  test("runner-kind block reason names the test suite", () => {
+    const d = decideLightTest({ pending: true, verified: false, stopHookActive: false, kind: "runner" });
+    expect(d.action).toBe("block");
+    expect(d.reason).toMatch(/test suite/);
+    expect(d.reason).toMatch(/npm test/);
+  });
+
+  test("pending + verified → pass, reset", () => {
+    const d = decideLightTest({ pending: true, verified: true, stopHookActive: false, kind: "dom" });
     expect(d.action).toBe("pass");
     expect(d.resetFlags).toBe(true);
   });
 
-  test("no web change → pass, reset", () => {
-    const d = decideBrowserTest({
-      webChangePending: false,
-      browserVerified: false,
-      stopHookActive: false,
-    });
+  test("no pending → pass, reset", () => {
+    const d = decideLightTest({ pending: false, verified: false, stopHookActive: false });
     expect(d.action).toBe("pass");
     expect(d.resetFlags).toBe(true);
   });
 
   test("stop_hook_active short-circuits — one-time bypass, reset", () => {
-    const d = decideBrowserTest({
-      webChangePending: true,
-      browserVerified: false,
-      stopHookActive: true,
-    });
+    const d = decideLightTest({ pending: true, verified: false, stopHookActive: true, kind: "dom" });
     expect(d.action).toBe("pass");
     expect(d.resetFlags).toBe(true);
   });
 
   test("silent turn → pass + reset regardless of pending state", () => {
-    const d = decideBrowserTest({
-      webChangePending: true,
-      browserVerified: false,
-      stopHookActive: false,
-      silent: true,
-    });
+    const d = decideLightTest({ pending: true, verified: false, stopHookActive: false, silent: true });
     expect(d.action).toBe("pass");
     expect(d.resetFlags).toBe(true);
   });
 
   test("silent short-circuits before stop_hook_active check", () => {
-    const d = decideBrowserTest({
-      webChangePending: true,
-      browserVerified: false,
-      stopHookActive: true,
-      silent: true,
-    });
+    const d = decideLightTest({ pending: true, verified: false, stopHookActive: true, silent: true });
     expect(d.action).toBe("pass");
     expect(d.resetFlags).toBe(true);
   });
 });
 
 // ---------------------------------------------------------------------------
-// buildBrowserTestReason — output contract
+// buildLightTestReason — output contract
 // ---------------------------------------------------------------------------
 
-describe("buildBrowserTestReason", () => {
-  test("names the Edge extension as primary and the fallback order", () => {
-    const r = buildBrowserTestReason();
+describe("buildLightTestReason", () => {
+  test("dom: names the Edge extension as primary and the fallback order", () => {
+    const r = buildLightTestReason("dom");
     expect(r).toMatch(/Claude-in-Chrome extension in Edge \(PRIMARY\)/);
     expect(r).toMatch(/Playwright → Preview/);
-    expect(r).toMatch(/Never plain\s+Chrome/);
-  });
-
-  test("requires console + network reads", () => {
-    const r = buildBrowserTestReason();
+    expect(r).toMatch(/Never plain Chrome/);
     expect(r).toMatch(/read_console_messages/);
     expect(r).toMatch(/read_network_requests/);
   });
 
-  test("documents the concept carve-out and the one-block escape", () => {
-    const r = buildBrowserTestReason();
-    expect(r).toMatch(/docs\/concepts/);
-    expect(r).toMatch(/yields after one block/);
+  test("runner: tells you to run the suite", () => {
+    const r = buildLightTestReason("runner");
+    expect(r).toMatch(/test suite/);
+    expect(r).toMatch(/pytest/);
+  });
+
+  test("any: routes through /devops-test-plan", () => {
+    const r = buildLightTestReason("any");
+    expect(r).toMatch(/devops-test-plan/);
+  });
+
+  test("every kind documents the delegation rule, concept carve-out and one-block escape", () => {
+    for (const kind of ["dom", "runner", "any"]) {
+      const r = buildLightTestReason(kind);
+      expect(r).toMatch(/delegation does NOT satisfy/);
+      expect(r).toMatch(/docs\/concepts/);
+      expect(r).toMatch(/yields/);
+    }
   });
 });

--- a/plugins/devops/hooks/post-tool-use/post.flow.completion.js
+++ b/plugins/devops/hooks/post-tool-use/post.flow.completion.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * @hook post.flow.completion
- * @version 0.16.0
+ * @version 0.17.0
  * @event PostToolUse
  * @plugin devops
  * @description After EVERY tool call: inject the completion-card reminder so
@@ -10,20 +10,40 @@
  *   Edit/Write calls additionally increment the session edit counter.
  *   At 5+ edits, injects desktop-testing prompt for UI projects.
  *   Writes a per-turn "work-happened" flag consumed by stop.flow.guard, plus
- *   the browser-test gate flags (web-change-pending / browser-verified)
- *   consumed by stop.flow.browsertest.
+ *   the Light-verification gate flags (light-pending / light-kind /
+ *   light-verified) consumed by stop.flow.browsertest. Pending/verified are
+ *   scoped to the active $TEST_PROFILE class (DOM → browser; runner → test
+ *   suite). Subagent delegation no longer satisfies the gate.
  */
 
 require('../lib/plugin-guard');
 
 const fs = require('fs');
+const os = require('os');
+const path = require('path');
 const { sessionFile, readSessionFile, writeSessionFile } = require('../lib/session-id');
 const { getLocale, t } = require('../lib/locale');
 const {
-  isWebRenderableChange,
-  isBrowserTool,
-  isVerificationDelegation,
+  classifyProfile,
+  needsLightVerification,
+  isLightVerification,
 } = require('../lib/browsertest-guard');
+
+/**
+ * Read the pinned $TEST_PROFILE for this session and classify it. The profile
+ * cache is written by /devops-test-plan. Missing / unreadable → 'any'.
+ * @param {string} sessionId
+ * @returns {'dom'|'runner'|'any'}
+ */
+function readProfileClass(sessionId) {
+  try {
+    const p = path.join(os.homedir(), '.claude', 'cache', 'devops', `test-profile-${sessionId}.json`);
+    const json = JSON.parse(fs.readFileSync(p, 'utf8'));
+    return classifyProfile(json.profile);
+  } catch {
+    return classifyProfile('');
+  }
+}
 
 // Bilingual strings for the desktop-test AskUserQuestion prompt.
 // Keys correspond to fields the user sees in Claude Code's question UI.
@@ -105,26 +125,35 @@ process.stdin.on('end', () => {
     writeSessionFile(activityFile, Date.now().toString());
   } catch {}
 
-  // --- 1e. Browser-test gate flags (consumed by stop.flow.browsertest) ---
-  //   web-change-pending → a browser-renderable file changed and still needs
-  //     verification (devops-concept pages under docs/concepts/*.html are
-  //     excluded by isWebRenderableChange).
-  //   browser-verified → a browser tool ran, or a verification subagent was
-  //     delegated, somewhere this session.
+  // --- 1e. Light-verification gate flags (consumed by stop.flow.browsertest) ---
+  //   light-pending → a code file changed and still needs a Light check, scoped
+  //     to the active $TEST_PROFILE (DOM profiles → web-renderable files only;
+  //     runner/unknown profiles → any source file). Docs/markdown/config edits,
+  //     *.test/*.spec files, and devops-concept pages never set this.
+  //   light-kind   → which Light check is required ('dom' | 'runner' | 'any'),
+  //     so the Stop hook can render the right instruction.
+  //   light-verified → an OBSERVABLE matching verification ran (browser tool for
+  //     DOM, test runner for runner). A subagent delegation does NOT count —
+  //     the main thread cannot see inside it (closed loophole, intentional).
   try {
+    const profileClass = readProfileClass(hook.session_id);
     if (isCodeEdit) {
       const editedPath = hook.tool_input && hook.tool_input.file_path;
-      if (isWebRenderableChange(editedPath)) {
+      if (needsLightVerification(profileClass, editedPath)) {
         writeSessionFile(
-          sessionFile('dotclaude-devops-web-change-pending', hook.session_id),
+          sessionFile('dotclaude-devops-light-pending', hook.session_id),
           String(editedPath),
+        );
+        writeSessionFile(
+          sessionFile('dotclaude-devops-light-kind', hook.session_id),
+          profileClass,
         );
       }
     }
-    const subagentType = hook.tool_input && hook.tool_input.subagent_type;
-    if (isBrowserTool(toolName) || isVerificationDelegation(toolName, subagentType)) {
+    const command = hook.tool_input && hook.tool_input.command;
+    if (isLightVerification(profileClass, toolName, command)) {
       writeSessionFile(
-        sessionFile('dotclaude-devops-browser-verified', hook.session_id),
+        sessionFile('dotclaude-devops-light-verified', hook.session_id),
         toolName,
       );
     }

--- a/plugins/devops/hooks/stop/stop.flow.browsertest.js
+++ b/plugins/devops/hooks/stop/stop.flow.browsertest.js
@@ -1,26 +1,30 @@
 #!/usr/bin/env node
 /**
  * @hook stop.flow.browsertest
- * @version 0.1.0
+ * @version 0.2.0
  * @event Stop
  * @plugin devops
- * @description Browser-test enforcement gate. Blocks the turn when a
- *   browser-renderable file changed this session but no browser tool ran
- *   (Claude-in-Chrome in Edge / Playwright / Preview) and no verification
- *   subagent was delegated. Flags are written by post.flow.completion;
- *   devops-concept pages (docs/concepts/*.html) are excluded there. Decision
- *   logic lives in lib/browsertest-guard.js (pure, unit-tested).
+ * @description Light-verification enforcement gate. Blocks the turn when a CODE
+ *   file changed this session but the matching Light check never ran:
+ *   DOM-surface profiles need a browser tool (Claude-in-Chrome in Edge /
+ *   Playwright / Preview); runner profiles need a test run (npm test / pytest /
+ *   …). Per test-autonomy.md the Light check is mandatory; Full (computer-use /
+ *   packaged app) stays opt-in and is NOT enforced here. A subagent delegation
+ *   does NOT satisfy the gate — verification must be observable in the main
+ *   thread. Flags are written by post.flow.completion; docs/markdown/config and
+ *   devops-concept pages are excluded there. Decision logic lives in
+ *   lib/browsertest-guard.js (pure, unit-tested).
  *
- *   Runs BEFORE stop.flow.guard so the "verify in the browser" instruction is
- *   delivered before the completion-card gate. Yields after one block
- *   (stop_hook_active) so it can never loop.
+ *   Runs BEFORE stop.flow.guard so the "verify first" instruction is delivered
+ *   before the completion-card gate. Yields after one block (stop_hook_active)
+ *   so it can never loop.
  */
 
 require('../lib/plugin-guard');
 
 const fs = require('fs');
 const { readSessionFile } = require('../lib/session-id');
-const { decideBrowserTest } = require('../lib/browsertest-guard');
+const { decideLightTest } = require('../lib/browsertest-guard');
 
 let inputData = '';
 process.stdin.setEncoding('utf8');
@@ -32,15 +36,17 @@ process.stdin.on('end', () => {
 
   const sessionId = hook.session_id;
 
-  const pendingResult = readSessionFile('dotclaude-devops-web-change-pending', sessionId);
-  const verifiedResult = readSessionFile('dotclaude-devops-browser-verified', sessionId);
+  const pendingResult = readSessionFile('dotclaude-devops-light-pending', sessionId);
+  const verifiedResult = readSessionFile('dotclaude-devops-light-verified', sessionId);
+  const kindResult = readSessionFile('dotclaude-devops-light-kind', sessionId);
   const silentResult = readSessionFile('dotclaude-devops-silent-turn', sessionId);
 
-  const decision = decideBrowserTest({
-    webChangePending: pendingResult !== null,
-    browserVerified: verifiedResult !== null,
+  const decision = decideLightTest({
+    pending: pendingResult !== null,
+    verified: verifiedResult !== null,
     stopHookActive: hook.stop_hook_active === true,
     silent: silentResult !== null,
+    kind: (kindResult && kindResult.content) || 'any',
   });
 
   if (decision.resetFlags) {
@@ -49,6 +55,7 @@ process.stdin.on('end', () => {
     // background tick as a real turn.
     if (pendingResult) try { fs.unlinkSync(pendingResult.filePath); } catch {}
     if (verifiedResult) try { fs.unlinkSync(verifiedResult.filePath); } catch {}
+    if (kindResult) try { fs.unlinkSync(kindResult.filePath); } catch {}
   }
 
   if (decision.action === 'block') {

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.95.0",
+  "version": "0.96.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary
Two-axis test-tool model (surface × depth) encoded in deep-knowledge, and the Stop-time test gate generalized from web-only to `$TEST_PROFILE`-aware Light enforcement.

## Changes
- `test-autonomy.md`: surface axis (DOM→text→a11y→pixels) × depth axis (Light always / Full opt-in); categories A/B/C; computer-use redefined as the no-DOM floor; standing `full_app_test` opt-in.
- `browser-tool-strategy.md`: computer-use section aligned to the no-DOM floor.
- `stop.flow.browsertest` + `browsertest-guard`: profile-aware gate (DOM→browser, runner→test suite); closed the subagent-delegation loophole (only observable tool calls count); recognise PowerShell test runs, not just Bash; pure doc/config/markdown edits excluded.

## Tests
- 305 vitest tests pass (gate logic: 39, was 26); eslint clean.

## Notes
- Codex review gate timed out (rc=124, 300s) — proceeded per ship protocol.