### PR TITLE
feat(repo-health): redesign report page — 2-state + inline detail

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.100.2"
+    "version": "0.101.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.100.2",
+      "version": "0.101.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.100.2",
+      "version": "0.101.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.101.0] — 2026-06-14
+
+### Changed
+
+- **`/devops-repo-health`'s report page is redesigned around a single branch model (skill 0.4.0→0.5.0).** The old report mixed a total with its own sub-categories and a second axis — four side-by-side KPI tiles (`Branches`, `Sicher löschbar`, `Untersuchen`, `Worktrees`) where the worktrees were double-counted (they *are* branches) and `4 + 2 ≠ Total` visually. The new model treats **every entry as one git branch**; a worktree is not a separate thing but a branch *with* a checked-out directory, surfaced as an **„Aktive Session"** (vs a plain **„Git-Session"**). The KPI is now **one total, partitioned into the two derived actions that sum to it** — 🟢 Löschbar + 🟡 Untersuchen — each with **sub-labels** breaking it down by type (Git-Session / Aktive Session) and location (lokal / nur-remote). A **Typ × Zustand matrix** documents how the status is derived. Per-row controls collapse from a three-way `Löschen / Untersuchen / Behalten` radio to a **single delete checkbox** (safe-delete pre-checked, conscious-keep by unchecking); **„Untersuchen" becomes an inline „?" detail** that expands commit-log + diff + recommendation on first render — which **removes the entire multi-iteration investigate loop** (the iteration counter, Convergence digest, Tombstone cards, the 5-round cap, and the Step 9b deep-dive-as-iteration are all deleted). The decision sidebar becomes a full **Apply-Manifest** with a **Dry-Run-Confirm** before execution; bulk select shows a **Gmail-style "visible vs. all-filtered" banner**; rows are **decision-first with progressive disclosure**; Aktive Sessions stay in a **co-located block**; and the run opens with a **scope question that defaults to the current repo** (all-repos is an explicit opt-in = safety default). Safety is preserved end-to-end: worktree-attached branches are never auto-deleted, has-changes Aktive Sessions expose no destructive control, and clean Aktive Sessions appear under Löschbar but are **not** pre-checked. Specs rewritten: `SKILL.md`, `page-structure.md`, `decision-schema.md`, `investigation.md`.
+
 ## [0.100.2] — 2026-06-14
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.100.2**
+**Version: 0.101.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.100.2",
+  "version": "0.101.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/skills/devops-repo-health/SKILL.md
+++ b/plugins/devops/skills/devops-repo-health/SKILL.md
@@ -1,13 +1,14 @@
 ---
 name: devops-repo-health
-version: 0.4.0
+version: 0.5.0
 description: >-
   Analyze repository branch hygiene: unmerged branches, stale locals with deleted
-  remotes, orphaned worktrees, verify work landed in main. Results: interactive
-  concept page with filters, batch actions, and an "Untersuchen" follow-up loop
-  for deeper per-item analysis. Triggers on: "repo health", "branch cleanup",
-  "branch hygiene". Explicit user request only.
-argument-hint: "[optional: focus area — branches, worktrees, PRs]"
+  remotes, active sessions (worktrees), verify work landed in main. Results:
+  interactive concept page with filters, 2-state delete controls, inline detail
+  expand, and an Apply-Manifest + Dry-Run-Confirm before executing cleanup.
+  Triggers on: "repo health", "branch cleanup", "branch hygiene".
+  Explicit user request only.
+argument-hint: "[optional: focus area — branches, sessions, PRs]"
 allowed-tools: Bash(git *), Bash(gh *), Bash(start *), Bash(cmd *), Read, Write, Glob, Grep, AskUserQuestion, mcp__Claude_Preview__*, mcp__plugin_playwright_playwright__*, mcp__Claude_in_Chrome__*, mcp__plugin_devops_dotclaude-completion__render_completion_card
 ---
 
@@ -16,7 +17,30 @@ allowed-tools: Bash(git *), Bash(gh *), Bash(start *), Bash(cmd *), Read, Write,
 Analyze the repository for branch hygiene, unmerged work, and cleanup opportunities.
 Present results as an interactive concept page with filters and decision controls.
 
-## Step 0 — Repo-mode check
+## Step 0 — Scope selection (AskUserQuestion)
+
+Before any git command, ask the user for scope:
+
+```
+Welches Repository soll analysiert werden?
+
+  (●) Aktuelles Projekt — <repo-name> (<local-path>)   ← vorausgewählt
+  ( ) Alle Projekte — aus ~/.claude/projects/ Registry
+
+"Alle": zeigt zuerst eine Repo-Übersicht (welches Repo hat wie viel
+aufzuräumen), dann Drill-down in einzelne Repos — KEIN globales
+übergreifendes Bulk-Delete.
+```
+
+DEFAULT = current project (pre-selected). "Alle" is the explicit opt-in.
+If "Alle" is selected: first generate a repo-overview page showing per-repo
+counts, then let the user pick one repo for the standard single-repo flow.
+Discovery: read `~/.claude/projects/` registry, dedupe (many entries are
+worktree subdirs or dead paths — skip paths where `git rev-parse --show-toplevel`
+fails or is a subdirectory of another already-listed root), fetch in parallel,
+lazy. NO global cross-repo select-all.
+
+## Step 0b — Repo-mode check
 
 Before any git command, verify this directory is a git repository:
 
@@ -26,14 +50,15 @@ git rev-parse --is-inside-work-tree
 
 If this fails (exit != 0), abort:
 
-> Repo health analysiert git-Branches/PRs/Worktrees — in einer Nicht-Git-Dir gibt es nichts zu pruefen. Aborting.
+> Repo health analysiert git-Branches/Sessions — in einer Nicht-Git-Dir gibt es
+> nichts zu pruefen. Aborting.
 
 Do NOT proceed. End the skill.
 
 ## SAFETY: Worktree Branch Protection
 
 **HARD RULE — no exceptions:**
-Branches attached to active worktrees are UNTOUCHABLE. You MUST NOT:
+Branches attached to active worktrees (Aktive Sessions) are UNTOUCHABLE. You MUST NOT:
 - Delete them locally (`git branch -D`)
 - Delete them remotely (`git push origin --delete`)
 - Checkout/switch away from them in their worktree
@@ -71,18 +96,25 @@ Run in parallel:
 Build the **protected branch set** from worktree output. Every branch in this set
 is excluded from ALL subsequent steps — classification, recommendations, AND cleanup.
 
-4. **Analyze each active worktree** for content status:
+4. **Analyze each active worktree** (each is an „Aktive Session") for content status:
    - `git -C <worktree_path> status --porcelain` — uncommitted / untracked files
    - `git log --oneline origin/main..<branch>` — commits not yet in main
-   - Classify each worktree:
+   - Classify each Aktive Session:
      - `has-changes` — uncommitted files OR untracked files OR commits ahead of main
      - `clean` — no local modifications AND no commits ahead
    - For `has-changes`: collect counts (modified, added, untracked files) and
      commit-ahead count for display
+   - **clean Aktive Sessions are placed in the Löschbar group but NOT pre-checked**
+     (default = keep); the user must consciously opt in to removing them.
 
 ## Step 3 — Branch Classification
 
-For each local branch (excluding worktree branches):
+Every entry is a **git branch** (a ref). The two attributes per entry are:
+- **Typ**: "Aktive Session" (branch WITH a checked-out worktree directory) or
+  "Git-Session" (plain branch without a worktree)
+- **Ort**: "lokal" / "nur-remote" / "lokal+remote"
+
+For each local branch (excluding worktree/Aktive-Session branches):
 
 1. **Check merge status against `origin/main`:**
    - `git merge-base --is-ancestor <branch> origin/main` -> MERGED (git ancestor)
@@ -102,21 +134,24 @@ For each local branch (excluding worktree branches):
 4. **Last commit info:**
    - `git log -1 --format="%h %s (%cr)" <branch>` — hash, message, relative date
 
-Classify each branch into one of:
+Classify each branch (Git-Session) into one of two top categories that
+**partition** all entries and **sum** to the total:
 
-| Category | Meaning | Default action (iteration 1) |
-|----------|---------|-------------------------------|
-| `safe-delete` | MERGED or SQUASH-MERGED | Radio default: `delete` |
-| `investigate` | UNMERGED, no PR or open PR | Radio default: `skip` (Behalten); user can opt into `investigate` for deep-dive |
-| `worktree` | Attached to a worktree | Info only; clean worktrees expose `remove`/`investigate`/`keep` radio (default `keep`); has-changes worktrees expose only an opt-in `investigate` checkbox |
+| Category | Meaning | Default checkbox |
+|----------|---------|-----------------|
+| 🟢 **Löschbar** | MERGED or SQUASH-MERGED Git-Sessions | Pre-checked (delete) |
+| 🟡 **Untersuchen** | UNMERGED Git-Sessions (no PR or open PR) | Unchecked (keep) |
+
+Aktive Sessions (worktree branches) are always placed in their own dedicated
+block per c6 — never mixed into the Git-Session list.
 
 ## Step 4 — Remote Branch Audit
 
 After `fetch --prune`, check for remaining remote branches that are NOT `origin/main`:
 
 - For each: check if merged into `origin/main` or has a merged PR
-- Classify as `safe-delete` or `investigate`
-- Track separately as remote-only branches
+- Classify as Löschbar or Untersuchen
+- Track separately as remote-only branches (Ort = "nur-remote")
 
 ## Step 5 — PR Cross-Reference
 
@@ -140,7 +175,41 @@ git log --oneline origin/main -1
 
 Verify local `main` is up to date with `origin/main`. Flag if behind.
 
-## Step 7 — Generate Concept Page
+## Step 7 — Gather Inline Detail Data
+
+For EVERY entry (both Löschbar and Untersuchen), gather up-front the data
+needed for the inline „?" detail panel. This replaces the old multi-iteration
+investigate loop — data is collected once, shown on-expand, no second round.
+
+For each Git-Session branch (regardless of category):
+
+1. **Full commit log** against `origin/main`:
+   ```bash
+   git log --format='%h|%s|%cr|%an' origin/main..<branch>
+   ```
+2. **Diff summary by file** (exclude CHANGELOG.md):
+   ```bash
+   git diff --numstat origin/main...<branch> -- . ':(exclude)CHANGELOG.md'
+   ```
+3. **Branch age and activity:**
+   ```bash
+   git log --reverse --format='%ct' origin/main..<branch> | head -1
+   git log -1 --format='%ct' <branch>
+   ```
+4. **PR status:** `gh pr list --head <branch> --state all --limit 5 --json number,title,state,mergedAt,createdAt,url`
+5. **Squash-merge cross-check** for Untersuchen branches with no PR.
+6. **WIP heuristic** on commit subjects.
+7. **Inline recommendation** — apply the same rules as in `deep-knowledge/investigation.md`
+   and produce a short label (e.g. "3 ungeschippte Commits — ship empfohlen").
+
+For each Aktive Session (worktree):
+- Gather modified file list, untracked files, commits-ahead data (same as investigation.md).
+- Inline recommendation label (e.g. "85 Zeilen — commit + ship empfohlen").
+
+All data is embedded in the HTML at first render, hidden behind a `<details>`
+expand. No round-trip to Claude is needed to view it.
+
+## Step 8 — Generate Concept Page
 
 Build a **self-contained HTML concept page** using the `dashboard` variant.
 Follow the design system and patterns from `/devops-concept` (see Step 2 of
@@ -148,28 +217,29 @@ the concept skill for full HTML/CSS/JS requirements).
 
 ### Page Structure & Tooltips
 
-The full ASCII mockup of the page (header, KPI cards, worktree section,
-filter bar, branch list, main-sync section, decision panel sidebar) and
-the mandatory tooltip table for every action control live in
-`deep-knowledge/page-structure.md`.
+The full ASCII mockup of the page (header, KPI summary, Aktive-Sessions section,
+filter bar, branch list grouped into Löschbar / Untersuchen, Apply-Manifest
+sidebar, main-sync section) and the mandatory tooltip table for every action
+control live in `deep-knowledge/page-structure.md`.
 
 ### Filter Behavior
 
 - Filters toggle visibility of branch cards by category
-- "Select all / Deselect all" buttons only affect **currently visible** cards
+- When a filter is active and the user clicks select-all, show a Gmail-style
+  banner: "Alle N gefilterten markieren (vs. M sichtbar)" — bulk selection must
+  never silently act only on rendered rows.
 - Filter state is preserved in the decisions JSON so Claude knows what the
   user was looking at when they submitted
-- Counter in decision panel updates based on checked items across ALL
+- Counter in Apply-Manifest sidebar updates based on checked items across ALL
   categories (not just visible ones)
 
 ### Decision Schema
 
 The submit payload shape (repo metadata, filter state, per-branch decisions,
-worktree actions, global options, comments, iteration counter) is documented in
-`deep-knowledge/decision-schema.md`. The schema supports a third action —
-`"investigate"` — which defers the item to a deep-dive iteration; see Step 9b
-and `deep-knowledge/investigation.md` for what data Claude gathers and how
-reclassification recommendations are computed.
+Aktive-Session actions, global options, comments) is documented in
+`deep-knowledge/decision-schema.md`. The schema uses 2-state controls:
+delete (checked) or keep (unchecked). The inline „?" detail is read-only and
+does NOT add a third action state.
 
 ### File Location
 
@@ -182,24 +252,28 @@ Create the directory if missing: `mkdir -p ~/.claude/devops-concepts` (Unix) or 
 ### Important Design Details
 
 - Branch names in monospace font, visually prominent
-- Category badges with distinct colors: green (safe), amber (investigate),
-  blue (worktree), purple (remote-only)
-- Branch action controls are a radio group (Loeschen / Untersuchen / Behalten);
-  default = Loeschen for safe-delete category, Behalten for investigate category
-- Worktree section is visually distinct from branch list (different background
-  tint, dedicated header, never mixed into the branch cards)
-- Worktrees with changes: amber badge, file summary, NO destructive controls.
-  The only allowed interactive element is an opt-in "Untersuchen" checkbox
-  (unchecked by default) for requesting a deep-dive iteration
-- Worktrees without changes: gray badge, radio group (Entfernen / Untersuchen
-  / Behalten) defaulting to Behalten
+- Category badges with distinct colors: green (Löschbar), amber (Untersuchen),
+  blue (Aktive Session)
+- Branch action controls are a **single delete checkbox** per row (NOT a radio group):
+  - Checked = löschen, unchecked = behalten
+  - Löschbar group: safe-delete items pre-checked; clean Aktive Sessions NOT pre-checked
+  - Untersuchen group: all items unchecked (user opts in consciously)
+- Aktive Sessions section is visually distinct from Git-Session list (different
+  background tint, dedicated header, never mixed into the branch cards)
+- Aktive Sessions with changes (has-changes): amber badge, file summary, NO
+  destructive controls. Only a read-only „?" inline detail toggle is shown.
+- Aktive Sessions without changes (clean): gray badge, delete checkbox (unchecked
+  by default, i.e. keep); removes the worktree only — the branch is NOT deleted.
 - Every action option has a `title` tooltip — see Tooltip Explanations table
-- "Remote-Branches auch loeschen" as a global toggle in the decision panel
+- "Remote-Branches auch loeschen" as a global toggle in the Apply-Manifest sidebar
   (not per-branch) — applies to all selected branches that have a remote
-- Smooth expand/collapse for comment fields
+- Smooth expand/collapse for „?" inline detail panels
+- "Alles aufklappen" button per section to expand all inline details at once
 - Dark/light mode toggle in header
+- Löschbar group: expandable, **open by default**
+- Untersuchen group: expandable, **collapsed by default**
 
-## Step 8 — Open & Monitor
+## Step 9 — Open & Monitor
 
 Open the page in the browser and monitor for the submit signal.
 Follow `/devops-concept` Step 3 (Open) and Step 4 (Monitor), respecting the
@@ -221,46 +295,73 @@ prefixing `file:///` — raw `$(pwd)`-style paths produce a broken
 `file:///c/Users/...` URL (missing drive colon → `ERR_FILE_NOT_FOUND`).
 See `deep-knowledge/browser-file-urls.md`.
 
-Inform the user (iteration 1):
+Inform the user:
 
-> Repo-Health geoeffnet. Filtere nach Kategorien, waehle pro Branch /
-> Worktree zwischen Loeschen, Untersuchen oder Behalten und klick den
-> Submit-Button — bei Untersuchen-Markierungen mache ich eine zweite
-> Iteration mit Detail-Analyse, sonst raeume ich direkt auf.
+> Repo-Health geoeffnet. Löschbar-Gruppe ist vorausgefuellt — hake ab, was du
+> behalten willst. Untersuchen-Gruppe ist eingeklappt — klappe auf und hake an,
+> was du loeschen willst. Klick „?" fuer Inline-Details pro Eintrag.
+> Submit startet Dry-Run-Vorschau bevor irgendetwas passiert.
 
-On iteration ≥ 2 (after a deep-dive round), inform the user:
-
-> Iteration {N}: Detail-Analyse fertig. Jede untersuchte Position hat
-> jetzt eine Empfehlung (Commit-Log, Diff, Branch-Alter). Entscheide
-> erneut — du kannst auch nochmal "Untersuchen" anklicken fuer eine
-> tiefere Runde.
-
-## Step 9 — Execute Decisions
+## Step 10 — Execute Decisions
 
 When the user submits via the concept page:
 
-1. **Read decisions** from `#concept-decisions` JSON, including the
-   `iteration` counter.
+1. **Read decisions** from `#concept-decisions` JSON.
 2. **Partition items by action:**
-   - Branches with `action: "delete"` -> Step 9a (cleanup)
-   - Worktrees with `action: "remove"` -> Step 9a (cleanup)
-   - Anything with `action: "investigate"` -> Step 9b (deep-dive)
-   - `action: "skip"` / `"keep"` -> no-op
+   - Branches with `delete: true` -> Step 10a (cleanup)
+   - Aktive Sessions (clean) with `remove: true` -> Step 10a (cleanup)
+   - Everything else -> no-op (keep)
 3. **Re-check worktree branches** — run `git worktree list --porcelain` again
    and rebuild the protected set. NEVER trust cached data for deletion.
 4. **Validate** every branch marked for deletion:
    - Is it in the protected set? -> SKIP with warning, update page
    - Does it still exist? -> Skip silently if already gone
 
-### Step 9a — Cleanup (delete / remove items)
+### Step 10a — Apply-Manifest + Dry-Run-Confirm
 
-Execute in order:
+Before executing any action, generate the **Apply-Manifest**: a complete list
+of everything that will happen, shown to the user for confirmation.
+
+**Apply-Manifest format:**
+
+```
+Folgende Aktionen werden ausgeführt:
+
+Lokal löschen (N):
+  - branch-a
+  - branch-b
+
+Remote löschen (M):
+  - branch-a (origin)
+
+Worktrees entfernen (K):
+  - claude/old-session (/path/to/worktree)
+
+Main synchronisieren: ja / nein
+Remote prunen: ja / nein
+```
+
+Then show a **Dry-Run-Confirm** prompt before executing:
+
+> Löscht N lokal, M remote, entfernt K Worktrees.
+> Lokales Löschen und remote Löschen ist NICHT rückgängig zu machen.
+> Fortfahren?  [Ja] [Abbrechen]
+
+Only proceed after explicit confirmation.
+
+### Step 10b — Cleanup Execution
+
+Execute in order after Dry-Run-Confirm:
    a. Delete selected local branches: `git branch -D <branch>`
    b. If `delete_remote` is true: `git push origin --delete <branch>` for
       each selected branch that has a remote
-   c. If `prune_worktrees` is true: `git worktree prune`
-   d. `git remote prune origin`
-   e. If `sync_main` is true: `git checkout main && git pull origin main`,
+   c. Remove selected clean worktrees: `git worktree remove <path>` (no --force)
+      - Re-check `git -C <path> status --porcelain` immediately before each removal.
+        If ANY output → SKIP with warning: "Worktree hat inzwischen Aenderungen —
+        Entfernung abgebrochen."
+   d. If `prune_worktrees` is true: `git worktree prune`
+   e. `git remote prune origin`
+   f. If `sync_main` is true: `git checkout main && git pull origin main`,
       then return to original branch
 
 Update the concept page via browser eval:
@@ -269,81 +370,6 @@ Update the concept page via browser eval:
    - Show summary: "X Branches geloescht, Y uebersprungen"
 
 Persist results to `~/.claude/devops-concepts/{date}-repo-health-decisions.json`.
-
-### Step 9b — Deep-Dive (investigate items)
-
-Triggered when at least one branch or worktree has `action: "investigate"`.
-
-**Ordering vs. Step 9a:** 9b runs **AFTER** 9a finishes. Sequential, not
-parallel. Reason: 9b must build iteration N+1 from the post-cleanup git
-state — otherwise just-deleted branches can be rendered again, or a
-`delete` that hit the worktree-protection validation skip silently carries
-a stale "delete" preselection into the next round. Cleanup typically takes
-seconds; the wait does not meaningfully delay the user.
-
-1. **Re-fetch git state:** `git fetch --all --prune`,
-   `git worktree list --porcelain`, `git branch -a --no-color`. Build the
-   fresh protected branch set and the fresh existing-branch set. Treat
-   these as ground truth for what is now in the repo.
-2. **Revalidate every investigate target against fresh state:**
-   - **Branch missing** (not in `git branch -a` anymore — e.g. deleted in
-     another terminal between iterations): render an "Already removed"
-     tombstone card in iteration N+1 with a single "Bestaetigen" button
-     to drop it from the next submit. No deepDive data is gathered.
-   - **Branch newly attached to a worktree** (race condition): move it to
-     the worktree section as a `has-changes`/`clean` card, with
-     "Untersuchen" preserved if appropriate. Drop any `investigate` flag
-     from the branch list rendering.
-   - **Worktree path missing** (`git -C <path> status` fails): tombstone,
-     same as above.
-   - **Target still valid** → continue to step 3.
-3. **Reconcile Step 9a results into the iteration model:**
-   - Items that 9a actually deleted/removed: drop from iteration N+1 entirely.
-   - Items that 9a SKIPPED (validation failures): re-include them with a
-     warning banner and default action = `Behalten`. Never carry forward a
-     failed `delete` as the new default.
-   - Items with `action: "skip"` / `"keep"` from iteration N: only carry
-     forward if still present in the fresh git state.
-4. **Gather per-item deep-dive data** for revalidated investigate targets
-   as documented in `deep-knowledge/investigation.md` — full commit log,
-   diff stats by file, branch age, PR cross-reference, squash-merge
-   cross-check (branches only), modified/untracked file lists (worktrees
-   only).
-5. **Apply recommendation rules** from `investigation.md` to attach a
-   `deepDive` block per item (`recommendation`, `rationale`, raw data).
-6. **Convergence check** — for each investigate item already carrying a
-   `deepDive` from iteration N−1: compute a stable digest over
-   `recommendation` + `commits[].hash` + `files[].path+added+deleted` (for
-   branches) or `modifiedFiles[].path+added+deleted` +
-   `commitsAhead[].hash` (for worktrees). If digest is **identical** to
-   the previous iteration's digest, the page has produced no new
-   information for that item. In iteration N+1: render the deepDive as
-   usual but **suppress the "Untersuchen" radio option** for that card —
-   only `Loeschen` / `Behalten` (branches) or `Behalten` / `Entfernen`
-   (clean worktrees) / `Behalten` (has-changes worktrees) remain. Force a
-   terminal decision.
-7. **Regenerate the concept page** as iteration N+1:
-   - Increment `iteration` in the embedded JSON
-   - Header badge: "Iteration 2 — Deep Dive" (or higher counter)
-   - Render `deepDive` blocks inline inside cards for investigated items
-     (see `page-structure.md` § Iteration ≥ 2)
-   - Render tombstone cards for items detected as missing in step 2
-   - Flip the action radio default to the recommended action
-   - Honor the convergence suppression from step 6
-8. **Reload the page** through the bridge `/reload` endpoint (same protocol
-   `/devops-concept` uses). The user now sees enriched info and a fresh
-   submit cycle.
-9. **No deletion** happens for investigated items in this iteration. Their
-   fate is decided in iteration N+1 (where the user can choose
-   `delete` / `keep` / again `investigate` for a deeper loop — unless
-   suppressed by convergence).
-
-**Hard cap:** iterations are capped at **5 rounds**. On iteration 5, the
-"Untersuchen" radio option is suppressed for ALL items regardless of
-digest stability. Render a banner: "Letzte Iteration — bitte abschliessend
-entscheiden." If iteration N+1 would be > 5, refuse to regenerate and
-proceed to Step 10 instead. This is a guard against the spec being used
-as an infinite parking lot rather than a deep-dive tool.
 
 ### Safety Invariants
 
@@ -357,39 +383,38 @@ as an infinite parking lot rather than a deep-dive tool.
 
 ### Worktree Removal Safety
 
-Worktree removal (action `"remove"` in the decisions JSON) is only allowed
-for worktrees classified as `clean` in Step 2. Enforce these rules:
+Worktree removal (action `remove: true` in the decisions JSON) is only allowed
+for Aktive Sessions classified as `clean` in Step 2. Enforce these rules:
 
 1. **Re-check before removal:** Run `git -C <worktree_path> status --porcelain`
    again immediately before acting. If ANY output → SKIP with warning:
    "Worktree hat inzwischen Aenderungen — Entfernung abgebrochen."
 2. **Never force-remove:** Use `git worktree remove <path>` (without `--force`).
    If it fails, report the error — do NOT retry with `--force`.
-3. **Never discard changes:** If a worktree has `status: has-changes`, the UI
-   must NOT render any DESTRUCTIVE action controls — no Entfernen, no
-   "discard", no "reset", no implicit-cleanup option. The ONLY allowed
-   interactive element is an opt-in "Untersuchen" checkbox (read-only
-   deep-dive request, see Step 9b). Even when iteration 2 recommends
+3. **Never discard changes:** If a worktree (Aktive Session) has `status: has-changes`,
+   the UI must NOT render any DESTRUCTIVE action controls — no delete checkbox,
+   no "discard", no "reset", no implicit-cleanup option. The ONLY allowed
+   interactive element is the read-only „?" inline detail toggle (no destructive
+   action can be triggered from it). Even when the inline detail recommends
    `discard`, the action stays advisory: the user must commit or checkout
    manually. This is enforced in the HTML generation, not just in execution.
 4. **Branch cleanup after removal:** After successfully removing a clean
-   worktree, the associated branch can be deleted locally. But check that
-   the branch is not the current branch in the main repo first.
+   worktree, the associated branch is NOT automatically deleted. The branch
+   can be scheduled for deletion via the normal Löschbar flow, but it must
+   be checked independently (check that it is not the current branch in the
+   main repo first).
 
-## Step 10 — Completion Card
+## Step 11 — Completion Card
 
 Trigger this step only when the run is **done** — i.e. the user closed the
-monitor or the most recent submit produced no `investigate` items. If
-Step 9b regenerated the page for another iteration, SKIP the completion
-card and continue monitoring (Step 8). The card fires once per repo-health
-run, not once per iteration.
+monitor or the most recent submit was processed.
 
 When triggered, call `mcp__plugin_devops_dotclaude-completion__render_completion_card`:
 
 | Situation | Variant |
 |-----------|---------|
-| Branches / remotes / worktrees deleted across any iteration | `ready` |
-| User reviewed (possibly multiple iterations) but didn't delete anything | `analysis` |
+| Branches / remotes / worktrees deleted | `ready` |
+| User reviewed but didn't delete anything | `analysis` |
 | User aborted mid-flow | `aborted` |
 
 Pass: `variant`, `summary` (e.g. "Repo hygiene — 4 branches cleaned"), `lang`,

--- a/plugins/devops/skills/devops-repo-health/deep-knowledge/decision-schema.md
+++ b/plugins/devops/skills/devops-repo-health/deep-knowledge/decision-schema.md
@@ -1,63 +1,70 @@
 # Repo-Health Decision Schema
 
 Submit payload shape collected by the concept page and POSTed back via
-the bridge server. Claude reads this in Step 9 to execute the user's
+the bridge server. Claude reads this in Step 10 to execute the user's
 cleanup decisions.
 
 ```json
 {
   "submitted": true,
-  "iteration": 1,
   "repo": {
     "name": "dotclaude",
     "path": "/path/to/repo",
     "remote": "git@github.com:user/repo.git"
   },
   "filters": {
-    "safe-delete": true,
-    "investigate": true,
-    "worktree": false,
-    "remote": true
+    "loeschbar": true,
+    "untersuchen": true,
+    "nur-remote": true
   },
   "decisions": [
     {
       "id": "branch-feature-xyz",
       "branch": "feature/xyz",
-      "category": "safe-delete",
-      "action": "delete",
-      "scope": "local+remote"
+      "typ": "Git-Session",
+      "ort": "lokal+remote",
+      "kategorie": "loeschbar",
+      "delete": true
     },
     {
       "id": "branch-old-experiment",
       "branch": "old-experiment",
-      "category": "investigate",
-      "action": "investigate"
+      "typ": "Git-Session",
+      "ort": "lokal",
+      "kategorie": "untersuchen",
+      "delete": false
     },
     {
       "id": "branch-stale-wip",
       "branch": "stale-wip",
-      "category": "investigate",
-      "action": "skip"
+      "typ": "Git-Session",
+      "ort": "lokal+remote",
+      "kategorie": "untersuchen",
+      "delete": true
     }
   ],
-  "worktrees": [
+  "aktiveSessions": [
     {
       "branch": "claude/brave-pike",
       "path": "/repo/.claude/worktrees/brave-pike",
+      "typ": "Aktive Session",
+      "ort": "lokal",
       "status": "has-changes",
       "modified": 3,
       "untracked": 1,
       "commits_ahead": 2,
-      "action": "investigate"
+      "remove": false
     },
     {
       "branch": "claude/old-session",
       "path": "/repo/.claude/worktrees/old-session",
+      "typ": "Aktive Session",
+      "ort": "lokal",
       "status": "clean",
       "modified": 0,
       "untracked": 0,
       "commits_ahead": 0,
-      "action": "remove"
+      "remove": true
     }
   ],
   "options": {
@@ -66,32 +73,44 @@ cleanup decisions.
     "sync_main": true
   },
   "comments": [
-    { "id": "branch-old-experiment", "text": "Might still need this — please dig deeper" }
+    { "id": "branch-old-experiment", "text": "Might still need this" }
   ]
 }
 ```
 
 **Notes:**
-- `iteration` — counter starting at `1`. Incremented when Claude regenerates
-  the page after an `investigate` round so the user can distinguish initial
-  vs. follow-up analysis. Iteration ≥ 2 pages contain a `deepDive` block per
-  investigated item (see `investigation.md`).
-- `action` for branches: `"delete"`, `"skip"`, or `"investigate"`.
-- `action` for worktrees: `"keep"`, `"remove"`, or `"investigate"`. `"remove"`
-  is only valid for `status: clean` worktrees.
-- `scope`: `"local"` or `"local+remote"` — combined with global
-  `options.delete_remote` to decide the final scope.
-- `filters` preserves the user's category selection at submit time so
-  Claude knows what was visible when the user clicked.
-- An item with `action: "investigate"` is **deferred** — it is NOT deleted,
-  removed, or otherwise modified in this iteration. Claude gathers deep-dive
-  data on it and regenerates the page as iteration 2 with enriched info and
-  a recommended reclassification.
-- On iteration ≥ 2, an item may also carry a `tombstone` block instead of a
-  `deepDive` block (see `investigation.md` § Tombstone Shape). Tombstones
-  represent items that disappeared between iterations and accept only a
-  "Bestaetigen" action (drop from next submit) — no `action: "delete"` or
-  similar is valid for them.
-- Iterations are capped at 5. On iteration 5 the "Untersuchen" option is
-  globally suppressed; the page accepts only terminal actions
-  (`delete` / `skip` / `keep` / `remove` / `confirm`).
+
+- `decisions[].delete` — boolean, two states only: `true` = löschen, `false` = behalten.
+  There is no `"investigate"` action value; investigation is handled inline via the
+  „?" detail panel (read-only, no submit action required).
+
+- `decisions[].typ` — `"Git-Session"` or `"Aktive Session"` (user-facing category).
+
+- `decisions[].ort` — `"lokal"`, `"nur-remote"`, or `"lokal+remote"`.
+
+- `decisions[].kategorie` — `"loeschbar"` or `"untersuchen"`. Combined with
+  `options.delete_remote` to decide the full scope of the delete.
+
+- `aktiveSessions[].remove` — boolean. `true` only valid for `status: clean`
+  Aktive Sessions. Triggers `git worktree remove <path>` (never `--force`).
+  The associated branch is NOT deleted as part of this action.
+
+- `aktiveSessions` with `status: has-changes` MUST always have `remove: false`.
+  The UI must never render a remove control for them; if this value arrives as
+  `true` in the payload, Claude must skip with a warning (safety guard).
+
+- `filters` preserves the user's category selection at submit time so Claude
+  knows what was visible when the user clicked. This is for logging and
+  Apply-Manifest display — not for scoping the actions.
+
+- `options.delete_remote` — when `true`, also delete the remote tracking branch
+  for every `decisions` item with `delete: true` and `ort` of `"lokal+remote"`
+  or `"nur-remote"`.
+
+- `options.prune_worktrees` — run `git worktree prune` after removals to clean
+  up stale worktree references (does NOT touch active Aktive Sessions).
+
+- `options.sync_main` — pull `origin/main` into local `main` after cleanup.
+
+- `comments` — per-item freeform notes captured from the comment fields.
+  Logged to the decisions JSON file; do not affect which actions are taken.

--- a/plugins/devops/skills/devops-repo-health/deep-knowledge/investigation.md
+++ b/plugins/devops/skills/devops-repo-health/deep-knowledge/investigation.md
@@ -1,13 +1,12 @@
-# Repo-Health Deep Investigation
+# Repo-Health Inline Detail Investigation
 
-When the user marks a branch or worktree with `action: "investigate"` on
-the iteration 1 page, Claude does NOT delete or modify it. Instead it
-runs a per-item deep-dive, attaches the enriched data to the regenerated
-concept page (iteration 2), and recommends a concrete reclassification.
+Data gathered **up-front** (SKILL.md Step 7) for every entry in the concept page.
+All data is embedded in the HTML at first render, hidden behind a `<details>` „?"
+toggle per card. There is no separate iteration loop, no round-trip to Claude.
 
-## Branch Deep-Dive
+## Git-Session Branch — Data Gathering
 
-For each branch with `action: "investigate"`, gather:
+For each Git-Session branch (both Löschbar and Untersuchen), gather:
 
 1. **Full commit log** against `origin/main`:
    ```bash
@@ -34,9 +33,9 @@ For each branch with `action: "investigate"`, gather:
      --json number,title,state,mergedAt,createdAt,url
    ```
 
-5. **Squash-merge cross-check** — only do this if the branch is classified
-   `investigate` AND has no detected PR. For each commit on the branch,
-   check whether its diff content already exists in `origin/main`:
+5. **Squash-merge cross-check** — only for Untersuchen branches with no detected PR.
+   For each commit on the branch, check whether its diff content already exists in
+   `origin/main`:
    ```bash
    git log --format='%H' origin/main..<branch> | while read c; do
      patch_id=$(git show "$c" | git patch-id --stable | awk '{print $1}')
@@ -57,21 +56,21 @@ For each branch with `action: "investigate"`, gather:
 
 Apply rules in order, first match wins:
 
-| Recommendation | When | Default action in iteration 2 |
-|----------------|------|-------------------------------|
-| `safe-delete` | Squash-merge cross-check ≥ 80% match, OR all commits empty (`git diff` clean against main) | "Loeschen" |
-| `pr-open` | An open PR points to this branch | "Behalten" |
-| `ship-needed` | Has substantive diff (≥ 5 lines changed outside CHANGELOG), no open PR, last commit ≤ 30 days old | "Behalten" |
-| `rebase-needed` | Last commit > 90 days old, AND ≥ 30 commits between branch base and current `origin/main` | "Behalten" |
-| `wip-keep` | WIP heuristic > 50%, last commit ≤ 14 days old | "Behalten" |
-| `stale-investigate` | Fallback when nothing else matches | "Behalten" |
+| Recommendation | When | Label shown in inline detail |
+|----------------|------|------------------------------|
+| `safe-delete` | Squash-merge cross-check ≥ 80% match, OR all commits empty (`git diff` clean against main) | "Bereits in main — sicher löschbar" |
+| `pr-open` | An open PR points to this branch | "Offener PR — nicht löschen" |
+| `ship-needed` | Has substantive diff (≥ 5 lines changed outside CHANGELOG), no open PR, last commit ≤ 30 days old | "N ungeschippte Commits — ship empfohlen" |
+| `rebase-needed` | Last commit > 90 days old, AND ≥ 30 commits between branch base and current `origin/main` | "Veraltet — rebase empfohlen" |
+| `wip-keep` | WIP heuristic > 50%, last commit ≤ 14 days old | "WIP — Arbeit laeuft noch" |
+| `stale-investigate` | Fallback when nothing else matches | "Unklar — bitte pruefen" |
 
 Always attach a 1-2 sentence rationale referencing the concrete evidence
 (commit count, file count, dates, PR number).
 
-## Worktree Deep-Dive
+## Aktive Session (Worktree) — Data Gathering
 
-For each worktree with `action: "investigate"`, gather:
+For each Aktive Session, gather:
 
 1. **Modified file list with line counts:**
    ```bash
@@ -100,31 +99,32 @@ For each worktree with `action: "investigate"`, gather:
 
 ### Recommendation Logic
 
-| Recommendation | When | Default action in iteration 2 |
-|----------------|------|-------------------------------|
-| `commit-and-ship` | Substantive changes (≥ 20 lines or ≥ 3 files), last activity ≤ 7 days, no open PR yet | "Behalten" (user should commit + ship manually) |
-| `wip-continue` | Last activity ≤ 3 days, has any uncommitted changes | "Behalten" |
-| `discard` | Only mechanical changes (whitespace, generated files, lock files), OR < 5 lines across < 2 files | "Behalten" (recommendation in rationale, but actual discard requires explicit user action — never auto-discard) |
-| `commit-only` | Branch already has commits ahead of main but no open PR, no recent uncommitted activity | "Behalten" |
-| `stale-investigate` | Fallback | "Behalten" |
+| Recommendation | When | Label shown in inline detail |
+|----------------|------|------------------------------|
+| `commit-and-ship` | Substantive changes (≥ 20 lines or ≥ 3 files), last activity ≤ 7 days, no open PR yet | "N Dateien — commit + ship empfohlen" |
+| `wip-continue` | Last activity ≤ 3 days, has any uncommitted changes | "Aktiv — Arbeit laeuft noch" |
+| `discard` | Only mechanical changes (whitespace, generated files, lock files), OR < 5 lines across < 2 files | "Nur Kleinaenderungen — verwerfen moeglich" |
+| `commit-only` | Branch already has commits ahead of main but no open PR, no recent uncommitted activity | "Commits vorhanden — PR erstellen empfohlen" |
+| `stale-investigate` | Fallback | "Unklar — bitte pruefen" |
 
-**Hard rule:** Even `discard` recommendation MUST NOT trigger automatic
-discard. The user must commit or `git checkout` manually. The page only
-surfaces the recommendation; the action radio for has-changes worktrees
-remains "Untersuchen / Behalten" only — no destructive option.
+**Hard rule:** Even `discard` recommendation MUST NOT trigger automatic discard.
+The user must commit or `git checkout` manually. The inline detail panel is
+read-only — no button in it triggers any git action for has-changes Aktive Sessions.
 
 ## Output Shape
 
-Per investigated item, attach a `deepDive` block to the iteration 2
-concept page payload. Branch example:
+Data is embedded in the concept page HTML at first render time as a `<details>`
+block per card. Example branch inline detail data structure (rendered as HTML, not
+sent back as JSON):
 
 ```json
 {
   "id": "branch-old-experiment",
   "branch": "old-experiment",
-  "category": "investigate",
-  "deepDive": {
+  "kategorie": "untersuchen",
+  "inlineDetail": {
     "recommendation": "ship-needed",
+    "label": "12 ungeschippte Commits — ship empfohlen",
     "rationale": "12 commits, 8 files (~340 lines) changed outside CHANGELOG. Last commit 4 days ago, no PR. Looks shippable.",
     "commits": [
       { "hash": "a1b2c3d", "subject": "feat: add foo", "relativeDate": "vor 4 Tagen", "author": "Jerry" }
@@ -141,13 +141,16 @@ concept page payload. Branch example:
 }
 ```
 
-Worktree example:
+Aktive Session inline detail data structure:
 
 ```json
 {
   "branch": "claude/old-session",
-  "deepDive": {
+  "typ": "Aktive Session",
+  "status": "clean",
+  "inlineDetail": {
     "recommendation": "commit-and-ship",
+    "label": "3 Dateien (~85 Zeilen) — commit + ship empfohlen",
     "rationale": "3 modified files (~85 lines), letzte Aktivitaet vor 2 Tagen. Sieht nach abgeschlossener Feature-Arbeit aus — commit + ship empfohlen.",
     "modifiedFiles": [
       { "path": "src/bar.ts", "added": 45, "deleted": 10 }
@@ -161,63 +164,5 @@ Worktree example:
 }
 ```
 
-The iteration 2 page renders `deepDive` inline inside the corresponding
-card (see `page-structure.md` § Iteration ≥ 2 — Deep-Dive Panel).
-
-## Tombstone Shape (item disappeared between iterations)
-
-When SKILL.md Step 9b revalidation finds an investigate target no longer
-present in the fresh git state (branch deleted in another terminal,
-worktree path removed, etc.), the item is rendered as a tombstone instead
-of a deepDive panel:
-
-```json
-{
-  "id": "branch-old-experiment",
-  "branch": "old-experiment",
-  "category": "investigate",
-  "tombstone": {
-    "reason": "branch-missing",
-    "detectedAt": "2026-05-11T13:35:00+02:00",
-    "lastKnownStatus": "investigate"
-  }
-}
-```
-
-`reason` values: `"branch-missing"`, `"worktree-path-missing"`,
-`"branch-attached-to-worktree"` (race: moved to worktree section instead).
-Tombstone cards show a single "Bestaetigen" button that drops the item
-from the next submit payload — no further action is available.
-
-## Convergence Digest
-
-Step 9b's convergence check (terminate vs. allow another deep-dive round)
-hashes a stable subset of the `deepDive` payload. The digest is recomputed
-each iteration; if it matches the previous iteration's digest verbatim,
-the "Untersuchen" radio is suppressed for that item — no new evidence
-exists, so another round would be pure noise.
-
-**Branch digest input** (in order, JSON-stringify with sorted keys, then SHA-1):
-```
-{
-  "recommendation": "<value>",
-  "commits": [<sorted by hash ascending, hash field only>],
-  "files": [<sorted by path ascending, {path, added, deleted}>]
-}
-```
-
-**Worktree digest input:**
-```
-{
-  "recommendation": "<value>",
-  "modifiedFiles": [<sorted by path, {path, added, deleted}>],
-  "commitsAhead": [<sorted by hash ascending, hash field only>]
-}
-```
-
-Excluded from the digest on purpose: relative-date strings ("vor 4 Tagen"
-changes every render but does not represent new information), the
-free-form `rationale` text, and PR metadata (PR state can flip while
-nothing about the branch content has changed — track that via a separate
-"PR-Status changed" badge if needed in future iterations, not by gating
-convergence on it).
+The page renders `inlineDetail` inside a `<details><summary>[?] Details</summary>...</details>`
+element inside the corresponding card (see `page-structure.md` § Inline Detail Panel).

--- a/plugins/devops/skills/devops-repo-health/deep-knowledge/page-structure.md
+++ b/plugins/devops/skills/devops-repo-health/deep-knowledge/page-structure.md
@@ -1,5 +1,38 @@
 # Repo-Health Concept Page — Structure & Tooltips
 
+## Conceptual Model
+
+Every entry is a **git branch** (a ref). A worktree is NOT a separate entity —
+it is a branch WITH a checked-out directory.
+
+**Typ** (type attribute per entry):
+- **Aktive Session** — a branch WITH a checked-out worktree directory
+  (a running or paused Claude session)
+- **Git-Session** — a plain branch WITHOUT a worktree
+
+**Ort** (location attribute per entry):
+- `lokal` — exists only locally
+- `nur-remote` — exists only on the remote
+- `lokal+remote` — exists in both
+
+## Typ × Zustand Matrix
+
+Status is derived into exactly **two categories** that **partition** all entries
+and **sum** to the total. Every entry belongs to exactly one.
+
+| | merged / clean | unmerged / has-changes |
+|---|---|---|
+| **Git-Session** | 🟢 **Löschbar** — delete branch | 🟡 **Untersuchen** — investigate; no destructive action |
+| **Aktive Session** | 🟢 **Löschbar** — remove worktree ONLY (branch stays); NOT pre-checked by default | 🟡 **Untersuchen** — has changes; inline detail only; NEVER destructive |
+
+Notes on cells:
+- "Aktive Session + merged/clean → Löschbar" means: worktree removal is offered, but
+  the branch itself is NOT automatically queued for deletion. The branch may still be
+  needed (it is protected). After worktree removal, the branch transitions to a plain
+  Git-Session and can be cleaned in a subsequent run.
+- "has-changes → never destructive": no delete checkbox, no remove option; only the
+  read-only „?" inline detail toggle is rendered.
+
 ## Page Structure
 
 ```
@@ -7,114 +40,137 @@
   Repo name (large)
   Local path | Remote URL | Current branch | Default branch
   Last fetch timestamp
-  Iteration badge: "Iteration 1" (or "Iteration 2 — Deep Dive" on follow-up)
 
-[Summary KPI Cards]
-  Total branches | Safe to delete | Needs investigation | Active worktrees (X with changes / Y clean) | Main sync status
+[Summary KPI — one total partitioned into two]
+  ┌─────────────────────────────────────────────────────────────┐
+  │  Gesamt: 9      🟢 Löschbar: 6          🟡 Untersuchen: 3  │
+  │                    ├ Git-Sessions: 4        ├ Git-Sessions: 3 │
+  │                    │   lokal: 2             │   lokal: 2      │
+  │                    │   nur-remote: 1        │   nur-remote: 1 │
+  │                    │   lokal+remote: 1      │   lokal+remote: 0│
+  │                    └ Aktive Sessions: 2     └ Aktive Sessions: 0│
+  │                        lokal: 2                              │
+  └─────────────────────────────────────────────────────────────┘
+  Main sync status (separate line): up to date / X commits behind
 
-[Active Worktrees Section — DEDICATED, separate from branch list]
-  Only shown if worktrees exist. NOT part of the branch list below.
-  Per worktree card:
+[Aktive Sessions Section — DEDICATED, separate from Git-Session list]
+  Only shown if Aktive Sessions (worktrees) exist.
+  Header: "Aktive Sessions (N)"  — expandable block
+  Sub-labels behind header: "mit Aenderungen: X / sauber: Y"
+
+  Per Aktive Session card:
     Branch name (monospace) + worktree path (smaller, muted)
+    Typ badge: "Aktive Session" (blue)
+    Ort badge: "lokal" (gray)
     Status badge:
-      - "Mit Aenderungen" (amber badge) if has-changes
-      - "Sauber" (gray badge) if clean
+      - "Mit Aenderungen" (amber) if has-changes
+      - "Sauber" (gray) if clean
+    Merge status: merged / unmerged (last known state; note a session may
+      have multiple PRs/merges — show the most recent)
     If has-changes:
       File summary: "X geaendert, Y ungetrackt" (compact inline)
       Commits ahead: "Z Commits vor main" (if any)
-      Visual: info icon, clearly labeled read-only by default
-      HARD RULE: NO delete, discard, reset, or cleanup options whatsoever
-      Action controls (limited):
-        Checkbox: "Untersuchen" (UNCHECKED by default)
-        Tooltip on checkbox — see Tooltip section below
-        Optional comment field (collapsed by default, expandable)
+      HARD RULE: NO delete checkbox, no discard, no reset, no cleanup options.
+      Action controls (read-only detail only):
+        [?] inline detail toggle (expands commit log + file list + recommendation)
+        No comment field, no submit-affecting controls.
     If clean:
       "Keine lokalen Aenderungen"
-      Action controls (radio group, default "Behalten"):
-        ( ) Entfernen
-        ( ) Untersuchen
-        (*) Behalten
-        Tooltips on each — see Tooltip section below
-  Card styling: subtle border, lower visual weight than branch cards,
-  distinct background tint (e.g. blue-gray) to avoid confusion with branches
+      Action controls:
+        [ ] Entfernen (checkbox, UNCHECKED by default — must consciously opt in)
+        [?] inline detail toggle
+        Tooltip on checkbox — see Tooltip section below
+  Card styling: subtle border, lower visual weight than Git-Session cards,
+  distinct background tint (blue-gray) to avoid confusion with Git-Sessions
 
 [Filter Bar]
-  Category toggles: [Sicher loeschbar] [Untersuchen] [Remote]
-  (NO worktree toggle — worktrees have their own section above)
+  Category toggles: [Löschbar] [Untersuchen] [nur-remote]
+  (NO Aktive-Session toggle — Aktive Sessions have their own section above)
   Select all / Deselect all buttons (apply to visible items only)
+  When a filter is active and select-all is clicked:
+    Banner: "Alle N gefilterten markieren (vs. M sichtbar)" — must confirm
+    before bulk-acting on rows outside the current view.
 
-[Branch List — filterable, excludes worktree branches]
-  Per branch card:
+[Git-Session List — filterable, excludes Aktive Session branches]
+
+  [Löschbar Group — expandable, OPEN by default]
+  Header: "🟢 Löschbar (N)" with sub-labels "merged X / not-merged Y"
+  "Alles aufklappen" button for this section
+
+  Per Git-Session card in Löschbar:
     Branch name (monospace, prominent)
-    Category badge (color-coded: green=safe, yellow=investigate)
+    Typ badge: "Git-Session" (neutral)
+    Ort badge: lokal / nur-remote / lokal+remote
+    Kategorie badge: "Löschbar" (green)
+    Merge status: merged / squash-merged
     PR reference (if exists): #123 — title
-    Merge status: merged / squash-merged / unmerged / no PR
     Last commit: hash + message + relative date
     Diff stats: X files changed (excluding CHANGELOG)
     Remote status: exists / gone / n/a
-
-    [Action controls — radio group, only for safe-delete and investigate categories]:
-      ( ) Loeschen      — default for safe-delete category
-      ( ) Untersuchen
-      ( ) Behalten      — default for investigate category
-      Tooltips on each — see Tooltip section below
+    Action controls:
+      [x] Löschen  (checkbox, PRE-CHECKED for safe-delete Git-Sessions)
+      [?] inline detail toggle (expands commit-log + diff + recommendation)
       Optional comment field (collapsed by default, expandable)
 
-  [Iteration ≥ 2 — Deep-Dive Panel per investigated branch]
-    Rendered inline inside the branch card, below the action controls:
-      Section heading: "Detail-Analyse"
+  [Untersuchen Group — expandable, COLLAPSED by default]
+  Header: "🟡 Untersuchen (N)" with sub-labels "merged X / not-merged Y"
+  "Alles aufklappen" button for this section
+
+  Per Git-Session card in Untersuchen:
+    Branch name (monospace, prominent)
+    Typ badge: "Git-Session" (neutral)
+    Ort badge: lokal / nur-remote / lokal+remote
+    Kategorie badge: "Untersuchen" (amber)
+    Merge status: unmerged / open PR
+    PR reference (if exists): #123 — title — state
+    Last commit: hash + message + relative date
+    Diff stats: X files changed (excluding CHANGELOG)
+    Remote status: exists / gone / n/a
+    Action controls:
+      [ ] Löschen  (checkbox, UNCHECKED by default — user opts in consciously)
+      [?] inline detail toggle (expands commit-log + diff + recommendation)
+      Optional comment field (collapsed by default, expandable)
+
+  [Inline Detail Panel — per card, triggered by „?" toggle]
+    Rendered inside the card below the action controls, hidden by default.
+    No round-trip to Claude — all data is embedded at first render.
+    Content:
+      Section heading: "Detail"
       Recommendation badge: ship-needed / safe-delete / rebase-needed /
-        wip-keep / pr-open (color-coded, see investigation.md)
+        wip-keep / pr-open / commit-and-ship / wip-continue / stale-investigate
+        (color-coded, see investigation.md)
+      Short recommendation label (e.g. "3 ungeschippte Commits — ship empfohlen")
       Full commit log (scrollable, monospace, latest first)
       Diff summary by file (path + +X/-Y)
       Branch age: "Erster Commit vor 14 Tagen, letzter vor 2 Tagen"
       Open PRs (if any): #N — title — state
       Rationale text (1-2 sentences explaining the recommendation)
-    The action radio defaults flip to match the recommendation:
-      ship-needed   -> default "Behalten" (user should ship before deleting)
-      pr-open       -> default "Behalten"
-      safe-delete   -> default "Loeschen"
-      rebase-needed -> default "Behalten"
-      wip-keep      -> default "Behalten"
-
-  [Iteration ≥ 2 — Tombstone card (item disappeared)]
-    Replaces the normal card when SKILL.md Step 9b revalidation finds the
-    branch / worktree no longer present in fresh git state:
-      Visual: gray-out, strikethrough on the branch name
-      Header: "Nicht mehr vorhanden" badge + reason label
-        (branch-missing / worktree-path-missing / branch-attached-to-worktree)
-      Body: lastKnownStatus + detectedAt timestamp, no deepDive data
-      Single button: "Bestaetigen" — drops the item from the next submit
-      NO radio group, NO Untersuchen, NO destructive actions
-
-  [Iteration ≥ 2 — Convergence-suppressed card]
-    When SKILL.md Step 9b detects an identical deepDive digest vs. the
-    previous iteration for an investigate item, render the deepDive
-    normally BUT remove the "Untersuchen" radio option (only Loeschen /
-    Behalten for branches, only Entfernen / Behalten for clean worktrees,
-    only Behalten for has-changes worktrees). Show a small info chip:
-    "Keine neuen Erkenntnisse — bitte entscheiden."
-
-  [Iteration 5 banner]
-    Render at the top of the branch + worktree sections on iteration 5:
-    "Letzte Iteration — bitte abschliessend entscheiden. Untersuchen ist
-    deaktiviert." Untersuchen is suppressed across ALL cards regardless
-    of digest stability.
+    Implemented as a `<details><summary>[?] Details</summary>...</details>` element.
 
 [Main Sync Section]
   Current status: up to date / X commits behind
   Checkbox: "Main synchronisieren" (pre-checked if behind)
 
-[Decision Panel Sidebar]
-  Summary lines (live counters):
-    "X Branches zum Loeschen ausgewaehlt"
-    "Y Items zur Detail-Analyse markiert" (only shown if > 0)
-  Grouped summary: Z local + W remote branches
+[Apply-Manifest Sidebar]
+  A complete list of everything that will happen, live-updated as user
+  toggles checkboxes. Acts as a preview / manifest before submission.
+
+  Content:
+    "Folgende Aktionen:"
+    Lokal löschen (N): branch-a, branch-b, ...
+    Remote löschen (M): branch-a (origin), ...
+    Worktrees entfernen (K): claude/old-session (/path)
+    Main synchronisieren: ja / nein
+    Remote prunen: ja / nein
+
   Checkbox: "Remote-Branches auch loeschen" (default: checked) + tooltip
   Checkbox: "Worktrees prunen" (default: checked) + tooltip
-  Submit button label adapts:
-    - Any item marked Untersuchen: "Details pruefen + Aufraeumen"
-    - Otherwise: "Aufraeumen starten"
+  Submit button label: "Aufraeumen starten"
+
+  On Submit: show Dry-Run-Confirm before executing anything:
+    "Löscht N lokal, M remote, entfernt K Worktrees.
+    Lokales Löschen und remote Löschen ist NICHT rückgängig zu machen.
+    Fortfahren?" [Ja] [Abbrechen]
 ```
 
 ## Tooltip Explanations
@@ -124,29 +180,31 @@ Every action control and global option MUST have an explanatory tooltip
 
 | Element | Tooltip text |
 |---------|-------------|
-| "Loeschen" radio (safe-delete) | "Branch lokal loeschen. Arbeit ist bereits in main (merged/squash-merged)." |
-| "Loeschen" radio (investigate) | "Branch lokal loeschen. ACHTUNG: Aenderungen sind moeglicherweise NICHT in main!" |
-| "Untersuchen" radio (branch) | "Branch NICHT loeschen. Claude analysiert Commits, Diff und Alter und schlaegt in einer zweiten Iteration eine konkrete Aktion vor (shippen / loeschen / rebasen)." |
-| "Behalten" radio (branch) | "Branch unveraendert lassen — keine Aktion in dieser Iteration." |
-| "Entfernen" radio (clean worktree) | "Worktree und zugehoerigen Branch entfernen. Nur moeglich ohne lokale Aenderungen." |
-| "Untersuchen" checkbox/radio (worktree) | "Worktree NICHT anfassen. Claude prueft geaenderte Dateien, Commits und letztes Aktivitaetsdatum und empfiehlt in der naechsten Iteration: shippen, weiterarbeiten oder verwerfen." |
-| "Behalten" radio (worktree) | "Worktree unveraendert lassen." |
+| Löschen checkbox (Löschbar Git-Session) | "Branch lokal loeschen. Arbeit ist bereits in main (merged/squash-merged)." |
+| Löschen checkbox (Untersuchen Git-Session) | "Branch lokal loeschen. ACHTUNG: Aenderungen sind moeglicherweise NICHT in main!" |
+| Entfernen checkbox (clean Aktive Session) | "Nur den Worktree entfernen. Der Branch bleibt erhalten und kann spaeter separat geloescht werden." |
+| „?" inline detail toggle | "Commit-Log, Diff-Statistik und Empfehlung anzeigen — keine Aktion wird ausgeloest." |
 | "Remote-Branches auch loeschen" | "Loescht die Branches auch auf GitHub/origin. Betrifft nur die oben ausgewaehlten Branches." |
-| "Worktrees prunen" | "Entfernt verwaiste Worktree-Referenzen (bereits geloeschte Verzeichnisse). Aktive Worktrees werden NICHT beruehrt." |
+| "Worktrees prunen" | "Entfernt verwaiste Worktree-Referenzen (bereits geloeschte Verzeichnisse). Aktive Sessions werden NICHT beruehrt." |
 | "Main synchronisieren" | "Holt die neuesten Aenderungen von origin/main und aktualisiert den lokalen main-Branch." |
-| "Select all" button | "Alle sichtbaren Branches zum Loeschen markieren." |
-| "Deselect all" button | "Alle sichtbaren Branches auf Behalten setzen." |
+| "Select all" button | "Alle sichtbaren Git-Sessions zum Loeschen markieren." |
+| "Deselect all" button | "Alle sichtbaren Git-Sessions auf Behalten setzen." |
 
-Implement tooltips as `title` attributes on the label/radio wrapper.
+Implement tooltips as `title` attributes on the label/checkbox wrapper.
 Keep text concise — one sentence max, no jargon.
 
 ## Action Control Notes
 
-- Radio groups are exclusive: exactly one of Loeschen / Untersuchen / Behalten
-  is selected per branch at any time. Same for clean worktrees with
-  Entfernen / Untersuchen / Behalten.
-- has-changes worktrees keep a single "Untersuchen" checkbox (no radio) —
-  the only allowed user action; defaulting to unchecked = Behalten.
-- "Select all" sets visible items to "Loeschen". "Deselect all" sets them
-  to "Behalten". Untersuchen is never set in bulk — it is an explicit
-  per-item opt-in.
+- Each Git-Session card has exactly **one checkbox** (delete / keep — two states only).
+  There is no radio group, no third "Untersuchen" action state.
+- has-changes Aktive Sessions expose NO submit-affecting controls — only the „?"
+  inline detail toggle (read-only). The inline detail may include a recommendation
+  (e.g. "commit + ship"), but it is advisory; no button triggers any git action.
+- clean Aktive Sessions expose one checkbox (Entfernen, unchecked by default).
+  The associated branch is NOT included in the deletion — only the worktree directory
+  is removed via `git worktree remove`.
+- "Select all" sets all visible Git-Session checkboxes to checked (delete).
+  "Deselect all" sets them to unchecked (keep). Aktive Session checkboxes are
+  never affected by bulk select.
+- Comment fields are per-card, collapsed by default; their content is included in
+  the submit payload for logging purposes only.

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.100.2",
+  "version": "0.101.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
Redesign of the `/devops-repo-health` report page around a single branch model (repo-health skill 0.4.0→0.5.0), from a 4-iteration concept review.

## Highlights
- **Unified model** — every entry is a git branch; a worktree = branch + checked-out dir, surfaced as an **Aktive Session** (vs a plain **Git-Session**).
- **KPI** — one total partitioned into 🟢 Löschbar + 🟡 Untersuchen (they sum), each with sub-labels by type (Git/Aktive Session) and location (lokal/nur-remote). Replaces the 4 double-counting tiles.
- **2-state controls** — single delete checkbox (safe-delete pre-checked) instead of the 3-way radio; "Untersuchen" → inline **"?" detail**.
- **Iteration loop removed** — inline detail expands commit-log/diff/recommendation on first render; convergence digest, tombstones, 5-round cap and Step 9b are deleted.
- **Apply-Manifest + Dry-Run-Confirm**, Gmail-style select-all banner, decision-first + progressive disclosure, co-located Aktive-Sessions block, scope question defaulting to the current repo.
- **Safety preserved** — worktree-attached branches never auto-deleted; has-changes sessions get no destructive control; clean sessions are not pre-checked.

Specs: `SKILL.md`, `page-structure.md`, `decision-schema.md`, `investigation.md`. Suite green (385), lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)