### PR TITLE
fix(autonomous): arm watchdog on non-US Windows locales

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.100.0"
+    "version": "0.100.1"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.100.0",
+      "version": "0.100.1",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.100.0",
+      "version": "0.100.1",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.100.1] — 2026-06-13
+
+### Fixed
+
+- **The 8h autonomous watchdog can now arm on non-US Windows locales.** `autonomous-watchdog.js register` created the Scheduled Task via `schtasks /Create /SD <MM/DD/YYYY> /ST <HH:mm>`, hard-coding an en-US date string. A non-US `schtasks` validates `/SD` against the active culture — a de-DE install answers `06/13/2026` with `FEHLER: Ungültiges Startdatum`, so `/devops-autonomous` Step 4d failed and the entire AFK run proceeded with **no external safety net** (the deadman that force-shuts the PC, or writes a visible `AUTONOMOUS-STALLED.txt`, when the in-session Step 8 is never reached). Registration now goes through the PowerShell ScheduledTasks module: the fire time is passed to `Get-Date` as integer `-Year/-Month/-Day/-Hour/-Minute` components plus `New-ScheduledTaskTrigger -Once -At <DateTime>`, so no date string is ever parsed against the culture — verified by a real register/status/unregister roundtrip on de-DE (query/delete stay on `schtasks.exe`, which is locale-independent and resolves PS-created tasks). The trigger also sets `-AllowStartIfOnBatteries`/`-DontStopIfGoingOnBatteries` so the deadman still fires on a laptop running AFK on battery — the `schtasks` default (`DisallowStartIfOnBatteries`) would have skipped it. `buildRegisterPsCommand`/`buildRecoveryScript` are extracted as pure exports behind a `require.main` guard; new `autonomous-watchdog.test.js` (10 tests) pins that the register path emits integer date components and no locale-dependent date string.
+
 ## [0.100.0] — 2026-06-08
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.100.0**
+**Version: 0.100.1**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.100.0",
+  "version": "0.100.1",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/scripts/autonomous-watchdog.js
+++ b/plugins/devops/scripts/autonomous-watchdog.js
@@ -37,7 +37,8 @@
  *   status [task-name]             Check if the task still exists.
  *                                  → { ok, taskName, active }
  *
- * Platform: Windows-only (uses schtasks.exe). No-op on other platforms.
+ * Platform: Windows-only. Registration uses the PowerShell ScheduledTasks module
+ * (Register-ScheduledTask); query/delete use schtasks.exe. No-op on other platforms.
  */
 
 const { spawnSync } = require('child_process');
@@ -57,12 +58,6 @@ function ok(extra) {
   process.stdout.write(JSON.stringify({ ok: true, ...extra }) + '\n');
   process.exit(0);
 }
-
-if (process.platform !== 'win32') {
-  ok({ skipped: true, reason: 'non-windows platform' });
-}
-
-const [, , subcmd, ...args] = process.argv;
 
 function readSentinel() {
   if (!fs.existsSync(SENTINEL_FILE)) return null;
@@ -110,7 +105,87 @@ function isValidWatchdogScriptPath(scriptPath) {
   return true;
 }
 
-if (subcmd === 'register') {
+/**
+ * Build the recovery PowerShell script that the scheduled task executes on fire.
+ * It checks the done-flag and, if missing, runs the mode-specific recovery.
+ * @param {{action:string, hours:number, flagPath:string, stalledPath:string}} o
+ * @returns {string} PowerShell script body, written to a self-deleting .ps1.
+ */
+function buildRecoveryScript({ action, hours, flagPath, stalledPath }) {
+  const flagPs = flagPath.replace(/'/g, "''");
+  const stalledPs = stalledPath.replace(/'/g, "''");
+  // Recovery action when the flag is missing — differs by mode.
+  const recoveryPs = action === 'shutdown'
+    ? `  Add-Content -Path $logPath -Value "[$ts] flag MISSING at $flag — forcing shutdown"
+  & "$env:SystemRoot\\System32\\shutdown.exe" /s /t 0 /c "Claude autonomous watchdog: session unresponsive after ${hours}h, forcing shutdown"`
+    : `  Add-Content -Path $logPath -Value "[$ts] flag MISSING at $flag — writing stalled marker (notify mode)"
+  $msg = @(
+    "Claude autonomous session was unresponsive after ${hours}h and never reached completion.",
+    "",
+    "The run wedged (likely an Anthropic API hang or a stuck subagent). Nothing was shut down.",
+    "Check AUTONOMOUS-RESUME.json for saved state, then resume or restart the session.",
+    "",
+    "Stalled at: $ts"
+  )
+  Set-Content -Path '${stalledPs}' -Value $msg -Encoding UTF8`;
+  return `$ErrorActionPreference = 'Continue'
+$flag = '${flagPs}'
+$logPath = Join-Path $env:TEMP 'claude-autonomous-watchdog.log'
+$ts = (Get-Date -Format 'o')
+if (Test-Path $flag) {
+  Add-Content -Path $logPath -Value "[$ts] flag present at $flag — no action"
+} else {
+${recoveryPs}
+}
+# Self-delete this script after run
+try { Remove-Item -Path $MyInvocation.MyCommand.Path -Force -ErrorAction SilentlyContinue } catch {}
+`;
+}
+
+/**
+ * Build the PowerShell command that registers the one-shot watchdog task.
+ *
+ * Culture-agnostic by construction: the fire time is passed to `Get-Date` as
+ * separate integer components (-Year/-Month/-Day/-Hour/-Minute), never as a
+ * locale-formatted date string. This sidesteps the `schtasks /SD /ST` trap where
+ * a hard-coded en-US `MM/DD/YYYY` is rejected by a non-US `schtasks` — e.g. a
+ * de-DE install expects `TT.MM.JJJJ` and answers a US string with
+ * "FEHLER: Ungültiges Startdatum", which left the 8h deadman unarmed.
+ * `Register-ScheduledTask` with `New-ScheduledTaskTrigger -At <DateTime>` takes a
+ * real DateTime object, so no date string is ever parsed against the active culture.
+ *
+ * The wall-clock components come from the local-time getters of `fireAt`, matching
+ * the previous `/ST` semantics (the Task Scheduler interprets `-At` as local time).
+ * Battery flags are set so the deadman still fires on a laptop running AFK on
+ * battery — the schtasks default (DisallowStartIfOnBatteries) would have skipped it.
+ *
+ * @param {{taskName:string, scriptPath:string, fireAt:Date}} opts
+ * @returns {string} PowerShell script to run via `powershell.exe -Command`.
+ */
+function buildRegisterPsCommand({ taskName, scriptPath, fireAt }) {
+  const tnPs = String(taskName).replace(/'/g, "''");
+  const spPs = String(scriptPath).replace(/'/g, "''");
+  const year = fireAt.getFullYear();
+  const month = fireAt.getMonth() + 1; // getMonth() is 0-based
+  const day = fireAt.getDate();
+  const hour = fireAt.getHours();
+  const minute = fireAt.getMinutes();
+  return [
+    `$ErrorActionPreference = 'Stop'`,
+    `try {`,
+    `  $at = Get-Date -Year ${year} -Month ${month} -Day ${day} -Hour ${hour} -Minute ${minute} -Second 0`,
+    `  $action = New-ScheduledTaskAction -Execute 'powershell.exe' -Argument '-NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -File "${spPs}"'`,
+    `  $trigger = New-ScheduledTaskTrigger -Once -At $at`,
+    `  $settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries`,
+    `  Register-ScheduledTask -TaskName '${tnPs}' -Action $action -Trigger $trigger -Settings $settings -Force | Out-Null`,
+    `} catch {`,
+    `  Write-Error $_.Exception.Message`,
+    `  exit 1`,
+    `}`,
+  ].join('\n');
+}
+
+function runRegister(args) {
   const [flagPathRaw, hoursRaw, actionRaw] = args;
   if (!flagPathRaw || !hoursRaw) {
     fail('Usage: register <flag-path> <hours> [shutdown|notify]');
@@ -145,56 +220,19 @@ if (subcmd === 'register') {
   // Write a separate PowerShell script — robust escaping, self-deletes after run.
   const scriptPath = path.join(os.tmpdir(),
     `claude-autonomous-watchdog-${Date.now()}.ps1`);
-  const flagPs = flagPath.replace(/'/g, "''");
-  const stalledPs = stalledPath.replace(/'/g, "''");
-  // Recovery action when the flag is missing — differs by mode.
-  const recoveryPs = action === 'shutdown'
-    ? `  Add-Content -Path $logPath -Value "[$ts] flag MISSING at $flag — forcing shutdown"
-  & "$env:SystemRoot\\System32\\shutdown.exe" /s /t 0 /c "Claude autonomous watchdog: session unresponsive after ${hours}h, forcing shutdown"`
-    : `  Add-Content -Path $logPath -Value "[$ts] flag MISSING at $flag — writing stalled marker (notify mode)"
-  $msg = @(
-    "Claude autonomous session was unresponsive after ${hours}h and never reached completion.",
-    "",
-    "The run wedged (likely an Anthropic API hang or a stuck subagent). Nothing was shut down.",
-    "Check AUTONOMOUS-RESUME.json for saved state, then resume or restart the session.",
-    "",
-    "Stalled at: $ts"
-  )
-  Set-Content -Path '${stalledPs}' -Value $msg -Encoding UTF8`;
-  const psScript =
-`$ErrorActionPreference = 'Continue'
-$flag = '${flagPs}'
-$logPath = Join-Path $env:TEMP 'claude-autonomous-watchdog.log'
-$ts = (Get-Date -Format 'o')
-if (Test-Path $flag) {
-  Add-Content -Path $logPath -Value "[$ts] flag present at $flag — no action"
-} else {
-${recoveryPs}
-}
-# Self-delete this script after run
-try { Remove-Item -Path $MyInvocation.MyCommand.Path -Force -ErrorAction SilentlyContinue } catch {}
-`;
-  fs.writeFileSync(scriptPath, psScript, 'utf8');
+  fs.writeFileSync(scriptPath,
+    buildRecoveryScript({ action, hours, flagPath, stalledPath }), 'utf8');
 
-  const sd = `${String(fireAt.getMonth() + 1).padStart(2, '0')}/` +
-             `${String(fireAt.getDate()).padStart(2, '0')}/` +
-             `${fireAt.getFullYear()}`;
-  const st = `${String(fireAt.getHours()).padStart(2, '0')}:` +
-             `${String(fireAt.getMinutes()).padStart(2, '0')}`;
-  const tr = `powershell.exe -NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -File "${scriptPath}"`;
-
-  const result = spawnSync('schtasks.exe', [
-    '/Create',
-    '/TN', taskName,
-    '/SC', 'ONCE',
-    '/SD', sd,
-    '/ST', st,
-    '/TR', tr,
-    '/F',
-  ], { encoding: 'utf8' });
+  // Register via the PowerShell ScheduledTasks module rather than `schtasks /SD /ST`:
+  // the trigger time is passed as a real DateTime, so it is culture-agnostic and
+  // does not break on non-US locales (see buildRegisterPsCommand).
+  const psCommand = buildRegisterPsCommand({ taskName, scriptPath, fireAt });
+  const result = spawnSync('powershell.exe',
+    ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-Command', psCommand],
+    { encoding: 'utf8' });
 
   if (result.status !== 0) {
-    fail(`schtasks /Create failed: ${(result.stderr || result.stdout || '').trim()}`);
+    fail(`watchdog task registration failed: ${(result.stderr || result.stdout || '').trim()}`);
   }
 
   writeSentinel({
@@ -209,7 +247,7 @@ try { Remove-Item -Path $MyInvocation.MyCommand.Path -Force -ErrorAction Silentl
   ok({ taskName, flagPath, fireAt: fireAt.toISOString(), scriptPath, action });
 }
 
-if (subcmd === 'flag') {
+function runFlag(args) {
   const [flagPathRaw] = args;
   let flagPath;
   if (flagPathRaw) {
@@ -233,7 +271,7 @@ if (subcmd === 'flag') {
   ok({ flagPath });
 }
 
-if (subcmd === 'unregister') {
+function runUnregister(args) {
   let taskName = args[0];
   const sentinel = readSentinel();
   if (!taskName) {
@@ -269,7 +307,7 @@ if (subcmd === 'unregister') {
   ok({ taskName, deleted: !notFound });
 }
 
-if (subcmd === 'status') {
+function runStatus(args) {
   let taskName = args[0];
   const sentinel = readSentinel();
   if (!taskName) {
@@ -286,5 +324,25 @@ if (subcmd === 'status') {
   });
 }
 
-fail(`Unknown subcommand: ${subcmd || '(empty)'}. ` +
-  `Use: register | flag | unregister | status`);
+// --- CLI entry (skipped when require()'d by tests) ---
+if (require.main === module) {
+  if (process.platform !== 'win32') {
+    ok({ skipped: true, reason: 'non-windows platform' });
+  }
+  const [, , subcmd, ...args] = process.argv;
+  if (subcmd === 'register') runRegister(args);
+  else if (subcmd === 'flag') runFlag(args);
+  else if (subcmd === 'unregister') runUnregister(args);
+  else if (subcmd === 'status') runStatus(args);
+  else {
+    fail(`Unknown subcommand: ${subcmd || '(empty)'}. ` +
+      `Use: register | flag | unregister | status`);
+  }
+}
+
+module.exports = {
+  buildRegisterPsCommand,
+  buildRecoveryScript,
+  isValidWatchdogTaskName,
+  isValidWatchdogScriptPath,
+};

--- a/plugins/devops/scripts/autonomous-watchdog.test.js
+++ b/plugins/devops/scripts/autonomous-watchdog.test.js
@@ -1,0 +1,111 @@
+import { describe, test, expect } from "vitest";
+import {
+  buildRegisterPsCommand,
+  buildRecoveryScript,
+} from "./autonomous-watchdog.js";
+
+// A fire time with day-of-month > 12 so an accidental MM/DD vs DD/MM swap is
+// detectable, built via the local-time constructor so the assertions are
+// independent of the CI machine's timezone (getters read back the same
+// components that were passed in).
+const FIRE_AT = new Date(2026, 5, 13, 20, 5, 0); // 2026-06-13 20:05 local
+const REG_OPTS = {
+  taskName: "ClaudeAutonomousWatchdog-1700000000000",
+  scriptPath: "C:\\Users\\dev\\AppData\\Local\\Temp\\claude-autonomous-watchdog-1700000000000.ps1",
+  fireAt: FIRE_AT,
+};
+
+describe("buildRegisterPsCommand — culture-agnostic scheduling (de-DE regression)", () => {
+  const cmd = buildRegisterPsCommand(REG_OPTS);
+
+  test("passes the fire time as integer Get-Date components, not a date string", () => {
+    expect(cmd).toContain("-Year 2026");
+    expect(cmd).toContain("-Month 6");   // 0-based getMonth() + 1, no zero-pad
+    expect(cmd).toContain("-Day 13");
+    expect(cmd).toContain("-Hour 20");
+    expect(cmd).toContain("-Minute 5");
+    expect(cmd).toContain("New-ScheduledTaskTrigger -Once -At $at");
+  });
+
+  test("emits NO locale-dependent date string — the schtasks /SD trap", () => {
+    // The old bug hard-coded en-US MM/DD/YYYY into schtasks /SD, which a de-DE
+    // schtasks rejects with "FEHLER: Ungültiges Startdatum".
+    expect(cmd).not.toMatch(/\d{1,2}\/\d{1,2}\/\d{2,4}/); // any slash-separated date
+    expect(cmd).not.toContain("06/13/2026"); // the exact prior-bug string
+    expect(cmd).not.toContain("/SD");
+    expect(cmd).not.toContain("/ST");
+    expect(cmd).not.toContain("schtasks");
+  });
+
+  test("registers via the culture-agnostic ScheduledTasks cmdlets", () => {
+    expect(cmd).toContain("Register-ScheduledTask");
+    expect(cmd).toContain("New-ScheduledTaskAction -Execute 'powershell.exe'");
+    expect(cmd).toContain(`-TaskName '${REG_OPTS.taskName}'`);
+    // The recovery .ps1 is wired in as the task action.
+    expect(cmd).toContain(`-File "${REG_OPTS.scriptPath}"`);
+  });
+
+  test("fires even on battery (deadman must survive a laptop running AFK)", () => {
+    expect(cmd).toContain("-AllowStartIfOnBatteries");
+    expect(cmd).toContain("-DontStopIfGoingOnBatteries");
+  });
+
+  test("propagates a registration failure as a non-zero exit", () => {
+    // Without Stop + exit 1, a failed Register-ScheduledTask would still exit 0
+    // and the caller would falsely report the deadman as armed.
+    expect(cmd).toContain("$ErrorActionPreference = 'Stop'");
+    expect(cmd).toContain("exit 1");
+  });
+
+  test("single-quotes in task name / script path are PowerShell-escaped", () => {
+    const tricky = buildRegisterPsCommand({
+      ...REG_OPTS,
+      taskName: "ClaudeAutonomousWatchdog-1",
+      scriptPath: "C:\\Temp\\o'brien\\claude-autonomous-watchdog-1.ps1",
+    });
+    expect(tricky).toContain("o''brien"); // ' doubled, not left raw
+    expect(tricky).not.toContain("o'brien");
+  });
+
+  test("uses local wall-clock getters (matches prior /ST semantics)", () => {
+    // A fire time in a month/day that differs between UTC and most local zones
+    // still serializes from the local getters, not UTC.
+    const local = new Date(2026, 0, 1, 1, 30, 0); // Jan 1 2026 01:30 local
+    const c = buildRegisterPsCommand({ ...REG_OPTS, fireAt: local });
+    expect(c).toContain("-Year 2026");
+    expect(c).toContain("-Month 1");
+    expect(c).toContain("-Day 1");
+    expect(c).toContain("-Hour 1");
+    expect(c).toContain("-Minute 30");
+  });
+});
+
+describe("buildRecoveryScript — mode-specific recovery", () => {
+  const base = {
+    hours: 8,
+    flagPath: "C:\\proj\\AUTONOMOUS-DONE.flag",
+    stalledPath: "C:\\proj\\AUTONOMOUS-STALLED.txt",
+  };
+
+  test("shutdown mode forces a power-off when the flag is missing", () => {
+    const s = buildRecoveryScript({ ...base, action: "shutdown" });
+    expect(s).toContain("shutdown.exe");
+    expect(s).toContain("/s /t 0");
+    expect(s).not.toContain("AUTONOMOUS-STALLED");
+  });
+
+  test("notify mode writes a visible stalled marker and never powers off", () => {
+    const s = buildRecoveryScript({ ...base, action: "notify" });
+    expect(s).toContain("Set-Content -Path 'C:\\proj\\AUTONOMOUS-STALLED.txt'");
+    expect(s).not.toContain("shutdown.exe");
+  });
+
+  test("escapes single-quotes in the flag path", () => {
+    const s = buildRecoveryScript({
+      ...base,
+      action: "shutdown",
+      flagPath: "C:\\users\\o'brien\\AUTONOMOUS-DONE.flag",
+    });
+    expect(s).toContain("o''brien");
+  });
+});

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.100.0",
+  "version": "0.100.1",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

Fixes the 8h external watchdog (`/devops-autonomous` Step 4d) failing to arm on non-US Windows. `autonomous-watchdog.js register` built an en-US `MM/DD/YYYY` string for `schtasks /Create /SD`, which a non-US `schtasks` rejects against the active culture (de-DE: `FEHLER: Ungültiges Startdatum`) — leaving an autonomous AFK run with **no external safety net** (the deadman that force-shuts the PC or writes a visible `AUTONOMOUS-STALLED.txt` when the in-session Step 8 is never reached).

## Fix

- Register via the PowerShell ScheduledTasks module: fire time passed to `Get-Date` as integer `-Year/-Month/-Day/-Hour/-Minute` components + `New-ScheduledTaskTrigger -Once -At <DateTime>` — culture-agnostic, no date string parsed against the locale.
- `schtasks.exe` query/delete left unchanged (locale-independent and resolves PS-created tasks — verified by a real register/status/unregister roundtrip on de-DE).
- Set `-AllowStartIfOnBatteries`/`-DontStopIfGoingOnBatteries` so the deadman still fires on a laptop running AFK on battery (the `schtasks` default would have skipped it).
- Extract `buildRegisterPsCommand`/`buildRecoveryScript` as pure exports behind a `require.main` guard.

## Tests

- New `autonomous-watchdog.test.js` (10 tests): asserts the register path emits integer date components and **no** locale-dependent date string.
- Full suite: **385 passed**, lint clean.
- Real de-DE verification: the new path builds the trigger cleanly; the old `/SD "06/13/2026"` path reproduces `FEHLER: Ungültiges Startdatum`.