### PR TITLE
fix(ship): fast-forward local base after worktree ship

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.96.0"
+    "version": "0.96.1"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.96.0",
+      "version": "0.96.1",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.96.0",
+      "version": "0.96.1",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.96.1] — 2026-06-06
+
+### Fixed
+
+- **Ship from a worktree no longer leaves the local base branch stale (#206).** After a remote-side PR merge `origin/<base>` advances, but the local `<base>` ref does not move on its own — and `ship_release`'s worktree path only ran `git fetch origin <base>` (which updates `origin/<base>`, never the local ref). Across successive ships the local `main` drifted further behind origin, so testing from the main checkout showed weeks-old code and gave the false impression that merged work had not landed. `ship_release` now calls a new worktree-safe `syncLocalBranch(base)` helper that fast-forwards the local ref **wherever it is checked out** (`git -C <worktree> merge --ff-only origin/<base>`) or, when no worktree owns it, updates the bare ref directly (`git fetch origin <base>:<base>`). It only ever fast-forwards — a diverged local branch or a dirty working tree is reported as a warning, never force-moved or clobbered. `devops-ship/deep-knowledge/cleanup.md` now recommends the ff-only refspec over the force-moving `git update-ref`. 10 new `git.test.js` cases cover every sync path.
+
+### Changed
+
+- **Multi-wave orchestration now hardens handoff *durability*, not just handoff content (#202).** A between-wave working-tree reset (e.g. a background-agent-triggered worktree re-sync running `git reset --hard`) could silently drop a prior wave's committed-but-unpushed work, so the next wave ran on a tree missing those files. `deep-knowledge/agent-orchestration.md` now requires push-per-wave and a HEAD re-assertion before a wave consumes the prior handoff, and recommends inline (foreground) handoffs where between-wave resets are likely.
+
 ## [0.96.0] — 2026-06-06
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.96.0**
+**Version: 0.96.1**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.96.0",
+  "version": "0.96.1",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/deep-knowledge/agent-orchestration.md
+++ b/plugins/devops/deep-knowledge/agent-orchestration.md
@@ -224,6 +224,33 @@ reuse (this is how memory pollution turns one agent's hallucination into the
 team's shared assumption). This is the cheapest place to stop an error — the cost
 rises with every wave it survives.
 
+**Verify handoff *durability*, not just handoff content.** The content checks
+above assume the prior wave's commits are still in the working tree. That is not
+guaranteed: a between-wave working-tree reset can silently erase them — observed
+when a background-agent spawn triggers a worktree re-sync that does
+`git reset --hard origin/<base>`, but equally possible from a CI reset, an
+accidental `git reset`, or a junction/worktree refresh. The next wave then runs
+on a tree **missing the prior wave's files** and re-invents (or stubs with
+`as any`) work that was already committed. Two cheap guards, both mandatory
+before a wave consumes the prior wave's handoff:
+
+1. **Push, don't just commit.** A local-only commit is not durable against a
+   reset. After each wave, `git push -u origin <integration-branch>` so the work
+   survives in `origin` and is recoverable.
+2. **Re-assert HEAD.** Confirm the expected commit is still reachable:
+   ```bash
+   git log --oneline -1            # is this the wave-N commit you expect?
+   git merge-base --is-ancestor <expected-sha> HEAD || echo "✗ HEAD diverged"
+   ```
+   If HEAD diverged, restore before proceeding — `git reset --hard origin/<integration-branch>`
+   (work was pushed in guard 1), or recover dropped commits from `git reflog` +
+   `git checkout <sha> -- <paths>`. Never let a wave start on a tree that lost a
+   prior wave's output.
+
+If the environment is prone to between-wave resets, prefer **inline (foreground)
+wave handoffs** over background-agent spawns — a foreground handoff has no
+spawn-triggered refresh window.
+
 ## QA Wave — Testing Protocol
 
 The QA agent (Wave 3) MUST follow these testing rules. Include ALL applicable
@@ -317,5 +344,9 @@ The orchestrator (calling skill) is responsible for:
 
 1. Creating the integration branch if not already on a feature branch
 2. Pushing it to origin before spawning sub-agents
-3. Merging each wave's branches back before spawning the next wave
+3. Merging each wave's branches back before spawning the next wave — then
+   **pushing the integration branch again** (`git push origin <integration-branch>`)
+   so the merged-back work is durable before the next wave spawns. A reset
+   between waves can only lose what was never pushed (see Inter-Wave Verification
+   Gate § handoff durability).
 4. Shipping the integration branch ONCE at the end — sub-branches are merged back (step 3), not shipped individually. Sub-branch names are dash-joined `<parent>-<role>`, never slash-nested (a slash collides with the checked-out integration branch's ref).

--- a/plugins/devops/mcp-server/ship/lib/git.js
+++ b/plugins/devops/mcp-server/ship/lib/git.js
@@ -160,6 +160,94 @@ export function getWorktreeBranches(opts) {
 }
 
 /**
+ * Return the absolute path of the worktree that currently has `branch` checked
+ * out, or null if no worktree has it. Used to fast-forward a branch in-place
+ * (you cannot update the ref of a checked-out branch from elsewhere).
+ */
+export function worktreePathForBranch(branch, opts) {
+  const output = git("worktree list --porcelain", opts);
+  if (!output) return null;
+  let currentPath = null;
+  for (const line of output.split("\n")) {
+    if (line.startsWith("worktree ")) {
+      currentPath = line.slice("worktree ".length);
+    } else if (line === `branch refs/heads/${branch}`) {
+      return currentPath;
+    }
+  }
+  return null;
+}
+
+/**
+ * Fast-forward the LOCAL `branch` ref to its `origin/branch` counterpart,
+ * worktree-safe. After a PR merges remote-side, `origin/branch` advances but the
+ * local ref does NOT move on its own — leaving the local branch (and any
+ * checkout used for local testing) stale across ships.
+ *
+ * Strategy depends on whether the branch is checked out:
+ *   - checked out in some worktree W → `git -C W merge --ff-only origin/branch`
+ *     (git refuses `fetch origin branch:branch` into a checked-out branch).
+ *   - not checked out anywhere        → `git fetch origin branch:branch`
+ *     (direct ref update; no working tree to touch).
+ *
+ * Only ever fast-forwards — never force-moves a diverged local branch and never
+ * touches a dirty working tree's conflicting files (merge --ff-only aborts
+ * rather than overwrite). On a non-ff divergence it returns a warning instead.
+ *
+ * Returns { updated, method, path?, warning? } where method is one of
+ * "merge-ff" | "fetch-refspec" | "already-current" | "none".
+ */
+export function syncLocalBranch(branch, opts = {}) {
+  // Refresh origin/branch first (best-effort; failure surfaces below as "none").
+  git(`fetch origin ${branch}`, opts);
+
+  const remoteRef = git(`rev-parse --verify refs/remotes/origin/${branch}`, opts);
+  if (!remoteRef) {
+    return {
+      updated: false,
+      method: "none",
+      warning: `origin/${branch} not found — cannot sync local '${branch}'.`,
+    };
+  }
+
+  const localRef = git(`rev-parse --verify refs/heads/${branch}`, opts);
+  if (localRef === remoteRef) {
+    return { updated: false, method: "already-current" };
+  }
+
+  const wtPath = worktreePathForBranch(branch, opts);
+  if (wtPath) {
+    try {
+      gitStrict(`merge --ff-only origin/${branch}`, { ...opts, cwd: wtPath });
+      return { updated: true, method: "merge-ff", path: wtPath };
+    } catch (e) {
+      return {
+        updated: false,
+        method: "merge-ff",
+        path: wtPath,
+        warning:
+          `Local '${branch}' (checked out at ${wtPath}) is not fast-forwardable to ` +
+          `origin/${branch} — diverged or its working tree blocks the merge. ` +
+          `Reconcile manually: cd "${wtPath}" && git merge origin/${branch}. ` +
+          `(${(e.message || "").slice(0, 160)})`,
+      };
+    }
+  }
+
+  // Not checked out anywhere → update the ref directly (ff-only by git default).
+  try {
+    gitStrict(`fetch origin ${branch}:${branch}`, opts);
+    return { updated: true, method: "fetch-refspec" };
+  } catch (e) {
+    return {
+      updated: false,
+      method: "fetch-refspec",
+      warning: `Could not fast-forward local '${branch}' to origin/${branch}: ${(e.message || "").slice(0, 200)}`,
+    };
+  }
+}
+
+/**
  * Detect the repository's default branch (the branch `origin/HEAD` points to,
  * typically "main" or "master"). Returns null if origin/HEAD is not set.
  *

--- a/plugins/devops/mcp-server/ship/lib/git.test.js
+++ b/plugins/devops/mcp-server/ship/lib/git.test.js
@@ -16,6 +16,8 @@ import {
   isWorktree,
   getWorktreeBranches,
   branchExists,
+  worktreePathForBranch,
+  syncLocalBranch,
 } from "./git.js";
 
 beforeEach(() => {
@@ -271,5 +273,154 @@ describe("branchExists", () => {
       throw new Error("fatal");
     });
     expect(branchExists("nonexistent")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// worktreePathForBranch
+// ---------------------------------------------------------------------------
+
+describe("worktreePathForBranch", () => {
+  const wtList = [
+    "worktree /repo",
+    "HEAD abc1234",
+    "branch refs/heads/main",
+    "",
+    "worktree /repo/.claude/worktrees/topic",
+    "HEAD def5678",
+    "branch refs/heads/claude/topic",
+    "",
+  ].join("\n");
+
+  test("returns the path of the worktree holding the branch", () => {
+    execSync.mockReturnValue(wtList);
+    expect(worktreePathForBranch("claude/topic")).toBe("/repo/.claude/worktrees/topic");
+  });
+
+  test("returns the main worktree path for the base branch", () => {
+    execSync.mockReturnValue(wtList);
+    expect(worktreePathForBranch("main")).toBe("/repo");
+  });
+
+  test("returns null when no worktree has the branch", () => {
+    execSync.mockReturnValue(wtList);
+    expect(worktreePathForBranch("feat/unrelated")).toBeNull();
+  });
+
+  test("returns null on git failure", () => {
+    execSync.mockImplementation(() => {
+      throw new Error("fatal");
+    });
+    expect(worktreePathForBranch("main")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// syncLocalBranch — worktree-safe local-ref fast-forward (#206)
+// ---------------------------------------------------------------------------
+
+describe("syncLocalBranch", () => {
+  const wtListMainHere = [
+    "worktree /repo",
+    "HEAD aaaaaaa",
+    "branch refs/heads/main",
+    "",
+  ].join("\n");
+  const wtListMainElsewhere = [
+    "worktree /repo",
+    "HEAD aaaaaaa",
+    "branch refs/heads/feat/topic",
+    "",
+    "worktree /repo/main-wt",
+    "HEAD bbbbbbb",
+    "branch refs/heads/main",
+    "",
+  ].join("\n");
+  const wtListMainAbsent = [
+    "worktree /repo",
+    "HEAD aaaaaaa",
+    "branch refs/heads/feat/topic",
+    "",
+  ].join("\n");
+
+  test("no-op when local base already equals origin/base", () => {
+    execSync.mockImplementation((cmd) => {
+      if (cmd.includes("rev-parse --verify refs/remotes/origin/main")) return "aaa\n";
+      if (cmd.includes("rev-parse --verify refs/heads/main")) return "aaa\n";
+      return "";
+    });
+    expect(syncLocalBranch("main")).toEqual({ updated: false, method: "already-current" });
+  });
+
+  test("warns (no force) when origin/base is missing", () => {
+    execSync.mockImplementation((cmd) => {
+      if (cmd.includes("rev-parse --verify refs/remotes/origin/main")) throw new Error("bad rev");
+      return "";
+    });
+    const r = syncLocalBranch("main");
+    expect(r.updated).toBe(false);
+    expect(r.method).toBe("none");
+    expect(r.warning).toMatch(/origin\/main not found/);
+  });
+
+  test("fast-forwards via merge --ff-only in the worktree that owns the branch", () => {
+    const calls = [];
+    execSync.mockImplementation((cmd, optsArg) => {
+      calls.push({ cmd, cwd: optsArg?.cwd });
+      if (cmd.includes("rev-parse --verify refs/remotes/origin/main")) return "bbb\n";
+      if (cmd.includes("rev-parse --verify refs/heads/main")) return "aaa\n";
+      if (cmd.includes("worktree list --porcelain")) return wtListMainHere;
+      return "";
+    });
+    const r = syncLocalBranch("main");
+    expect(r).toEqual({ updated: true, method: "merge-ff", path: "/repo" });
+    // The merge runs in the worktree that holds main, never with --force/--hard.
+    const merge = calls.find((c) => c.cmd.includes("merge --ff-only origin/main"));
+    expect(merge).toBeTruthy();
+    expect(merge.cwd).toBe("/repo");
+    expect(calls.some((c) => /--force|--hard/.test(c.cmd))).toBe(false);
+  });
+
+  test("targets the OTHER worktree when base is checked out away from cwd", () => {
+    const calls = [];
+    execSync.mockImplementation((cmd, optsArg) => {
+      calls.push({ cmd, cwd: optsArg?.cwd });
+      if (cmd.includes("rev-parse --verify refs/remotes/origin/main")) return "bbb\n";
+      if (cmd.includes("rev-parse --verify refs/heads/main")) return "aaa\n";
+      if (cmd.includes("worktree list --porcelain")) return wtListMainElsewhere;
+      return "";
+    });
+    const r = syncLocalBranch("main", { cwd: "/repo" });
+    expect(r).toEqual({ updated: true, method: "merge-ff", path: "/repo/main-wt" });
+    const merge = calls.find((c) => c.cmd.includes("merge --ff-only origin/main"));
+    expect(merge.cwd).toBe("/repo/main-wt");
+  });
+
+  test("warns instead of forcing when the checked-out branch cannot fast-forward", () => {
+    execSync.mockImplementation((cmd) => {
+      if (cmd.includes("rev-parse --verify refs/remotes/origin/main")) return "bbb\n";
+      if (cmd.includes("rev-parse --verify refs/heads/main")) return "aaa\n";
+      if (cmd.includes("worktree list --porcelain")) return wtListMainHere;
+      if (cmd.includes("merge --ff-only origin/main")) throw new Error("Not possible to fast-forward, aborting.");
+      return "";
+    });
+    const r = syncLocalBranch("main");
+    expect(r.updated).toBe(false);
+    expect(r.method).toBe("merge-ff");
+    expect(r.warning).toMatch(/not fast-forwardable/i);
+  });
+
+  test("updates the bare ref directly when no worktree owns the branch", () => {
+    const calls = [];
+    execSync.mockImplementation((cmd) => {
+      calls.push(cmd);
+      if (cmd.includes("rev-parse --verify refs/remotes/origin/main")) return "bbb\n";
+      if (cmd.includes("rev-parse --verify refs/heads/main")) return "aaa\n";
+      if (cmd.includes("worktree list --porcelain")) return wtListMainAbsent;
+      return "";
+    });
+    const r = syncLocalBranch("main");
+    expect(r).toEqual({ updated: true, method: "fetch-refspec" });
+    expect(calls.some((c) => c.includes("fetch origin main:main"))).toBe(true);
   });
 });

--- a/plugins/devops/mcp-server/ship/tools/release.js
+++ b/plugins/devops/mcp-server/ship/tools/release.js
@@ -5,7 +5,7 @@
 
 import { z } from "zod";
 import { execFileSync } from "node:child_process";
-import { git, gitStrict, currentBranch, headShort, dirtyState, isWorktree, isRebasedOnto, fileOverlap } from "../lib/git.js";
+import { git, gitStrict, currentBranch, headShort, dirtyState, isWorktree, isRebasedOnto, fileOverlap, syncLocalBranch } from "../lib/git.js";
 import { createPR, mergePR, createRelease, findExistingPR, watchPRChecks } from "../lib/github.js";
 import { detectRepoMode } from "../lib/repo-mode.js";
 
@@ -160,13 +160,16 @@ export async function handler(params) {
     result.merged = base;
     result.mergeSha = mergeSha;
 
-    // Sync local base branch (worktree-safe: can't checkout base if another worktree owns it)
-    if (isWorktree(opts)) {
-      gitStrict(`fetch origin ${base}`, opts);
-    } else {
-      gitStrict(`checkout ${base}`, opts);
-      gitStrict(`pull origin ${base}`, opts);
-    }
+    // Sync the LOCAL base ref to the just-merged origin/base. After a remote-side
+    // merge, origin/base advanced but the local base ref does NOT move on its own.
+    // A bare `git fetch origin base` (the previous worktree-path behaviour) only
+    // moves origin/base, leaving local base — and the main checkout used for local
+    // testing — stale across ships (drifting further behind every release). This
+    // worktree-safe sync fast-forwards local base wherever it is checked out, or
+    // updates the bare ref directly when no worktree owns it. (#206)
+    const baseSync = syncLocalBranch(base, opts);
+    result.baseSync = baseSync.method;
+    if (baseSync.warning) result.baseSyncWarning = baseSync.warning;
 
     // Tag + Release (only for final merges to main, skip for intermediate)
     if (!intermediate && tag) {

--- a/plugins/devops/skills/devops-ship/deep-knowledge/cleanup.md
+++ b/plugins/devops/skills/devops-ship/deep-knowledge/cleanup.md
@@ -51,9 +51,12 @@ git fetch origin main                  # advance the remote-tracking ref
 git worktree list --porcelain          # find any tree with "branch refs/heads/main"
 ```
 
-- **No working tree holds `main`** → move the ref directly, no checkout needed:
+- **No working tree holds `main`** → move the ref directly, no checkout needed.
+  Use a fetch refspec (fast-forward-only — it refuses a non-ff update rather
+  than force-moving the ref, unlike `git update-ref`, so a diverged local `main`
+  is never silently rewound):
   ```bash
-  git update-ref refs/heads/main origin/main
+  git fetch origin main:main
   ```
 - **A working tree holds `main`** → fast-forward that one in place:
   ```bash

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.96.0",
+  "version": "0.96.1",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
Closes #206, #202

## Summary
- **#206** — `ship_release`'s worktree path only ran `git fetch origin <base>`, which advances `origin/<base>` but never the local `<base>` ref. Across ships, local `main` drifted behind origin, so testing from the main checkout showed stale code (false "my work didn't land" impression). New worktree-safe `syncLocalBranch()` fast-forwards the local ref wherever it is checked out (`merge --ff-only`) or via a direct refspec when no worktree owns it. Fast-forward only — never force-moves a diverged ref or clobbers a dirty tree.
- **#202** — `agent-orchestration.md` now requires push-per-wave + HEAD re-assertion before a wave consumes the prior handoff, so a between-wave worktree reset cannot silently drop committed work.

## Verification
- 315 tests pass (10 new `git.test.js` cases covering every sync path), eslint clean.
- #207 reviewed: no code bug — merge runs server-side via `gh pr merge` (no force-push to `main`) and the rebase-onto-base gate prevents the feared squash drop. The squash-vs-merge default remains a policy choice, left open.