### PR TITLE
fix(plugin-update): reliable MCP install + ship self-update

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.104.1"
+    "version": "0.104.2"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.104.1",
+      "version": "0.104.2",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.104.1",
+      "version": "0.104.2",
       "author": {
         "name": "Jerry0022"
       },

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: ship
+description: >-
+  Project ship extension for the dotclaude plugin-source repo. After a successful
+  ship to main, syncs the locally-installed devops plugin to the just-shipped
+  version so this Claude Code instance doesn't end up on a stale install.
+---
+
+# Ship Extension — dotclaude (plugin-source repo)
+
+Adds one project-specific step to `/devops-ship`: a **post-ship self-update** of the
+installed devops plugin. This repo ships the plugin that runs the ship, so the local
+install must be reconciled with what was just merged. See `reference.md` in this folder
+for the full rationale (double-restart problem, observed cache/registry drift).
+
+This extension is **additive** — every plugin-default step still runs unchanged.
+
+## Step 6.5 — Announce the self-update IN the completion card
+
+Runs only when the **self-update will actually run** (see Step 8 guards). Do this
+**before** calling `render_completion_card` in Step 6, using pure file reads (no MCP):
+
+1. Read marketplace version: `~/.claude/plugins/marketplaces/dotclaude/plugins/devops/.claude-plugin/plugin.json` → `version`.
+2. Read installed version: `~/.claude/plugins/installed_plugins.json` → `plugins["devops@dotclaude"][0].version`.
+3. If they differ (or will differ because this ship bumped the version), add one
+   `userFinalTest` item to the Step 6 card payload, in the user's language:
+
+   > `{ action: "devops lokal auf v<vNew> synchronisiert — Claude einmal neu starten, dann ist die neue Version aktiv.", afterDeployment: true }`
+
+This keeps the completion card the **last visible output** (per plugin Step 6) while
+still telling the user the one thing they must do: restart once. Do **not** print any
+restart notice as separate prose after the card — the card carries it.
+
+If the versions already match and this ship did not bump the plugin version, skip the
+card item (the Step 8 sync will be a silent no-op / in-place cache repair).
+
+## Step 8 — Self-update finalizer (silent, runs LAST)
+
+> **Ordering is mandatory.** This MUST run **after** `render_completion_card` (Step 6)
+> and after Memory Dream (Step 7). The sync rebuilds the cache to a new `installPath`
+> and writes `~/.claude/plugins/.mcp-stale.json`; once that sentinel exists,
+> `pre.mcp.health` blocks every further MCP call (including the completion card).
+> Running it before the card would brick the card render.
+
+### Guards — skip the finalizer entirely when ANY of:
+
+- **Not a final ship to main.** `intermediate: true` from Step 1 → skip. Intermediate
+  merges don't change the published plugin version.
+- **Keep-mode** (Step 5a chose keep / Step 5c ran). The user keeps working in this same
+  session; marking MCP stale would break their next `ship_*` / card call mid-flow. Skip,
+  and do **not** add the Step 6.5 card item either. The plugin syncs on their next real
+  restart via `ss.plugin.update` as usual.
+- **Ship did not succeed** (`ship_release.success` falsy / `ship-blocked` card). Nothing
+  was merged → nothing to sync.
+- **devops not installed here** ("falls vorhanden"). If
+  `~/.claude/plugins/marketplaces/dotclaude` does not exist, there is no install to sync.
+  The hook no-ops on its own, so just running it is safe — no extra guard needed.
+
+### Action
+
+Run the canonical updater (same hook `/devops-plugin-update` delegates to — single
+source of truth, no duplicated logic):
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/hooks/session-start/ss.plugin.update.js"
+```
+
+The hook handles `git pull --ff-only` on the marketplace clone, cache rebuild to the
+shipped version, `installed_plugins.json` update, and the MCP-stale sentinel on a real
+version move.
+
+**Produce NO visible output after this.** The completion card (with the restart item from
+Step 6.5) is the last thing the user sees. Capture the hook's stdout into the tool result
+only — do not echo it into the chat. The session is now in a deliberately MCP-stale state;
+that is expected and resolves on the user's single restart.
+
+### After-restart contract
+
+On the user's next session start, `ss.plugin.update` finds the marketplace clone and cache
+already on the shipped version → nothing moves → it **clears** the stale sentinel → MCP
+tools work immediately, new version active. One restart, no blocked-tool window.

--- a/.claude/skills/ship/reference.md
+++ b/.claude/skills/ship/reference.md
@@ -1,0 +1,66 @@
+# Ship Reference — dotclaude (plugin-source repo)
+
+This is the **plugin-source** repo. A ship here changes the devops plugin itself,
+so after the merge the locally-installed devops in *this* Claude Code instance must
+be brought in sync with what was just shipped — otherwise the running instance keeps
+the old version and the next session lands in a stale state ("devops nicht verfügbar").
+
+## Why a post-ship self-update is needed here (and nowhere else)
+
+A normal consumer project shipping its app has nothing to do with the devops plugin
+version, so the stock `/devops-ship` never self-updates. This repo is the exception:
+the artifact it ships *is* the plugin running the ship.
+
+Without a post-ship sync, the update is left to the next `SessionStart`
+(`ss.plugin.update` hook). That path has two failure modes we keep hitting:
+
+1. **Double restart.** When `ss.plugin.update` discovers a *version change* at session
+   start, it rebuilds the cache to a new `installPath` and writes
+   `~/.claude/plugins/.mcp-stale.json`. The MCP servers were already spawned from the
+   old path → `pre.mcp.health` blocks every `ship_*` / completion-card / issues call
+   until the user restarts **again**. So: ship → restart → blocked → restart. Two restarts.
+2. **Cache/registry drift in worktree/autonomous sessions.** Observed on 2026-06-22:
+   marketplace clone pulled to `0.104.1`, but `installed_plugins.json` still pointed at
+   `cache\…\devops\0.104.0` (SHA of the previous commit) with **no** stale sentinel — so
+   the MCP tools silently ran against the old version. SessionStart did not reconcile it.
+
+Running the sync **at ship time** (in the session that is about to be discarded) moves
+the version-change rebuild into that throwaway session. The user's *next* restart then
+finds nothing to do (`ss.plugin.update` clears the sentinel when nothing moved) and lands
+directly on a clean, upgraded session. **Two restarts collapse into one.**
+
+## Single source of truth
+
+The finalizer delegates to the **same hook** as `/devops-plugin-update`:
+
+```
+node "${CLAUDE_PLUGIN_ROOT}/hooks/session-start/ss.plugin.update.js"
+```
+
+No update logic is duplicated here. The hook does: `git pull --ff-only` on every
+marketplace clone → cache rebuild (`fs.cpSync`, archive-mode for dotfiles) →
+`installed_plugins.json` registry update → MCP-stale sentinel on a real version move.
+For the detailed verify/report contract, see `skills/devops-plugin-update/SKILL.md`.
+
+## Paths
+
+| What | Path |
+|---|---|
+| Update hook | `${CLAUDE_PLUGIN_ROOT}/hooks/session-start/ss.plugin.update.js` |
+| Marketplace clone | `~/.claude/plugins/marketplaces/dotclaude` |
+| Plugin subdir in clone | `plugins/devops/.claude-plugin/plugin.json` |
+| Cache root | `~/.claude/plugins/cache/dotclaude/devops/<version>` |
+| Registry | `~/.claude/plugins/installed_plugins.json` (`devops@dotclaude`) |
+| Stale sentinel | `~/.claude/plugins/.mcp-stale.json` |
+
+## "falls vorhanden" — only when devops is actually installed
+
+If `~/.claude/plugins/marketplaces/dotclaude` does not exist, there is no installed
+devops to sync (e.g. running from a bare checkout without the plugin installed). The
+hook already no-ops in that case (`if (!existsSync(marketplacesDir)) exit 0`) — the
+finalizer just runs it and stays silent.
+
+## deliver / verify
+
+deliver: git+gh
+<!-- No remote-deploy surface. The "delivery" of this repo is the plugin update above. -->

--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,10 @@ node_modules/
 # Plugin-managed runtime dirs
 .claude/.plugin-version
 .claude/hooks/
-.claude/skills/
+# .claude/skills is a runtime dir, EXCEPT this repo's own tracked ship extension
+# (it is the plugin-source repo — it dogfoods its own skill-extension mechanism).
+.claude/skills/*
+!.claude/skills/ship/
 .claude/agents/
 .claude/deep-knowledge/
 .claude/templates/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.104.2] — 2026-06-22
+
+### Fixed
+
+- **The devops MCP servers (`ship`, `completion`, `issues`) no longer silently go missing after a plugin update that moves the install dir without changing the version string — the recurring "devops nicht verfügbar" after a ship.** The `ss.plugin.update` SessionStart hook (`@version` 0.8.0→0.9.1) only wrote the MCP-stale sentinel (`~/.claude/plugins/.mcp-stale.json`) when the marketplace git HEAD moved *this run* (`versionChanged = headChanged && version differs`). But a `cacheStale` rebuild can repoint the registry `installPath` to a different version dir with `headChanged=false` — e.g. the marketplace was pulled to the new version in an earlier session while the cache/registry still pointed at the old version dir. `rebuildCache` then deletes the old dir and registers the new one, leaving the running MCP processes spawned from the now-deleted `installPath` with **no sentinel** — `pre.mcp.health` never blocked them, and the ship/completion/issues tools ended up dead or unregistered (observed live: registry pinned at a deleted `…/devops/0.104.0` while the complete cache sat at `0.104.1`). The hook now captures the registry `installPath` **before** the rebuild and flags staleness whenever the rebuild **moves** it (`previousInstallPath !== newCache`), regardless of `headChanged`; a same-version in-place repair keeps the path equal and writes no sentinel (preserving #219). `rebuildCache` now returns its `installPath`. New `ss.plugin.update.sentinel.test.js` (6 tests) pins the move-vs-in-place decision.
+
+- **A plugin whose `mcp-server/` layout differs from devops (e.g. `local-llm`) is no longer falsely flagged as an incomplete cache and rebuilt in a loop every session.** `missingMcpFiles()` asserted the devops-shaped `MCP_CRITICAL_FILES` list (`mcp-server/ship/index.js`, `mcp-server/issues/index.js`, `mcp-server/lib/heartbeat.js`, …) against **every** plugin that merely ships an `.mcp.json`. `local-llm` ships only `mcp-server/index.js`, so it was permanently reported as missing three files → `cacheStale` every session → a rebuild that could never satisfy the check → the registry SHA never advanced → perpetual churn. The check now asserts only the candidate files the **source** plugin actually ships; the gate stays the source's `.mcp.json` (not the target's), so a dropped target `.mcp.json` is still caught (#190 protection preserved). New `ss.plugin.update.completeness.test.js` (6 tests). Verified end-to-end: `local-llm` reports ✓ and the rebuild loop settles on the next run (502 tests pass).
+
+### Added
+
+- **A project ship extension (`.claude/skills/ship/`) self-updates the locally-installed devops after a ship to main.** This is the plugin-source repo, so a ship here changes the plugin running the ship — leaving the sync to the next `SessionStart` caused stale installs and a two-restart upgrade window. Step 6.5 announces the pending sync as a completion-card item; Step 8 runs the canonical `ss.plugin.update` hook **last** (after the card, since the sync marks MCP stale) to pull the marketplace clone, rebuild the cache to the just-shipped version, and repoint the registry — collapsing the two restarts into one. Guarded to a final ship to main with normal cleanup (skipped for intermediate merges, keep-mode, and when no devops install is present). Because this repo ignores all of `.claude/`, a narrow `.gitignore` carve-out tracks just `.claude/skills/ship/`.
+
 ## [0.104.1] — 2026-06-21
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.104.1**
+**Version: 0.104.2**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.104.1",
+  "version": "0.104.2",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/hooks/session-start/ss.plugin.update.completeness.test.js
+++ b/plugins/devops/hooks/session-start/ss.plugin.update.completeness.test.js
@@ -1,0 +1,121 @@
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+/**
+ * Characterization test for the PER-PLUGIN MCP completeness check in
+ * ss.plugin.update.js's missingMcpFiles().
+ *
+ * The bug: MCP_CRITICAL_FILES is a devops-shaped list (mcp-server/ship/index.js,
+ * mcp-server/issues/index.js, mcp-server/lib/heartbeat.js, ...) but the old
+ * missingMcpFiles(targetRoot, expectMcp) asserted that WHOLE list against every
+ * plugin that merely ships an .mcp.json. The local-llm plugin ships an .mcp.json
+ * but its mcp-server/ has only index.js — so the check reported 3 files
+ * permanently missing, forcing a cacheStale rebuild every session that could
+ * never satisfy the check (the files don't exist upstream) → registry SHA never
+ * advanced → churn. Observed: "local-llm … ⚠ mcp-server files: …heartbeat.js,
+ * …ship\index.js, …issues\index.js".
+ *
+ * The fix: assert only the candidate files the SOURCE plugin actually ships.
+ * The #190 guarantee is preserved — a file present upstream but dropped from the
+ * cache is still flagged, and the gate is the SOURCE's .mcp.json (not the
+ * target's) so a target whose .mcp.json was dropped is not masked.
+ *
+ * missingMcpFiles() is a non-exported internal of a SessionStart hook whose
+ * module body self-executes on import (see the #190 copydir and #219 inplace
+ * tests for the same constraint). So this mirrors the EXACT post-fix function
+ * against temp source/target trees.
+ */
+
+// Mirror of MCP_CRITICAL_FILES and missingMcpFiles() after the fix.
+const MCP_CRITICAL_FILES = [
+  ".mcp.json",
+  path.join("mcp-server", "index.js"),
+  path.join("mcp-server", "lib", "heartbeat.js"),
+  path.join("mcp-server", "ship", "index.js"),
+  path.join("mcp-server", "issues", "index.js"),
+];
+
+function hasMcpServer(root) {
+  return fs.existsSync(path.join(root, ".mcp.json"));
+}
+
+function missingMcpFiles(targetRoot, sourceRoot) {
+  if (!hasMcpServer(sourceRoot)) return [];
+  return MCP_CRITICAL_FILES.filter(
+    (rel) => fs.existsSync(path.join(sourceRoot, rel)) && !fs.existsSync(path.join(targetRoot, rel)),
+  );
+}
+
+let tmpRoot;
+let src;
+let dst;
+
+function write(root, rel, content) {
+  const full = path.join(root, rel);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, content);
+}
+
+// A faithful cache mirror: copy exactly the files the source has.
+function mirror(srcRoot, dstRoot, rels) {
+  for (const rel of rels) write(dstRoot, rel, fs.readFileSync(path.join(srcRoot, rel), "utf8"));
+}
+
+const DEVOPS_FILES = [...MCP_CRITICAL_FILES]; // ships the full set
+const LOCAL_LLM_FILES = [".mcp.json", path.join("mcp-server", "index.js")]; // minimal layout
+
+beforeEach(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "dotclaude-completeness-"));
+  src = path.join(tmpRoot, "src");
+  dst = path.join(tmpRoot, "dst");
+  fs.mkdirSync(src, { recursive: true });
+  fs.mkdirSync(dst, { recursive: true });
+});
+
+afterEach(() => {
+  try {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  } catch { /* ignore */ }
+});
+
+describe("ss.plugin.update missingMcpFiles — per-plugin completeness", () => {
+  test("local-llm-shaped source (only mcp-server/index.js), cache mirrors it → NOT flagged", () => {
+    // The regression: previously this reported ship/issues/heartbeat as missing.
+    LOCAL_LLM_FILES.forEach((rel) => write(src, rel, `// ${rel}`));
+    mirror(src, dst, LOCAL_LLM_FILES);
+    expect(missingMcpFiles(dst, src)).toEqual([]);
+  });
+
+  test("devops-shaped source (full set), cache mirrors all 5 → NOT flagged", () => {
+    DEVOPS_FILES.forEach((rel) => write(src, rel, `// ${rel}`));
+    mirror(src, dst, DEVOPS_FILES);
+    expect(missingMcpFiles(dst, src)).toEqual([]);
+  });
+
+  test("devops-shaped source, cache dropped mcp-server/ship/index.js → flagged (#190 preserved)", () => {
+    DEVOPS_FILES.forEach((rel) => write(src, rel, `// ${rel}`));
+    const dropped = path.join("mcp-server", "ship", "index.js");
+    mirror(src, dst, DEVOPS_FILES.filter((rel) => rel !== dropped));
+    expect(missingMcpFiles(dst, src)).toEqual([dropped]);
+  });
+
+  test("local-llm-shaped source, cache dropped its index.js → still flagged (real drop)", () => {
+    LOCAL_LLM_FILES.forEach((rel) => write(src, rel, `// ${rel}`));
+    mirror(src, dst, [".mcp.json"]); // index.js missing from cache
+    expect(missingMcpFiles(dst, src)).toEqual([path.join("mcp-server", "index.js")]);
+  });
+
+  test("source without an .mcp.json (not an MCP plugin) → asserts nothing", () => {
+    // No .mcp.json in source → hasMcpServer(source) is false → empty, even with an empty target.
+    write(src, "skills/x/SKILL.md", "# x");
+    expect(missingMcpFiles(dst, src)).toEqual([]);
+  });
+
+  test("target dropped its .mcp.json while source has it → flagged (gate is the source)", () => {
+    DEVOPS_FILES.forEach((rel) => write(src, rel, `// ${rel}`));
+    mirror(src, dst, DEVOPS_FILES.filter((rel) => rel !== ".mcp.json"));
+    expect(missingMcpFiles(dst, src)).toEqual([".mcp.json"]);
+  });
+});

--- a/plugins/devops/hooks/session-start/ss.plugin.update.js
+++ b/plugins/devops/hooks/session-start/ss.plugin.update.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * @hook ss.plugin.update
- * @version 0.8.0
+ * @version 0.9.0
  * @event SessionStart
  * @plugin devops
  * @description Auto-update plugin marketplace clones, rebuild cache, and update registry.
@@ -12,7 +12,12 @@
  *   When a plugin with an MCP server is upgraded mid-session, the running
  *   MCP processes point at the now-deleted old installPath. A sentinel file
  *   (~/.claude/plugins/.mcp-stale.json) is written so pre.mcp.health can
- *   block MCP tool calls until the user restarts Claude Code.
+ *   block MCP tool calls until the user restarts Claude Code. The sentinel is
+ *   written whenever a rebuild MOVES the installPath to a different version dir
+ *   — not only on a git-HEAD version bump. A cacheStale rebuild can repoint the
+ *   installPath with headChanged=false (marketplace pulled in an earlier
+ *   session, cache still on the old version), which equally invalidates the
+ *   running MCP processes.
  *
  *   A same-version cache REPAIR overwrites the existing version dir in place
  *   instead of deleting + recreating it. Nuking the dir mid-session changes its
@@ -276,7 +281,7 @@ function rebuildCache(marketplace, pluginName, pluginDir, version, sha, { versio
     // Registry update failed — non-fatal, plugin still works from marketplace dir
   }
 
-  return { ok: true };
+  return { ok: true, installPath: newCache };
 }
 
 // If the marketplaces directory is missing, there are no updates to run.
@@ -346,11 +351,16 @@ for (const marketplace of fs.readdirSync(marketplacesDir)) {
     let cacheMissing = false;
     // Cache-staleness guard: rebuild if cached plugin.json version doesn't match marketplace
     let cacheStale = false;
+    // The installPath the running MCP servers were spawned from this session.
+    // Captured BEFORE rebuildCache rewrites the registry, so we can detect an
+    // installPath MOVE and flag MCP staleness even when git HEAD didn't move.
+    let previousInstallPath = null;
     try {
       const registry = JSON.parse(fs.readFileSync(registryFile, 'utf8'));
       const key = `${name}@${marketplace}`;
       const entry = registry.plugins[key]?.[0];
       if (entry) {
+        previousInstallPath = entry.installPath || null;
         if (!fs.existsSync(entry.installPath)) {
           cacheMissing = true;
         } else {
@@ -386,11 +396,23 @@ for (const marketplace of fs.readdirSync(marketplacesDir)) {
         error: result.ok ? null : (result.missing || result.mismatch),
       });
 
-      // Real version upgrades of MCP-bearing plugins invalidate running MCP
-      // processes — they were spawned from the now-deleted installPath.
-      // Cache repairs at the same version overwrite files in place, so the
-      // running Node process (code already in RAM) keeps working.
-      if (versionChanged && result.ok && fs.existsSync(path.join(dir, '.mcp.json'))) {
+      // MCP-bearing plugins: the running MCP processes were spawned from
+      // previousInstallPath. Flag them stale whenever the rebuild MOVED the
+      // install to a different version dir — NOT only on a git-HEAD version bump.
+      // A cacheStale rebuild can repoint the installPath with headChanged=false
+      // (e.g. the marketplace was pulled to the new version in an earlier session
+      // but the cache still pointed at the old version dir); rebuildCache then
+      // deletes the old dir and registers the new one, leaving the running MCP
+      // servers pointing at deleted files with no sentinel to block them. A
+      // same-version in-place repair keeps installPath === previousInstallPath
+      // (files overwritten; the RAM-resident Node process keeps working) → no
+      // sentinel, preserving #219 behavior.
+      const installMoved =
+        result.ok &&
+        previousInstallPath != null &&
+        result.installPath != null &&
+        path.resolve(previousInstallPath) !== path.resolve(result.installPath);
+      if (installMoved && fs.existsSync(path.join(dir, '.mcp.json'))) {
         mcpAffected.push({
           name,
           marketplace,

--- a/plugins/devops/hooks/session-start/ss.plugin.update.js
+++ b/plugins/devops/hooks/session-start/ss.plugin.update.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * @hook ss.plugin.update
- * @version 0.9.0
+ * @version 0.9.1
  * @event SessionStart
  * @plugin devops
  * @description Auto-update plugin marketplace clones, rebuild cache, and update registry.
@@ -61,12 +61,14 @@ const cacheDir = path.join(home, '.claude', 'plugins', 'cache');
 const registryFile = path.join(home, '.claude', 'plugins', 'installed_plugins.json');
 const sentinelFile = path.join(home, '.claude', 'plugins', '.mcp-stale.json');
 
-// Files whose absence means a cache is functionally broken even when its
-// version/sha look correct (issue #190 — sync dropped mcp-server files and
-// .mcp.json, so the MCP servers never registered). Checked both to flag an
-// existing cache for rebuild and to verify a freshly-built one. Paths are
-// relative to a plugin root; only assert files that exist in every plugin
-// that ships an .mcp.json — guarded by hasMcpServer() below.
+// Candidate set of files whose absence means a cache is functionally broken
+// even when its version/sha look correct (issue #190 — sync dropped mcp-server
+// files and .mcp.json, so the MCP servers never registered). This is a SUPERSET
+// across plugins, NOT a list every plugin ships: missingMcpFiles() asserts only
+// the entries a given plugin's SOURCE actually has. A plugin with a smaller
+// mcp-server layout (e.g. local-llm ships just mcp-server/index.js — no
+// ship/issues/heartbeat) is therefore not falsely flagged for files it never
+// had, which previously caused a never-satisfiable rebuild loop every session.
 const MCP_CRITICAL_FILES = [
   '.mcp.json',
   path.join('mcp-server', 'index.js'),
@@ -79,13 +81,18 @@ function hasMcpServer(root) {
   return fs.existsSync(path.join(root, '.mcp.json'));
 }
 
-// Returns the MCP-critical files missing from `targetRoot`. `expectMcp` must be
-// derived from the SOURCE plugin dir, not the target — otherwise a target whose
-// own .mcp.json was dropped would report "nothing to assert" and mask the very
-// breakage we are checking for (issue #190).
-function missingMcpFiles(targetRoot, expectMcp) {
-  if (!expectMcp) return [];
-  return MCP_CRITICAL_FILES.filter((rel) => !fs.existsSync(path.join(targetRoot, rel)));
+// Returns the MCP-critical files missing from `targetRoot`, asserted PER-PLUGIN
+// against what the SOURCE actually ships. `sourceRoot` is the marketplace plugin
+// dir (NOT the target): the gate is the source's .mcp.json — otherwise a target
+// whose own .mcp.json was dropped would report "nothing to assert" and mask the
+// very breakage we check for (issue #190). Only candidate files present in the
+// source are required in the target, so plugins with different mcp-server
+// layouts are each held to their own real file set.
+function missingMcpFiles(targetRoot, sourceRoot) {
+  if (!hasMcpServer(sourceRoot)) return [];
+  return MCP_CRITICAL_FILES.filter(
+    (rel) => fs.existsSync(path.join(sourceRoot, rel)) && !fs.existsSync(path.join(targetRoot, rel)),
+  );
 }
 
 function run(cmd, cwd) {
@@ -242,7 +249,7 @@ function rebuildCache(marketplace, pluginName, pluginDir, version, sha, { versio
   // mcp-server tree + .mcp.json — otherwise the servers never register
   // (issue #190). Fail the rebuild so the registry is not pointed at a
   // broken cache; the next session retries from the (complete) marketplace.
-  const mcpMissing = missingMcpFiles(newCache, hasMcpServer(pluginDir));
+  const mcpMissing = missingMcpFiles(newCache, pluginDir);
   if (mcpMissing.length) {
     return { ok: false, missing: `mcp-server files: ${mcpMissing.join(', ')}` };
   }
@@ -377,7 +384,7 @@ for (const marketplace of fs.readdirSync(marketplacesDir)) {
             // Completeness guard: version/sha can match while the MCP server
             // files were dropped by an incomplete sync (issue #190). Rebuild
             // from the marketplace clone to heal the cache in place.
-            if (!cacheStale && missingMcpFiles(entry.installPath, hasMcpServer(dir)).length) {
+            if (!cacheStale && missingMcpFiles(entry.installPath, dir).length) {
               cacheStale = true;
             }
           }

--- a/plugins/devops/hooks/session-start/ss.plugin.update.sentinel.test.js
+++ b/plugins/devops/hooks/session-start/ss.plugin.update.sentinel.test.js
@@ -1,0 +1,120 @@
+import { describe, test, expect } from "vitest";
+import path from "node:path";
+
+/**
+ * Characterization test for the MCP-stale sentinel decision in
+ * ss.plugin.update.js — the fix that writes ~/.claude/plugins/.mcp-stale.json
+ * whenever a rebuild MOVES the installPath, not only on a git-HEAD version bump.
+ *
+ * The bug: the sentinel was gated on `versionChanged` (= headChanged && version
+ * differs). But a cacheStale rebuild can repoint the registry installPath to a
+ * NEW version dir with headChanged=false — e.g. the marketplace clone was pulled
+ * to the new version in an EARLIER session, but the cache/registry still point at
+ * the old version dir. rebuildCache then deletes the old dir (the new version dir
+ * doesn't exist yet → inPlace=false → fs.rmSync(pluginCache)) and registers the
+ * new one. The running MCP servers, spawned from the now-deleted old installPath,
+ * are stale — but no sentinel was written, so pre.mcp.health let their tool calls
+ * through to read deleted/old files. Observed 2026-06-22: marketplace 0.104.1,
+ * registry still installPath …\devops\0.104.0, no .mcp-stale.json.
+ *
+ * rebuildCache()/the rebuild loop are non-exported internals of a SessionStart
+ * hook whose module body self-executes on import (see the #190 copydir and #219
+ * inplace tests for the same constraint). So this mirrors the EXACT decision the
+ * fix encodes — `installMoved && hasMcp` where installMoved compares the registry
+ * installPath captured BEFORE the rebuild against rebuildCache's returned
+ * installPath (newCache) — against realistic native-separator cache paths.
+ */
+
+// Mirror of the sentinel decision in the rebuild loop (post-fix).
+//   previousInstallPath: registry installPath BEFORE rebuildCache (what the
+//     running MCP server was spawned from), or null when there is no entry.
+//   newInstallPath: rebuildCache result.installPath (newCache), or null on failure.
+//   hasMcp: source plugin ships an .mcp.json.
+function shouldFlagMcpStale({ resultOk, previousInstallPath, newInstallPath, hasMcp }) {
+  const installMoved =
+    resultOk &&
+    previousInstallPath != null &&
+    newInstallPath != null &&
+    path.resolve(previousInstallPath) !== path.resolve(newInstallPath);
+  return installMoved && hasMcp;
+}
+
+// Realistic cache layout: ~/.claude/plugins/cache/dotclaude/devops/<version>.
+// Built with path.join so both sides use the SAME native separator — exactly as
+// production does (registry stores installPath with path.sep; newCache comes from
+// path.join). A same-version repair therefore yields byte-identical strings.
+const CACHE = path.join("C:", "Users", "x", ".claude", "plugins", "cache", "dotclaude", "devops");
+const v = (version) => path.join(CACHE, version);
+
+describe("ss.plugin.update MCP-stale sentinel decision", () => {
+  test("stale cache, HEAD did not move: rebuild moves 0.104.0 → 0.104.1 → sentinel IS written", () => {
+    // The exact regression: marketplace already pulled to the new version in a
+    // prior session, cache still on the old version dir. headChanged=false, so
+    // the OLD code wrote no sentinel; the fix flags the move.
+    expect(
+      shouldFlagMcpStale({
+        resultOk: true,
+        previousInstallPath: v("0.104.0"),
+        newInstallPath: v("0.104.1"),
+        hasMcp: true,
+      }),
+    ).toBe(true);
+  });
+
+  test("version upgrade (HEAD moved): 0.104.0 → 0.105.0 still writes the sentinel", () => {
+    expect(
+      shouldFlagMcpStale({
+        resultOk: true,
+        previousInstallPath: v("0.104.0"),
+        newInstallPath: v("0.105.0"),
+        hasMcp: true,
+      }),
+    ).toBe(true);
+  });
+
+  test("same-version in-place repair: installPath unchanged → NO sentinel (#219 preserved)", () => {
+    // The RAM-resident Node process keeps working; nuking it would needlessly
+    // force a restart. previousInstallPath === newInstallPath → not a move.
+    expect(
+      shouldFlagMcpStale({
+        resultOk: true,
+        previousInstallPath: v("0.104.1"),
+        newInstallPath: v("0.104.1"),
+        hasMcp: true,
+      }),
+    ).toBe(false);
+  });
+
+  test("first install (no prior registry entry) → NO sentinel", () => {
+    expect(
+      shouldFlagMcpStale({
+        resultOk: true,
+        previousInstallPath: null,
+        newInstallPath: v("0.104.1"),
+        hasMcp: true,
+      }),
+    ).toBe(false);
+  });
+
+  test("plugin without an MCP server → NO sentinel even when the install moves", () => {
+    expect(
+      shouldFlagMcpStale({
+        resultOk: true,
+        previousInstallPath: v("0.104.0"),
+        newInstallPath: v("0.104.1"),
+        hasMcp: false,
+      }),
+    ).toBe(false);
+  });
+
+  test("failed rebuild (result.ok=false) → NO sentinel (registry not repointed)", () => {
+    expect(
+      shouldFlagMcpStale({
+        resultOk: false,
+        previousInstallPath: v("0.104.0"),
+        newInstallPath: null,
+        hasMcp: true,
+      }),
+    ).toBe(false);
+  });
+});

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.104.1",
+  "version": "0.104.2",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary
Stops the devops plugin from becoming "unavailable" after a ship, and makes this
source repo self-update its own install.

## Changes
- **fix(plugin-update): MCP-stale sentinel on any installPath move** (f5e6f79) — a
  `cacheStale` rebuild that repoints `installPath` with `headChanged=false` no longer
  leaves the running MCP servers stale without a sentinel. Observed live: registry
  pinned at a deleted `…/devops/0.104.0` while the complete cache was at `0.104.1`.
- **fix(plugin-update): per-plugin MCP cache completeness** (a2418ae) — `local-llm`'s
  smaller `mcp-server/` layout is no longer falsely flagged as incomplete and rebuilt
  in a loop every session. #190 protection preserved (gate stays the source `.mcp.json`).
- **feat(ship): project ship extension to self-update devops after ship** (3767c16) —
  Step 6.5 announces in the completion card, Step 8 runs the canonical update hook last;
  collapses the two-restart upgrade window into one.

## Tests
502 pass (12 new across sentinel + completeness guards). Lint clean.