### PR TITLE
feat(concept): enforce live panel + bridge submit via gate hook

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.96.1"
+    "version": "0.97.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.96.1",
+      "version": "0.97.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.96.1",
+      "version": "0.97.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.97.0] — 2026-06-07
+
+### Added
+
+- **`post.concept.gate` hook — the live decision panel + bridge submit is now deterministically enforced, not just documented.** `devops-concept` pages must collect decisions via the live bridge server (persistent decision panel → POST `/decisions` → heartbeat/cron pickup), but the only safeguard was a text-only 35-pattern validation gate that Claude could skip when "half-using" the skill — shipping a page that instead bakes in a "copy the decisions JSON and paste it into chat" clipboard fallback, or omits the decision panel entirely. A new PostToolUse hook validates every concept HTML on write (path under `docs/concepts/` or a concept content signature) and **blocks** (exit 2) when the live panel / bridge-submit markers are missing or a clipboard / paste-into-chat handoff is present — so the regression survives only until the next regenerate, never until the user has to copy JSON by hand. Decision logic lives in unit-tested `hooks/lib/concept-gate.js` (16 tests). The skill text is hardened to match: a new Phase 0 forbidden-pattern section in `validation-gate.md` and an explicit Step 3 prohibition in `SKILL.md`. New hook `post.concept.gate` 0.1.0.
+
 ## [0.96.1] — 2026-06-06
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ For the full extension guide with examples per skill, see `deep-knowledge/skill-
 
 ## Features
 
-- **<!--devops:count:hooks-->31<!--/devops:count:hooks--> Hooks** — automated guards and triggers across the full session lifecycle
+- **<!--devops:count:hooks-->32<!--/devops:count:hooks--> Hooks** — automated guards and triggers across the full session lifecycle
 - **<!--devops:count:skills-->19<!--/devops:count:skills--> Skills** — devops-ship, devops-commit, devops-flow, devops-new-issue, devops-project-setup, devops-readme, devops-refresh-usage, devops-extend-skill, devops-repo-health, devops-claude-md-lint, devops-concept, devops-agents, devops-plugin-update, devops-autonomous, devops-burn, devops-learn, devops-harden, devops-polish, devops-test-plan
 - **<!--devops:count:agents-->11<!--/devops:count:agents--> Agents** — AI, Core, Designer, Feature, Frontend, Gamer, PO, QA, Redteam, Research, Windows
 - **Completion Flow** — mandatory card after every task (8 variants), visual verification, ship recommendation
@@ -178,7 +178,7 @@ For the full extension guide with examples per skill, see `deep-knowledge/skill-
 
 ### Hooks (automatic, no user action needed)
 
-<!--devops:count:hooks-->31<!--/devops:count:hooks--> hooks fire automatically across the session lifecycle — no user action needed.
+<!--devops:count:hooks-->32<!--/devops:count:hooks--> hooks fire automatically across the session lifecycle — no user action needed.
 
 <details>
 <summary><strong>By session lifecycle</strong> — when does it fire?</summary>
@@ -227,6 +227,7 @@ SessionStart  ──>  UserPromptSubmit  ──>  PreToolUse  ──>  PostToolU
 
 - `post.flow.completion` — After EVERY tool call: inject the completion-card reminder so Claude always has the i…
 - `post.flow.debug` — After 2+ consecutive Bash failures: recommend the flow skill.
+- `post.concept.gate` — Deterministic backstop for devops-concept pages.
 
 #### Stop — runs when Claude finishes responding
 
@@ -643,7 +644,7 @@ Wk  ━━──╏─────────   15% +1%   · 4d 22h left
 devops/
 ├── .claude-plugin/plugin.json     ← Plugin manifest
 ├── CONVENTIONS.md                 ← Naming, versioning, extension rules
-├── hooks/                         ← <!--devops:count:hooks-->31<!--/devops:count:hooks--> hooks (JS) registered in hooks.json
+├── hooks/                         ← <!--devops:count:hooks-->32<!--/devops:count:hooks--> hooks (JS) registered in hooks.json
 ├── skills/                        ← <!--devops:count:skills-->19<!--/devops:count:skills--> skill definitions (SKILL.md)
 ├── agents/                        ← <!--devops:count:agents-->11<!--/devops:count:agents--> agent definitions
 ├── deep-knowledge/                ← Cross-cutting reference docs

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.96.1**
+**Version: 0.97.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.96.1",
+  "version": "0.97.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/docs/architecture.html
+++ b/plugins/devops/docs/architecture.html
@@ -169,7 +169,7 @@
 <section id="overview">
 <h1>Architecture Documentation <small>devops v0.87.0</small></h1>
 <p class="lead">
-  A comprehensive DevOps automation plugin for Claude Code &mdash; <!--devops:count:hooks-->31<!--/devops:count:hooks--> hooks, <!--devops:count:skills-->19<!--/devops:count:skills--> skills, <!--devops:count:agents-->11<!--/devops:count:agents--> agents,
+  A comprehensive DevOps automation plugin for Claude Code &mdash; <!--devops:count:hooks-->32<!--/devops:count:hooks--> hooks, <!--devops:count:skills-->19<!--/devops:count:skills--> skills, <!--devops:count:agents-->11<!--/devops:count:agents--> agents,
   2 MCP servers, a deterministic completion card engine, and a 3-layer extension system.
 </p>
 <div role="note" style="margin:.4rem 0 1.4rem;padding:.6rem .9rem;background:var(--bg2);border-left:3px solid var(--warn);border-radius:4px;color:var(--text2);font-size:.85rem;">
@@ -180,12 +180,12 @@
 
 <div class="card-grid">
   <div class="card">
-    <h4><!--devops:count:hooks-->31<!--/devops:count:hooks--> Hooks</h4>
+    <h4><!--devops:count:hooks-->32<!--/devops:count:hooks--> Hooks</h4>
     <p style="color:var(--text2);font-size:.85rem">Lifecycle guards across SessionStart, UserPromptSubmit, PreToolUse, PostToolUse, Stop</p>
     <span class="badge b-hook">SessionStart &times;<!--devops:count:hooks:ss-->13<!--/devops:count:hooks:ss--></span>
     <span class="badge b-hook">Prompt &times;<!--devops:count:hooks:prompt-->7<!--/devops:count:hooks:prompt--></span>
     <span class="badge b-hook">Pre &times;<!--devops:count:hooks:pre-->6<!--/devops:count:hooks:pre--></span>
-    <span class="badge b-hook">Post &times;<!--devops:count:hooks:post-->2<!--/devops:count:hooks:post--></span>
+    <span class="badge b-hook">Post &times;<!--devops:count:hooks:post-->3<!--/devops:count:hooks:post--></span>
     <span class="badge b-hook">Stop &times;<!--devops:count:hooks:stop-->3<!--/devops:count:hooks:stop--></span>
   </div>
   <div class="card">
@@ -220,7 +220,7 @@
 │   ├── session-start/         <span style="color:var(--purple)"># <!--devops:count:hooks:ss-->13<!--/devops:count:hooks:ss--> hooks (ss.*)</span>
 │   ├── user-prompt-submit/    <span style="color:var(--purple)"># <!--devops:count:hooks:prompt-->7<!--/devops:count:hooks:prompt--> hooks (prompt.*)</span>
 │   ├── pre-tool-use/          <span style="color:var(--purple)"># <!--devops:count:hooks:pre-->6<!--/devops:count:hooks:pre--> hooks (pre.*)</span>
-│   ├── post-tool-use/         <span style="color:var(--purple)"># <!--devops:count:hooks:post-->2<!--/devops:count:hooks:post--> hooks (post.*)</span>
+│   ├── post-tool-use/         <span style="color:var(--purple)"># <!--devops:count:hooks:post-->3<!--/devops:count:hooks:post--> hooks (post.*)</span>
 │   └── stop/                  <span style="color:var(--purple)"># <!--devops:count:hooks:stop-->3<!--/devops:count:hooks:stop--> hooks (stop.*)</span>
 ├── mcp-server/
 │   ├── index.js               <span style="color:var(--orange)"># dotclaude-completion MCP</span>

--- a/plugins/devops/hooks/hooks.json
+++ b/plugins/devops/hooks/hooks.json
@@ -60,6 +60,12 @@
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/post-tool-use/post.flow.debug.js" }
         ],
         "matcher": "Bash"
+      },
+      {
+        "hooks": [
+          { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/post-tool-use/post.concept.gate.js" }
+        ],
+        "matcher": "Write|Edit|NotebookEdit"
       }
     ],
     "Stop": [

--- a/plugins/devops/hooks/lib/concept-gate.js
+++ b/plugins/devops/hooks/lib/concept-gate.js
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+/**
+ * @module concept-gate
+ * @description Deterministic validator for devops-concept HTML pages.
+ *
+ *   Backstop for two recurring regressions where Claude only "half-uses" the
+ *   concept skill:
+ *     A) the page bakes in a "copy the JSON, paste it into chat" submit
+ *        instead of the live bridge — a clipboard fallback that defeats the
+ *        whole monitoring loop.
+ *     B) the page ships with no live decision panel at all.
+ *
+ *   This is a focused gate, NOT a re-implementation of the full 35-pattern
+ *   validation-gate.md. It checks only the markers whose absence equals
+ *   failure mode A or B, plus the forbidden clipboard/paste-to-chat anti-
+ *   pattern. The full pattern sweep stays Claude's Step-2 responsibility.
+ */
+
+const path = require('path');
+
+// Live decision-panel + bridge-submit markers that MUST be present.
+// Each label doubles as the grep token and the human-readable reason line.
+const REQUIRED = [
+  { token: 'concept-decisions', why: 'decision data container' },
+  { token: 'panel-ready', why: 'live decision panel (ready state)' },
+  { token: 'iteration-tabs', why: 'decision-panel iteration tab bar' },
+  { token: 'submit-iterate-btn', why: 'live "Zur nächsten Iteration" submit button' },
+  { token: 'submit-implement-btn', why: 'live "Mit Feedback implementieren" submit button' },
+  { token: 'pollHeartbeat', why: 'bridge-server heartbeat poll' },
+  { token: 'connection-warning', why: 'Claude-disconnected warning' },
+];
+
+// Clipboard / paste-into-chat submit anti-patterns. A valid live-bridge
+// concept page never copies anything to the clipboard, so any match here is
+// the exact regression the user reported.
+const FORBIDDEN = [
+  { re: /clipboard/i, why: 'clipboard copy (navigator.clipboard / "copy to clipboard")' },
+  { re: /zwischenablage/i, why: '"Zwischenablage kopieren" copy UI' },
+  { re: /in den chat (ein|einf)/i, why: '"in den Chat einfügen" paste instruction' },
+  { re: /paste[^.\n]{0,24}chat/i, why: '"paste … into chat" instruction' },
+];
+
+/**
+ * Is this written file a concept page we should gate?
+ * Triggers on the canonical output location (the `docs/concepts/*.html` path
+ * where SKILL.md Step 2 writes every concept) OR on a concept content
+ * signature, so a misplaced page is still caught. The narrow `docs/concepts/`
+ * match avoids false-positives on an unrelated `concepts/` folder a consumer
+ * project might happen to have.
+ */
+function isConceptHtml(filePath, html) {
+  if (!filePath || !/\.html?$/i.test(filePath)) return false;
+  const norm = String(filePath).replace(/\\/g, '/').toLowerCase();
+  if (norm.includes('docs/concepts/')) return true;
+  const body = html || '';
+  return (
+    body.includes('concept-decisions') ||
+    /data-template=["'](decision|prototype|free)["']/.test(body) ||
+    body.includes('submit-iterate-btn')
+  );
+}
+
+/** Required markers absent from the html. */
+function findMissing(html) {
+  const body = html || '';
+  return REQUIRED.filter(r => !body.includes(r.token));
+}
+
+/** Forbidden anti-patterns present in the html. */
+function findForbidden(html) {
+  const body = html || '';
+  return FORBIDDEN.filter(f => f.re.test(body));
+}
+
+/**
+ * Full evaluation for a written file.
+ * @returns {{applicable:boolean, ok:boolean, missing:Array, forbidden:Array}}
+ */
+function evaluate(filePath, html) {
+  if (!isConceptHtml(filePath, html)) {
+    return { applicable: false, ok: true, missing: [], forbidden: [] };
+  }
+  const missing = findMissing(html);
+  const forbidden = findForbidden(html);
+  return { applicable: true, ok: missing.length === 0 && forbidden.length === 0, missing, forbidden };
+}
+
+/** Build the blocking feedback shown to Claude (stderr, exit 2). */
+function buildBlockReason(filePath, missing, forbidden) {
+  const lines = [];
+  lines.push(`BLOCKED: "${path.basename(filePath || 'concept.html')}" is not a valid live-bridge concept page.`);
+  lines.push('');
+  if (forbidden.length) {
+    lines.push('Forbidden clipboard / paste-into-chat submit detected:');
+    forbidden.forEach(f => lines.push(`  - ${f.why}`));
+    lines.push('');
+  }
+  if (missing.length) {
+    lines.push('Missing mandatory live decision-panel / bridge markers:');
+    missing.forEach(m => lines.push(`  - ${m.token} — ${m.why}`));
+    lines.push('');
+  }
+  lines.push('The concept flow requires the LIVE bridge: a persistent decision panel whose');
+  lines.push('"Zur nächsten Iteration" / "Mit Feedback implementieren" buttons POST to the');
+  lines.push('bridge server (monitored via heartbeat + cron). A "copy the JSON and paste it');
+  lines.push('into chat" block is NEVER an acceptable substitute — that is the exact');
+  lines.push('regression this gate exists to prevent. The decision panel may never be omitted.');
+  lines.push('');
+  lines.push('Fix BEFORE opening the page (SKILL.md Step 3):');
+  lines.push('  1. Regenerate the HTML with the full decision panel + bridge submit handlers');
+  lines.push('     (deep-knowledge/templates.md) and run the 35-pattern check in');
+  lines.push('     deep-knowledge/validation-gate.md.');
+  lines.push('  2. Remove any clipboard / paste-into-chat fallback entirely.');
+  lines.push('  3. Re-write the file; only open it once this gate passes.');
+  return lines.join('\n');
+}
+
+module.exports = {
+  REQUIRED,
+  FORBIDDEN,
+  isConceptHtml,
+  findMissing,
+  findForbidden,
+  evaluate,
+  buildBlockReason,
+};

--- a/plugins/devops/hooks/lib/concept-gate.test.js
+++ b/plugins/devops/hooks/lib/concept-gate.test.js
@@ -1,0 +1,134 @@
+import { describe, test, expect } from "vitest";
+import {
+  REQUIRED,
+  isConceptHtml,
+  findMissing,
+  findForbidden,
+  evaluate,
+  buildBlockReason,
+} from "./concept-gate.js";
+
+// A minimal but valid live-bridge concept page: contains every required
+// marker, no clipboard fallback. Real pages are far larger; the gate only
+// cares about these tokens.
+const VALID = `<!doctype html><html data-template="decision" data-page-version="2026-06-07T10:00:00">
+<body>
+<script type="application/json" id="concept-decisions">{"submitted":false}</script>
+<div id="panel-ready"><div class="iteration-tabs"></div>
+  <button id="submit-iterate-btn">Zur nächsten Iteration</button>
+  <button id="submit-implement-btn">Mit Feedback implementieren</button>
+  <div class="connection-warning"></div></div>
+<section data-iteration="1" data-active class="concept-submitted-host"></section>
+<script>function pollHeartbeat(){} async function f(){const r=await fetch('/heartbeat');const d=await r.json();d.claude_ts;}</script>
+</body></html>`;
+
+// The reported regression: a "copy the JSON, paste into chat" page with no
+// live submit buttons / heartbeat.
+const CLIPBOARD_FALLBACK = `<!doctype html><html lang="de"><body>
+<div class="decision-panel"><button>✓ Entscheidungen übernehmen</button></div>
+<p>Kopier das und füg es mir in den Chat ein (oder sag einfach „passt"):</p>
+<pre id="md">## Concept-Entscheidungen</pre>
+<button onclick="navigator.clipboard.writeText(document.getElementById('md').textContent)">📋 In Zwischenablage kopieren</button>
+</body></html>`;
+
+describe("isConceptHtml", () => {
+  test("triggers on the canonical docs/concepts/ path ending in .html", () => {
+    expect(isConceptHtml("H:/docs/concepts/2026-06-07-foo.html", "")).toBe(true);
+    expect(isConceptHtml("C:\\proj\\docs\\concepts\\x.html", "")).toBe(true);
+  });
+
+  test("triggers on concept content signature even outside docs/concepts/", () => {
+    expect(isConceptHtml("/tmp/page.html", '<html data-template="decision">')).toBe(true);
+    expect(isConceptHtml("/tmp/page.html", '<script id="concept-decisions">')).toBe(true);
+  });
+
+  test("does NOT trigger on an unrelated concepts/ folder by path alone", () => {
+    // A consumer app may have e.g. src/concepts/Foo.html — gate only on the
+    // skill's canonical docs/concepts/ location (or a content signature).
+    expect(isConceptHtml("src/concepts/Foo.html", "<html><body>component</body></html>")).toBe(false);
+  });
+
+  test("ignores non-html files", () => {
+    expect(isConceptHtml("docs/concepts/notes.md", "concept-decisions")).toBe(false);
+    expect(isConceptHtml("src/app.js", "")).toBe(false);
+  });
+
+  test("ignores ordinary html with no concept signature", () => {
+    expect(isConceptHtml("public/index.html", "<html><body>hi</body></html>")).toBe(false);
+  });
+});
+
+describe("findMissing", () => {
+  test("valid page has no missing required markers", () => {
+    expect(findMissing(VALID)).toEqual([]);
+  });
+
+  test("flags every absent required marker", () => {
+    const missing = findMissing("<html></html>").map(m => m.token);
+    REQUIRED.forEach(r => expect(missing).toContain(r.token));
+  });
+
+  test("flags a page that has a panel but no live submit buttons", () => {
+    const html = VALID.replace(/submit-iterate-btn/g, "x").replace(/submit-implement-btn/g, "y");
+    const missing = findMissing(html).map(m => m.token);
+    expect(missing).toContain("submit-iterate-btn");
+    expect(missing).toContain("submit-implement-btn");
+  });
+});
+
+describe("findForbidden", () => {
+  test("valid live page has no forbidden anti-patterns", () => {
+    expect(findForbidden(VALID)).toEqual([]);
+  });
+
+  test("detects the clipboard / paste-into-chat fallback", () => {
+    const hits = findForbidden(CLIPBOARD_FALLBACK).map(f => f.why);
+    expect(hits.length).toBeGreaterThan(0);
+    expect(hits.join(" ")).toMatch(/clipboard|Zwischenablage|Chat/i);
+  });
+
+  test("catches navigator.clipboard even without German UI text", () => {
+    expect(findForbidden("<button onclick='navigator.clipboard.writeText(x)'>copy</button>").length)
+      .toBeGreaterThan(0);
+  });
+});
+
+describe("evaluate", () => {
+  test("non-concept file → applicable false, ok true", () => {
+    const r = evaluate("src/app.js", "");
+    expect(r.applicable).toBe(false);
+    expect(r.ok).toBe(true);
+  });
+
+  test("valid concept page → ok true", () => {
+    const r = evaluate("docs/concepts/2026-06-07-foo.html", VALID);
+    expect(r.applicable).toBe(true);
+    expect(r.ok).toBe(true);
+  });
+
+  test("clipboard-fallback page under concepts/ → ok false (missing + forbidden)", () => {
+    const r = evaluate("docs/concepts/2026-06-07-haushalt.html", CLIPBOARD_FALLBACK);
+    expect(r.applicable).toBe(true);
+    expect(r.ok).toBe(false);
+    expect(r.forbidden.length).toBeGreaterThan(0);
+    expect(r.missing.length).toBeGreaterThan(0);
+  });
+
+  test("panel-less page (failure mode B) → ok false", () => {
+    const r = evaluate("docs/concepts/2026-06-07-x.html", "<html data-template=\"decision\"><body>just content</body></html>");
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe("buildBlockReason", () => {
+  test("names the file, lists missing + forbidden, and forbids the clipboard fallback", () => {
+    const r = evaluate("docs/concepts/2026-06-07-haushalt.html", CLIPBOARD_FALLBACK);
+    const reason = buildBlockReason("docs/concepts/2026-06-07-haushalt.html", r.missing, r.forbidden);
+    expect(reason).toMatch(/BLOCKED/);
+    expect(reason).toMatch(/2026-06-07-haushalt\.html/);
+    expect(reason).toMatch(/submit-iterate-btn/);
+    expect(reason).toMatch(/paste/i);
+    expect(reason).toMatch(/validation-gate\.md/);
+    expect(reason).toMatch(/decision panel may never be omitted/);
+  });
+});

--- a/plugins/devops/hooks/post-tool-use/post.concept.gate.js
+++ b/plugins/devops/hooks/post-tool-use/post.concept.gate.js
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+/**
+ * @hook post.concept.gate
+ * @version 0.1.0
+ * @event PostToolUse
+ * @plugin devops
+ * @matcher Write|Edit|NotebookEdit
+ * @description Deterministic backstop for devops-concept pages. After a
+ *   concept HTML is written, verify it carries the live decision panel +
+ *   bridge-submit markers and contains NO clipboard / paste-into-chat
+ *   fallback. Blocks (exit 2) with actionable feedback when the page is
+ *   invalid, so the regression survives only until the next regenerate —
+ *   never until the user has to copy a JSON by hand.
+ *
+ *   Scope: only fires on concept HTML (the `docs/concepts/` path or a concept
+ *   content signature). Non-concept files pass through untouched. This is a
+ *   focused gate for the two catastrophic failure modes, not the full
+ *   35-pattern validation-gate.md sweep (that stays a Step-2 task).
+ */
+
+require('../lib/plugin-guard');
+
+const fs = require('fs');
+const { evaluate, buildBlockReason, isConceptHtml } = require('../lib/concept-gate');
+
+function targetPath(toolName, input) {
+  if (!input) return null;
+  if (toolName === 'Edit' || toolName === 'Write') return input.file_path || null;
+  if (toolName === 'NotebookEdit') return input.notebook_path || null;
+  return null;
+}
+
+let inputData = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', d => { inputData += d; });
+process.stdin.on('end', () => {
+  let hook;
+  try { hook = JSON.parse(inputData); } catch { process.exit(0); }
+
+  const toolName = hook.tool_name || '';
+  if (!['Edit', 'Write', 'NotebookEdit'].includes(toolName)) process.exit(0);
+
+  const file = targetPath(toolName, hook.tool_input || {});
+  if (!file || !/\.html?$/i.test(file)) process.exit(0); // fast path: only HTML
+
+  // Read the on-disk result (already written by the tool). Fall back to the
+  // Write payload; if neither is readable we cannot validate — pass through.
+  let html = null;
+  try { html = fs.readFileSync(file, 'utf8'); }
+  catch { html = (hook.tool_input && hook.tool_input.content) || null; }
+  if (html == null) process.exit(0);
+
+  if (!isConceptHtml(file, html)) process.exit(0);
+
+  const { ok, missing, forbidden } = evaluate(file, html);
+  if (ok) process.exit(0);
+
+  process.stderr.write(buildBlockReason(file, missing, forbidden) + '\n');
+  process.exit(2);
+});

--- a/plugins/devops/skills/devops-concept/SKILL.md
+++ b/plugins/devops/skills/devops-concept/SKILL.md
@@ -408,6 +408,13 @@ OS shell. **Forbidden alternatives** that will produce a broken session:
 - ❌ **Never** print "Concept opened at file:///… open it in your browser"
   and stop. The bridge server requires the page to be loaded via
   `http://localhost:{port}/…`, not `file://`.
+- ❌ **Never** bake a "copy the decisions JSON and paste it into the chat"
+  block (clipboard button, `navigator.clipboard`, "In Zwischenablage
+  kopieren", "füg es mir in den Chat ein") into the page. That manual
+  handoff is the failure this whole flow exists to avoid — the live bridge
+  already delivers decisions. The decision panel's two submit buttons +
+  bridge are the **only** sanctioned mechanism, and the panel may never be
+  omitted. The `post.concept.gate` hook blocks any page that violates this.
 
 The **only** correct invocation is the OS `start`/`open` shell command
 that hands the URL to the user's default Edge window, which then opens

--- a/plugins/devops/skills/devops-concept/deep-knowledge/validation-gate.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/validation-gate.md
@@ -2,8 +2,34 @@
 
 After writing the HTML file, validate that all mandatory interactive patterns
 are present. **Grep the generated file** for each required pattern. The check
-runs in two phases: first the shared patterns (all templates), then the
-template-specific extras selected by `<html data-template="...">`.
+runs in three phases: first the forbidden patterns (hard fail), then the
+shared patterns (all templates), then the template-specific extras selected
+by `<html data-template="...">`.
+
+> **Deterministic backstop:** the `post.concept.gate` PostToolUse hook
+> re-checks a critical subset of this gate (the live decision panel + bridge
+> submit markers + the forbidden clipboard list below) on every write to a
+> concept HTML and **blocks** if the page is invalid. The hook is the safety
+> net for the "skill only half-used" regression — but it is not a license to
+> skip this manual gate. Run the full sweep BEFORE opening the page.
+
+## Phase 0 — Forbidden patterns (hard fail)
+
+A concept page is driven **exclusively** by the live bridge: the decision
+panel's submit buttons POST to the bridge server and Claude picks the
+decisions up via heartbeat + cron. The page MUST therefore contain **none**
+of the following manual-handoff anti-patterns. Any match = reject the page
+and regenerate with the live submit, exactly like a missing required pattern.
+
+| Forbidden grep (case-insensitive) | Why it's banned |
+|---|---|
+| `clipboard` (`navigator.clipboard`, "copy to clipboard") | A "copy the decisions JSON" button is the regression this gate exists to kill — the live bridge already delivers decisions. |
+| `zwischenablage` | German variant of the same clipboard-copy fallback. |
+| `in den chat ein` / "paste … into chat" | Instructing the user to paste anything into chat means the live submit was never wired. |
+
+A valid live-bridge page never copies anything to the clipboard, so there are
+no legitimate matches — do not "keep it as a convenience". The decision panel
++ live submit is the only sanctioned mechanism, and it may never be omitted.
 
 ## Phase 1 — Shared patterns (ALL templates)
 
@@ -165,11 +191,16 @@ decision template with no changes.
 
 ## Failure handling
 
-**If ANY shared pattern is missing, or any template-specific mandatory pattern
-is missing → DO NOT open the page.** Fix the HTML first, then re-validate.
-This is a **blocking gate** — no exceptions, no "this page doesn't need it".
+**If ANY forbidden pattern (Phase 0) is present, OR any shared pattern is
+missing, OR any template-specific mandatory pattern is missing → DO NOT open
+the page.** Fix the HTML first, then re-validate. This is a **blocking gate**
+— no exceptions, no "this page doesn't need it". The `post.concept.gate` hook
+enforces the same on write.
 
 **Common failures this gate catches:**
+- Clipboard / paste-into-chat submit baked in instead of the live bridge →
+  the user is told to copy a JSON by hand, defeating the whole monitoring loop
+- Decision panel omitted entirely → no submit buttons, nothing to monitor
 - Heartbeat system omitted → submit button stays clickable without monitoring
 - Connection warning missing → user gets no feedback when Claude disconnects
 - Panel states missing → no visual transition on submit/reset cycle

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.96.1",
+  "version": "0.97.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary
`devops-concept` pages must collect decisions via the live bridge server, but the only safeguard was a text-only 35-pattern validation gate that Claude could skip when half-using the skill — shipping a page with a "copy the JSON, paste it into chat" clipboard fallback, or no decision panel at all (exactly the regression a user reported).

## Changes
- **New `post.concept.gate` PostToolUse hook** — validates every concept HTML on write (path under `docs/concepts/` or a concept content signature) and **blocks** (exit 2) when the live panel / bridge-submit markers are missing or a clipboard / paste-into-chat handoff is present.
- **`hooks/lib/concept-gate.js`** — pure, unit-tested gate logic (16 tests).
- **Skill text hardened** — a Phase 0 forbidden-pattern section in `validation-gate.md` + an explicit Step 3 prohibition in `SKILL.md`.

## Tests
- Full suite green: **331 passed** (16 new).
- Lint clean. Hook end-to-end (block/pass on 5 inputs) verified manually.

## Notes
- The mandatory Codex review gate hit the Codex usage limit (quota) mid-run — it streamed through the full diff with no finding before the cutoff; treated as non-blocking per the gate's "other non-zero → continue" rule.