### PR TITLE
feat(agents): show model in agent overviews + cache-repair fix (#219)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.102.1"
+    "version": "0.103.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.102.1",
+      "version": "0.103.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.102.1",
+      "version": "0.103.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.103.0] — 2026-06-20
+
+### Added
+
+- **The agent-orchestration overviews now show which model each agent runs on.** The chat-facing plans listed which agents run per wave/phase but never which model — so the user couldn't tell that `po`/`research`/`redteam` run on `opus` while the code agents run on `sonnet`. A **Model** column/field is added to every overview: the `/devops-agents` Step 3 plan table (plus a `plan.model` locale key — en "Model" / de "Modell"), the `/devops-burn` Step 6 execution strategy ("Agents per wave (+ model)"), and the `agent-collaboration` Execution Waves table. The orchestrator fills it from `agent-orchestration.md` § Model & Effort Defaults, which is now the **source of truth** and was synced with the actual agent frontmatter — the missing **`redteam`** row (opus/high) was added and the stale `"(default)"` effort placeholders corrected (medium for the code agents, low for `gamer`). When a model is overridden at invocation it renders as `default → override` so the change stays visible. Skills `devops-agents` 0.5.0→0.6.0, `devops-burn` 0.1.0→0.2.0.
+
+### Fixed
+
+- **`/devops-*` skills and slash-commands stay registered after a session resume that triggers a plugin cache-repair (#219).** The `ss.plugin.update` SessionStart hook (`@version` 0.7.0→0.8.0) repaired a same-version cache (the common case: a marketplace pull advances HEAD without bumping the plugin version, so the SHA drifts) by **deleting the entire plugin cache dir and recreating it**. That dir is exactly what Claude Code's already-loaded skill/slash-command registry points at, so nuking it mid-session **de-registered every `/devops-*` command for the rest of the session** — MCP tools (live in RAM) and agent types (separate registry) survived, only skills/commands broke, leaving the guided flows reachable only via raw MCP calls. `rebuildCache` now overwrites a same-version repair **in place** (it prunes only *other* version dirs and keeps the current one), preserving the dir identity so the registry stays valid and no restart is needed; a real version upgrade still wipes old dirs as before. A second guard hardens `copyDir`: a throwing `fs.cpSync` (Windows EBUSY/EPERM on a file Claude Code holds open) now surfaces as a **failed copy** instead of falling through to the Windows-no-op `cp` shell fallback and returning `true` on the leftover old `plugin.json` — without it, an in-place repair could report `ok:true` over a half-copied cache and advance the registry SHA, silently suppressing the self-healing retry next session. New `ss.plugin.update.inplace.test.js` (4 tests) pins the in-place-vs-wipe cleanup decision; `ss.plugin.update.copydir.test.js` gains 3 tests pinning that a throwing copy is not masked by a pre-existing sentinel.
+
 ## [0.102.1] — 2026-06-19
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.102.1**
+**Version: 0.103.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.102.1",
+  "version": "0.103.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/deep-knowledge/agent-collaboration.md
+++ b/plugins/devops/deep-knowledge/agent-collaboration.md
@@ -35,14 +35,16 @@ Ship (if approved)
 
 When multiple agents work on a feature, they execute in waves:
 
-| Wave | Agents | Why |
-|------|--------|-----|
-| 1 | **Core** | Defines contracts and interfaces first |
-| 2 | **Frontend**, **Windows**, **AI** (parallel) | Consume Core contracts |
-| 3 | **QA** | Verifies all changes together |
-| 4 | **PO** | Validates against requirements |
+| Wave | Agents | Model | Why |
+|------|--------|-------|-----|
+| 1 | **Core** | sonnet | Defines contracts and interfaces first |
+| 2 | **Frontend**, **Windows**, **AI** (parallel) | sonnet | Consume Core contracts |
+| 3 | **QA** | sonnet | Verifies all changes together |
+| 4 | **PO** | opus | Validates against requirements |
 
-Agents in the same wave can run in parallel (`||` suffix in naming).
+Agents in the same wave can run in parallel (`||` suffix in naming). The `Model`
+column is each agent's frontmatter default — see `agent-orchestration.md`
+§ Model & Effort Defaults for the full roster and override rules.
 
 ## Handoff Protocol
 

--- a/plugins/devops/deep-knowledge/agent-orchestration.md
+++ b/plugins/devops/deep-knowledge/agent-orchestration.md
@@ -33,18 +33,22 @@ Select agents based on domains touched, complexity, and risk:
 
 Each agent defines `model` and optionally `effort` in its frontmatter.
 The orchestrator can override `model` at invocation time but **not** `effort`.
+This table is the **source of truth for the `Model` column** the plan tables show
+(`/devops-agents` Step 3, `/devops-burn` plan) — keep it in sync with the agent
+frontmatter. When you override a model at invocation, show it as `default → override`.
 
 | Agent | model | effort | Notes |
 |-------|-------|--------|-------|
 | **po** | opus | high | Strategic decisions — needs deep reasoning |
 | **research** | opus | high | Cross-referencing, fact verification |
-| **core** | sonnet | *(default)* | Standard code generation |
-| **frontend** | sonnet | *(default)* | Standard code generation |
-| **ai** | sonnet | *(default)* | Standard code generation |
-| **windows** | sonnet | *(default)* | Standard code generation |
-| **designer** | sonnet | *(default)* | Design specs |
-| **qa** | sonnet | *(default)* | Test execution + evaluation |
-| **gamer** | sonnet | *(default)* | Quick UX feedback |
+| **redteam** | opus | high | Adversarial review — inter-wave risk gate |
+| **core** | sonnet | medium | Standard code generation |
+| **frontend** | sonnet | medium | Standard code generation |
+| **ai** | sonnet | medium | Standard code generation |
+| **windows** | sonnet | medium | Standard code generation |
+| **designer** | sonnet | medium | Design specs |
+| **qa** | sonnet | medium | Test execution + evaluation |
+| **gamer** | sonnet | low | Quick UX feedback |
 | **feature** | inherit | *(inherit)* | Inherits from parent session |
 
 **Model override rules:**

--- a/plugins/devops/hooks/session-start/ss.plugin.update.copydir.test.js
+++ b/plugins/devops/hooks/session-start/ss.plugin.update.copydir.test.js
@@ -134,3 +134,52 @@ describe("ss.plugin.update copyDir primitive (fs.cpSync) — issue #190", () => 
     expect(MCP_CRITICAL_FILES.every((rel) => fs.existsSync(path.join(dst, rel)))).toBe(true);
   });
 });
+
+/**
+ * Regression guard for the #219 in-place repair: a real fs.cpSync THROW must
+ * surface as a failed copy (copyDir → false), NOT be masked by a pre-existing
+ * .claude-plugin/plugin.json the in-place overwrite leaves behind.
+ *
+ * Before the fix, copyDir caught any cpSync error and fell back to a `cp -a`
+ * shell-out that is a no-op on Windows, then returned true because the OLD
+ * plugin.json (from the dir being overwritten in place) still existed. That made
+ * rebuildCache report ok:true over a half-copied cache and advance the registry
+ * SHA — silently suppressing the self-healing retry next session. The fix gates
+ * the shell fallback on fs.cpSync being UNAVAILABLE and returns false on a throw.
+ */
+
+// Mirror of production copyDir() AFTER the #219 hardening (cpSync injected so the
+// throw path is testable; in real Node fs.cpSync is always a function).
+function copyDirMirror(src, dst, cpSync) {
+  if (typeof cpSync === "function") {
+    try {
+      cpSync(src, dst, { recursive: true, force: true });
+    } catch {
+      return false;
+    }
+  }
+  return fs.existsSync(path.join(dst, ".claude-plugin", "plugin.json"));
+}
+
+describe("ss.plugin.update copyDir surfaces real cpSync failures — issue #219", () => {
+  test("a successful copy still returns true", () => {
+    write(src, path.join(".claude-plugin", "plugin.json"), '{"version":"9.9.9"}');
+    expect(copyDirMirror(src, dst, fs.cpSync)).toBe(true);
+    expect(fs.existsSync(path.join(dst, ".claude-plugin", "plugin.json"))).toBe(true);
+  });
+
+  test("a cpSync throw over an in-place dir with an OLD plugin.json returns false (failure not masked)", () => {
+    // The in-place repair overwrites an existing version dir → the OLD sentinel
+    // is already present and would mask a partial copy via the existence check.
+    write(dst, path.join(".claude-plugin", "plugin.json"), '{"version":"0.0.1-old"}');
+    const throwingCpSync = () => { throw new Error("EBUSY: resource busy or locked"); };
+    // Even though the old sentinel exists, the throw must surface as false so the
+    // caller returns ok:false and does NOT advance the registry SHA.
+    expect(copyDirMirror(src, dst, throwingCpSync)).toBe(false);
+  });
+
+  test("a cpSync throw on an empty destination returns false", () => {
+    const throwingCpSync = () => { throw new Error("EPERM: operation not permitted"); };
+    expect(copyDirMirror(src, dst, throwingCpSync)).toBe(false);
+  });
+});

--- a/plugins/devops/hooks/session-start/ss.plugin.update.inplace.test.js
+++ b/plugins/devops/hooks/session-start/ss.plugin.update.inplace.test.js
@@ -1,0 +1,113 @@
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+/**
+ * Characterization test for the cache-cleanup decision in ss.plugin.update.js's
+ * rebuildCache() — issue #219.
+ *
+ * The bug: a same-version cache REPAIR deleted the entire plugin cache dir
+ * (`fs.rmSync(pluginCache, { recursive })`) and recreated it. The version dir is
+ * exactly what Claude Code's already-loaded skill/slash-command registry points
+ * at — nuking and recreating it mid-session changed the dir's identity and
+ * de-registered every skill/slash-command for the rest of the session, leaving
+ * `/devops-*` as "Unknown command". MCP tools (RAM) and agent types survived;
+ * only skills/commands broke.
+ *
+ * The fix: branch on `versionChanged`. A version UPGRADE still nukes all old
+ * version dirs (new installPath, restart needed anyway). A same-version REPAIR
+ * overwrites IN PLACE — it keeps the current version dir (preserving its identity
+ * so the registry stays valid) and only prunes OTHER (old) version dirs.
+ *
+ * rebuildCache() is a non-exported internal of a SessionStart hook whose module
+ * body self-executes on import (see the #190 copydir test for the same
+ * constraint). So this test mirrors the EXACT cleanup decision the fix encodes,
+ * against a temp cache tree, and asserts the registry-referenced dir survives an
+ * in-place repair but not a version change.
+ */
+
+// Mirror of the cleanup block in rebuildCache() (the part the #219 fix changed).
+function applyCacheCleanup(pluginCache, version, versionChanged) {
+  const newCache = path.join(pluginCache, version);
+  const inPlace = !versionChanged && fs.existsSync(newCache);
+
+  if (inPlace) {
+    // Keep the current version dir (registry points at it); prune OTHER versions.
+    for (const entry of fs.readdirSync(pluginCache)) {
+      if (entry !== version) {
+        fs.rmSync(path.join(pluginCache, entry), { recursive: true, force: true });
+      }
+    }
+  } else if (fs.existsSync(pluginCache)) {
+    // Version change / first build: clean ALL old version dirs.
+    fs.rmSync(pluginCache, { recursive: true, force: true });
+  }
+  fs.mkdirSync(newCache, { recursive: true });
+  return { inPlace, newCache };
+}
+
+let tmpRoot;
+let pluginCache;
+
+// A sentinel inside the version dir standing in for the dir's session identity:
+// if it survives, the dir was overwritten in place (registry stays valid); if it
+// vanishes, the dir was deleted + recreated (the #219 de-registration trigger).
+const VERSION = "0.102.1";
+const IDENTITY_MARKER = ".session-identity";
+
+function write(root, rel, content) {
+  const full = path.join(root, rel);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, content);
+}
+
+beforeEach(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "dotclaude-inplace-"));
+  pluginCache = path.join(tmpRoot, "devops");
+  // Current version dir, with a marker that proves dir identity across a repair.
+  write(pluginCache, path.join(VERSION, IDENTITY_MARKER), "loaded-registry");
+  write(pluginCache, path.join(VERSION, "skills", "devops-ship", "SKILL.md"), "# old");
+  // A leftover OLD version dir that any cleanup should prune.
+  write(pluginCache, path.join("0.100.0", "skills", "devops-ship", "SKILL.md"), "# stale");
+});
+
+afterEach(() => {
+  try {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  } catch { /* ignore */ }
+});
+
+describe("ss.plugin.update rebuildCache cleanup decision — issue #219", () => {
+  test("same-version repair (versionChanged=false) keeps the version dir's identity", () => {
+    const { inPlace } = applyCacheCleanup(pluginCache, VERSION, false);
+    expect(inPlace).toBe(true);
+    // The marker survives → dir was NOT deleted+recreated → registry stays valid.
+    expect(fs.existsSync(path.join(pluginCache, VERSION, IDENTITY_MARKER))).toBe(true);
+  });
+
+  test("same-version repair still prunes OTHER (old) version dirs", () => {
+    applyCacheCleanup(pluginCache, VERSION, false);
+    expect(fs.existsSync(path.join(pluginCache, "0.100.0"))).toBe(false);
+    // ...but the cache holds exactly the current version.
+    expect(fs.readdirSync(pluginCache)).toEqual([VERSION]);
+  });
+
+  test("version change (versionChanged=true) nukes all dirs incl. the marker", () => {
+    const { inPlace } = applyCacheCleanup(pluginCache, "0.103.0", true);
+    expect(inPlace).toBe(false);
+    // Old version dir AND its identity marker are gone — a restart is expected
+    // on a real upgrade anyway (new installPath).
+    expect(fs.existsSync(path.join(pluginCache, VERSION))).toBe(false);
+    expect(fs.existsSync(path.join(pluginCache, "0.100.0"))).toBe(false);
+    expect(fs.existsSync(path.join(pluginCache, "0.103.0"))).toBe(true);
+  });
+
+  test("first build (cache dir absent) creates the version dir without error", () => {
+    fs.rmSync(pluginCache, { recursive: true, force: true });
+    const { inPlace, newCache } = applyCacheCleanup(pluginCache, VERSION, false);
+    // No existing dir → not an in-place repair; the fresh dir is created.
+    expect(inPlace).toBe(false);
+    expect(fs.existsSync(newCache)).toBe(true);
+  });
+});

--- a/plugins/devops/hooks/session-start/ss.plugin.update.js
+++ b/plugins/devops/hooks/session-start/ss.plugin.update.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * @hook ss.plugin.update
- * @version 0.7.0
+ * @version 0.8.0
  * @event SessionStart
  * @plugin devops
  * @description Auto-update plugin marketplace clones, rebuild cache, and update registry.
@@ -13,6 +13,12 @@
  *   MCP processes point at the now-deleted old installPath. A sentinel file
  *   (~/.claude/plugins/.mcp-stale.json) is written so pre.mcp.health can
  *   block MCP tool calls until the user restarts Claude Code.
+ *
+ *   A same-version cache REPAIR overwrites the existing version dir in place
+ *   instead of deleting + recreating it. Nuking the dir mid-session changes its
+ *   identity and de-registers the plugin's skills/slash-commands from Claude
+ *   Code's already-loaded registry for the rest of the session (issue #219) —
+ *   an in-place overwrite keeps the dir so /devops-* stays registered.
  */
 
 require('../lib/plugin-guard');
@@ -142,9 +148,26 @@ function copyDir(src, dst) {
   // Node's execSync sees. A failed copy left a partial cache (missing
   // mcp-server/*.js, .mcp.json, hooks) that crashed every MCP server — the
   // exact breakage the #190 completeness guard was meant to prevent.
-  try {
-    fs.cpSync(src, dst, { recursive: true, force: true });
-  } catch {
+  //
+  // Gate the shell fallback on fs.cpSync being genuinely UNAVAILABLE — not on it
+  // throwing. A throw from fs.cpSync is a REAL copy failure (e.g. Windows
+  // EBUSY/EPERM on a file Claude Code holds open mid-session), which must surface
+  // as a failed copy. Since the #219 same-version repair overwrites an EXISTING
+  // version dir IN PLACE, a pre-existing (old) .claude-plugin/plugin.json would
+  // survive a partial copy and mask the failure via the existence check below —
+  // letting rebuildCache return ok:true over a half-updated cache and advance the
+  // registry SHA, which then suppresses the self-healing retry next session.
+  // Returning false on a throw keeps that retry alive (the registry SHA is not
+  // advanced over a broken copy). The `cp` fallback never helped on Windows
+  // anyway (no-op), so reserving it for ancient Node without fs.cpSync loses
+  // nothing.
+  if (typeof fs.cpSync === 'function') {
+    try {
+      fs.cpSync(src, dst, { recursive: true, force: true });
+    } catch {
+      return false;
+    }
+  } else {
     // Last-resort fallback for environments where fs.cpSync is unavailable.
     run(`cp -a "${src}/." "${dst}/"`, path.dirname(src));
     run(`cp -r "${src}/.claude-plugin" "${dst}/"`, path.dirname(src));
@@ -157,19 +180,43 @@ function copyDir(src, dst) {
   return fs.existsSync(path.join(dst, '.claude-plugin', 'plugin.json'));
 }
 
-function rebuildCache(marketplace, pluginName, pluginDir, version, sha) {
+function rebuildCache(marketplace, pluginName, pluginDir, version, sha, { versionChanged = true } = {}) {
   const pluginCache = path.join(cacheDir, marketplace, pluginName);
+  const newCache = path.join(pluginCache, version);
 
-  // Clean ALL old version dirs
-  if (fs.existsSync(pluginCache)) {
+  // Same-version cache REPAIR on an existing dir → overwrite IN PLACE.
+  //
+  // A version UPGRADE gets a brand-new installPath, so deleting the old version
+  // dirs is correct (registry is repointed, a restart is needed anyway). But a
+  // cache REPAIR keeps the same version dir — and that dir is exactly what Claude
+  // Code's already-loaded skill/slash-command registry points at. Deleting and
+  // recreating it mid-session (rm + mkdir) changes the dir's identity and
+  // de-registers every skill/slash-command for the rest of the session, leaving
+  // /devops-* as "Unknown command" (issue #219). MCP tools (live in RAM) and
+  // agent types (separate registry) survive — only skills/commands break.
+  // Overwriting files in place keeps the dir, so the registry stays valid and no
+  // restart is needed. (Stale files removed upstream at the SAME version — rare —
+  // are not pruned this way; that trade-off is far cheaper than nuking the
+  // skill registry.)
+  const inPlace = !versionChanged && fs.existsSync(newCache);
+
+  if (inPlace) {
+    // Keep the current version dir (the registry points at it), but still prune
+    // any OTHER (old) version dirs so the cache holds only `version`.
+    for (const entry of fs.readdirSync(pluginCache)) {
+      if (entry !== version) {
+        fs.rmSync(path.join(pluginCache, entry), { recursive: true, force: true });
+      }
+    }
+  } else if (fs.existsSync(pluginCache)) {
+    // Version change / first build: clean ALL old version dirs.
     fs.rmSync(pluginCache, { recursive: true, force: true });
   }
 
-  // Create new cache dir
-  const newCache = path.join(pluginCache, version);
+  // Create (or keep) the version dir
   fs.mkdirSync(newCache, { recursive: true });
 
-  // Copy all files (archive mode for dotfiles)
+  // Copy all files (force-overwrites in place; fs.cpSync handles dotfiles + nested dirs)
   const copyOk = copyDir(pluginDir, newCache);
   if (!copyOk) {
     return { ok: false, missing: 'copy failed — .claude-plugin/plugin.json not found after copy' };
@@ -329,7 +376,7 @@ for (const marketplace of fs.readdirSync(marketplacesDir)) {
     } catch { /* registry unreadable — rebuild to be safe */ cacheMissing = true; }
 
     if (versionChanged || cacheMissing || cacheStale) {
-      const result = rebuildCache(marketplace, name, dir, after, newSha);
+      const result = rebuildCache(marketplace, name, dir, after, newSha, { versionChanged });
       updated.push({
         name,
         from: beforeVersions[name] || '?',

--- a/plugins/devops/skills/devops-agents/SKILL.md
+++ b/plugins/devops/skills/devops-agents/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: devops-agents
-version: 0.5.0
+version: 0.6.0
 description: >-
   Evaluate which agents are useful for a task and orchestrate their parallel or
   sequential execution. Use when the user explicitly wants orchestrated agent

--- a/plugins/devops/skills/devops-agents/SKILL.md
+++ b/plugins/devops/skills/devops-agents/SKILL.md
@@ -91,6 +91,7 @@ active `[ui-locale: ...]` (defaults to `en`):
 | Key             | en               | de                  |
 |-----------------|------------------|---------------------|
 | `plan.heading`  | Orchestration plan | Orchestrierungsplan |
+| `plan.model`    | Model            | Modell              |
 | `plan.task_col` | Task             | Aufgabe             |
 | `plan.deps`     | Dependencies     | Abhängigkeiten      |
 | `plan.estimate` | Estimated agents | Geschätzte Agents   |
@@ -102,12 +103,12 @@ Template (`{key}` → resolved per locale):
 
 ### Agents (N selected)
 
-| Wave | Agent(s) | {plan.task_col} |
-|------|----------|-----------------|
-| 0 | research | <what they investigate> |
-| 1 | core | <what contracts/APIs they define> |
-| 2 | frontend, windows | <what they build, in parallel> |
-| 3 | qa | <what they verify> |
+| Wave | Agent(s) | {plan.model} | {plan.task_col} |
+|------|----------|--------------|-----------------|
+| 0 | research | opus | <what they investigate> |
+| 1 | core | sonnet | <what contracts/APIs they define> |
+| 2 | frontend, windows | sonnet | <what they build, in parallel> |
+| 3 | qa | sonnet | <what they verify> |
 
 ### {plan.deps}
 - Wave 2 waits on Wave 1 (core contracts)   [de: Wave 2 wartet auf Wave 1 (Core-Contracts)]
@@ -115,6 +116,14 @@ Template (`{key}` → resolved per locale):
 
 ### {plan.estimate}: N
 ```
+
+**`{plan.model}` column** — the effective model each agent runs on. Take the
+default from `deep-knowledge/agent-orchestration.md` § Model & Effort Defaults
+(`opus` for po/research/redteam, `sonnet` for the rest, `inherit` for feature).
+If a wave has multiple agents on different models, list them aligned to the
+`Agent(s)` order (e.g. `opus, sonnet`); collapse to a single value when they
+match. If you override a model at invocation (§ Model override rules), show it as
+`default → override` (e.g. `opus → sonnet`) so the change is visible.
 
 Wait for user confirmation before proceeding. Accept:
 - en: "yes" / "go" / "do it" → proceed as planned

--- a/plugins/devops/skills/devops-burn/SKILL.md
+++ b/plugins/devops/skills/devops-burn/SKILL.md
@@ -184,9 +184,14 @@ Present the consolidated plan:
 
 ### Execution Strategy
 - Waves: {N waves planned}
-- Parallel agents per wave: {max feasible}
+- Agents per wave (+ model): {Wave 1: core (sonnet) · Wave 2: frontend, windows (sonnet) · Wave 3: qa (sonnet)}
 - Estimated token usage: {aggressive / moderate}
 ```
+
+Model per agent comes from `deep-knowledge/agent-orchestration.md` § Model & Effort
+Defaults (`opus` for po/research/redteam, `sonnet` for the rest). Show a `default →
+override` when you downgrade a model for cost (§ Model override rules) so the budget
+impact is visible.
 
 Wait for user confirmation:
 - "go" / "ja" / "burn" → proceed as planned

--- a/plugins/devops/skills/devops-burn/SKILL.md
+++ b/plugins/devops/skills/devops-burn/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: devops-burn
-version: 0.1.0
+version: 0.2.0
 description: >-
   High-throughput autonomous task runner with aggressive parallelization.
   EXPLICIT INVOCATION ONLY — the user must type /devops-burn to activate.

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.102.1",
+  "version": "0.103.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
Closes #219

## Summary
Two changes shipped together.

### feat(agents): per-agent model in orchestration overviews
The chat-facing wave/phase overviews now show which model each agent runs on (opus for po/research/redteam, sonnet for the rest). Adds a Model column to the `/devops-agents` Step 3 plan table (+ `plan.model` locale key), the `/devops-burn` execution strategy, and the `agent-collaboration` Execution Waves table. `agent-orchestration` § Model & Effort Defaults is now the source of truth and was synced with the agent frontmatter (added the missing `redteam` row, corrected stale effort values).

### fix(plugin): cache-repair no longer de-registers skills (#219)
A same-version cache repair deleted + recreated the plugin cache dir — the exact dir Claude Code's loaded skill/slash-command registry points at — de-registering every `/devops-*` command for the rest of a resumed session. `rebuildCache` now overwrites in place (preserving dir identity); `copyDir` surfaces a throwing `fs.cpSync` as a real failure so a half-copy can't advance the registry SHA over a broken cache and suppress the self-healing retry.

## Tests
- vitest: 432 passed (+7 new: 4 in-place cleanup decision, 3 copyDir failure-surfacing)
- eslint: clean