### PR TITLE
fix(local-llm): repair skill YAML frontmatter + add guard test

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.104.0"
+    "version": "0.104.1"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.104.0",
+      "version": "0.104.1",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.104.0",
+      "version": "0.104.1",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.104.1] — 2026-06-21
+
+### Fixed
+
+- **The `local-llm-setup` skill triggers again — its YAML frontmatter was silently unparseable.** The `description` was an unquoted plain scalar containing `` `phase: needs_api_key` `` (a colon + space inside backticks); YAML reads that inner colon as a mapping separator, so the whole frontmatter failed to parse and the Claude Code harness loaded the skill with **empty metadata and no error** — it never triggered and never appeared in the skill list. Switched to a folded block scalar (`description: >-`), matching every devops skill. Also repaired the local plugin caches (devops + local-llm had been left pointing at an empty / orphaned cache dir after an interrupted update) and re-synced README's stale version line.
+
+### Added
+
+- **A dependency-free `frontmatter-yaml.test.js` guard now parses every skill `SKILL.md` and agent `.md` frontmatter** for the same colon hazard and asserts skills declare `name` + `description`. Nothing in the release pipeline previously caught unparseable frontmatter (CI runs only on release tags, with no test gate), so this regression shipped undetected. The rule is documented in `CONVENTIONS.md` next to the frontmatter template (490 tests pass).
+
 ## [0.104.0] — 2026-06-21
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.103.0**
+**Version: 0.104.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.104.0**
+**Version: 0.104.1**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.104.0",
+  "version": "0.104.1",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/CONVENTIONS.md
+++ b/plugins/devops/CONVENTIONS.md
@@ -133,6 +133,14 @@ triggers:
 ---
 ```
 
+**YAML safety:** any frontmatter value with `: ` (colon + space) or a trailing
+`:` — usually `description` — MUST be a folded block scalar (`description: >-`,
+content indented on the next line) or be quoted. A plain scalar with an inner
+`: ` makes YAML parse the block as a broken mapping, so the harness loads the
+doc with **empty metadata and no error** — the skill never triggers / the agent
+never appears. Applies equally to `agents/*.md`. Guarded by
+`scripts/frontmatter-yaml.test.js`.
+
 ### Extension Mechanism (applies to ALL skills)
 
 Every plugin skill supports a **three-layer extension model**. Before executing

--- a/plugins/devops/scripts/frontmatter-yaml.test.js
+++ b/plugins/devops/scripts/frontmatter-yaml.test.js
@@ -1,0 +1,142 @@
+import { describe, test, expect } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+// Guards against the class of bug where a skill/agent ships with frontmatter
+// that fails to parse as YAML. The Claude Code harness does NOT error on this —
+// it silently loads the document with EMPTY metadata (no name/description), so
+// the skill never triggers and the agent never appears. Nothing in the release
+// pipeline caught the local-llm-setup regression (a `phase: needs_api_key`
+// backtick in an unquoted description), so this test is that safety net.
+
+const ROOT = process.cwd();
+
+/**
+ * Every file whose YAML frontmatter the harness parses:
+ *  - skills:  plugins/<plugin>/skills/<name>/SKILL.md
+ *  - agents:  plugins/<plugin>/agents/<name>.md
+ */
+function collectFrontmatterFiles() {
+  const files = [];
+  const pluginsDir = path.join(ROOT, "plugins");
+  for (const plugin of fs.readdirSync(pluginsDir, { withFileTypes: true })) {
+    if (!plugin.isDirectory()) continue;
+    const base = path.join(pluginsDir, plugin.name);
+
+    const skillsDir = path.join(base, "skills");
+    if (fs.existsSync(skillsDir)) {
+      for (const s of fs.readdirSync(skillsDir, { withFileTypes: true })) {
+        if (!s.isDirectory()) continue;
+        const f = path.join(skillsDir, s.name, "SKILL.md");
+        if (fs.existsSync(f)) files.push(f);
+      }
+    }
+
+    const agentsDir = path.join(base, "agents");
+    if (fs.existsSync(agentsDir)) {
+      for (const a of fs.readdirSync(agentsDir, { withFileTypes: true })) {
+        if (a.isFile() && a.name.endsWith(".md")) {
+          files.push(path.join(agentsDir, a.name));
+        }
+      }
+    }
+  }
+  return files;
+}
+
+function extractFrontmatter(text) {
+  if (!text.startsWith("---")) return null;
+  const firstNl = text.indexOf("\n");
+  if (firstNl === -1) return null;
+  const close = text.indexOf("\n---", firstNl);
+  if (close === -1) return null;
+  return text.slice(firstNl + 1, close + 1);
+}
+
+/**
+ * Conservatively flag the YAML hazard that silently drops all frontmatter: a
+ * top-level PLAIN scalar value — unquoted and not a block scalar (`|`/`>`) —
+ * that contains ": " (colon + space) or ends with ":". YAML reads that inner
+ * colon as a mapping separator and the whole block fails to parse. Block
+ * scalars (`key: >-`) and quoted values are safe and are skipped.
+ */
+export function findColonHazards(fm) {
+  const lines = fm.split("\n");
+  const hazards = [];
+  let blockKeyIndent = null;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (line.trim() === "") continue;
+    const indent = line.length - line.trimStart().length;
+    if (blockKeyIndent !== null) {
+      if (indent > blockKeyIndent) continue; // literal block-scalar / nested content
+      blockKeyIndent = null;
+    }
+    const m = line.match(/^(\s*)([A-Za-z0-9_-]+):(.*)$/);
+    if (!m) continue; // list items ("- x"), wrapped continuation lines
+    const keyIndent = m[1].length;
+    const rawValue = m[3];
+    const value = rawValue.trim();
+    // empty value (nested mapping / block scalar follows) or block scalar indicator
+    if (value === "" || /^[|>][+-]?\d*\s*(#.*)?$/.test(value)) {
+      blockKeyIndent = keyIndent;
+      continue;
+    }
+    if (value.startsWith('"') || value.startsWith("'")) continue; // quoted — colons safe
+    if (/:(\s|$)/.test(value)) {
+      hazards.push({ key: m[2], line: i + 1, value });
+    }
+  }
+  return hazards;
+}
+
+const FILES = collectFrontmatterFiles();
+
+describe("plugin skill/agent frontmatter", () => {
+  test("discovers frontmatter files", () => {
+    expect(FILES.length).toBeGreaterThan(0);
+  });
+
+  test.each(FILES.map((f) => [path.relative(ROOT, f), f]))(
+    "%s parses as YAML (no unquoted-colon hazard)",
+    (_rel, file) => {
+      const fm = extractFrontmatter(fs.readFileSync(file, "utf8"));
+      expect(fm, `${file}: missing or unterminated '---' frontmatter block`).not.toBeNull();
+      const hazards = findColonHazards(fm);
+      expect(
+        hazards,
+        `${file}: plain scalar contains ": " — breaks YAML and silently drops ALL frontmatter. ` +
+          `Use a block scalar ("key: >-") or quote the value. Offenders: ${JSON.stringify(hazards)}`,
+      ).toEqual([]);
+    },
+  );
+
+  test.each(
+    FILES.filter((f) => f.endsWith("SKILL.md")).map((f) => [path.relative(ROOT, f), f]),
+  )("%s declares name and description", (_rel, file) => {
+    const fm = extractFrontmatter(fs.readFileSync(file, "utf8")) ?? "";
+    expect(/^name:\s*\S/m.test(fm), `${file}: missing 'name'`).toBe(true);
+    expect(/^description:\s*(\S|[|>])/m.test(fm), `${file}: missing 'description'`).toBe(true);
+  });
+});
+
+describe("findColonHazards detector", () => {
+  test("flags the local-llm-setup regression (colon-space in plain scalar)", () => {
+    const broken =
+      "name: local-llm-setup\n" +
+      "description: setup — reports `phase: needs_api_key`, `auth_failed`.\n";
+    expect(findColonHazards(broken).map((h) => h.key)).toContain("description");
+  });
+
+  test("accepts the same value wrapped in a block scalar", () => {
+    const fixed =
+      "name: local-llm-setup\n" +
+      "description: >-\n" +
+      "  setup — reports `phase: needs_api_key`, `auth_failed`.\n";
+    expect(findColonHazards(fixed)).toEqual([]);
+  });
+
+  test("accepts colons not followed by whitespace (URLs, /plugin:skill)", () => {
+    expect(findColonHazards("description: see https://x.io and /devops:ship\n")).toEqual([]);
+  });
+});

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.104.0",
+  "version": "0.104.1",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/local-llm/skills/local-llm-setup/SKILL.md
+++ b/plugins/local-llm/skills/local-llm-setup/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: local-llm-setup
-description: Interactive setup for the local-llm plugin — ask the user for their AnythingLLM API key, save it user-globally, and verify the connection. Use when the SessionStart hook reports `phase: needs_api_key`, `auth_failed`, or when the user explicitly asks to configure or reconfigure the local LLM. Triggers on "local llm setup", "anythingllm key", "local-llm configure".
+description: >-
+  Interactive setup for the local-llm plugin — ask the user for their AnythingLLM API key, save it user-globally, and verify the connection. Use when the SessionStart hook reports `phase: needs_api_key`, `auth_failed`, or when the user explicitly asks to configure or reconfigure the local LLM. Triggers on "local llm setup", "anythingllm key", "local-llm configure".
 ---
 
 # local-llm-setup


### PR DESCRIPTION
## Summary

- Repairs the `local-llm-setup` skill: its `description` was an unquoted plain scalar containing `` `phase: needs_api_key` `` (colon + space inside backticks), which broke YAML parsing so the skill loaded with **empty metadata** and never triggered / never appeared in the skill list. Switched to a folded block scalar (`description: >-`).
- Adds `frontmatter-yaml.test.js` — a dependency-free guard that parses every skill `SKILL.md` and agent `.md` frontmatter for the same colon hazard and asserts skills declare `name` + `description`. Nothing in the release pipeline caught this before.
- Documents the rule in `CONVENTIONS.md` next to the frontmatter template.
- Repairs README's stale manual version line (0.103.0 → 0.104.0); bumps to 0.104.1.

## Tests

- `npm test` → 490 passed (incl. new 55-assertion frontmatter guard)
- `npm run lint` → clean
- `claude plugin validate` (devops + local-llm) → pass