### PR TITLE
feat(hooks): enforce passing tests + validation in V&V gate

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.97.0"
+    "version": "0.98.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.97.0",
+      "version": "0.98.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.97.0",
+      "version": "0.98.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.98.0] — 2026-06-07
+
+### Changed
+
+- **The post-implementation test gate now enforces *passing* tests + validation (V&V), and a skip can no longer be silent.** The Light-verification gate previously had loopholes that let the test be skipped: it blocked only once then yielded (the reason text even described the escape), a *failed* `npm test` still satisfied it, a test run *before* later edits counted, and a skip left no trace. This release closes them and adds the missing validation half. **Verification (`stop.flow.browsertest` / `browsertest-guard`):** a test run only verifies when it actually **passed** — the outcome is read best-effort from the PostToolUse `tool_response` (conservative: an unparseable-but-likely-green run is never false-blocked; a non-zero exit / interrupted / unambiguous failure summary is); a new qualifying edit **invalidates** a prior verification, so the check must run *after* the last change. The gate now **escalates** — it blocks up to `BLOCK_CAP` (2) times instead of once, and an early skip requires an explicit `SKIP-VERIFICATION: <reason>` token in the response; otherwise it blocks to the cap then yields (hard cap → never wedges). Any unverified / red finish is **stamped ⚠ UNVERIFIED on the completion card** (derived from the live `light-pending`/`light-verified` flags at render time, so it cannot be omitted). **Validation (`stop.flow.guard` / `card-guard`):** any source change now owes a validation attestation — the completion card must carry a `validation` field mapping each requirement to how the change meets it and how it was confirmed; a code-change card without it is blocked once and re-requested. `render_completion_card` gains the `validation` param + render block + the `validation-attested` flag. New session flags `light-red` / `light-blockcount` / `validation-pending` / `validation-attested`. `browsertest-guard` 0.2.0→0.3.0, `card-guard` 0.1.0→0.2.0, `stop.flow.browsertest` 0.2.0→0.3.0, `stop.flow.guard` 0.2.0→0.3.0, `post.flow.completion` 0.17.0→0.18.0, completion MCP 0.3.0→0.4.0; 102 new/changed gate tests.
+
 ## [0.97.0] — 2026-06-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -231,8 +231,8 @@ SessionStart  ──>  UserPromptSubmit  ──>  PreToolUse  ──>  PostToolU
 
 #### Stop — runs when Claude finishes responding
 
-- `stop.flow.browsertest` — Light-verification enforcement gate.
-- `stop.flow.guard` — Per-turn completion card enforcement.
+- `stop.flow.browsertest` — Light-verification enforcement gate (the "V" of the V&V gate).
+- `stop.flow.guard` — Per-turn completion card + validation enforcement (the validation half of the V&V gate).
 - `stop.flow.selfcalibration` — Run self-calibration when Claude finishes a response turn.
 <!--/devops:block:hook-lifecycle-->
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.97.0**
+**Version: 0.98.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.97.0",
+  "version": "0.98.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/deep-knowledge/test-autonomy.md
+++ b/plugins/devops/deep-knowledge/test-autonomy.md
@@ -182,6 +182,43 @@ when `$TEST_PROFILE` is absent. Do not duplicate profile-detection logic.
 
 ---
 
+## V&V Enforcement Gate (hooks — non-bypassable by accident)
+
+The Light check above is not advisory: a pair of Stop hooks enforce it. This is
+the **V&V gate** — Verification (*did we build it right*) and Validation (*did we
+build the right thing*). Decision logic is pure and unit-tested
+(`hooks/lib/browsertest-guard.js`, `hooks/lib/card-guard.js`).
+
+**Verification — `stop.flow.browsertest`.** When a qualifying code file changed
+but no matching Light check passed this turn, the turn is blocked.
+
+- **Green, not just ran.** A test run only counts when it *passed*. A red run
+  (non-zero exit, interrupted, or an unambiguous failure summary) does **not**
+  satisfy the gate — it must be fixed and re-run green. Outcome is read
+  best-effort from the tool response; an unparseable-but-likely-green run is
+  never falsely blocked.
+- **Order.** A new qualifying edit invalidates a prior verification, so the
+  check must run *after* the last code change — testing early then editing does
+  not count.
+- **Escalation.** The gate blocks up to **2×**, then yields (it never wedges the
+  session). To consciously skip — genuinely no startable surface, or a
+  non-runtime change the carve-outs missed — put a line
+  `SKIP-VERIFICATION: <one-line reason>` in the response. That yields early
+  **and** the completion card stamps **⚠ UNVERIFIED**, so a skip is never silent.
+
+**Validation — `stop.flow.guard`.** Any source change owes a validation
+attestation on the completion card: pass a `validation` field mapping each
+requirement / acceptance criterion to how the change meets it and how it was
+confirmed (`{ requirement, status: met|partial|unmet, evidence }`). A
+code-change card without `validation` is blocked once and re-requested. For a
+pure refactor/chore, one item stating the intent and how behaviour was kept
+equivalent suffices.
+
+**Carve-outs** (never trigger either gate): docs/markdown/config edits,
+`*.test`/`*.spec` files, and devops-concept pages under `docs/concepts/*.html`.
+
+---
+
 ## Cross-References
 
 | Topic | File |

--- a/plugins/devops/hooks/lib/browsertest-guard.js
+++ b/plugins/devops/hooks/lib/browsertest-guard.js
@@ -1,16 +1,16 @@
 /**
  * @module browsertest-guard
- * @version 0.2.0
- * @description Pure decision logic for the Light-verification enforcement gate.
- *   Split out of stop.flow.browsertest.js so the rules can be unit-tested
- *   without mocking stdin or temp files.
+ * @version 0.3.0
+ * @description Pure decision logic for the Light-verification enforcement gate
+ *   (the "V" in the V&V gate). Split out of stop.flow.browsertest.js so the
+ *   rules can be unit-tested without mocking stdin or temp files.
  *
  *   The gate forces a Light verification whenever a CODE file changed in a
- *   session but the matching Light check never ran:
+ *   session but the matching Light check never ran (or ran RED):
  *     - DOM-surface profiles (web-*, electron-ow, …) → a browser tool must run
  *       (Claude-in-Chrome in Edge / Playwright / Preview).
  *     - Runner profiles (cli-node, lib, generic, …) → a test runner must run
- *       (npm test / vitest / jest / pytest / go test / …).
+ *       AND pass (a red run does NOT satisfy — Kern ②).
  *     - Unknown / unpinned profile → either satisfies.
  *
  *   Per deep-knowledge/test-autonomy.md the Light check is mandatory and
@@ -18,9 +18,20 @@
  *   NOT enforced here. Delegating to a subagent does NOT satisfy the gate —
  *   verification must be observable in the main thread (closed loophole).
  *
- *   Inputs: flag state (light-pending / light-verified / kind) + stop_hook_active
- *           + silent.
- *   Output: { action: 'block' | 'pass', reason?, resetFlags }.
+ *   Hardening (V&V concept):
+ *     ② green-not-just-ran — a test run only verifies when it passed; the
+ *        outcome is read best-effort from the PostToolUse tool_response.
+ *     ③ order — a new qualifying edit invalidates a prior verification (the
+ *        verified flag is cleared by post.flow.completion on the next edit), so
+ *        verification must come AFTER the last code change.
+ *     Escalation — the gate blocks up to CAP times instead of once. An early
+ *        skip requires an explicit `SKIP-VERIFICATION: <reason>` token in the
+ *        response; otherwise the gate keeps blocking until the cap, then yields
+ *        (never wedges) and records a visible skip.
+ *
+ *   Inputs: flag state (light-pending / light-verified / red / kind) +
+ *           stop_hook_active + silent + blockCount + skipJustified.
+ *   Output: { action, reason?, resetFlags, incrementBlock?, markSkipped? }.
  */
 
 // ---------------------------------------------------------------------------
@@ -39,6 +50,9 @@ const CODE_EXT_RE =
 const TEST_FILE_RE = /\.(test|spec)\.[a-z]+$/i;
 // devops-concept artifacts — generated analysis pages, NOT product UI.
 const CONCEPT_RE = /(^|\/)docs\/concepts\//i;
+
+/** Max times the gate blocks for the same owed verification before yielding. */
+const BLOCK_CAP = 2;
 
 /**
  * Does a changed file require BROWSER verification (DOM surface)?
@@ -147,6 +161,10 @@ function isTestRunnerTool(toolName, command) {
 
 /**
  * Did an appropriate Light verification run for this profile class?
+ * NOTE: this only answers "did the right KIND of tool run". Whether a test run
+ * actually PASSED is a separate question — see testRunOutcome / Kern ②. The
+ * writer (post.flow.completion) combines both: it only sets the verified flag
+ * for a runner check when the run also passed.
  * @param {'dom'|'runner'|'any'} profileClass
  * @param {string} toolName
  * @param {string} [command]
@@ -161,6 +179,85 @@ function isLightVerification(profileClass, toolName, command) {
 }
 
 // ---------------------------------------------------------------------------
+// Run outcome — best-effort pass/fail of a test run (Kern ②)
+// ---------------------------------------------------------------------------
+
+// Strong, unambiguous failure signals in test-runner output. Conservative on
+// purpose: anything not matching stays a pass, so a green run we cannot parse is
+// never falsely blocked. Only obvious red runs are caught.
+const FAIL_TEXT_RE =
+  /\b\d+\s+fail(?:ed|ing|ures?)\b|\bFAIL\b|✗|✖|\bfailures=[1-9]\b|\bAssertionError\b|\bFAILURES!\b|\bFAILED\s*\(/i;
+// Counter-signal: "0 failed" / "0 failures" / "failures=0" must NOT count.
+const ZERO_FAIL_RE = /\b0\s+fail(?:ed|ures?)\b|\bfailures=0\b/i;
+
+/**
+ * Pull a usable text blob + numeric exit hint out of a PostToolUse tool_response,
+ * whose exact shape varies by Claude Code version. Defensive on every field.
+ * @param {*} toolResponse
+ * @returns {{ text: string, exitCode: (number|null), interrupted: boolean }}
+ */
+function normalizeToolResponse(toolResponse) {
+  let text = '';
+  let exitCode = null;
+  let interrupted = false;
+  if (toolResponse == null) return { text, exitCode, interrupted };
+  if (typeof toolResponse === 'string') return { text: toolResponse, exitCode, interrupted };
+  if (typeof toolResponse === 'object') {
+    const r = toolResponse;
+    for (const k of ['exit_code', 'exitCode', 'code', 'returnCode', 'status']) {
+      if (typeof r[k] === 'number') { exitCode = r[k]; break; }
+    }
+    if (r.interrupted === true) interrupted = true;
+    for (const k of ['stdout', 'stderr', 'output', 'text', 'result']) {
+      if (typeof r[k] === 'string') text += '\n' + r[k];
+    }
+    // content may be a plain string or an array of { type, text } blocks.
+    if (typeof r.content === 'string') text += '\n' + r.content;
+    if (Array.isArray(r.content)) {
+      for (const b of r.content) {
+        if (b && typeof b.text === 'string') text += '\n' + b.text;
+      }
+    }
+    if (!text) { try { text = JSON.stringify(r); } catch { /* ignore */ } }
+  }
+  return { text, exitCode, interrupted };
+}
+
+/**
+ * Best-effort outcome of a test run from its PostToolUse response.
+ * 'fail' only on strong signals (numeric non-zero exit, interrupted, or an
+ * unambiguous failure summary). Everything else → 'pass', so a green run we
+ * cannot parse is never falsely blocked. A zero exit code is authoritative.
+ * @param {*} toolResponse
+ * @returns {'pass'|'fail'}
+ */
+function testRunOutcome(toolResponse) {
+  const { text, exitCode, interrupted } = normalizeToolResponse(toolResponse);
+  if (typeof exitCode === 'number') return exitCode === 0 ? 'pass' : 'fail';
+  if (interrupted) return 'fail';
+  if (text && FAIL_TEXT_RE.test(text) && !ZERO_FAIL_RE.test(text)) return 'fail';
+  return 'pass';
+}
+
+// ---------------------------------------------------------------------------
+// Explicit skip token (Escalation)
+// ---------------------------------------------------------------------------
+
+// Claude must write this token (with a reason) to consciously skip verification
+// before the block cap is reached — e.g. genuinely no startable surface here.
+const SKIP_TOKEN_RE = /\bSKIP[- ]?VERIFICATION\b\s*[-:]\s*\S/i;
+
+/**
+ * Did the response contain an explicit, reasoned skip token?
+ * @param {string} text — last assistant message text
+ * @returns {boolean}
+ */
+function hasSkipJustification(text) {
+  if (!text) return false;
+  return SKIP_TOKEN_RE.test(String(text));
+}
+
+// ---------------------------------------------------------------------------
 // Decision
 // ---------------------------------------------------------------------------
 
@@ -169,47 +266,87 @@ function isLightVerification(profileClass, toolName, command) {
  *
  * @param {object} s
  * @param {boolean} s.pending        — a code file changed, Light check still owed
- * @param {boolean} s.verified       — a matching Light verification ran
+ * @param {boolean} s.verified       — a matching Light verification ran AND passed
+ * @param {boolean} [s.red]          — a test ran this turn but FAILED (enriches reason)
  * @param {boolean} s.stopHookActive — prior Stop hook already blocked this cycle
  * @param {boolean} [s.silent]       — background tick (cron / autonomous loop)
  * @param {'dom'|'runner'|'any'} [s.kind] — required verification kind (for reason)
- * @returns {{ action: 'block' | 'pass', resetFlags: boolean, reason?: string }}
+ * @param {number}  [s.blockCount]   — how many times this gate already blocked
+ * @param {boolean} [s.skipJustified]— response carries an explicit SKIP-VERIFICATION token
+ * @returns {{ action:'block'|'pass', resetFlags:boolean, reason?:string,
+ *            incrementBlock?:boolean, markSkipped?:boolean }}
  */
-function decideLightTest({ pending, verified, stopHookActive, silent, kind }) {
+function decideLightTest({
+  pending, verified, red, stopHookActive, silent, kind,
+  blockCount = 0, skipJustified = false,
+}) {
   if (silent) {
     // Background tick — never enforce. Clear our own flags so the next real
     // turn starts clean. (The silent flag itself is owned by stop.flow.guard.)
     return { action: 'pass', resetFlags: true };
   }
 
-  if (stopHookActive) {
-    // One-time bypass: if Claude stops again after being blocked, yield and
-    // clear the pending flag so we never loop.
+  const owed = pending && !verified;
+  if (!owed) {
+    // Verification satisfied (or nothing owed) — pass and clear gate flags.
     return { action: 'pass', resetFlags: true };
   }
 
-  if (pending && !verified) {
-    return { action: 'block', resetFlags: false, reason: buildLightTestReason(kind) };
+  // --- verification is still owed ---
+
+  if (skipJustified) {
+    // Conscious, reasoned skip — yield and record it so the card stays honest.
+    return { action: 'pass', resetFlags: true, markSkipped: true };
   }
 
-  return { action: 'pass', resetFlags: true };
+  if (blockCount >= BLOCK_CAP) {
+    // Hard cap reached — never wedge the session. Yield, but record the skip.
+    return { action: 'pass', resetFlags: true, markSkipped: true };
+  }
+
+  if (stopHookActive && blockCount === 0) {
+    // Safety net: a Stop is already active but our counter never advanced
+    // (flag write failed). Degrade to the legacy one-block behaviour rather
+    // than risk a loop — yield and record the skip.
+    return { action: 'pass', resetFlags: true, markSkipped: true };
+  }
+
+  return {
+    action: 'block',
+    resetFlags: false,
+    incrementBlock: true,
+    reason: buildLightTestReason(kind, { escalated: blockCount >= 1, red: red === true }),
+  };
 }
 
 // ---------------------------------------------------------------------------
 // Reason text
 // ---------------------------------------------------------------------------
 
-const FOOTER = [
-  '',
-  'A subagent delegation does NOT satisfy this gate — verification must be',
-  'observable in THIS thread (a browser or test-runner tool call). If a subagent',
-  'did the testing, re-run a quick observable check or surface its evidence.',
-  '',
-  'Auto-excluded: docs/markdown/config edits, *.test/*.spec files, and',
-  'devops-concept pages under docs/concepts/*.html. To intentionally skip',
-  '(non-runtime change, no startable surface): stop again — this gate yields',
-  'after one block.',
-];
+function escFooter(escalated) {
+  const lead = escalated
+    ? [
+        '',
+        'ESCALATED — this gate already asked once. It blocks up to ' + BLOCK_CAP +
+          ' times, then yields.',
+      ]
+    : [];
+  return lead.concat([
+    '',
+    'A subagent delegation does NOT satisfy this gate — verification must be',
+    'observable in THIS thread (a browser or test-runner tool call). If a subagent',
+    'did the testing, re-run a quick observable check or surface its evidence.',
+    '',
+    'Auto-excluded: docs/markdown/config edits, *.test/*.spec files, and',
+    'devops-concept pages under docs/concepts/*.html.',
+    '',
+    'To CONSCIOUSLY skip (genuinely no startable surface / non-runtime change):',
+    'put a line `SKIP-VERIFICATION: <one-line reason>` in your response. The skip',
+    'is then recorded and shown on the completion card as ⚠ UNVERIFIED — it is not',
+    'silent. Without that token the gate keeps blocking until it yields after ' +
+      BLOCK_CAP + ' blocks.',
+  ]);
+}
 
 function domReason() {
   return [
@@ -229,17 +366,25 @@ function domReason() {
   ];
 }
 
-function runnerReason() {
-  return [
-    '[stop.flow.browsertest] Code changed but no test run was observed this session.',
-    '',
-    'Per deep-knowledge/test-autonomy.md (non-DOM surface → Light = run the test',
-    'suite) this is mandatory. Do this FIRST, before the completion card:',
+function runnerReason(red) {
+  const head = red
+    ? [
+        '[stop.flow.browsertest] A test ran this session but FAILED — a red run does not verify.',
+        '',
+        'Fix the failure, then re-run the suite green. Do this FIRST, before the completion card:',
+      ]
+    : [
+        '[stop.flow.browsertest] Code changed but no passing test run was observed this session.',
+        '',
+        'Per deep-knowledge/test-autonomy.md (non-DOM surface → Light = run the test',
+        'suite) this is mandatory. Do this FIRST, before the completion card:',
+      ];
+  return head.concat([
     '',
     '1. Run the project test suite: npm test (or vitest / jest / pytest / go test / …).',
-    '2. For a CLI, also exercise the changed command path once and read its output.',
-    '3. Fix failures before finishing.',
-  ];
+    '2. The run must PASS — a failing run does not satisfy this gate.',
+    '3. For a CLI, also exercise the changed command path once and read its output.',
+  ]);
 }
 
 function anyReason() {
@@ -251,24 +396,28 @@ function anyReason() {
     '',
     '1. Invoke /devops-test-plan to pin the profile.',
     '2. Then run the matching Light check: a browser snapshot for a web/DOM surface,',
-    '   or the test suite (npm test / pytest / …) otherwise.',
+    '   or the test suite (npm test / pytest / …) otherwise — and it must pass.',
   ];
 }
 
 /**
  * Build the block reason for a given verification kind.
  * @param {'dom'|'runner'|'any'} [kind]
+ * @param {{ escalated?: boolean, red?: boolean }} [opts]
  * @returns {string}
  */
-function buildLightTestReason(kind) {
+function buildLightTestReason(kind, opts = {}) {
   let body;
   if (kind === 'dom') body = domReason();
-  else if (kind === 'runner') body = runnerReason();
+  else if (kind === 'runner') body = runnerReason(opts.red === true);
   else body = anyReason();
-  return body.concat(['', 'Then render the completion card as the LAST action.'], FOOTER).join('\n');
+  return body
+    .concat(['', 'Then render the completion card as the LAST action.'], escFooter(opts.escalated === true))
+    .join('\n');
 }
 
 module.exports = {
+  BLOCK_CAP,
   isWebRenderableChange,
   isCodeChange,
   classifyProfile,
@@ -276,6 +425,9 @@ module.exports = {
   isBrowserTool,
   isTestRunnerTool,
   isLightVerification,
+  normalizeToolResponse,
+  testRunOutcome,
+  hasSkipJustification,
   decideLightTest,
   buildLightTestReason,
 };

--- a/plugins/devops/hooks/lib/browsertest-guard.test.js
+++ b/plugins/devops/hooks/lib/browsertest-guard.test.js
@@ -1,5 +1,6 @@
 import { describe, test, expect } from "vitest";
 import {
+  BLOCK_CAP,
   isWebRenderableChange,
   isCodeChange,
   classifyProfile,
@@ -7,6 +8,9 @@ import {
   isBrowserTool,
   isTestRunnerTool,
   isLightVerification,
+  normalizeToolResponse,
+  testRunOutcome,
+  hasSkipJustification,
   decideLightTest,
   buildLightTestReason,
 } from "./browsertest-guard.js";
@@ -343,5 +347,183 @@ describe("buildLightTestReason", () => {
       expect(r).toMatch(/docs\/concepts/);
       expect(r).toMatch(/yields/);
     }
+  });
+
+  test("every kind documents the explicit skip token", () => {
+    for (const kind of ["dom", "runner", "any"]) {
+      expect(buildLightTestReason(kind)).toMatch(/SKIP-VERIFICATION:/);
+    }
+  });
+
+  test("escalated reason is louder; runner red reason names the failure", () => {
+    expect(buildLightTestReason("runner", { escalated: true })).toMatch(/ESCALATED/);
+    expect(buildLightTestReason("runner", { escalated: false })).not.toMatch(/ESCALATED/);
+    const red = buildLightTestReason("runner", { red: true });
+    expect(red).toMatch(/FAILED|red run/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// normalizeToolResponse — defensive field extraction
+// ---------------------------------------------------------------------------
+
+describe("normalizeToolResponse", () => {
+  test("string response → text only", () => {
+    const r = normalizeToolResponse("raw output");
+    expect(r.text).toBe("raw output");
+    expect(r.exitCode).toBe(null);
+    expect(r.interrupted).toBe(false);
+  });
+
+  test("object with stdout/stderr → concatenated text", () => {
+    const r = normalizeToolResponse({ stdout: "out", stderr: "err" });
+    expect(r.text).toMatch(/out/);
+    expect(r.text).toMatch(/err/);
+  });
+
+  test("content array of text blocks is flattened", () => {
+    const r = normalizeToolResponse({ content: [{ type: "text", text: "hello" }] });
+    expect(r.text).toMatch(/hello/);
+  });
+
+  test("numeric exit code is picked up from several field names", () => {
+    expect(normalizeToolResponse({ exit_code: 0 }).exitCode).toBe(0);
+    expect(normalizeToolResponse({ exitCode: 2 }).exitCode).toBe(2);
+    expect(normalizeToolResponse({ code: 127 }).exitCode).toBe(127);
+  });
+
+  test("interrupted flag is surfaced", () => {
+    expect(normalizeToolResponse({ interrupted: true }).interrupted).toBe(true);
+  });
+
+  test("null / undefined → empty, neutral", () => {
+    for (const v of [null, undefined]) {
+      const r = normalizeToolResponse(v);
+      expect(r.text).toBe("");
+      expect(r.exitCode).toBe(null);
+      expect(r.interrupted).toBe(false);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// testRunOutcome — green-not-just-ran (Kern ②)
+// ---------------------------------------------------------------------------
+
+describe("testRunOutcome", () => {
+  test("zero exit code is authoritative pass, non-zero is fail", () => {
+    expect(testRunOutcome({ exit_code: 0 })).toBe("pass");
+    expect(testRunOutcome({ exit_code: 1 })).toBe("fail");
+    expect(testRunOutcome({ exitCode: 2 })).toBe("fail");
+  });
+
+  test("interrupted run is a fail", () => {
+    expect(testRunOutcome({ interrupted: true })).toBe("fail");
+  });
+
+  test("failure summaries in text are detected", () => {
+    expect(testRunOutcome("Tests  2 failed | 5 passed")).toBe("fail");
+    expect(testRunOutcome("=== 1 failed, 3 passed ===")).toBe("fail");
+    expect(testRunOutcome("FAIL src/foo.test.ts")).toBe("fail");
+    expect(testRunOutcome({ stdout: "  3 passing\n  1 failing" })).toBe("fail");
+    expect(testRunOutcome("Tests: 1 failed, 2 total")).toBe("fail");
+  });
+
+  test("'0 failed' / all-passing output is a pass (no false fail)", () => {
+    expect(testRunOutcome("Tests  0 failed | 7 passed")).toBe("pass");
+    expect(testRunOutcome("Test Suites: 3 passed, 3 total\nTests: 12 passed")).toBe("pass");
+    expect(testRunOutcome("ok 5 - everything works")).toBe("pass");
+    expect(testRunOutcome("failures=0")).toBe("pass");
+  });
+
+  test("unparseable / empty output defaults to pass (never false-block)", () => {
+    expect(testRunOutcome(null)).toBe("pass");
+    expect(testRunOutcome("")).toBe("pass");
+    expect(testRunOutcome({ stdout: "build done" })).toBe("pass");
+  });
+
+  test("zero exit code wins even if text mentions a failure", () => {
+    expect(testRunOutcome({ exit_code: 0, stdout: "note: a flaky thing FAILED earlier" })).toBe("pass");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hasSkipJustification — explicit skip token
+// ---------------------------------------------------------------------------
+
+describe("hasSkipJustification", () => {
+  test("token with a reason is honored", () => {
+    expect(hasSkipJustification("SKIP-VERIFICATION: no startable surface here")).toBe(true);
+    expect(hasSkipJustification("...\nskip verification: pure docs change\n...")).toBe(true);
+  });
+
+  test("token without a reason does NOT count", () => {
+    expect(hasSkipJustification("SKIP-VERIFICATION:")).toBe(false);
+  });
+
+  test("incidental mention does NOT count", () => {
+    expect(hasSkipJustification("I will not skip-verification this time")).toBe(false);
+    expect(hasSkipJustification("let me run the tests")).toBe(false);
+  });
+
+  test("empty / missing → false", () => {
+    expect(hasSkipJustification("")).toBe(false);
+    expect(hasSkipJustification(null)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// decideLightTest — escalation & explicit skip
+// ---------------------------------------------------------------------------
+
+describe("decideLightTest — escalation", () => {
+  test("BLOCK_CAP is 2", () => {
+    expect(BLOCK_CAP).toBe(2);
+  });
+
+  test("first owed stop → block + incrementBlock", () => {
+    const d = decideLightTest({ pending: true, verified: false, stopHookActive: false, kind: "runner", blockCount: 0 });
+    expect(d.action).toBe("block");
+    expect(d.incrementBlock).toBe(true);
+    expect(d.resetFlags).toBe(false);
+  });
+
+  test("second owed stop (blockCount 1) → block again, escalated reason", () => {
+    const d = decideLightTest({ pending: true, verified: false, stopHookActive: true, kind: "runner", blockCount: 1 });
+    expect(d.action).toBe("block");
+    expect(d.incrementBlock).toBe(true);
+    expect(d.reason).toMatch(/ESCALATED/);
+  });
+
+  test("cap reached (blockCount >= CAP) → yield, mark skipped, never wedge", () => {
+    const d = decideLightTest({ pending: true, verified: false, stopHookActive: true, kind: "runner", blockCount: 2 });
+    expect(d.action).toBe("pass");
+    expect(d.resetFlags).toBe(true);
+    expect(d.markSkipped).toBe(true);
+  });
+
+  test("explicit skip token yields early + marks skipped", () => {
+    const d = decideLightTest({ pending: true, verified: false, stopHookActive: false, kind: "runner", blockCount: 0, skipJustified: true });
+    expect(d.action).toBe("pass");
+    expect(d.markSkipped).toBe(true);
+  });
+
+  test("safety net: stop active but counter never advanced → yield (legacy one-block)", () => {
+    const d = decideLightTest({ pending: true, verified: false, stopHookActive: true, kind: "runner", blockCount: 0 });
+    expect(d.action).toBe("pass");
+    expect(d.resetFlags).toBe(true);
+    expect(d.markSkipped).toBe(true);
+  });
+
+  test("red run still owes verification (red is not verified)", () => {
+    const d = decideLightTest({ pending: true, verified: false, red: true, stopHookActive: false, kind: "runner", blockCount: 0 });
+    expect(d.action).toBe("block");
+    expect(d.reason).toMatch(/FAILED|red run/);
+  });
+
+  test("verified green → pass even with a stale red flag absent", () => {
+    const d = decideLightTest({ pending: true, verified: true, stopHookActive: false, kind: "runner", blockCount: 1 });
+    expect(d.action).toBe("pass");
+    expect(d.resetFlags).toBe(true);
   });
 });

--- a/plugins/devops/hooks/lib/card-guard.js
+++ b/plugins/devops/hooks/lib/card-guard.js
@@ -1,11 +1,19 @@
 /**
  * @module card-guard
- * @version 0.1.0
- * @description Pure decision logic for the completion-card enforcement flow.
- *   Split out of stop.flow.guard.js so the rules can be unit-tested without
- *   mocking stdin or temp files.
+ * @version 0.2.0
+ * @description Pure decision logic for the completion-card enforcement flow,
+ *   plus the validation half of the V&V gate. Split out of stop.flow.guard.js so
+ *   the rules can be unit-tested without mocking stdin or temp files.
  *
- *   Inputs: flag state (work/card) + transcript + stop_hook_active.
+ *   Two stacked gates, both one-block (stop_hook_active yields):
+ *     1. Completion card — block when work happened but no card was rendered.
+ *     2. Validation — once a card exists, block when a code change owes a
+ *        validation attestation (validationPending && !validationAttested). The
+ *        `validation` field rides on the card; the MCP sets the attested flag
+ *        when it is populated. This is the "did we build the RIGHT thing" half;
+ *        the test gate (stop.flow.browsertest) is the "did we build it right".
+ *
+ *   Inputs: flag state (work/card/validation) + transcript + stop_hook_active.
  *   Output: { action: 'block' | 'pass', reason?, resetFlags }.
  */
 
@@ -73,9 +81,14 @@ function lastAssistantContainsCard(transcriptContent) {
  * @param {boolean} s.substantial    — last assistant turn had substantial prose
  * @param {boolean} [s.silent]       — turn was triggered by cron/autonomous loop,
  *                                     not the user. Never enforce the card.
+ * @param {boolean} [s.validationPending]  — a code change owes a validation attestation
+ * @param {boolean} [s.validationAttested] — the card was rendered with a `validation` field
  * @returns {{ action: 'block' | 'pass', resetFlags: boolean, reason?: string }}
  */
-function decideAction({ workHappened, cardRendered, stopHookActive, substantial, silent }) {
+function decideAction({
+  workHappened, cardRendered, stopHookActive, substantial, silent,
+  validationPending, validationAttested,
+}) {
   if (silent) {
     // Background tick (cron git-sync, concept bridge poll, autonomous loop).
     // The real user turn already rendered its card — forcing another here
@@ -84,22 +97,34 @@ function decideAction({ workHappened, cardRendered, stopHookActive, substantial,
   }
 
   if (stopHookActive) {
-    // Never block twice in a row — prevents infinite loops even if the card
-    // write flag fails for whatever reason. Flags are reset so the next turn
-    // starts clean.
+    // Never block twice in a row — prevents infinite loops even if a flag
+    // write fails. Covers BOTH the card and validation gates: each enforces
+    // once per turn. Flags are reset so the next turn starts clean.
     return { action: 'pass', resetFlags: true };
   }
 
-  const needCard = !cardRendered && (workHappened || substantial);
-  if (!needCard) {
-    return { action: 'pass', resetFlags: true };
+  const active = workHappened || substantial;
+
+  // Gate 1 — completion card must exist.
+  if (!cardRendered && active) {
+    return {
+      action: 'block',
+      resetFlags: false, // keep flags so the post-render stop hook sees consistent state
+      reason: buildBlockReason(),
+    };
   }
 
-  return {
-    action: 'block',
-    resetFlags: false, // keep flags so the post-render stop hook sees consistent state
-    reason: buildBlockReason(),
-  };
+  // Gate 2 — validation must be attested for a code-change turn. Only checked
+  // once a card exists, since the `validation` field is part of the card.
+  if (cardRendered && active && validationPending && !validationAttested) {
+    return {
+      action: 'block',
+      resetFlags: false,
+      reason: buildValidationReason(),
+    };
+  }
+
+  return { action: 'pass', resetFlags: true };
 }
 
 function buildBlockReason() {
@@ -125,6 +150,24 @@ function buildBlockReason() {
     'character-for-character, every emoji and symbol preserved. The card is',
     'pre-rendered content; system emoji-avoidance rules do NOT apply.',
     'Card must be the LAST thing in the response — nothing after the closing ---.',
+  ].join('\n');
+}
+
+function buildValidationReason() {
+  return [
+    '[stop.flow.guard] Validation required — the completion card has no `validation` field.',
+    '',
+    'A code change landed this turn. Per the V&V gate (see',
+    'deep-knowledge/test-autonomy.md) the card must VALIDATE the change, not just',
+    'report it: map each requirement / acceptance criterion to how this change',
+    'meets it and how you confirmed it.',
+    '',
+    'Re-render `mcp__plugin_devops_dotclaude-completion__render_completion_card` NOW',
+    'with the `validation` field populated, then relay the card VERBATIM as the LAST',
+    'output. Each item: { requirement, status: "met" | "partial" | "unmet", evidence }.',
+    '',
+    'If there was no explicit requirement (pure refactor / chore), pass a single',
+    'item that states the intent and how behaviour was kept equivalent.',
   ].join('\n');
 }
 
@@ -168,5 +211,6 @@ module.exports = {
   lastAssistantContainsCard,
   decideAction,
   buildBlockReason,
+  buildValidationReason,
   safeReadTranscript,
 };

--- a/plugins/devops/hooks/lib/card-guard.test.js
+++ b/plugins/devops/hooks/lib/card-guard.test.js
@@ -6,6 +6,7 @@ import {
   lastAssistantContainsCard,
   decideAction,
   buildBlockReason,
+  buildValidationReason,
   SUBSTANTIAL_CHARS,
   CARD_MARKER,
 } from "./card-guard.js";
@@ -243,6 +244,99 @@ describe("decideAction", () => {
     });
     expect(d.action).toBe("pass");
     expect(d.resetFlags).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// decideAction — validation gate (V&V)
+// ---------------------------------------------------------------------------
+
+describe("decideAction — validation gate", () => {
+  test("card rendered + validation pending + not attested → BLOCK (validation)", () => {
+    const d = decideAction({
+      workHappened: true,
+      cardRendered: true,
+      stopHookActive: false,
+      substantial: false,
+      validationPending: true,
+      validationAttested: false,
+    });
+    expect(d.action).toBe("block");
+    expect(d.resetFlags).toBe(false);
+    expect(d.reason).toMatch(/Validation required/);
+    expect(d.reason).toMatch(/validation/);
+  });
+
+  test("card rendered + validation pending + attested → pass", () => {
+    const d = decideAction({
+      workHappened: true,
+      cardRendered: true,
+      stopHookActive: false,
+      substantial: false,
+      validationPending: true,
+      validationAttested: true,
+    });
+    expect(d.action).toBe("pass");
+    expect(d.resetFlags).toBe(true);
+  });
+
+  test("no card yet → card gate wins over validation gate", () => {
+    const d = decideAction({
+      workHappened: true,
+      cardRendered: false,
+      stopHookActive: false,
+      substantial: false,
+      validationPending: true,
+      validationAttested: false,
+    });
+    expect(d.action).toBe("block");
+    expect(d.reason).toMatch(/render_completion_card/);
+    expect(d.reason).not.toMatch(/Validation required/);
+  });
+
+  test("validation pending but no active work/prose → pass (no spurious block)", () => {
+    const d = decideAction({
+      workHappened: false,
+      cardRendered: true,
+      stopHookActive: false,
+      substantial: false,
+      validationPending: true,
+      validationAttested: false,
+    });
+    expect(d.action).toBe("pass");
+  });
+
+  test("stop_hook_active yields the validation gate too (one-block, never wedge)", () => {
+    const d = decideAction({
+      workHappened: true,
+      cardRendered: true,
+      stopHookActive: true,
+      substantial: false,
+      validationPending: true,
+      validationAttested: false,
+    });
+    expect(d.action).toBe("pass");
+    expect(d.resetFlags).toBe(true);
+  });
+
+  test("no validation pending → card-rendered turn passes (back-compat)", () => {
+    const d = decideAction({
+      workHappened: true,
+      cardRendered: true,
+      stopHookActive: false,
+      substantial: false,
+    });
+    expect(d.action).toBe("pass");
+  });
+});
+
+describe("buildValidationReason", () => {
+  test("names the validation field and the re-render instruction", () => {
+    const r = buildValidationReason();
+    expect(r).toMatch(/validation/);
+    expect(r).toMatch(/render_completion_card/);
+    expect(r).toMatch(/met.*partial.*unmet|requirement/);
+    expect(r).toMatch(/VERBATIM|LAST/);
   });
 });
 

--- a/plugins/devops/hooks/post-tool-use/post.flow.completion.js
+++ b/plugins/devops/hooks/post-tool-use/post.flow.completion.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * @hook post.flow.completion
- * @version 0.17.0
+ * @version 0.18.0
  * @event PostToolUse
  * @plugin devops
  * @description After EVERY tool call: inject the completion-card reminder so
@@ -10,10 +10,18 @@
  *   Edit/Write calls additionally increment the session edit counter.
  *   At 5+ edits, injects desktop-testing prompt for UI projects.
  *   Writes a per-turn "work-happened" flag consumed by stop.flow.guard, plus
- *   the Light-verification gate flags (light-pending / light-kind /
- *   light-verified) consumed by stop.flow.browsertest. Pending/verified are
- *   scoped to the active $TEST_PROFILE class (DOM → browser; runner → test
- *   suite). Subagent delegation no longer satisfies the gate.
+ *   the V&V gate flags consumed by stop.flow.browsertest and stop.flow.guard:
+ *     - light-pending / light-kind — a code file changed and still owes a Light
+ *       check, scoped to the active $TEST_PROFILE class (DOM → browser; runner →
+ *       test suite).
+ *     - light-verified — set only when an OBSERVABLE matching check ran AND, for
+ *       a test runner, the run PASSED (Kern ②). A new qualifying edit clears it
+ *       (Kern ③ — order: verification must come after the last change).
+ *     - light-red — a test ran but FAILED (does not verify; enriches the gate
+ *       reason and the card stamp).
+ *     - validation-pending — any source change owes a validation attestation in
+ *       the completion card; a new edit clears a prior validation-attested flag.
+ *   Subagent delegation does not satisfy any of these gates.
  */
 
 require('../lib/plugin-guard');
@@ -26,7 +34,10 @@ const { getLocale, t } = require('../lib/locale');
 const {
   classifyProfile,
   needsLightVerification,
-  isLightVerification,
+  isCodeChange,
+  isBrowserTool,
+  isTestRunnerTool,
+  testRunOutcome,
 } = require('../lib/browsertest-guard');
 
 /**
@@ -137,8 +148,13 @@ process.stdin.on('end', () => {
   //     the main thread cannot see inside it (closed loophole, intentional).
   try {
     const profileClass = readProfileClass(hook.session_id);
+    const unlinkFlag = (prefix) => {
+      try { fs.unlinkSync(sessionFile(prefix, hook.session_id)); } catch {}
+    };
+
     if (isCodeEdit) {
       const editedPath = hook.tool_input && hook.tool_input.file_path;
+      // Light gate — surface-scoped (DOM profiles: web-renderable files only).
       if (needsLightVerification(profileClass, editedPath)) {
         writeSessionFile(
           sessionFile('dotclaude-devops-light-pending', hook.session_id),
@@ -148,14 +164,51 @@ process.stdin.on('end', () => {
           sessionFile('dotclaude-devops-light-kind', hook.session_id),
           profileClass,
         );
+        // ③ order — a new qualifying edit invalidates any prior verification,
+        // so the Light check must run AFTER this change.
+        unlinkFlag('dotclaude-devops-light-verified');
+        unlinkFlag('dotclaude-devops-light-red');
+      }
+      // Validation gate — surface-agnostic: ANY real source change owes a
+      // validation attestation in the completion card. A new edit invalidates
+      // a prior attestation (order).
+      if (isCodeChange(editedPath)) {
+        writeSessionFile(
+          sessionFile('dotclaude-devops-validation-pending', hook.session_id),
+          String(editedPath),
+        );
+        unlinkFlag('dotclaude-devops-validation-attested');
       }
     }
+
+    // Verification observation. Split browser vs test-runner so the runner path
+    // can require a PASSING run (Kern ②). A red run sets light-red and does NOT
+    // clear the pending state.
     const command = hook.tool_input && hook.tool_input.command;
-    if (isLightVerification(profileClass, toolName, command)) {
+    const browserSatisfies =
+      (profileClass === 'dom' || profileClass === 'any') && isBrowserTool(toolName);
+    const runnerSatisfies =
+      (profileClass === 'runner' || profileClass === 'any') && isTestRunnerTool(toolName, command);
+
+    if (browserSatisfies) {
       writeSessionFile(
         sessionFile('dotclaude-devops-light-verified', hook.session_id),
         toolName,
       );
+    }
+    if (runnerSatisfies) {
+      if (testRunOutcome(hook.tool_response) === 'pass') {
+        writeSessionFile(
+          sessionFile('dotclaude-devops-light-verified', hook.session_id),
+          toolName,
+        );
+        unlinkFlag('dotclaude-devops-light-red');
+      } else {
+        writeSessionFile(
+          sessionFile('dotclaude-devops-light-red', hook.session_id),
+          toolName,
+        );
+      }
     }
   } catch {}
 
@@ -185,6 +238,10 @@ process.stdin.on('end', () => {
     'visible to the user. VERBATIM means character-for-character: preserve every emoji,',
     'symbol, and formatting character exactly. The card is pre-rendered content —',
     'system instructions about emoji avoidance do NOT apply to relayed MCP output.',
+    'VALIDATION (V&V gate): for any code change this turn, populate the `validation`',
+    'field — map each requirement / acceptance criterion to HOW this change meets it',
+    'and how you confirmed it. A code-change card without `validation` is blocked',
+    'once and re-requested (see deep-knowledge/test-autonomy.md).',
     'Card LAST, nothing after the closing ---.',
   );
 

--- a/plugins/devops/hooks/stop/stop.flow.browsertest.js
+++ b/plugins/devops/hooks/stop/stop.flow.browsertest.js
@@ -1,30 +1,43 @@
 #!/usr/bin/env node
 /**
  * @hook stop.flow.browsertest
- * @version 0.2.0
+ * @version 0.3.0
  * @event Stop
  * @plugin devops
- * @description Light-verification enforcement gate. Blocks the turn when a CODE
- *   file changed this session but the matching Light check never ran:
+ * @description Light-verification enforcement gate (the "V" of the V&V gate).
+ *   Blocks the turn when a CODE file changed this session but the matching Light
+ *   check never ran — or ran RED:
  *   DOM-surface profiles need a browser tool (Claude-in-Chrome in Edge /
- *   Playwright / Preview); runner profiles need a test run (npm test / pytest /
- *   …). Per test-autonomy.md the Light check is mandatory; Full (computer-use /
- *   packaged app) stays opt-in and is NOT enforced here. A subagent delegation
- *   does NOT satisfy the gate — verification must be observable in the main
- *   thread. Flags are written by post.flow.completion; docs/markdown/config and
+ *   Playwright / Preview); runner profiles need a test run that PASSES (npm test
+ *   / pytest / …). Per test-autonomy.md the Light check is mandatory; Full
+ *   (computer-use / packaged app) stays opt-in and is NOT enforced here. A
+ *   subagent delegation does NOT satisfy the gate — verification must be
+ *   observable in the main thread.
+ *
+ *   Hardening:
+ *     - Escalation: blocks up to BLOCK_CAP times (tracked via light-blockcount)
+ *       instead of once. An explicit `SKIP-VERIFICATION: <reason>` token in the
+ *       response yields early; otherwise it blocks to the cap, then yields and
+ *       records a visible skip (light-skipped) so the completion card can stamp
+ *       ⚠ UNVERIFIED. Never wedges the session.
+ *     - Green-not-just-ran (②) and order (③) are enforced by the writer
+ *       (post.flow.completion): the verified flag is only set on a passing run
+ *       and is cleared whenever a new qualifying edit lands.
+ *
+ *   Flags are written by post.flow.completion; docs/markdown/config and
  *   devops-concept pages are excluded there. Decision logic lives in
  *   lib/browsertest-guard.js (pure, unit-tested).
  *
  *   Runs BEFORE stop.flow.guard so the "verify first" instruction is delivered
- *   before the completion-card gate. Yields after one block (stop_hook_active)
- *   so it can never loop.
+ *   before the completion-card gate.
  */
 
 require('../lib/plugin-guard');
 
 const fs = require('fs');
-const { readSessionFile } = require('../lib/session-id');
-const { decideLightTest } = require('../lib/browsertest-guard');
+const { sessionFile, readSessionFile, writeSessionFile } = require('../lib/session-id');
+const { decideLightTest, hasSkipJustification } = require('../lib/browsertest-guard');
+const { safeReadTranscript, lastAssistantText } = require('../lib/card-guard');
 
 let inputData = '';
 process.stdin.setEncoding('utf8');
@@ -38,24 +51,58 @@ process.stdin.on('end', () => {
 
   const pendingResult = readSessionFile('dotclaude-devops-light-pending', sessionId);
   const verifiedResult = readSessionFile('dotclaude-devops-light-verified', sessionId);
+  const redResult = readSessionFile('dotclaude-devops-light-red', sessionId);
   const kindResult = readSessionFile('dotclaude-devops-light-kind', sessionId);
   const silentResult = readSessionFile('dotclaude-devops-silent-turn', sessionId);
+  const blockCountResult = readSessionFile('dotclaude-devops-light-blockcount', sessionId);
+
+  const blockCount = blockCountResult ? (parseInt(blockCountResult.content, 10) || 0) : 0;
+
+  // Explicit skip token — read only when needed (verification still owed) to
+  // avoid touching the transcript on the common pass path.
+  let skipJustified = false;
+  if (pendingResult && !verifiedResult && !silentResult) {
+    const transcript = safeReadTranscript(hook.transcript_path);
+    skipJustified = hasSkipJustification(lastAssistantText(transcript));
+  }
 
   const decision = decideLightTest({
     pending: pendingResult !== null,
     verified: verifiedResult !== null,
+    red: redResult !== null,
     stopHookActive: hook.stop_hook_active === true,
     silent: silentResult !== null,
     kind: (kindResult && kindResult.content) || 'any',
+    blockCount,
+    skipJustified,
   });
+
+  if (decision.incrementBlock) {
+    try {
+      writeSessionFile(
+        sessionFile('dotclaude-devops-light-blockcount', sessionId),
+        String(blockCount + 1),
+      );
+    } catch { /* ignore */ }
+  }
+
+  // Note on the visible-skip stamp (⚠ UNVERIFIED): it is NOT driven from here.
+  // A skip is only yielded at THIS Stop, but the completion card was already
+  // rendered just before it — so a flag written now would arrive too late. The
+  // card instead derives the stamp itself at render time from the same
+  // light-pending / light-verified flags (pending && !verified ⇒ finishing
+  // unverified). decision.markSkipped therefore needs no persistence here.
 
   if (decision.resetFlags) {
     // Only clear our own gate flags. The silent flag is owned by
     // stop.flow.guard — never delete it here, or the card gate would treat a
-    // background tick as a real turn.
+    // background tick as a real turn. light-skipped is also owned by
+    // stop.flow.guard (it must outlive this reset to reach the card).
     if (pendingResult) try { fs.unlinkSync(pendingResult.filePath); } catch {}
     if (verifiedResult) try { fs.unlinkSync(verifiedResult.filePath); } catch {}
+    if (redResult) try { fs.unlinkSync(redResult.filePath); } catch {}
     if (kindResult) try { fs.unlinkSync(kindResult.filePath); } catch {}
+    if (blockCountResult) try { fs.unlinkSync(blockCountResult.filePath); } catch {}
   }
 
   if (decision.action === 'block') {

--- a/plugins/devops/hooks/stop/stop.flow.guard.js
+++ b/plugins/devops/hooks/stop/stop.flow.guard.js
@@ -1,17 +1,18 @@
 #!/usr/bin/env node
 /**
  * @hook stop.flow.guard
- * @version 0.2.0
+ * @version 0.3.0
  * @event Stop
  * @plugin devops
- * @description Per-turn completion card enforcement.
- *   Fires when Claude finishes a response turn.
+ * @description Per-turn completion card + validation enforcement (the validation
+ *   half of the V&V gate). Fires when Claude finishes a response turn.
  *   Logic lives in lib/card-guard.js (pure functions, unit-tested).
  *
- *   Block (JSON `{decision:"block"}` on stdout) when:
- *     - no card rendered AND
- *     - (tool calls happened OR last assistant text is substantial prose)
- *     - AND this is not already a blocked stop cycle (stop_hook_active=false)
+ *   Block (JSON `{decision:"block"}` on stdout) when, and this is not already a
+ *   blocked stop cycle (stop_hook_active=false):
+ *     1. no card rendered AND (tool calls happened OR substantial prose), OR
+ *     2. a card exists but a code change owes validation
+ *        (validation-pending set, validation-attested not).
  *
  *   Pass (silent exit 0) otherwise — flags are reset so the next turn is
  *   evaluated independently.
@@ -41,10 +42,14 @@ process.stdin.on('end', () => {
   const workResult = readSessionFile('dotclaude-devops-work-happened', sessionId);
   const cardResult = readSessionFile('dotclaude-devops-card-rendered', sessionId);
   const silentResult = readSessionFile('dotclaude-devops-silent-turn', sessionId);
+  const valPendingResult = readSessionFile('dotclaude-devops-validation-pending', sessionId);
+  const valAttestedResult = readSessionFile('dotclaude-devops-validation-attested', sessionId);
 
   const workHappened = workResult !== null;
   const flagCardRendered = cardResult !== null;
   const silent = silentResult !== null;
+  const validationPending = valPendingResult !== null;
+  const validationAttested = valAttestedResult !== null;
   const stopHookActive = hook.stop_hook_active === true;
 
   // Scan transcript when the flag state alone cannot settle the decision:
@@ -65,12 +70,17 @@ process.stdin.on('end', () => {
     stopHookActive,
     substantial,
     silent,
+    validationPending,
+    validationAttested,
   });
 
   if (decision.resetFlags) {
     if (workResult) try { fs.unlinkSync(workResult.filePath); } catch {}
     if (cardResult) try { fs.unlinkSync(cardResult.filePath); } catch {}
     if (silentResult) try { fs.unlinkSync(silentResult.filePath); } catch {}
+    // Validation flags are owned by this gate — clear them at a clean turn end.
+    if (valPendingResult) try { fs.unlinkSync(valPendingResult.filePath); } catch {}
+    if (valAttestedResult) try { fs.unlinkSync(valAttestedResult.filePath); } catch {}
   }
 
   if (decision.action === 'block') {

--- a/plugins/devops/mcp-server/index.js
+++ b/plugins/devops/mcp-server/index.js
@@ -1,11 +1,15 @@
 #!/usr/bin/env node
 /**
  * @module dotclaude-completion-mcp
- * @version 0.3.0
+ * @version 0.4.0
  * @plugin devops
  * @description MCP server with two tools:
  *   - `get_usage`              — scrapes live usage data from claude.ai via CDP
- *   - `render_completion_card` — fetches usage, computes build-ID, renders card
+ *   - `render_completion_card` — fetches usage, computes build-ID, renders card.
+ *       V&V gate: stamps ⚠ UNVERIFIED/RED when the Light-verification flags show
+ *       the turn is finishing without a passing check, renders the `validation`
+ *       block, and writes the validation-attested flag consumed by
+ *       stop.flow.guard.
  *
  *   Registered in plugin.json → started automatically by Claude Code.
  *   Stdout is the JSON-RPC wire — all logging goes to stderr.
@@ -490,6 +494,80 @@ function renderContextHealth(toolCallCount) {
   return toolCallCount + ' calls \u00b7 consider /clear';
 }
 
+// ---------------------------------------------------------------------------
+// V&V gate \u2014 read the Light-verification flags written by post.flow.completion
+// so the card can stamp \u26a0 UNVERIFIED when the turn is finishing without a
+// passing check. Same tmp-file convention as the hooks (session-id.js); exact
+// match first, then a newest-wins glob fallback for the session_id-mismatch bug.
+// ---------------------------------------------------------------------------
+
+const FLAG_MAX_AGE_MS = 2 * 60 * 60 * 1000; // 2h \u2014 matches session-id.js
+
+function readSessionFlagRaw(prefix, sessionId) {
+  const key = sessionId || 'unknown';
+  try { return readFileSync(join(tmpdir(), `${prefix}-${key}`), 'utf8'); } catch { /* fall through */ }
+  try {
+    const p = `${prefix}-`;
+    const tmp = tmpdir();
+    const now = Date.now();
+    const files = readdirSync(tmp)
+      .filter(f => f.startsWith(p))
+      .map(f => ({ full: join(tmp, f), mtime: statSync(join(tmp, f)).mtimeMs }))
+      .filter(f => (now - f.mtime) < FLAG_MAX_AGE_MS)
+      .sort((a, b) => b.mtime - a.mtime);
+    if (files.length > 0) return readFileSync(files[0].full, 'utf8');
+  } catch { /* ignore */ }
+  return null;
+}
+
+function sessionFlagExists(prefix, sessionId) {
+  return readSessionFlagRaw(prefix, sessionId) !== null;
+}
+
+/**
+ * Derive the verification state at card-render time. `unverified` is true when a
+ * code change still owes a passing Light check (pending && !verified) \u2014 i.e. the
+ * turn is finishing without verification (a silent skip, an order violation, or
+ * a red run). `red` distinguishes "a test ran but failed" for the stamp wording.
+ */
+function readVVState(sessionId) {
+  const pending = sessionFlagExists('dotclaude-devops-light-pending', sessionId);
+  const verified = sessionFlagExists('dotclaude-devops-light-verified', sessionId);
+  const red = sessionFlagExists('dotclaude-devops-light-red', sessionId);
+  return { unverified: pending && !verified, red };
+}
+
+const UNVERIFIED_STAMP = {
+  de: {
+    plain: '\u26a0\ufe0f **UNVERIFIZIERT** \u2014 Code ge\u00e4ndert, aber kein bestandener Test/Check in diesem Turn.',
+    red:   '\u26a0\ufe0f **TESTS ROT** \u2014 ein Test lief, schlug aber fehl. Nicht verifiziert.',
+  },
+  en: {
+    plain: '\u26a0\ufe0f **UNVERIFIED** \u2014 code changed but no passing test/check ran this turn.',
+    red:   '\u26a0\ufe0f **TESTS RED** \u2014 a test ran but failed. Not verified.',
+  },
+};
+
+function renderUnverifiedStamp(lang, red) {
+  const d = UNVERIFIED_STAMP[lang] || UNVERIFIED_STAMP.de;
+  return red ? d.red : d.plain;
+}
+
+const VALIDATION_LABEL = { de: '\u2705 **Validierung**', en: '\u2705 **Validation**' };
+const VALIDATION_STATUS_ICON = { met: '\u2705', partial: '\u26a0\ufe0f', unmet: '\u274c' };
+
+function renderValidation(items, lang) {
+  if (!items || items.length === 0) return '';
+  const header = VALIDATION_LABEL[lang] || VALIDATION_LABEL.de;
+  const bullets = items.slice(0, 4).map(it => {
+    const icon = VALIDATION_STATUS_ICON[it && it.status] || '\u2022';
+    const req = (it && it.requirement) || '';
+    const ev = it && it.evidence ? ' \u2014 ' + it.evidence : '';
+    return '* ' + icon + ' ' + req + ev;
+  });
+  return header + '\n' + bullets.join('\n');
+}
+
 function renderCard(input, meterText, buildId) {
   const variant = input.variant || 'fallback';
   const config = VARIANTS[variant] || VARIANTS.fallback;
@@ -511,6 +589,14 @@ function renderCard(input, meterText, buildId) {
   parts.push(renderTitle(input.summary || 'Task completed'));
   parts.push('');
 
+  // V&V stamp — flagged directly under the title so an unverified / red finish
+  // is impossible to miss. Driven by the Light-verification flags (read at the
+  // call site and passed in as input.vv), not a self-reported param.
+  if (input.vv && input.vv.unverified) {
+    parts.push(blockquote(renderUnverifiedStamp(lang, input.vv.red)));
+    parts.push('');
+  }
+
   if (config.changes) {
     const changesBlock = renderChanges(input.changes);
     if (changesBlock) {
@@ -523,6 +609,18 @@ function renderCard(input, meterText, buildId) {
     const testsBlock = renderTests(input.tests);
     if (testsBlock) {
       parts.push(blockquote(testsBlock));
+      parts.push('');
+    }
+  }
+
+  // Validation block (V&V gate) — "did we build the RIGHT thing": maps the
+  // change to its requirements. Rendered whenever provided (variant-agnostic,
+  // mirroring the gate, which keys off validation-pending not the variant);
+  // stop.flow.guard blocks a code-change card that omits it.
+  {
+    const validationBlock = renderValidation(input.validation, lang);
+    if (validationBlock) {
+      parts.push(blockquote(validationBlock));
       parts.push('');
     }
   }
@@ -843,6 +941,14 @@ server.registerTool(
           }),
         ])).optional(),
       ).describe("User-final-test items — for changes where automation cannot cover the last step (packaged Electron/Tauri without desktop takeover, 3rd-party integrations). Pass strings for local final tests; pass { action, afterDeployment: true } for 3rd-party items that require deployment first. Available in all variants except test-minimal and test — in the test variant all manual steps go into userTest (single test section, no duplicate)."),
+      validation: z.preprocess(
+        v => typeof v === 'string' ? tryParse(v) : v,
+        z.array(z.object({
+          requirement: z.string().describe("A requirement / acceptance criterion the change had to satisfy — in user-domain language."),
+          status: z.enum(["met", "partial", "unmet"]).optional().describe("Whether this change satisfies the requirement."),
+          evidence: z.string().optional().describe("How you CONFIRMED it (the test that proves it, the behaviour observed) — not a restatement of the requirement."),
+        })).max(4).optional(),
+      ).describe("V&V gate — validation attestation (“did we build the RIGHT thing”). REQUIRED for any turn that changed source code: map each requirement / acceptance criterion to how this change meets it and how you confirmed it. A code-change card without `validation` is blocked once by stop.flow.guard and re-requested. For a pure refactor/chore with no explicit requirement, pass one item stating the intent and how behaviour was kept equivalent. Each item: { requirement, status: met|partial|unmet, evidence }."),
     }),
   },
   async (params) => {
@@ -875,16 +981,26 @@ server.registerTool(
     // 3. Use pre-computed build-ID if provided, otherwise compute from cwd
     const buildId = params.buildId || getBuildId(params.cwd);
 
+    // 3b. V&V gate — derive the verification state from the Light flags so the
+    //     card can stamp ⚠ UNVERIFIED on an unverified / red finish.
+    params.vv = readVVState(params.session_id);
+
     // 4. Render the full card
     const cardMarkdown = renderCard(params, meterText, buildId);
 
-    // 5. Write card-rendered flag for stop.flow.guard
+    // 5. Write completion flags for stop.flow.guard:
+    //    - card-rendered satisfies the card gate.
+    //    - validation-attested satisfies the validation gate, but ONLY when the
+    //      `validation` field was actually populated (an empty array does not
+    //      attest anything).
     try {
       const key = params.session_id || 'unknown';
-      const flagPath = join(tmpdir(), 'dotclaude-devops-card-rendered-' + key);
-      writeFileSync(flagPath, new Date().toISOString());
+      writeFileSync(join(tmpdir(), 'dotclaude-devops-card-rendered-' + key), new Date().toISOString());
+      if (Array.isArray(params.validation) && params.validation.length > 0) {
+        writeFileSync(join(tmpdir(), 'dotclaude-devops-validation-attested-' + key), new Date().toISOString());
+      }
     } catch (e) {
-      console.error('[dotclaude-completion-mcp] Failed to write card flag:', e.message);
+      console.error('[dotclaude-completion-mcp] Failed to write completion flag:', e.message);
     }
 
     return {

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.97.0",
+  "version": "0.98.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

Harden the post-implementation test gate so the test can no longer be silently skipped, and add the missing validation half (V&V).

- **Verification** — a test run only counts when it actually PASSED (best-effort from `tool_response`, conservative); a new qualifying edit invalidates a prior verification (order); the gate escalates (blocks up to 2×, an early skip needs an explicit `SKIP-VERIFICATION: <reason>` token) and stamps ⚠ UNVERIFIED on the completion card.
- **Validation** — any source change must carry a `validation` attestation on the card (requirement → status → evidence), enforced once by `stop.flow.guard`; `render_completion_card` gains the `validation` param + stamp + attested flag.

364 tests green (102 new/changed gate tests), eslint clean. Codex review skipped (usage quota exhausted).