### PR TITLE
feat(usage): decouple completion-card usage from interactive login

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.103.0"
+    "version": "0.104.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.103.0",
+      "version": "0.104.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.103.0",
+      "version": "0.104.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.104.0] — 2026-06-21
+
+### Changed
+
+- **The completion card's usage line is now strictly zero-interaction — the automatic refresh never opens a browser login window.** The native statusLine `rate_limits` source already keeps `usage-live.json` minute-fresh token-free, so the Edge scraper was only ever a fallback; its one remaining cost was popping a visible claude.ai login window when the dedicated scraper profile was logged out — the only place the usage subsystem still demanded user interaction. `refresh-usage-headless.js` (`@version` 0.4.0→0.5.0) gains a `--no-login` flag backed by a pure, unit-tested policy `shouldOpenLoginWindow({ noLogin, loginPending })`: in `--no-login` mode a logged-out profile returns code 2 and serves cache instead of opening a window. The `dotclaude-completion` MCP (server 0.3.0→0.4.0) always invokes the fallback scrape with `--no-login`, so the card path can never steal focus; its `_loginRequired` indicator is downgraded to a soft, non-actionable note (the numbers shown come from statusLine/cache, and a one-time login is offered only via an explicit `/devops-refresh-usage` run), and the misleading "Always scrapes fresh data" `get_usage` description is corrected to warm-read-first. SKILL `devops-refresh-usage` (0.1.0→0.2.0) documents the manual-vs-automatic login split. `refresh-usage-headless.test.js` gains 3 `shouldOpenLoginWindow` cases (435 tests pass).
+- Rationale (investigated, recorded): the undocumented `GET /api/oauth/usage` endpoint was evaluated as an always-on alternative source and rejected — on Claude Code 2.1.175 the OAuth token is host-managed in-memory, the on-disk `.credentials.json` token is expired with an empty refresh token, and the Windows keychain entry holds only a 16-byte key (the real token is in an encrypted vault), so no script can obtain or renew a usable token without reverse-engineering the credential store. The card renders only the 5h and weekly numbers, both already provided token-free by the statusLine source, so dropping the scraper from the card path loses nothing the card displays (`weeklySonnet` and plan tier appear only in the manual summary, the latter also readable token-free via `claude auth status --json`).
+
 ## [0.103.0] — 2026-06-20
 
 ### Added

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.103.0",
+  "version": "0.104.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/mcp-server/index.js
+++ b/plugins/devops/mcp-server/index.js
@@ -164,11 +164,13 @@ function renderUsageMeterForCard(usageData, delta5h, deltaWk, healthLine) {
     lines.push(dimMeterLine(renderUsageLine('Wk', w.pct, elapsedWkPct, deltaWk, w.resetInMinutes)));
   }
 
-  // Failure indicator — login required is always shown prominently regardless
-  // of cache age (the scraper can't refresh until the user logs in once).
+  // Failure indicator — the automatic path never opens a login window, so this
+  // is a SOFT, non-actionable note: the numbers shown come from statusLine/cache,
+  // and the optional Edge scrape (its only extra is the manual weekly-Sonnet box)
+  // is offline until a one-time manual login. Never nags, never blocks.
   if (usageData._loginRequired) {
     lines.push('');
-    lines.push('\u26a0 Scraper not logged in \u2014 Edge login window opened, log in once (then fresh data on every card)');
+    lines.push('\u26a0 Edge scrape offline (not logged in) \u2014 showing statusLine/cached; /devops-refresh-usage to reconnect');
   } else if (usageData._cached && usageData._ageMinutes > 30) {
     const ageLabel = usageData._ageMinutes >= 60
       ? `~${Math.round(usageData._ageMinutes / 60)}h old`
@@ -761,13 +763,17 @@ function refreshUsage() {
     return finish(warm);
   }
 
-  // 2. Fallback — Edge scrape. Covers pre-first-API-response, unsupported
-  //    logins, weeklySonnet/plan, and hosts without the statusLine writer. The
-  //    script manages the dedicated scraper lifecycle internally (launch,
-  //    scrape, kill). Worst case ~44s; keep the timeout above that.
+  // 2. Fallback — Edge scrape, ALWAYS non-interactive (--no-login). Covers
+  //    pre-first-API-response and hosts without the statusLine writer. The card
+  //    only renders 5h + weekly, which this still provides when the profile is
+  //    logged in; if it is logged out the scraper just returns code 2 WITHOUT
+  //    opening a window (the automatic path must stay zero-interaction). A
+  //    one-time login is offered only via an explicit `/devops-refresh-usage`
+  //    run. The script manages the dedicated scraper lifecycle internally
+  //    (launch, scrape, kill). Worst case ~44s; keep the timeout above that.
   let lastExitCode = null;
   try {
-    execSync(`node "${SCRAPER_SCRIPT}" --quiet`, {
+    execSync(`node "${SCRAPER_SCRIPT}" --quiet --no-login`, {
       timeout: 60000,
       stdio: ['pipe', 'pipe', 'pipe'],
     });
@@ -779,7 +785,7 @@ function refreshUsage() {
   }
 
   const reasons = {
-    2: 'scraper profile not logged in — visible login window was opened, log in once and retry',
+    2: 'scraper profile not logged in — no window opened (automatic path); run /devops-refresh-usage once to log in for the manual weekly-Sonnet summary',
     3: 'usage page parse error',
     4: 'CDP WebSocket failed',
     5: 'scraper instance could not launch (Edge not installed?)',
@@ -813,20 +819,22 @@ function refreshUsage() {
 
 const server = new McpServer({
   name: "dotclaude-completion",
-  version: "0.3.0",
+  version: "0.4.0",
 });
 
-// --- Tool 1: get_usage (unchanged) ---
+// --- Tool 1: get_usage ---
 
 server.registerTool(
   "get_usage",
   {
     title: "Get Usage",
     description:
-      "Fetch live token usage data from claude.ai. Always scrapes fresh data. " +
+      "Fetch live token usage. Reads the native statusLine-written cache first " +
+      "(no scrape, no extra turn); only falls back to a non-interactive, isolated " +
+      "Edge scrape when that is stale, and NEVER opens a login window. " +
       "Returns structured usage percentages, reset times, deltas against " +
-      "the previous scrape, and a pre-rendered ASCII usage meter. " +
-      "Uses a dedicated, isolated Edge scraper profile — user's main Edge is untouched.",
+      "the previous reading, and a pre-rendered ASCII usage meter. " +
+      "The user's main Edge is untouched.",
     inputSchema: z.object({}),
   },
   async () => {

--- a/plugins/devops/scripts/refresh-usage-headless.js
+++ b/plugins/devops/scripts/refresh-usage-headless.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * @script refresh-usage-headless
- * @version 0.4.0
+ * @version 0.5.0
  * @plugin devops
  *
  * Headless Usage Scraper for claude.ai
@@ -18,7 +18,7 @@
  *
  * Exit codes:
  *   0 = success
- *   2 = not logged in (visible login window was opened)
+ *   2 = not logged in (a visible login window is opened only WITHOUT --no-login)
  *   3 = parse error
  *   4 = scrape failed
  *   5 = scraper instance could not be launched
@@ -27,6 +27,12 @@
  *   --quiet           suppress debug logs (--summary still prints)
  *   --summary         after success, print formatted usage box
  *   --check-only      report whether the scraper CDP is currently alive (0/5)
+ *   --no-login        never open a visible login window — on a logged-out
+ *                     profile just return code 2 and serve cache. Used by the
+ *                     automatic completion-card path so it stays zero-interaction
+ *                     (the card needs only the 5h/weekly numbers, which the native
+ *                     statusLine source already provides token-free). A one-time
+ *                     login is offered only on an explicit manual run (no flag).
  */
 
 const { execSync, spawn } = require('child_process');
@@ -100,6 +106,9 @@ if (process.platform !== 'win32' && require.main === module) {
 const isQuiet = process.argv.includes('--quiet');
 const printSummary = process.argv.includes('--summary');
 const checkOnly = process.argv.includes('--check-only');
+// Automatic card path passes this — it must never steal focus with a login
+// window. Only an explicit manual run (without the flag) may open one.
+const noLogin = process.argv.includes('--no-login');
 
 function log(...args) {
   if (!isQuiet) console.log(...args);
@@ -598,6 +607,17 @@ function isMarkerPending(marker, nowMs) {
   return (nowMs - opened) < LOGIN_RETRY_AFTER_MS;
 }
 
+/**
+ * Pure policy: may main() open a visible login window after a logged-out scrape?
+ * Never in --no-login mode (the automatic completion-card path, which must stay
+ * zero-interaction) and never while a window is already pending (so parallel
+ * sessions can't stack windows). A login window is only ever offered on an
+ * explicit manual run.
+ */
+function shouldOpenLoginWindow({ noLogin, loginPending }) {
+  return !noLogin && !loginPending;
+}
+
 function loginPending() {
   try {
     return isMarkerPending(JSON.parse(fs.readFileSync(LOGIN_MARKER_FILE, 'utf8')), Date.now());
@@ -688,11 +708,15 @@ async function main() {
   }
 
   if (code === 2) {
-    // Genuinely logged out. Open AT MOST one visible window per
-    // LOGIN_RETRY_AFTER_MS — and never while one is already pending — so
-    // parallel sessions can't stack login windows.
-    if (loginPending()) {
-      log('LOGIN_REQUIRED: a login window is already pending — not opening another');
+    // Genuinely logged out. The automatic card path passes --no-login, so it
+    // NEVER opens a window — it just serves cache (the card's 5h/weekly numbers
+    // come from the native statusLine source anyway). A window is offered only on
+    // an explicit manual run, at most once per LOGIN_RETRY_AFTER_MS, and never
+    // while one is already pending — so parallel sessions can't stack windows.
+    if (!shouldOpenLoginWindow({ noLogin, loginPending: loginPending() })) {
+      log(noLogin
+        ? 'LOGIN_REQUIRED: --no-login (automatic path) — serving cache, no window'
+        : 'LOGIN_REQUIRED: a login window is already pending — not opening another');
       useCacheOrExit(2);
       return;
     }
@@ -737,6 +761,7 @@ if (require.main === module) {
 module.exports = {
   parseUsageText,
   isMarkerPending,
+  shouldOpenLoginWindow,
   loginPending,
   reapScraperInstances,
   LOGIN_RETRY_AFTER_MS,

--- a/plugins/devops/scripts/refresh-usage-headless.test.js
+++ b/plugins/devops/scripts/refresh-usage-headless.test.js
@@ -2,6 +2,7 @@ import { describe, test, expect } from "vitest";
 import {
   parseUsageText,
   isMarkerPending,
+  shouldOpenLoginWindow,
   LOGIN_RETRY_AFTER_MS,
 } from "./refresh-usage-headless.js";
 
@@ -38,6 +39,21 @@ describe("isMarkerPending — login-once retry window", () => {
     ["unparseable openedAt", { openedAt: "not-a-date" }],
   ])("%s → not pending (fail open, allow a fresh window)", (_label, marker) => {
     expect(isMarkerPending(marker, NOW)).toBe(false);
+  });
+});
+
+describe("shouldOpenLoginWindow — login-window policy", () => {
+  test("--no-login mode never opens a window (automatic card path)", () => {
+    expect(shouldOpenLoginWindow({ noLogin: true, loginPending: false })).toBe(false);
+    expect(shouldOpenLoginWindow({ noLogin: true, loginPending: true })).toBe(false);
+  });
+
+  test("manual run with no pending window may open one", () => {
+    expect(shouldOpenLoginWindow({ noLogin: false, loginPending: false })).toBe(true);
+  });
+
+  test("manual run never stacks onto an already-pending window", () => {
+    expect(shouldOpenLoginWindow({ noLogin: false, loginPending: true })).toBe(false);
   });
 });
 

--- a/plugins/devops/skills/devops-refresh-usage/SKILL.md
+++ b/plugins/devops/skills/devops-refresh-usage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: devops-refresh-usage
-version: 0.1.0
+version: 0.2.0
 description: >-
   Fetch live token usage for completion card battery line. Reads the native
   statusLine-written usage file first (no scrape), falls back to the Edge CDP
@@ -32,10 +32,18 @@ writer** ([statusline-usage.js](../../scripts/statusline-usage.js), registered b
 usage schema with **no browser and no extra Claude turn**. If the file's
 `timestamp` is recent (≤ a couple of minutes), just **read it — you are done**;
 skip the Edge scrape entirely. Only when it is stale/absent (pre-first-API
-response, an unsupported login, `weeklySonnet`/`plan` needed, or a host without
+response, an unsupported login, `weeklySonnet` needed, or a host without
 the statusLine writer) fall through to the Edge scraper below. The
 `dotclaude-completion` MCP server applies this same warm-read-first logic
 automatically in `get_usage` / `render_completion_card`.
+
+**Automatic path is zero-interaction.** The MCP fallback always runs the scraper
+with `--no-login`, so the completion card **never opens a login window** — a
+logged-out profile just serves statusLine/cached data. A one-time login is
+offered **only** when you run this skill manually (the command in 1a omits
+`--no-login`). The card itself renders only the 5h + weekly numbers, which the
+native statusLine source already provides token-free; `weeklySonnet` is a
+manual-summary extra, not a card field.
 
 ### 1·1. Edge CDP scraper (fallback)
 
@@ -47,7 +55,11 @@ instance by PID tree.
 
 The script path is `${CLAUDE_PLUGIN_ROOT}/scripts/refresh-usage-headless.js` (use the plugin root, NOT a relative path).
 
-### 1a. Run the scraper
+### 1a. Run the scraper (manual run — login allowed)
+
+This skill is the **manual** entry point (the user explicitly asked for usage /
+weeklySonnet), so the command deliberately omits `--no-login`: a one-time login
+window may open here. The automatic card path uses `--no-login` and never does.
 
 ```bash
 node "${CLAUDE_PLUGIN_ROOT}/scripts/refresh-usage-headless.js" --quiet --summary
@@ -55,7 +67,7 @@ node "${CLAUDE_PLUGIN_ROOT}/scripts/refresh-usage-headless.js" --quiet --summary
 
 Exit codes:
 - `0` → success. Usage written to `~/.claude/usage-live.json`.
-- `2` → **scraper profile is not logged in**. A visible Edge window has been opened at `https://claude.ai/login`. **Tell the user inline**, e.g.:
+- `2` → **scraper profile is not logged in**. On this manual run a visible Edge window has been opened at `https://claude.ai/login`. **Tell the user inline**, e.g.:
   > ⚠️ Der Usage-Scraper hat ein eigenes Edge-Profil unter `~/.claude/edge-usage-profile`. Dieses ist noch nicht bei Claude eingeloggt — ein Edge-Fenster wurde gerade geöffnet. Bitte einmal einloggen (Cookies bleiben danach im Scraper-Profil persistent). Danach funktioniert der Scraper dauerhaft headless im Hintergrund.
   After the message, use cached data for this turn (see 1c).
 - `3` / `4` / `5` → scrape/launch failure. Fall through to 1b.
@@ -107,7 +119,7 @@ ratio > 1.3  → 🪫 + "Hoher Verbrauch — neue Session oder Haiku empfohlen"
 ## Rules
 
 - **Never touch the user's main Edge.** The scraper always spawns a dedicated, isolated Edge instance with its own user-data-dir (`~/.claude/edge-usage-profile`). It reaps **only that profile's** instances — matched by the `--user-data-dir` on the live command line, not by a stored PID (which dies on Windows when Edge re-execs into its singleton, the bug that let orphan instances pile up). The user's main Edge is never matched.
-- **One-time login is expected, opened at most once.** On first run (or after a profile wipe) the scraper profile has no cookies. The script opens a visible login window, writes a sticky `edge-usage-login-pending.json` marker, and exits code `2`. While that marker is fresh (≤ 30 min) **no** session opens another window — so parallel sessions can't stack login windows. Tell the user inline — do NOT retry silently.
+- **Login windows only on manual runs.** The automatic card path passes `--no-login`, so it **never** opens a window (a logged-out profile just serves cache). On a manual run (this skill, no `--no-login`) a one-time login is expected, opened at most once: on first run (or after a profile wipe) the scraper profile has no cookies, so the script opens a visible login window, writes a sticky `edge-usage-login-pending.json` marker, and exits code `2`. While that marker is fresh (≤ 30 min) **no** session opens another window — so parallel sessions can't stack login windows. Tell the user inline — do NOT retry silently.
 - **Silent after first login.** A successful scrape clears the marker immediately; once the profile has cookies, all subsequent runs are invisible and reuse the one hidden instance.
 - **Transient render failures never open a window.** A slow/unrendered page returns a scrape error (cache fallback), not code `2`. Only an explicit `/login` redirect or login UI counts as logged-out.
 - **Playwright fallback is acceptable** — if the scraper fails, opening a browser tab via Playwright to scrape is fine.

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.103.0",
+  "version": "0.104.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## What & why

The completion card's usage line must work across sessions and PC restarts **without any user interaction**. The native statusLine `rate_limits` source already covers the common case token-free; the only remaining interaction point was the Edge scraper fallback opening a **login window**.

This makes the automatic card path strictly zero-interaction.

## Changes

- **`refresh-usage-headless.js`** (v0.5.0): new `--no-login` flag + pure policy `shouldOpenLoginWindow({ noLogin, loginPending })`. In `--no-login` mode a logged-out profile returns code 2 and serves cache — it never opens a window.
- **`mcp-server/index.js`** (server v0.4.0): the card fallback always calls the scraper with `--no-login`; the `_loginRequired` indicator is now a soft, non-actionable note; `get_usage` description corrected (warm-read-first, never opens a window).
- **`devops-refresh-usage/SKILL.md`** (v0.2.0): documents the manual-vs-automatic login split — a one-time login is offered **only** on an explicit manual run.
- **tests**: 3 new `shouldOpenLoginWindow` policy cases.

## Investigation result (recorded)

Tested the undocumented `GET /api/oauth/usage` endpoint as an alternative zero-interaction source. **Not viable**: the OAuth token is host-managed in-memory, the on-disk `.credentials.json` token is expired with an empty refresh token, and the Windows keychain entry holds only a 16-byte key (the real token is in an encrypted vault). The card renders only `5h` + `weekly`, both already provided token-free by the statusLine source — so the Edge scraper is non-essential for the card and only the manual weekly-Sonnet summary still uses it.

## Verification

- `npm test` → 435 passed
- `npm run lint` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)