### PR TITLE
docs(test): dev-only full-permission local test user convention

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.99.0"
+    "version": "0.99.1"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.99.0",
+      "version": "0.99.1",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.99.0",
+      "version": "0.99.1",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.99.1] — 2026-06-08
+
+### Added
+
+- **Local test user convention for local testing.** `test-strategy.md` documents a dev-only **local test user** that holds all application permissions, so authenticated and admin-gated flows can be exercised in an autonomous Light browser check without permission walls — while existing **only on the developer's machine** (local DB / dev seed / fixtures, gated behind a dev-only guard like `NODE_ENV !== 'production'`) and **never** in production migrations, seeds, or deployed data (a full-permission account reaching prod is treated as a critical vulnerability, not a preference). It pairs with Preview's per-baseRepo login persistence and is not a substitute for the Mock-First + User-Final-Test protocol covering real external identity providers. `preview-testing.md` cross-links it from the persistence note.
+
 ## [0.99.0] — 2026-06-08
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.99.0**
+**Version: 0.99.1**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.99.0",
+  "version": "0.99.1",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/deep-knowledge/preview-testing.md
+++ b/plugins/devops/deep-knowledge/preview-testing.md
@@ -38,7 +38,9 @@ Preview persists cookies + localStorage in an Electron partition keyed by the
 Consequences (empirically verified):
 
 - A login done once in a repo's Preview **persists across worktrees and chats** of
-  that repo — no per-window Edge profile juggling, no re-login per chat.
+  that repo — no per-window Edge profile juggling, no re-login per chat. The account
+  you log in as is normally the **local test user** (full app permissions, dev-only,
+  never deployed to prod — see [test-strategy.md](test-strategy.md) § Local Test User).
 - It survives `preview_stop` → `preview_start` (the partition is held by the Claude
   Desktop App main process).
 - Scope is **per baseRepo**: a different repo has its own jar (one login per repo).

--- a/plugins/devops/deep-knowledge/test-strategy.md
+++ b/plugins/devops/deep-knowledge/test-strategy.md
@@ -42,6 +42,30 @@ changed view in a real browser engine, not to hit production services.
 preview server configured" or "Electron app, no web server".** If the project is
 pure web tech, configure a dev preview or mount the HTML directly.
 
+## Local Test User — full-permission, dev-only
+
+Authenticated flows must be testable locally without real production accounts. A
+project with auth SHOULD provide a **local test user** for development testing:
+
+- **Full application permissions.** The test user holds every role/permission the
+  app defines (admin / superuser), so any feature — including gated and admin-only
+  views — can be exercised in a Light browser check without hitting a permission
+  wall. This is what lets autonomous Light verification reach the whole UI.
+- **Local-only — NEVER deployed to prod/live.** The test user exists **only on the
+  developer's machine** (local DB / dev seed / fixtures). It MUST be gated behind a
+  dev-only guard (`NODE_ENV !== 'production'`, a `seed:dev`-style script, or a
+  fixture the local stack loads exclusively) and MUST NOT appear in production
+  migrations, seeds, or deployed data. **A full-permission account reaching prod is
+  a critical vulnerability — its prod-exclusion is a hard rule, not a preference.**
+- **Pairs with Preview persistence.** Log in once as the local test user in the
+  active browser tool; the session persists per-baseRepo across worktrees and chats
+  (see [preview-testing.md](preview-testing.md)), so authenticated Light checks run
+  without re-login.
+- **Not a substitute for the real-integration step.** Real OAuth / SSO / 3rd-party
+  identity against production still follows the Mock-First + User-Final-Test
+  protocol below — the local test user covers **in-app authorization**, not
+  external identity providers.
+
 ## Electron / Native UI — Dev-Browser + User-Final-Test
 
 Packaged Electron, Tauri, native-UI hybrid apps cannot be reached by Chrome-MCP /

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.99.0",
+  "version": "0.99.1",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
Document a **local test user** for local testing: it holds all application permissions (so authenticated/admin-gated flows are reachable in an autonomous Light browser check) but exists **only on the developer's machine** — gated behind a dev-only guard and **never** present in production migrations, seeds, or deployed data. A full-permission account reaching prod is treated as a critical vulnerability. Pairs with Preview's per-baseRepo login persistence; not a substitute for the Mock-First + User-Final-Test protocol covering real external identity providers.

- `deep-knowledge/test-strategy.md`: new "Local Test User — full-permission, dev-only" section
- `deep-knowledge/preview-testing.md`: cross-link from the persistence note

Docs-only; 364 tests + lint green. build-id `861b051`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>