### PR TITLE
fix(ship): prevent parallel-merge data loss + live deploy verify

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.99.1"
+    "version": "0.100.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.99.1",
+      "version": "0.100.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.99.1",
+      "version": "0.100.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.100.0] — 2026-06-08
+
+### Fixed
+
+- **Ship/merge can no longer silently drop parallel `main` changes (#207).** `ship_release` verified the branch was rebased onto `base` only at the *start* of the pipeline — but the pre-merge CI-checks gate then blocks for up to `checksTimeoutSec` (default 600s), and the merge runs `gh pr merge --admin`, which **bypasses GitHub's own "require branches to be up to date before merging" rule**. A parallel ship landing on `base` during that wait was therefore force-merged over a stale branch with `--admin` — the silent-overwrite vector. The tool now **re-asserts `isRebasedOnto(origin/base)` immediately before the merge**: if `base` advanced, it returns `rebaseRequired: true` + `baseAdvancedDuringChecks: true`, leaves the PR open and unmerged, and the ship skill rebases + retries. A **post-merge tree guard** (`treeOf(HEAD)` vs `treeOf(origin/base)`) then proves the merge captured exactly the rebased + built + tested tree; a mismatch (a concurrent non-overlapping ship three-way-merged in) surfaces a non-fatal `postMergeWarning` rather than passing silently. The force-push now uses an **explicit `--force-with-lease=<branch>:<sha>`** pinned to the last-known remote sha (only ever on the feature branch, never `base`), so an implicit background fetch can't widen the lease. `merge-safety.md` documents the two-phase gate invariant and why `squash` stays safe (every merge is fast-forward-equivalent post-rebase). New `treeOf` helper in `git.js`; `release.test.js` adds an 11-case regression suite pinning both gates, the skipChecks bypass, the fail-closed checks gate, and the tree guard. `devops-ship` SKILL 0.4.0→0.5.0.
+
+### Added
+
+- **`/devops-ship` verifies the live deploy result in a browser before declaring done (#210).** A green pipeline ≠ a release users can see: a `prerelease`-flagged GitHub release leaves the prior version as `/releases/latest`, a download page driven by a DB row / API keeps serving the old version until that row is registered, and multi-surface releases (web + desktop binary + edge functions) can have one surface silently lag. New **Step 4c — Live Surface Verification** opens each declared user-facing surface in Edge (Claude-in-Chrome), reads the **rendered** version marker via Eval JS, and asserts it matches the just-shipped version before the completion card — complementing (not replacing) the pre-merge `stop.flow.browsertest` gate and the headless post-merge watcher (Step 4b). Surfaces are declared opt-in via a `surfaces:` list in `{project}/.claude/skills/ship/reference.md` (`deep-knowledge/post-merge-verify.md` documents the format); a lagging or old-version surface becomes a prominent `userFinalTest` item on the card rather than a silent success. Skips cleanly when no surfaces are declared (libraries, CLIs, internal tooling).
+
 ## [0.99.1] — 2026-06-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.99.1**
+**Version: 0.100.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.99.1",
+  "version": "0.100.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/deep-knowledge/merge-safety.md
+++ b/plugins/devops/deep-knowledge/merge-safety.md
@@ -194,15 +194,67 @@ As of v0.3.0, `git-sync.js` resolves conflicts in two tiers:
 
 ## How ship_release Prevents Overwrites
 
-The release tool verifies the branch is rebased before allowing merge:
+`ship_release` enforces a **two-phase rebase gate** plus a **post-merge tree
+guard**. Together these make a parallel change on `base` impossible to drop or
+overwrite — regardless of merge strategy.
+
+### Phase 1 — entry gate (before push/PR)
 
 1. `git fetch origin <base>` — get latest base
 2. `isRebasedOnto(origin/<base>)` — verify HEAD includes all base commits
 3. If not rebased → return `rebaseRequired: true` with overlap analysis
 4. The ship skill (Step 1 loop) handles rebase + AI conflict resolution + test
 
-Additionally, when file overlap is detected in preflight, the skill switches from
-`squash` to `merge` strategy to preserve the ancestry chain for future merges.
+### Phase 2 — pre-merge re-check (the critical one)
+
+The entry gate alone is **not enough**: the pre-merge CI-checks gate blocks for
+up to `checksTimeoutSec` (default 600s), and a parallel ship can land on `base`
+during that wait. Crucially, the merge runs `gh pr merge --admin` — needed for
+the bot to self-merge past required-review protection — which **bypasses
+GitHub's own "require branches to be up to date before merging" rule**. So the
+tool re-asserts `isRebasedOnto(origin/<base>)` immediately before the merge:
+
+- still up to date → proceed to merge
+- base advanced → return `rebaseRequired: true` + `baseAdvancedDuringChecks:
+  true`, PR left **open** (not merged). The skill rebases and retries.
+
+This restores, in our own code, the up-to-date guarantee that `--admin`
+discards. It is the fix for the silent-overwrite vector in #207.
+
+### Phase 3 — post-merge tree guard
+
+After the merge, `treeOf(HEAD)` is compared to `treeOf(origin/<base>)`. Because
+Phase 2 guarantees `HEAD ⊇ origin/base` at merge time, the merge is
+**fast-forward-equivalent for every strategy** (squash/merge/rebase all yield
+`base`'s tree == HEAD's tree). So:
+
+- **`postMergeTreeMatch: true`** → `base` captured exactly the tree that was
+  rebased + built + tested. The pre-merge build/test **is** the post-merge
+  validation — no separate post-merge build needed.
+- **`postMergeTreeMatch: false`** → a concurrent ship squeezed into the ~1s
+  window between the re-check and gh's merge and was three-way merged in (its
+  changes are **preserved**, not lost), or an unexpected divergence. Non-fatal
+  (the merge already landed) but surfaced as `postMergeWarning` so the skill
+  flags "verify main is consistent".
+
+### Why squash is safe here
+
+The classic squash data-loss (see "Why Squash Merges Cause Data Loss" above)
+requires merging **without** a rebase. Phase 2 forbids that: every merge —
+intermediate *and* final — is ff-equivalent, so the squash commit's tree equals
+HEAD's tree and a later branch sharing history is itself forced to rebase before
+it can merge. `squash` therefore cannot sever ancestry in a data-losing way. The
+skill still upgrades `squash` → `merge` when preflight reports file overlap, as a
+belt-and-suspenders for history readability.
+
+### Force-push scoping
+
+The `git push --force-with-lease` only ever targets the **feature branch**,
+never `base` — so it cannot clobber base commits. It uses an **explicit lease**
+pinned to the last-known remote sha (`--force-with-lease=<branch>:<sha>`) rather
+than the bare form, so an implicit background fetch (the git-sync cron) cannot
+widen the lease and let a concurrent push to the same branch slip through
+unseen. Brand-new branches (no remote-tracking ref) push without a lease.
 
 ## Timestamp Caveat
 

--- a/plugins/devops/mcp-server/ship/lib/git.js
+++ b/plugins/devops/mcp-server/ship/lib/git.js
@@ -302,6 +302,20 @@ export function isRebasedOnto(base, opts) {
 }
 
 /**
+ * Return the tree object id of a ref (e.g. "HEAD", "origin/main"), or null.
+ *
+ * The tree id is content-addressed: two refs with byte-identical working
+ * trees share the same tree id even when their commit ids differ — e.g. a
+ * squash-merged base and the branch it was built from. ship_release uses this
+ * to assert, AFTER the merge, that origin/base captured exactly the tree that
+ * was rebased + built + tested — proving no parallel change was dropped or
+ * overwritten. See merge-safety.md "How ship_release Prevents Overwrites". (#207)
+ */
+export function treeOf(ref, opts) {
+  return git(`rev-parse ${ref}^{tree}`, opts);
+}
+
+/**
  * Check git config value. Returns the value or null.
  */
 export function getConfig(key, opts) {

--- a/plugins/devops/mcp-server/ship/tools/release.js
+++ b/plugins/devops/mcp-server/ship/tools/release.js
@@ -5,7 +5,7 @@
 
 import { z } from "zod";
 import { execFileSync } from "node:child_process";
-import { git, gitStrict, currentBranch, headShort, dirtyState, isWorktree, isRebasedOnto, fileOverlap, syncLocalBranch } from "../lib/git.js";
+import { git, gitStrict, currentBranch, headShort, dirtyState, isWorktree, isRebasedOnto, fileOverlap, syncLocalBranch, treeOf } from "../lib/git.js";
 import { createPR, mergePR, createRelease, findExistingPR, watchPRChecks } from "../lib/github.js";
 import { detectRepoMode } from "../lib/repo-mode.js";
 
@@ -104,8 +104,19 @@ export async function handler(params) {
     }
     result.rebased = true;
 
-    // Push (use longer timeout for large repos / slow networks)
-    gitStrict(`push -u origin ${branch} --force-with-lease`, { cwd, timeout: 60_000 });
+    // Push. The force-with-lease only ever targets the feature `branch` —
+    // NEVER `base` — so it structurally cannot clobber base commits. Use an
+    // EXPLICIT lease pinned to the last-known remote sha (not the bare
+    // `--force-with-lease`): a bare lease trusts the remote-tracking ref, which
+    // an implicit background fetch (the git-sync cron) can silently advance,
+    // widening the lease so a concurrent push to the SAME branch would be
+    // overwritten unseen. A brand-new branch has no remote-tracking ref → push
+    // without a lease (nothing to overwrite). (#207)
+    const remoteBranchSha = git(`rev-parse --verify --quiet refs/remotes/origin/${branch}`, opts);
+    const leaseArg = remoteBranchSha
+      ? `--force-with-lease=${branch}:${remoteBranchSha}`
+      : `--force-with-lease`;
+    gitStrict(`push -u origin ${branch} ${leaseArg}`, { cwd, timeout: 60_000 });
     result.pushed = true;
 
     // Check for existing open PR before creating a new one
@@ -153,12 +164,67 @@ export async function handler(params) {
       result.checks = { status: "skipped", reason: skipChecks ? "skipChecks param" : "DEVOPS_SHIP_SKIP_CHECKS env" };
     }
 
+    // Re-assert up-to-date against base IMMEDIATELY before merging — close the
+    // time-of-check/time-of-use window. The rebase gate above can be minutes
+    // stale: the pre-merge CI checks gate blocks for up to checksTimeoutSec
+    // (default 600s), and a parallel ship / worktree can land on `base` during
+    // that wait. Because mergePR uses `gh pr merge --admin` (needed for the bot
+    // to self-merge past required-review protection), GitHub's own "require
+    // branches to be up to date before merging" rule is BYPASSED — so without
+    // this re-check, a stale branch would be force-merged over an advanced base
+    // with --admin, the exact silent-overwrite vector #207 describes. Re-checking
+    // here restores that guarantee at merge time. The skill's Step 1 loop rebases
+    // and retries on rebaseRequired. (#207)
+    gitStrict(`fetch origin ${base}`, { cwd, timeout: 30_000 });
+    if (!isRebasedOnto(`origin/${base}`, opts)) {
+      const overlap = fileOverlap(`origin/${base}`, opts);
+      result.success = false;
+      result.rebaseRequired = true;
+      result.baseAdvancedDuringChecks = true;
+      result.overlapFiles = overlap.overlap;
+      result.error =
+        `origin/${base} advanced while the ship was in progress (likely a parallel ship) — ` +
+        `branch is no longer up to date. PR #${pr.number} left OPEN, NOT merged. ` +
+        `Rebase onto origin/${base} and retry ship_release. ` +
+        (overlap.overlap.length > 0
+          ? `${overlap.overlap.length} overlapping file(s): ${overlap.overlap.slice(0, 10).join(", ")}`
+          : "No file overlap detected — rebase should be clean.");
+      return result;
+    }
+
+    // Snapshot the validated tree BEFORE the merge. Because we just re-asserted
+    // HEAD ⊇ origin/base, merging HEAD into base is fast-forward-equivalent for
+    // every strategy (squash/merge/rebase all yield base == HEAD's tree). The
+    // post-merge guard below compares against this to prove the merge captured
+    // exactly the tree that was rebased + built + tested. (#207)
+    const shippedTree = treeOf("HEAD", opts);
+
     // Merge PR (delete branch; skip --delete-branch in worktrees
     // where gh tries to switch to base locally — cleanup handles branch deletion)
     const worktree = isWorktree(opts);
     const mergeSha = mergePR(pr.number, base, opts, { skipDeleteBranch: worktree, strategy: mergeStrategy });
     result.merged = base;
     result.mergeSha = mergeSha;
+
+    // Post-merge tree verification. mergePR already fetched origin/base, so its
+    // tree is current. With the pre-merge re-check holding, origin/base's tree
+    // MUST equal the shipped HEAD tree — squash/merge/rebase are all ff-equivalent
+    // here, so the merge result is byte-identical to the built+tested branch.
+    //   match  → the pre-merge build/test IS the post-merge validation; nothing
+    //            was dropped or overwritten.
+    //   differ → either a parallel non-overlapping ship squeezed into the ~1s
+    //            window between the re-check and gh's merge (GitHub 3-way merged
+    //            it in — those changes are PRESERVED, not lost) OR an unexpected
+    //            divergence. Non-fatal (the merge already landed) but surfaced so
+    //            the skill flags "verify main is consistent". (#207)
+    const baseTree = treeOf(`origin/${base}`, opts);
+    result.postMergeTreeMatch = shippedTree !== null && baseTree !== null && shippedTree === baseTree;
+    if (!result.postMergeTreeMatch) {
+      result.postMergeWarning =
+        `origin/${base} after merge does not match the shipped tree byte-for-byte. ` +
+        `Most likely a concurrent ship landed in parallel and was three-way merged in ` +
+        `(its changes are preserved). Verify main is logically consistent before relying on it.`;
+    }
 
     // Sync the LOCAL base ref to the just-merged origin/base. After a remote-side
     // merge, origin/base advanced but the local base ref does NOT move on its own.

--- a/plugins/devops/mcp-server/ship/tools/release.test.js
+++ b/plugins/devops/mcp-server/ship/tools/release.test.js
@@ -1,0 +1,268 @@
+import { describe, test, expect, vi, beforeEach } from "vitest";
+
+// zod is a runtime dependency of the MCP server (installed where the server
+// runs) but is not a devDependency of this repo, so the test environment can't
+// resolve it. The handler never invokes the schema — only the MCP registration
+// does — so a minimal chainable stub is enough to load the module.
+vi.mock("zod", () => {
+  const node = new Proxy(() => node, { get: () => () => node });
+  return { z: { object: () => node, string: () => node, boolean: () => node, enum: () => node, number: () => node } };
+});
+
+// Mock node:child_process so the optional commit path (execFileSync) never
+// shells out to a real git during tests. The mocked git.js / github.js below
+// cover every other process call.
+vi.mock("node:child_process", () => ({
+  execFileSync: vi.fn(() => ""),
+  execSync: vi.fn(() => ""),
+}));
+
+vi.mock("../lib/repo-mode.js", () => ({
+  detectRepoMode: vi.fn(() => "git"),
+}));
+
+vi.mock("../lib/git.js", () => ({
+  git: vi.fn(() => ""),
+  gitStrict: vi.fn(() => ""),
+  currentBranch: vi.fn(() => "feature-x"),
+  headShort: vi.fn(() => "abc1234"),
+  dirtyState: vi.fn(() => ({ dirty: false, modified: [], untracked: [], lines: [] })),
+  isWorktree: vi.fn(() => false),
+  isRebasedOnto: vi.fn(() => true),
+  fileOverlap: vi.fn(() => ({ mergeBase: "base", branchFiles: [], baseFiles: [], overlap: [] })),
+  syncLocalBranch: vi.fn(() => ({ updated: true, method: "fetch-refspec" })),
+  treeOf: vi.fn((ref) => (ref === "HEAD" ? "T1" : "T1")),
+}));
+
+vi.mock("../lib/github.js", () => ({
+  createPR: vi.fn(() => ({ number: 42, url: "https://example.com/pull/42" })),
+  mergePR: vi.fn(() => "merge12"),
+  createRelease: vi.fn(() => undefined),
+  findExistingPR: vi.fn(() => null),
+  watchPRChecks: vi.fn(() => ({ status: "passed", checks: [] })),
+}));
+
+import { handler } from "./release.js";
+import * as gitLib from "../lib/git.js";
+import * as ghLib from "../lib/github.js";
+
+function params(overrides = {}) {
+  return {
+    base: "main",
+    title: "feat: thing",
+    body: "## Summary\nCloses #1",
+    tag: "v1.0.0",
+    releaseNotes: "notes",
+    prerelease: false,
+    commitMessage: null,
+    mergeStrategy: "squash",
+    skipChecks: false,
+    checksTimeoutSec: 600,
+    cwd: "/repo",
+    ...overrides,
+  };
+}
+
+// All `gitStrict` invocations that fetch the base branch, with their global
+// invocation order — used to prove the pre-merge re-check fetches a FRESH
+// origin/base before re-checking (the load-bearing #207 ordering invariant).
+function fetchBaseCalls() {
+  return gitLib.gitStrict.mock.calls
+    .map((c, i) => ({ cmd: c[0], order: gitLib.gitStrict.mock.invocationCallOrder[i] }))
+    .filter((x) => typeof x.cmd === "string" && /^fetch origin main\b/.test(x.cmd));
+}
+
+function pushCall() {
+  return gitLib.gitStrict.mock.calls.find(
+    (c) => typeof c[0] === "string" && c[0].startsWith("push "),
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Restore the default happy-path implementations (detectRepoMode lives on the
+  // repo-mode mock and keeps its factory default through clearAllMocks).
+  gitLib.currentBranch.mockReturnValue("feature-x");
+  gitLib.headShort.mockReturnValue("abc1234");
+  gitLib.dirtyState.mockReturnValue({ dirty: false, modified: [], untracked: [], lines: [] });
+  gitLib.isWorktree.mockReturnValue(false);
+  gitLib.isRebasedOnto.mockReturnValue(true);
+  gitLib.fileOverlap.mockReturnValue({ mergeBase: "base", branchFiles: [], baseFiles: [], overlap: [] });
+  gitLib.syncLocalBranch.mockReturnValue({ updated: true, method: "fetch-refspec" });
+  // Distinct-but-equal trees keyed by ref → postMergeTreeMatch is true ONLY when
+  // the code looks up the two correct refs (HEAD and origin/main), not by accident.
+  gitLib.treeOf.mockImplementation((ref) => (ref === "HEAD" ? "T1" : "T1"));
+  // ls-remote --tags returns the tag → tag already exists, skip creation path.
+  gitLib.git.mockImplementation((cmd) =>
+    cmd.includes("ls-remote --tags") ? "abc\trefs/tags/v1.0.0" : "remoteSha",
+  );
+  gitLib.gitStrict.mockReturnValue("");
+  ghLib.findExistingPR.mockReturnValue(null);
+  ghLib.createPR.mockReturnValue({ number: 42, url: "https://example.com/pull/42" });
+  ghLib.mergePR.mockReturnValue("merge12");
+  ghLib.watchPRChecks.mockReturnValue({ status: "passed", checks: [] });
+});
+
+describe("ship_release — #207 parallel-change data-loss guards", () => {
+  test("REGRESSION: base advancing during the CI-checks wait blocks the merge", async () => {
+    // Phase-1 entry gate passes; Phase-2 pre-merge re-check fails — simulates a
+    // parallel ship landing on main while we waited for CI checks.
+    gitLib.isRebasedOnto.mockReturnValueOnce(true).mockReturnValueOnce(false);
+    gitLib.fileOverlap.mockReturnValue({
+      mergeBase: "base",
+      branchFiles: ["a.js"],
+      baseFiles: ["b.js"],
+      overlap: [],
+    });
+
+    const res = await handler(params());
+
+    expect(res.success).toBe(false);
+    expect(res.rebaseRequired).toBe(true);
+    expect(res.baseAdvancedDuringChecks).toBe(true);
+    // The merge MUST NOT have happened — that is the whole point of #207.
+    expect(ghLib.mergePR).not.toHaveBeenCalled();
+    expect(res.error).toMatch(/no longer up to date|advanced/i);
+
+    // The re-check must observe FRESH data: a second `fetch origin main` must
+    // precede the second isRebasedOnto. Without this, a refactor could drop the
+    // re-check's fetch and silently re-introduce the stale-ref overwrite vector.
+    const fetches = fetchBaseCalls();
+    expect(fetches.length).toBe(2);
+    expect(fetches[1].order).toBeLessThan(gitLib.isRebasedOnto.mock.invocationCallOrder[1]);
+  });
+
+  test("REGRESSION: re-check survives the skipChecks bypass (hot-fix path)", async () => {
+    // Hot-fix bypass skips the CI wait — but is exactly when a human is rushing
+    // and a parallel ship is most likely to have landed. The Phase-2 re-check
+    // MUST still fire. Guards against a refactor folding it into the checks block.
+    gitLib.isRebasedOnto.mockReturnValueOnce(true).mockReturnValueOnce(false);
+
+    const res = await handler(params({ skipChecks: true }));
+
+    expect(res.checks.status).toBe("skipped");
+    expect(res.success).toBe(false);
+    expect(res.baseAdvancedDuringChecks).toBe(true);
+    expect(ghLib.mergePR).not.toHaveBeenCalled();
+    expect(fetchBaseCalls().length).toBe(2);
+  });
+
+  test("REGRESSION: Phase-1 entry gate blocks a non-rebased branch before any push/PR/merge", async () => {
+    // Both gates would fail — but Phase 1 must catch it FIRST, before push.
+    // baseAdvancedDuringChecks stays undefined (the discriminator between the
+    // two gates), and nothing reaches the network-mutating steps.
+    gitLib.isRebasedOnto.mockReturnValue(false);
+
+    const res = await handler(params());
+
+    expect(res.success).toBe(false);
+    expect(res.rebaseRequired).toBe(true);
+    expect(res.baseAdvancedDuringChecks).toBeUndefined();
+    expect(res.pushed).toBeUndefined();
+    expect(pushCall()).toBeUndefined();
+    expect(ghLib.createPR).not.toHaveBeenCalled();
+    expect(ghLib.mergePR).not.toHaveBeenCalled();
+    // Only the entry-gate fetch ran — the re-check is never reached.
+    expect(fetchBaseCalls().length).toBe(1);
+  });
+
+  test("checks gate failure blocks the merge (fail-closed)", async () => {
+    ghLib.watchPRChecks.mockReturnValue({
+      status: "failed",
+      checks: [],
+      failed: [{ name: "build", link: "https://example.com/run/1" }],
+      pending: [],
+      error: "1 check(s) failed: build",
+    });
+
+    const res = await handler(params());
+
+    expect(res.success).toBe(false);
+    expect(res.checksBlocked).toBe(true);
+    expect(ghLib.mergePR).not.toHaveBeenCalled();
+    // Blocked before the re-check — only the entry-gate fetch ran.
+    expect(fetchBaseCalls().length).toBe(1);
+  });
+
+  test("probe-error on checks is fail-closed (treated as block-worthy)", async () => {
+    ghLib.watchPRChecks.mockReturnValue({ status: "probe-error", error: "gh auth failed" });
+
+    const res = await handler(params());
+
+    expect(res.success).toBe(false);
+    expect(res.checksBlocked).toBe(true);
+    expect(ghLib.mergePR).not.toHaveBeenCalled();
+  });
+
+  test("existing CONFLICTING PR is refused before merge", async () => {
+    ghLib.findExistingPR.mockReturnValue({ number: 7, url: "https://example.com/pull/7", mergeable: "CONFLICTING" });
+
+    const res = await handler(params());
+
+    expect(res.success).toBe(false);
+    expect(res.error).toMatch(/CONFLICTING/);
+    expect(ghLib.createPR).not.toHaveBeenCalled();
+    expect(ghLib.mergePR).not.toHaveBeenCalled();
+  });
+
+  test("happy path: rebased at both gates → merge proceeds, tree matches the two correct refs", async () => {
+    const res = await handler(params());
+
+    expect(res.success).toBe(true);
+    expect(res.merged).toBe("main");
+    expect(ghLib.mergePR).toHaveBeenCalledTimes(1);
+    // Both gates ran: entry + re-check.
+    expect(gitLib.isRebasedOnto).toHaveBeenCalledTimes(2);
+    expect(fetchBaseCalls().length).toBe(2);
+    // The post-merge guard compares the two CORRECT, distinct refs (not HEAD↔HEAD).
+    expect(gitLib.treeOf).toHaveBeenCalledWith("HEAD", expect.anything());
+    expect(gitLib.treeOf).toHaveBeenCalledWith("origin/main", expect.anything());
+    expect(res.postMergeTreeMatch).toBe(true);
+    expect(res.postMergeWarning).toBeUndefined();
+  });
+
+  test("post-merge tree mismatch surfaces a non-fatal warning (parallel non-overlap merge)", async () => {
+    // HEAD tree differs from origin/main tree after merge → a concurrent ship was
+    // three-way merged in. The ship still succeeded (changes preserved), but the
+    // skill is told to verify consistency.
+    gitLib.treeOf.mockImplementation((ref) => (ref === "HEAD" ? "tree-head" : "tree-base"));
+
+    const res = await handler(params());
+
+    expect(res.success).toBe(true);
+    expect(res.postMergeTreeMatch).toBe(false);
+    expect(res.postMergeWarning).toMatch(/does not match|consistent/i);
+  });
+
+  test("a null tree (rev-parse failure) yields a non-fatal mismatch warning, not a false match", async () => {
+    gitLib.treeOf.mockReturnValue(null);
+
+    const res = await handler(params());
+
+    expect(res.success).toBe(true);
+    expect(res.postMergeTreeMatch).toBe(false);
+    expect(res.postMergeWarning).toBeTruthy();
+  });
+
+  test("push uses an explicit lease pinned to the remote sha (not a bare lease)", async () => {
+    await handler(params());
+
+    const push = pushCall();
+    expect(push).toBeDefined();
+    expect(push[0]).toContain("--force-with-lease=feature-x:remoteSha");
+  });
+
+  test("brand-new branch (no remote-tracking ref) falls back to a bare lease", async () => {
+    gitLib.git.mockImplementation((cmd) => {
+      if (cmd.includes("ls-remote --tags")) return "abc\trefs/tags/v1.0.0";
+      if (cmd.includes("rev-parse --verify --quiet")) return null; // no remote branch yet
+      return "";
+    });
+
+    await handler(params());
+
+    const push = pushCall();
+    expect(push[0]).toContain("--force-with-lease");
+    expect(push[0]).not.toContain("--force-with-lease=");
+  });
+});

--- a/plugins/devops/skills/devops-ship/SKILL.md
+++ b/plugins/devops/skills/devops-ship/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: devops-ship
-version: 0.4.0
+version: 0.5.0
 description: >-
   Full end-to-end shipping pipeline using MCP tools: ship_preflight, ship_build,
   ship_version_bump, ship_release, ship_cleanup, render_completion_card,
@@ -209,9 +209,9 @@ See `deep-knowledge/call-examples.md` for the three reference payloads
 For intermediate merges: no tag, no release notes, no version commit —
 the tool automatically skips tag/release creation when `base` is not `main`.
 
-The tool handles: commit (optional), rebase verification, push (force-with-lease after rebase), PR create (or reuse with mergeability check), **pre-merge CI checks gate (waits for green)**, merge (squash or merge commit), tag (main only), GitHub release (main only).
+The tool handles: commit (optional), rebase verification, push (explicit force-with-lease after rebase), PR create (or reuse with mergeability check), **pre-merge CI checks gate (waits for green)**, **pre-merge rebase re-check (closes the checks-window race)**, merge (squash or merge commit), **post-merge tree guard**, tag (main only), GitHub release (main only).
 
-Returns: `{ branch, commit, rebased, pushed, pr: {number, url}, checks: {status, passed, failed, pending}, merged, mergeStrategy, intermediate, tag, tagVerified, release }`.
+Returns: `{ branch, commit, rebased, pushed, pr: {number, url}, checks: {status, passed, failed, pending}, merged, mergeStrategy, intermediate, tag, tagVerified, release, postMergeTreeMatch, postMergeWarning }`.
 
 **Pre-merge CI gate** (default ON): after PR create, `ship_release` runs `gh pr checks --watch` (default 600s timeout). If checks fail or timeout → `success: false`, `checksBlocked: true`, PR stays open, branch not deleted. Render `ship-blocked` card with the failing check names + run URLs.
 
@@ -219,7 +219,9 @@ Returns: `{ branch, commit, rebased, pushed, pr: {number, url}, checks: {status,
 - Tune timeout per call: `checksTimeoutSec: <30..3600>`.
 - See `deep-knowledge/quality-gates.md → Pre-Merge CI Checks Gate` for the full state matrix.
 
-**If `rebaseRequired: true`**: the branch is not rebased onto base. Go back to Step 1b and rebase before retrying.
+**If `rebaseRequired: true`**: the branch is not rebased onto base. Go back to Step 1b and rebase before retrying. This also fires as `baseAdvancedDuringChecks: true` when a **parallel ship landed on base while we waited for CI** — the PR is left open and unmerged (no silent overwrite). Same action: rebase + retry. See `deep-knowledge/merge-safety.md → How ship_release Prevents Overwrites`.
+
+**If `postMergeTreeMatch: false`** (merge succeeded but `postMergeWarning` is set): a concurrent ship was three-way merged into base during the merge — its changes are preserved, but surface `postMergeWarning` as a `userFinalTest` item ("Verify main is consistent — a parallel ship merged in concurrently") so the user double-checks. Do NOT treat it as a ship failure — the merge landed.
 
 If `success: false` → do NOT proceed to cleanup. Report error and render completion card with variant `ship-blocked`.
 
@@ -293,6 +295,72 @@ a best-effort Windows toast fires immediately.
 
 Pass `state.watcher = { spawned: true, sha: "<sha>" }` (or `spawned: false`) into the
 completion card in Step 6 so it can render "Deploy-Verify läuft im Hintergrund".
+
+## Step 4c — Live Surface Verification (final ship only)
+
+**A green pipeline ≠ a release users can see.** CI can pass, the merge can land,
+the Step 4b watcher's HTTP probe can return 200 — and the version users actually
+get can still be the **old** one. This step opens the real user-facing surface(s)
+in a browser and asserts the **shipped version is live and visible** before the
+completion card declares done. It complements (does NOT replace) the
+`stop.flow.browsertest` gate (which verifies code changes *pre*-merge) and the
+Step 4b watcher (headless, post-session). (#210)
+
+**Skip this step entirely when ANY of:**
+- `intermediate: true` (intermediate merges have no live surface).
+- The project declares **no surfaces** — see config below. This is the default
+  (libraries, CLIs, internal tooling have no user-facing deploy). Skip silently.
+- User passed `--no-verify` / `--no-watch` intent in the ship trigger.
+
+### Config — declare surfaces
+
+Read `{project}/.claude/skills/ship/reference.md` for a `surfaces:` list (or, for
+a single surface, the existing `verify:` block's `url`/`selector`/`expected`).
+Each surface: `{ name, url, selector, expected }` where `expected` may use the
+`$VERSION` placeholder (expands to the just-shipped `vNew` / tag). Full format:
+`deep-knowledge/post-merge-verify.md → Declarative surfaces`.
+
+### Verify each surface
+
+For every declared surface:
+
+1. Pick the browser tool via the waterfall in
+   `deep-knowledge/browser-tool-strategy.md` (Claude-in-Chrome in Edge first).
+   This is a live post-deploy read — see `deep-knowledge/test-autonomy.md`.
+   Works in foreground, background, and autonomous mode.
+2. Open `url` in the **separate Edge testing window** (per the Edge Credo).
+3. Read the **rendered** version marker. Use **Eval JS** (`javascript_tool` /
+   `browser_evaluate` / `preview_eval`) to read structured data
+   (`document.querySelector(selector)?.textContent` or the documented attribute)
+   — NOT "read page", which strips scripts and misses client-rendered values.
+4. Assert the rendered value contains the shipped version (`vNew` / tag).
+
+**Why a browser, not just the watcher's HTTP probe:** the headless probe fetches
+raw response bytes — it misses **client-rendered** version strings (SPA where JS
+injects the version) and cannot see a download page whose served artifact is
+gated behind a DB row or an API. A real browser renders the DOM and follows the
+same path a user does. Gaps this catches that pass CI:
+- a GitHub release marked `prerelease` leaves the prior version as
+  `/releases/latest` → the "latest" download link still serves the old version;
+- a download page driven by a DB row / API (not GitHub directly) keeps serving
+  the old version until that row is registered;
+- multi-surface releases (web + desktop binary + edge functions) where one
+  surface silently lags.
+
+### Feed the result into Step 6
+
+- **All surfaces serve the shipped version** → clean `ship-successful`.
+- **Any surface lags / still shows the old version / unreachable** → STILL
+  `ship-successful` (the merge happened — per the Step 6 variant rule, never
+  downgrade after a merge), but add one **prominent `userFinalTest` item per
+  lagging surface**, e.g.
+  `{ action: "Download-Seite zeigt noch <alt> statt <neu> — prerelease-Flag / DB-Row prüfen", afterDeployment: true }`.
+  When a surface definitively serves the **old** version (a real regression
+  risk), make that item the first and loudest.
+- **No browser tool available** (waterfall fails): do NOT block the ship. Record
+  a `userFinalTest` item "Live-Surface manuell verifizieren: <url> sollte <vNew> zeigen".
+
+Pass `state.surfaceVerify = { checked: N, live: M, lagging: [...] }` into the card.
 
 ## Step 5a — Continue-Intent Check (auto-detect keep-mode)
 

--- a/plugins/devops/skills/devops-ship/deep-knowledge/post-merge-verify.md
+++ b/plugins/devops/skills/devops-ship/deep-knowledge/post-merge-verify.md
@@ -3,10 +3,24 @@
 Optional per-project extension. Opt-in by adding a `verify:` block to your
 project's `{project}/.claude/skills/ship/reference.md`.
 
-The post-merge watcher (`scripts/post-merge-watcher.js`) reads this block
-**after** GitHub Actions on the merge commit have gone green, and probes the
-configured target. Result lands in
-`<repo>/.claude/.ship-watcher/<merge-sha>.json` and is surfaced by the
+There are **two complementary verifiers**, both driven from the same
+`reference.md`:
+
+| Verifier | Source key | When | Fidelity |
+|---|---|---|---|
+| **Headless watcher** (`scripts/post-merge-watcher.js`, ship Step 4b) | flat `verify:` block | post-session, after CI goes green | raw HTTP response / shell command |
+| **Live browser check** (ship Step 4c) | `surfaces:` list (or `verify:` url) | in the ship flow, before the completion card | **rendered DOM** via Claude-in-Chrome (Edge) |
+
+Use the headless watcher for unattended/AFK coverage (CI can take 30 min); use
+the browser check for the high-fidelity "is the version users see actually the
+new one" assertion before declaring done. A client-rendered SPA version, a
+`prerelease`-flagged release that leaves the prior version as `/releases/latest`,
+or a download page gated behind a DB row are all invisible to a raw HTTP probe
+but caught by the browser check. See `SKILL.md → Step 4c`.
+
+The post-merge watcher reads the flat `verify:` block **after** GitHub Actions on
+the merge commit have gone green, and probes the configured target. Result lands
+in `<repo>/.claude/.ship-watcher/<merge-sha>.json` and is surfaced by the
 `ss.ship.verify` SessionStart hook in the next session.
 
 ## Format
@@ -45,6 +59,46 @@ verify:
 | `command` | command | Shell command. Exit 0 = success, anything else = retry |
 | `poll_interval_seconds` | both | Pause between retries |
 | `timeout_seconds` | both | Hard deadline. `failed` once exceeded |
+
+## Declarative surfaces (live browser verification)
+
+For the **live browser check** (ship Step 4c), declare one or more user-facing
+surfaces as a top-level `surfaces:` list (sibling to `verify:`). Each surface is
+opened in Edge via Claude-in-Chrome and its **rendered** version marker is
+asserted against the just-shipped version.
+
+```yaml
+surfaces:
+  - name: "Web app"
+    url: https://app.example.com
+    selector: '[data-app-version]'        # CSS selector; its textContent / matching attribute is read via Eval JS
+    expected: "$VERSION"                   # $VERSION = just-shipped vX.Y.Z (tag) or vNew
+  - name: "Download page"
+    url: https://example.com/download
+    selector: '.latest-version'
+    expected: "$VERSION"
+  - name: "Edge function health"
+    url: https://app.example.com/api/version
+    selector: 'body'                       # JSON/text endpoint — match the version anywhere in the body
+    expected: "$VERSION"
+```
+
+| Field | Purpose |
+|---|---|
+| `name` | Human label shown in the completion card if the surface lags |
+| `url` | Page the browser opens (the real user-facing surface) |
+| `selector` | CSS selector whose rendered text/attribute holds the version. Read with **Eval JS**, never "read page" |
+| `expected` | String the rendered value must contain. `$VERSION` expands to the shipped tag / `vNew` |
+
+Notes:
+- A single surface can be declared in the flat `verify:` block instead — Step 4c
+  falls back to `verify:`'s `url`/`selector`/`expected` when no `surfaces:` list
+  exists, so simple projects need only one block.
+- The `surfaces:` list drives the **interactive** browser check only. The
+  headless watcher (Step 4b) still probes the single flat `verify:` target;
+  multi-surface **headless** probing is not yet wired — list every surface under
+  `surfaces:` so the supervised Step 4c covers them, and put the most critical
+  one in `verify:` for unattended coverage.
 
 ## Failure handling
 

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.99.1",
+  "version": "0.100.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
Closes #207
Closes #210

## Summary
- **#207** — `ship_release` now re-asserts `isRebasedOnto(origin/base)` immediately before the merge, closing the TOCTOU window during the CI-checks wait that `gh pr merge --admin` bypasses. Adds a post-merge tree guard (`treeOf(HEAD)` vs `treeOf(origin/base)`) and an explicit `--force-with-lease=<branch>:<sha>`. `merge-safety.md` documents the two-phase gate; `release.test.js` adds an 11-case regression suite.
- **#210** — new ship **Step 4c** verifies declared user-facing surfaces live in the browser (rendered DOM) after merge, asserting the shipped version before declaring done. Declarative `surfaces:` config in `post-merge-verify.md`; lagging surfaces become `userFinalTest` items, never silent success.

## Verification
- vitest: 375/375 green (incl. 11 new #207 regression cases) · eslint clean
- 21-agent adversarial review: 0 data-loss / doc / integration findings; 6 test-coverage gaps fixed