### PR TITLE
feat(autonomous): schedule worktree auto-resume after token reset

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.101.1"
+    "version": "0.102.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.101.1",
+      "version": "0.102.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.102.0] — 2026-06-14
+
+### Added
+
+- **`/devops-autonomous` can now schedule an automatic worktree-resume after the 5h token-window resets.** When the user declines shutdown (PC stays on), a new conditional **Step 2 Q4** offers to arm a one-shot session cron that — once the rolling 5-hour token window has reset — nudges every hard-capped Claude worktree to continue with »weiter« (new **Step 0.2** handler enumerates `claude/` worktrees, skips finished ones via `AUTONOMOUS-DONE.flag` / COMPLETED-report, and resumes the rest through `ccd_session_mgmt` `list_sessions` + `send_message`). The question is skipped entirely when shutdown=yes — a powered-off PC has nothing to resume. The fire time is **not** a blind `now + 5h`: new **Step 4e** calls `autonomous-resume-schedule.js`, which derives the moment from the live `session.resetInMinutes` (age-corrected against the snapshot timestamp, +10 min buffer past the reset boundary so budget is truly back) and falls back to a flat 5h only when usage data is missing, stale (>5h), future-dated, or already reset — emitting a ready-to-use 5-field cron expression so no LLM date math is involved. The cron is deliberately **in-memory / session-bound** (fires only while Claude stays open — closing it, e.g. to game, is an accepted, even desired, trade-off) and **one-shot with no retry** (a single nudge; if the account is still capped at fire time — a fresh window already drained, or the weekly limit, which does not reset in 5h — the attempt simply errors, an accepted limitation). New `autonomous-resume-schedule.js` (+18 tests) pins the resetInMinutes→delay mapping, the no-floor imminent-reset case, the 5h cap, age-correction, and every flat-5h fallback branch. Skill `devops-autonomous` 0.3.0→0.4.0.
+
 ## [0.101.1] — 2026-06-14
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.101.1**
+**Version: 0.102.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.101.1",
+  "version": "0.102.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/scripts/autonomous-resume-schedule.js
+++ b/plugins/devops/scripts/autonomous-resume-schedule.js
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+/**
+ * autonomous-resume-schedule.js — Compute WHEN the auto-resume cron should fire.
+ *
+ * Used by devops-autonomous Step 4e. When the user opted into auto-resume
+ * ($AUTO_RESUME=yes, only possible when shutdown=no), a one-shot session cron is
+ * armed that — once the 5h token window has reset — nudges hard-capped Claude
+ * worktrees to continue with »weiter« (Step 0.2).
+ *
+ * Timing — "just after the current window resets, else a flat 5h":
+ *   - Read `session.resetInMinutes` from ~/.claude/usage-live.json (last scrape),
+ *     age-correct it against the snapshot `timestamp`.
+ *   - Fire at `now + effectiveMin + BUFFER`. The BUFFER pushes the fire moment
+ *     PAST the reset boundary (clock skew, scrape lag) — the cron must wake up
+ *     when budget is back, not a hair before. effectiveMin is clamped to one full
+ *     window (≤ 5h) defensively.
+ *   - Fall back to a flat 5h whenever usage data is missing, stale (>5h old),
+ *     future-dated, or already reset. 5h is always safe: the active window started
+ *     at or before "now", so its reset is at or before now+5h ("im Zweifel 5h").
+ *
+ * Unlike autonomous-shutdown-timer.js there is NO 90-min floor: firing close to
+ * an imminent reset is exactly what we want (don't wait a needless 5h), and the
+ * 5h CAP applies to the window estimate, not to the BUFFER on top of it.
+ *
+ * CLI (stdout: JSON):
+ *   (no subcommand)   → { ok, delayMinutes, cron, fireAtLocal, source }
+ *                       `cron` is a ready-to-use 5-field expression in LOCAL time
+ *                       for a one-shot CronCreate — no LLM date math needed.
+ *
+ * Cross-platform: pure file-read + date math, no native calls.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const USAGE_JSON_PATH = path.join(os.homedir(), '.claude', 'usage-live.json');
+
+const WINDOW_MAX_MIN = 5 * 60; // 300 — one full token period (cap & flat fallback)
+const RESET_BUFFER_MIN = 10;   // pad past the reset boundary so budget is truly back
+const MAX_STALE_MIN = 300;     // usage older than a full window → unreliable → fallback
+
+/**
+ * Pure delay resolver — no I/O, exported for tests.
+ * @param {object|null} usageData  Parsed usage-live.json (or null/garbage).
+ * @param {number} nowMs           Current epoch ms (injected for determinism).
+ * @returns {{delayMinutes:number, source:string, effectiveMin?:number}}
+ */
+function computeResumeDelayMinutes(usageData, nowMs) {
+  const fallback = { delayMinutes: WINDOW_MAX_MIN, source: 'fallback-5h' };
+
+  const resetMin = usageData && usageData.session && usageData.session.resetInMinutes;
+  const ts = usageData && usageData.timestamp;
+  if (typeof resetMin !== 'number' || !Number.isFinite(resetMin) || resetMin <= 0) {
+    return fallback;
+  }
+  if (!ts) return fallback;
+
+  const ageMin = (nowMs - new Date(ts).getTime()) / 60000;
+  if (!Number.isFinite(ageMin) || ageMin < 0 || ageMin > MAX_STALE_MIN) {
+    return fallback; // stale or future-dated snapshot → unreliable
+  }
+
+  const effectiveMin = resetMin - ageMin;
+  if (effectiveMin <= 0) return fallback; // period already reset → assume a fresh 5h
+
+  // Clamp the window estimate to one full period, then add the buffer ON TOP so
+  // we always land after the reset, never on it.
+  const windowMin = Math.min(effectiveMin, WINDOW_MAX_MIN);
+  const delayMinutes = Math.round(windowMin) + RESET_BUFFER_MIN;
+  const source = effectiveMin > WINDOW_MAX_MIN ? 'reset-window-capped' : 'reset-window';
+
+  return { delayMinutes, source, effectiveMin: Math.round(effectiveMin) };
+}
+
+/**
+ * Build a one-shot 5-field cron expression for `fireAtMs` in LOCAL time.
+ * Day-of-week is left `*` so the (day-of-month, month) pair pins the date.
+ * @param {number} fireAtMs  Absolute epoch ms when the cron should fire.
+ * @returns {string} "M H D Mo *"
+ */
+function toCronExpression(fireAtMs) {
+  const d = new Date(fireAtMs);
+  return `${d.getMinutes()} ${d.getHours()} ${d.getDate()} ${d.getMonth() + 1} *`;
+}
+
+function readUsageJson() {
+  try {
+    return JSON.parse(fs.readFileSync(USAGE_JSON_PATH, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function pad2(n) {
+  return String(n).padStart(2, '0');
+}
+
+// --- CLI entry (skipped when require()'d by tests) ---
+if (require.main === module) {
+  const now = Date.now();
+  const plan = computeResumeDelayMinutes(readUsageJson(), now);
+  const fireAtMs = now + plan.delayMinutes * 60000;
+  const f = new Date(fireAtMs);
+  const fireAtLocal =
+    `${f.getFullYear()}-${pad2(f.getMonth() + 1)}-${pad2(f.getDate())} ` +
+    `${pad2(f.getHours())}:${pad2(f.getMinutes())}`;
+  process.stdout.write(
+    JSON.stringify({
+      ok: true,
+      delayMinutes: plan.delayMinutes,
+      cron: toCronExpression(fireAtMs),
+      fireAtLocal,
+      source: plan.source,
+    }) + '\n',
+  );
+}
+
+module.exports = {
+  computeResumeDelayMinutes,
+  toCronExpression,
+  WINDOW_MAX_MIN,
+  RESET_BUFFER_MIN,
+  MAX_STALE_MIN,
+};

--- a/plugins/devops/scripts/autonomous-resume-schedule.test.js
+++ b/plugins/devops/scripts/autonomous-resume-schedule.test.js
@@ -1,0 +1,104 @@
+import { describe, test, expect } from "vitest";
+import {
+  computeResumeDelayMinutes,
+  toCronExpression,
+  WINDOW_MAX_MIN,
+  RESET_BUFFER_MIN,
+} from "./autonomous-resume-schedule.js";
+
+// Fixed "now" so age-correction is deterministic.
+const NOW = Date.parse("2026-06-04T12:00:00.000Z");
+const atNow = (resetInMinutes, ageMin = 0) => ({
+  timestamp: new Date(NOW - ageMin * 60000).toISOString(),
+  session: { pct: 30, resetInMinutes },
+});
+
+describe("computeResumeDelayMinutes — reset-window mapping", () => {
+  test("mid window (180 min remaining) → 180 + buffer", () => {
+    const r = computeResumeDelayMinutes(atNow(180), NOW);
+    expect(r.delayMinutes).toBe(180 + RESET_BUFFER_MIN);
+    expect(r.source).toBe("reset-window");
+    expect(r.effectiveMin).toBe(180);
+  });
+
+  test("imminent reset (3 min remaining) → fires soon, NO floor", () => {
+    const r = computeResumeDelayMinutes(atNow(3), NOW);
+    expect(r.delayMinutes).toBe(3 + RESET_BUFFER_MIN); // 13 — not floored to 90+
+    expect(r.source).toBe("reset-window");
+  });
+
+  test("full window (300 min) → 300 + buffer, not flagged capped", () => {
+    const r = computeResumeDelayMinutes(atNow(300), NOW);
+    expect(r.delayMinutes).toBe(WINDOW_MAX_MIN + RESET_BUFFER_MIN);
+    expect(r.source).toBe("reset-window");
+  });
+
+  test("over-window estimate (>5h) → clamped to 5h + buffer, flagged capped", () => {
+    const r = computeResumeDelayMinutes(atNow(600), NOW);
+    expect(r.delayMinutes).toBe(WINDOW_MAX_MIN + RESET_BUFFER_MIN);
+    expect(r.source).toBe("reset-window-capped");
+  });
+});
+
+describe("computeResumeDelayMinutes — age correction", () => {
+  test("200 min remaining but snapshot 60 min old → 140 + buffer", () => {
+    const r = computeResumeDelayMinutes(atNow(200, 60), NOW);
+    expect(r.delayMinutes).toBe(140 + RESET_BUFFER_MIN);
+    expect(r.effectiveMin).toBe(140);
+    expect(r.source).toBe("reset-window");
+  });
+
+  test("window already elapsed after age correction → fallback 5h", () => {
+    // 30 min remaining at snapshot, but 45 min have passed → period reset.
+    const r = computeResumeDelayMinutes(atNow(30, 45), NOW);
+    expect(r.delayMinutes).toBe(WINDOW_MAX_MIN);
+    expect(r.source).toBe("fallback-5h");
+  });
+});
+
+describe("computeResumeDelayMinutes — fallback to flat 5h (no buffer)", () => {
+  test.each([
+    ["null usage", null],
+    ["empty object", {}],
+    ["missing session", { timestamp: new Date(NOW).toISOString() }],
+    ["missing timestamp", { session: { resetInMinutes: 120 } }],
+    ["non-numeric resetInMinutes", atNow("nope")],
+    ["zero resetInMinutes", atNow(0)],
+    ["negative resetInMinutes", atNow(-10)],
+  ])("%s → fallback 5h", (_label, usage) => {
+    const r = computeResumeDelayMinutes(usage, NOW);
+    expect(r.delayMinutes).toBe(WINDOW_MAX_MIN);
+    expect(r.source).toBe("fallback-5h");
+  });
+
+  test("stale snapshot (>5h old) → fallback 5h", () => {
+    const r = computeResumeDelayMinutes(atNow(180, 6 * 60), NOW);
+    expect(r.delayMinutes).toBe(WINDOW_MAX_MIN);
+    expect(r.source).toBe("fallback-5h");
+  });
+
+  test("future-dated snapshot (clock skew) → fallback 5h", () => {
+    const r = computeResumeDelayMinutes(atNow(180, -30), NOW);
+    expect(r.delayMinutes).toBe(WINDOW_MAX_MIN);
+    expect(r.source).toBe("fallback-5h");
+  });
+
+  test("fallback delay carries NO buffer (flat 5h == 300)", () => {
+    const r = computeResumeDelayMinutes(null, NOW);
+    expect(r.delayMinutes).toBe(300);
+  });
+});
+
+describe("toCronExpression — local-time 5-field one-shot", () => {
+  test("builds M H D Mo * from local time, month is 1-based", () => {
+    // Construct a known LOCAL time to avoid TZ flakiness in assertions.
+    const local = new Date(2026, 5, 4, 14, 26, 0); // 2026-06-04 14:26 local (month idx 5 = June)
+    expect(toCronExpression(local.getTime())).toBe("26 14 4 6 *");
+  });
+
+  test("rolls into next day/month correctly via Date arithmetic", () => {
+    const local = new Date(2026, 0, 31, 23, 55, 0); // Jan 31 23:55 local
+    const fireAt = local.getTime() + 30 * 60000; // +30 min → Feb 1 00:25
+    expect(toCronExpression(fireAt)).toBe("25 0 1 2 *");
+  });
+});

--- a/plugins/devops/skills/devops-autonomous/SKILL.md
+++ b/plugins/devops/skills/devops-autonomous/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: devops-autonomous
-version: 0.3.0
+version: 0.4.0
 description: >-
   Fully autonomous agent orchestration for when the user is away from the PC.
   Runs agents without supervision (implementation, desktop interaction, live
@@ -18,7 +18,9 @@ allowed-tools: >-
   mcp__plugin_playwright_playwright__*,
   mcp__plugin_devops_dotclaude-completion__*,
   mcp__plugin_devops_dotclaude-ship__*,
-  mcp__plugin_devops_dotclaude-issues__*
+  mcp__plugin_devops_dotclaude-issues__*,
+  mcp__ccd_session_mgmt__list_sessions,
+  mcp__ccd_session_mgmt__send_message
 ---
 
 # Devops Autonomous
@@ -43,11 +45,34 @@ If the incoming user message starts with `AUTONOMOUS_AUTOSTART:`, this is the
    `AUTONOMOUS_AUTOSTART:` prompt and context, log "Autostart verschoben —
    offene Frage aktiv", continue waiting.
 2. If no question is pending: parse `task`, `mode`, `desktop`, `shutdown`,
-   `branch` from the prompt.
+   `autoResume`, `branch` from the prompt.
 3. Output once: **"3-Minuten-Timeout — starte jetzt autonom."**
 4. Skip Steps 1-4 entirely. Permissions were already primed in the parent session.
-5. Jump directly to Step 5 with the parsed context. The Post-Confirmation Lockout
+5. If `autoResume=yes`, arm the resume cron now (Step 4e) — Step 4c never ran on
+   this path.
+6. Jump directly to Step 5 with the parsed context. The Post-Confirmation Lockout
    is active from this moment.
+
+## Step 0.2 — Auto-Resume Handler
+
+If the incoming user message starts with `AUTONOMOUS_RESUME:`, the Step 4e one-shot
+cron has fired: the 5h token window has reset and any Claude worktrees that were
+hard-capped mid-run should be nudged to continue. The user is AFK — do this without
+questions, then stop. Steps 1-8 do NOT apply.
+
+1. `git worktree list --porcelain` → collect every worktree whose branch starts
+   with `claude/` (each is an active Claude session; same detection as
+   `devops-repo-health`).
+2. Classify each. A worktree is **done** if its root holds `AUTONOMOUS-DONE.flag`,
+   or an `AUTONOMOUS-REPORT.html` with COMPLETED status and **no**
+   `AUTONOMOUS-RESUME.json`. Skip done worktrees — never re-trigger finished work.
+3. For each remaining (mid-task / hard-capped) worktree, resume it with a single
+   `weiter`: use `mcp__ccd_session_mgmt__list_sessions` to find the live session
+   bound to that worktree path, then `mcp__ccd_session_mgmt__send_message` with the
+   one word `weiter`. If the session-mgmt tools are unavailable, list the worktree
+   paths that need a manual `weiter` instead of nudging.
+4. Output a short summary: nudged / skipped-done / manual-needed. Do not start new
+   work — only continue what was interrupted.
 
 ## Step 0.5 — Resume Detection
 
@@ -130,9 +155,10 @@ If ambiguous, ask ONE clarifying question — time is limited.
 
 ## Step 2 — Mode & Preference Questions
 
-Ask via `AskUserQuestion` — three sequential questions. **Option order is fixed** as
-listed below (option 1 first, option 2 second). Never shuffle. Mark the recommended
-option with "(empfohlen)" in its label.
+Ask via `AskUserQuestion` — three sequential questions (a fourth, Q4 Auto-Resume,
+follows conditionally when shutdown is declined). **Option order is fixed** as listed
+below (option 1 first, option 2 second). Never shuffle. Mark the recommended option
+with "(empfohlen)" in its label.
 
 **Question 1 — Execution Mode:**
 > header: "Modus"
@@ -167,6 +193,24 @@ In `analyze` mode, desktop is only used for visual inspection (screenshots), nev
 > Options (fixed order):
 > 1. label: "Nein, nur Bericht (empfohlen)" — description: "Ergebnisse als Report, PC bleibt an."
 > 2. label: "Ja, herunterfahren" — description: "PC fährt 60s nach Abschluss herunter. Wartet vorher, falls andere Claude-Sessions (egal welches Projekt) noch arbeiten."
+
+Save the choice as `$SHUTDOWN` (`yes` if option 2, `no` if option 1).
+
+**Question 4 — Auto-Resume (ONLY ask when Q3 = "Nein, nur Bericht"):**
+
+A shutdown PC has nothing to resume, so this question is **skipped entirely when
+`$SHUTDOWN=yes`** — set `$AUTO_RESUME=no` and move on. Ask it only when the PC stays
+on:
+
+> header: "Auto-Resume"
+> question: "Falls das 5h-Token-Limit zwischendurch hart greift, bleiben Worktrees mitten in der Arbeit stehen. Soll ich nach 5h (Reset des Token-Fensters) automatisch alle aktiven Claude-Worktrees mit »weiter« anstoßen?"
+> multiSelect: false
+> Options (fixed order):
+> 1. label: "Ja, Resume nach 5h planen (empfohlen)" — description: "Einmaliger Anstoß: nach 5h werden alle aktiven Claude-Worktrees, die noch mitten in der Arbeit hängen, mit »weiter« fortgesetzt. Fertige Worktrees werden übersprungen."
+> 2. label: "Nein" — description: "Kein automatischer Resume. Hängengebliebene Worktrees setzt du später selbst fort."
+
+Save the choice as `$AUTO_RESUME` (`yes` if option 1, `no` if option 2). It is armed
+at "Ja, los!" (Step 4c) — or on auto-start (Step 0.1) — via Step 4e.
 
 ## Step 3 — Permission Priming (ALL permissions BEFORE confirmation)
 
@@ -244,7 +288,7 @@ execution context (the user will not be there to re-enter it):
 CronCreate({
   cron: "<M> <H> <D> <Mo> *",
   recurring: false,
-  prompt: "AUTONOMOUS_AUTOSTART: 3-minute confirmation timeout reached. Resume devops-autonomous Step 5 with: task=<goal>, mode=<EXEC_MODE>, desktop=<yes|no>, shutdown=<yes|no>, branch=<current-branch>."
+  prompt: "AUTONOMOUS_AUTOSTART: 3-minute confirmation timeout reached. Resume devops-autonomous Step 5 with: task=<goal>, mode=<EXEC_MODE>, desktop=<yes|no>, shutdown=<yes|no>, autoResume=<yes|no>, branch=<current-branch>."
 })
 ```
 
@@ -261,7 +305,8 @@ Ask via `AskUserQuestion`:
 
 ### 4c — Resolve
 
-- **"Ja, los!"** → `CronDelete($TIMEOUT_JOB_ID)`, proceed to Step 5.
+- **"Ja, los!"** → `CronDelete($TIMEOUT_JOB_ID)`. If `$AUTO_RESUME=yes`, arm the
+  resume cron now (Step 4e). Then proceed to Step 5.
 - **"Noch nicht"** → `CronDelete($TIMEOUT_JOB_ID)`, then re-arm fresh: `CronCreate`
   one-shot at `now + 3min` with the same `AUTONOMOUS_AUTOSTART:` prompt, save
   new `$TIMEOUT_JOB_ID`. The user may now ask clarifying questions or reconsider.
@@ -299,6 +344,60 @@ Full mechanics (Bash, JSON parsing, budget tuning) live in
 call with `"$ACTION"`, then save `taskName`, `action` (`$WATCHDOG_ACTION`), and
 `$WATCHDOG_REGISTERED` for Step 8c. On `ok:false`/non-Windows → log the one-line
 warning and continue.
+
+### 4e — Auto-Resume Scheduling (only if `$AUTO_RESUME=yes`)
+
+Armed at "Ja, los!" (Step 4c) or on auto-start (Step 0.1) — the instant execution
+begins. A one-shot session cron that, 5h from now (after the rolling token window
+has reset), nudges every still-stalled Claude worktree to continue with `weiter`.
+
+**Rationale:** if the 5h token limit hits mid-run, the autonomous session (and any
+sibling worktrees) hard-cap and freeze. Once the window resets nothing restarts them
+on its own — this cron is the global "budget is back, keep going" nudge. It only
+applies in `notify` mode (shutdown=no): a shutdown PC has nothing to resume, which is
+why Step 2 Q4 is never asked when shutdown=yes.
+
+**Fire timing — compute it, don't guess.** Run the helper; it derives the fire moment
+from the live token-window reset (with a buffer past the reset boundary) and falls
+back to a flat 5h when usage data is missing or stale:
+
+```bash
+node "$CLAUDE_PLUGIN_ROOT/scripts/autonomous-resume-schedule.js"
+```
+
+Parse the JSON: `{ delayMinutes, cron, fireAtLocal, source }`. `cron` is a ready-to-use
+5-field one-shot expression in local time — use it verbatim, no manual date math. Then:
+
+```
+CronCreate({
+  cron: "<cron from helper>",
+  recurring: false,
+  prompt: "AUTONOMOUS_RESUME: token-window reset reached. Execute devops-autonomous Step 0.2 — resume hard-capped Claude worktrees with »weiter« (skip finished ones)."
+})
+```
+
+Save the returned `jobId` as `$RESUME_JOB_ID` and log `fireAtLocal` + `source` to
+`AUTONOMOUS-LOG.md` (so the audit trail shows whether the precise reset window or the
+5h fallback was used).
+
+**Notes:**
+- **Timing source:** `source=reset-window` means the fire time was derived from the
+  live `resetInMinutes` (fires shortly after the actual reset — no needless waiting);
+  `source=fallback-5h` means usage data was missing/stale, so a safe flat 5h was used.
+  5h is always past the current window's reset (it started ≤ now), so the fallback
+  never fires too early.
+- One-shot — it never re-arms, so there is no resume loop. A single nudge per run. If
+  it fires while the account is *still* capped (a fresh window already exhausted, or
+  the **weekly** limit — which does not reset in 5h), that single attempt simply
+  errors with no retry. This is an accepted limitation.
+- Session-only (in-memory), like the Step 4 autostart cron: it fires only if this
+  Claude session is still open and idle at the fire moment. In notify mode the PC
+  stays on, so this normally holds — but if the user closes Claude (intentionally,
+  e.g. to game), the cron is gone and no resume happens. This is the accepted, even
+  desired, trade-off. Tell the user verbally: the session must remain open to resume.
+- NOT cancelled on this run's completion — its purpose is global (sibling worktrees
+  may still be capped). It self-expires after firing once. Step 0.2 skips any
+  worktree that already finished, so a completed run is never re-triggered.
 
 ### Post-Confirmation Lockout
 

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.101.1",
+  "version": "0.102.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

`/devops-autonomous` gains an opt-in (shutdown=no only) that arms a one-shot session cron at the 5h token-window reset to resume hard-capped Claude worktrees with »weiter«.

- **Step 2 Q4** — conditional Auto-Resume question, skipped when shutdown=yes
- **Step 0.2** — `AUTONOMOUS_RESUME` handler: enumerate `claude/` worktrees, skip finished ones, nudge the rest via `ccd_session_mgmt` `send_message`
- **Step 4e** — arm resume cron; fire timing derived from live `resetInMinutes` (age-corrected, +10 min buffer) with a flat-5h fallback via new `autonomous-resume-schedule.js`
- **Accepted trade-offs** — in-memory/session-bound cron (fires only while Claude stays open) and one-shot with no retry (weekly-limit blind spot)

## Tests
- `autonomous-resume-schedule.test.js` — 18 tests (resetInMinutes→cron, no-floor imminent reset, cap, age-correction, all fallback branches)
- Full suite 411 green · lint clean