### PR TITLE
feat: graphify knowledge graph + opt-in enforcement (devops-graph)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.104.2"
+    "version": "0.105.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.104.2",
+      "version": "0.105.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.104.2",
+      "version": "0.105.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.105.0] — 2026-06-23
+
+### Added
+
+- **A new `/devops-graph` skill integrates the external [graphify](https://github.com/safishamsi/graphify) knowledge-graph CLI, with opt-in enforcement so the graph is actually *used*, not just built.** graphify turns a codebase into a queryable graph (`graphify-out/graph.json`) so broad questions hit the graph instead of grepping raw files (token saver). The skill stays a thin orchestration layer — it never reimplements graphify and deliberately never runs `graphify claude install` (whose PreToolUse hook would collide with the devops token-guard). A multi-agent verification first established that graphify's own registration only *nudges* (its hook emits `permissionDecision:"allow"` guarded with `|| true`, never a block), so real enforcement is **stronger** than registered-graphify, not equivalent to it. On a per-project opt-in recorded in `.claude/graphify.json` (written only after explicit consent — never silent): **(1) auto-build** — the new `ss.graphify` SessionStart hook checks install, runs `graphify hook install` once (git post-commit AST rebuild, free) and background-rebuilds when the graph is missing/stale; **(2) a hard gate** — `pre.tokens.guard` (`@version` 0.3.0→0.5.0) blocks (exit 2) a broad raw-file Grep/Glob toward `graphify query`, but only when consented **and** the graph is fresh **and** no query ran yet this session. Two safety preconditions are enforced in code: a fail-safe staleness guard (`graph-nudge.graphIsStale` — a truncated, empty, or unreadable scan counts as stale, symlinks are followed, so the gate never forces Claude onto an out-of-date graph) and a retry escape hatch (a blocked search falls through on retry; `post.graphify.query` relents the gate for the session once a real query runs). New: `hooks/lib/graphify-state.js` (consent + session state), `hooks/lib/graph-nudge.js` (ambient hint + staleness), and the generic, reusable `scripts/check-tool.js` cross-platform PATH probe. The implementation was adversarially red-teamed and reworked to close a false-fresh bug class (maxFiles truncation, empty/unreadable repos, symlinked sources, Windows `.cmd` shim spawns). Covered by unit + a spawn-based integration test of the gate (549 tests pass).
+
 ## [0.104.2] — 2026-06-22
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.104.2**
+**Version: 0.105.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/README.md
+++ b/README.md
@@ -319,6 +319,7 @@ SessionStart  ──>  UserPromptSubmit  ──>  PreToolUse  ──>  PostToolU
 | `/devops-harden` | Explicit | Stabilization pass: full test suite, autonomous bug fixes, regression + consistency |
 | `/devops-polish` | Explicit | UI refinement: visual consistency, state-visuals, UI-side functionality checks |
 | `/devops-test-plan` | Explicit + Hook | Detect test profile, deterministic tool-chain recommendations per test request |
+| `/devops-graph` | Explicit + Hook | On-demand code knowledge graph via graphify, with opt-in auto-build + hard-gate enforcement |
 
 ### Agents (spawned for parallel work)
 

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ For the full extension guide with examples per skill, see `deep-knowledge/skill-
 ## Features
 
 - **<!--devops:count:hooks-->32<!--/devops:count:hooks--> Hooks** — automated guards and triggers across the full session lifecycle
-- **<!--devops:count:skills-->19<!--/devops:count:skills--> Skills** — devops-ship, devops-commit, devops-flow, devops-new-issue, devops-project-setup, devops-readme, devops-refresh-usage, devops-extend-skill, devops-repo-health, devops-claude-md-lint, devops-concept, devops-agents, devops-plugin-update, devops-autonomous, devops-burn, devops-learn, devops-harden, devops-polish, devops-test-plan
+- **<!--devops:count:skills-->20<!--/devops:count:skills--> Skills** — devops-ship, devops-commit, devops-flow, devops-new-issue, devops-project-setup, devops-readme, devops-refresh-usage, devops-extend-skill, devops-repo-health, devops-claude-md-lint, devops-concept, devops-agents, devops-plugin-update, devops-autonomous, devops-burn, devops-learn, devops-harden, devops-polish, devops-test-plan
 - **<!--devops:count:agents-->11<!--/devops:count:agents--> Agents** — AI, Core, Designer, Feature, Frontend, Gamer, PO, QA, Redteam, Research, Windows
 - **Completion Flow** — mandatory card after every task (8 variants), visual verification, ship recommendation
 - **Ship Enforcement** — intent detection, PR command blocking, automatic /devops-ship skill routing
@@ -645,7 +645,7 @@ devops/
 ├── .claude-plugin/plugin.json     ← Plugin manifest
 ├── CONVENTIONS.md                 ← Naming, versioning, extension rules
 ├── hooks/                         ← <!--devops:count:hooks-->32<!--/devops:count:hooks--> hooks (JS) registered in hooks.json
-├── skills/                        ← <!--devops:count:skills-->19<!--/devops:count:skills--> skill definitions (SKILL.md)
+├── skills/                        ← <!--devops:count:skills-->20<!--/devops:count:skills--> skill definitions (SKILL.md)
 ├── agents/                        ← <!--devops:count:agents-->11<!--/devops:count:agents--> agent definitions
 ├── deep-knowledge/                ← Cross-cutting reference docs
 ├── templates/                     ← Output format templates

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ For the full extension guide with examples per skill, see `deep-knowledge/skill-
 
 ## Features
 
-- **<!--devops:count:hooks-->32<!--/devops:count:hooks--> Hooks** — automated guards and triggers across the full session lifecycle
+- **<!--devops:count:hooks-->34<!--/devops:count:hooks--> Hooks** — automated guards and triggers across the full session lifecycle
 - **<!--devops:count:skills-->20<!--/devops:count:skills--> Skills** — devops-ship, devops-commit, devops-flow, devops-new-issue, devops-project-setup, devops-readme, devops-refresh-usage, devops-extend-skill, devops-repo-health, devops-claude-md-lint, devops-concept, devops-agents, devops-plugin-update, devops-autonomous, devops-burn, devops-learn, devops-harden, devops-polish, devops-test-plan
 - **<!--devops:count:agents-->11<!--/devops:count:agents--> Agents** — AI, Core, Designer, Feature, Frontend, Gamer, PO, QA, Redteam, Research, Windows
 - **Completion Flow** — mandatory card after every task (8 variants), visual verification, ship recommendation
@@ -178,7 +178,7 @@ For the full extension guide with examples per skill, see `deep-knowledge/skill-
 
 ### Hooks (automatic, no user action needed)
 
-<!--devops:count:hooks-->32<!--/devops:count:hooks--> hooks fire automatically across the session lifecycle — no user action needed.
+<!--devops:count:hooks-->34<!--/devops:count:hooks--> hooks fire automatically across the session lifecycle — no user action needed.
 
 <details>
 <summary><strong>By session lifecycle</strong> — when does it fire?</summary>
@@ -200,6 +200,7 @@ SessionStart  ──>  UserPromptSubmit  ──>  PreToolUse  ──>  PostToolU
 - `ss.tokens.scan` — Scan project for expensive files and update config for the pre.tokens.guard hook.
 - `ss.git.check` — Check for stale changes AND workspace setup issues at session start.
 - `ss.git.sync` — Registers a recurring git sync cron job (every 10 minutes).
+- `ss.graphify` — graphify enforcement — install-check + auto-build wiring for the devops-graph feature.
 - `ss.ship.verify` — Surface results from the post-merge watcher (post-ship CI + optional deploy verify).
 - `ss.concept.resume` — Recover an open concept session after a Claude restart.
 - `ss.team.changelog` — Show a summary of changes made by other contributors on remote main since the last ti…
@@ -227,6 +228,7 @@ SessionStart  ──>  UserPromptSubmit  ──>  PreToolUse  ──>  PostToolU
 
 - `post.flow.completion` — After EVERY tool call: inject the completion-card reminder so Claude always has the i…
 - `post.flow.debug` — After 2+ consecutive Bash failures: recommend the flow skill.
+- `post.graphify.query` — When Claude runs `graphify query ...`, record a per-session flag so the PreToolUse gr…
 - `post.concept.gate` — Deterministic backstop for devops-concept pages.
 
 #### Stop — runs when Claude finishes responding
@@ -644,7 +646,7 @@ Wk  ━━──╏─────────   15% +1%   · 4d 22h left
 devops/
 ├── .claude-plugin/plugin.json     ← Plugin manifest
 ├── CONVENTIONS.md                 ← Naming, versioning, extension rules
-├── hooks/                         ← <!--devops:count:hooks-->32<!--/devops:count:hooks--> hooks (JS) registered in hooks.json
+├── hooks/                         ← <!--devops:count:hooks-->34<!--/devops:count:hooks--> hooks (JS) registered in hooks.json
 ├── skills/                        ← <!--devops:count:skills-->20<!--/devops:count:skills--> skill definitions (SKILL.md)
 ├── agents/                        ← <!--devops:count:agents-->11<!--/devops:count:agents--> agent definitions
 ├── deep-knowledge/                ← Cross-cutting reference docs

--- a/docs/superpowers/specs/2026-06-23-devops-graph-companion-skill-design.md
+++ b/docs/superpowers/specs/2026-06-23-devops-graph-companion-skill-design.md
@@ -25,7 +25,6 @@ offer, and command invocation.
 
 ## Non-Goals
 
-- No always-on grep→graph nudge (i.e. no PreToolUse hook).
 - No replacement of `project-map` — different layer: always-on orientation
   (cheap, inlined every session) vs on-demand deep retrieval (heavy, queried).
 - No graphify MCP server in v1 (shell-out per call; MCP is a later option).
@@ -68,6 +67,18 @@ offer, and command invocation.
 
 Detect → offer → confirm. The SKILL.md documents the collision rationale inline
 so a future maintainer does not "helpfully" re-add `graphify claude install`.
+
+## Ambient nudge (added — option B)
+
+The "Build + Query on-demand" core is supplemented by a **devops-owned** ambient
+nudge so the graph is actually *used* during normal coding (the token-saving
+payoff). Rather than installing graphify's colliding hook, the existing
+`pre.tokens.guard` PreToolUse hook is extended: on the first broad search of a
+session it injects a one-line hint (alongside the project-map) steering Claude
+toward `graphify query` — **only when `graphify-out/graph.json` exists**, at most
+once per session. The collision was never "a hook is bad"; it was graphify's
+*uncoordinated* hook beside ours. Logic lives in `hooks/lib/graph-nudge.js`,
+unit-tested independently of the hook's stdin plumbing.
 
 ## Architecture rationale — the hook collision
 

--- a/docs/superpowers/specs/2026-06-23-devops-graph-companion-skill-design.md
+++ b/docs/superpowers/specs/2026-06-23-devops-graph-companion-skill-design.md
@@ -1,0 +1,97 @@
+# /devops-graph — Companion Skill Design
+
+**Date:** 2026-06-23
+**Status:** Approved (design) — pending implementation
+**Repo:** dotclaude (plugin source)
+
+## Summary
+
+A thin, on-demand orchestration skill that wires the external
+[`graphify`](https://github.com/safishamsi/graphify) knowledge-graph CLI into the
+devops plugin. graphify turns a codebase into a queryable knowledge graph so the
+assistant can query the graph instead of grepping/reading full files
+(token saver). The skill deliberately does **not** adopt graphify's
+auto-installed PreToolUse hook / CLAUDE.md skill, which would collide with the
+devops plugin's own PreToolUse hooks. graphify stays the single source of truth
+for graph building and querying; this skill owns only detection, an install
+offer, and command invocation.
+
+## Goals
+
+- On-demand **build + query** of a codebase knowledge graph via the real
+  `graphify` CLI (no reimplementation — "no parallel world").
+- **Never silently install** anything: detect + offer with confirmation.
+- **Zero collision** with existing devops PreToolUse hooks and `project-map`.
+
+## Non-Goals
+
+- No always-on grep→graph nudge (i.e. no PreToolUse hook).
+- No replacement of `project-map` — different layer: always-on orientation
+  (cheap, inlined every session) vs on-demand deep retrieval (heavy, queried).
+- No graphify MCP server in v1 (shell-out per call; MCP is a later option).
+- No migration of `check-local-llm.js` onto the new generic helper in this
+  iteration (helper is built reusable; migration deferred — YAGNI).
+
+## Placement
+
+- Skill: `plugins/devops/skills/devops-graph/SKILL.md`
+- Helper: `plugins/devops/scripts/check-tool.js` (generic PATH/availability check)
+- Test: `plugins/devops/scripts/check-tool.test.js`
+
+## Components
+
+### 1. `check-tool.js` (generic, reusable)
+
+- Input: a command/binary name (e.g. `graphify`), optional version-probe args.
+- Behavior: resolves whether the command is on PATH (cross-platform — Windows
+  `where` / POSIX `command -v`, or a Node PATH scan) and returns
+  `{ installed: boolean, path?: string, version?: string }`.
+- Detection logic separable from process spawning so tests run **without**
+  graphify installed.
+- Generalizes the intent of `check-local-llm.js`; local-llm may migrate onto it
+  later (out of scope now).
+
+### 2. `SKILL.md` flow
+
+1. **Detect** `graphify` via `check-tool.js`.
+2. **If missing** → present an offer to run
+   `uv tool install graphifyy && graphify install` (fallbacks: `pipx`, `pip`).
+   Only after explicit user OK. Never silent.
+3. **Ensure graph**: if `graphify-out/graph.json` is missing or stale →
+   `graphify extract . --update` (incremental, AST-only = free, no API cost).
+4. **Query**: `graphify query "<question>"`, return the result to the
+   conversation.
+5. **Explicitly does NOT** run `graphify claude install` (the hook / CLAUDE.md
+   writer) — see rationale below.
+
+### Install policy
+
+Detect → offer → confirm. The SKILL.md documents the collision rationale inline
+so a future maintainer does not "helpfully" re-add `graphify claude install`.
+
+## Architecture rationale — the hook collision
+
+`graphify claude install` writes graphify's own PreToolUse hook + CLAUDE.md skill
+that nudges the assistant away from grep toward `graphify query`. The devops
+plugin already ships PreToolUse hooks — the `project-map` re-scoping hint and
+`pre.tokens.guard.js`. Running both means every search gets two competing
+injections with unclear precedence, and a third-party tool writes into config the
+plugin treats as its own. Mitigation: invoke graphify **on-demand from our
+skill**; never install graphify's hook. The "Build + Query on-demand" scope
+inherently avoids the collision.
+
+## Testing
+
+- `check-tool.test.js`: detection returns `installed: false` for a nonexistent
+  binary and `installed: true` for a known one (e.g. `node`), without requiring
+  graphify to be installed.
+- Frontmatter YAML guard (`frontmatter-yaml.test.js`) already validates SKILL.md
+  frontmatter.
+- `npm test` must pass.
+
+## Out of scope / future
+
+- graphify MCP server registration for repeated queries.
+- Migrating `check-local-llm.js` onto `check-tool.js`.
+- A `deep-knowledge/graphify.md` reference doc (add only if usage proves it
+  needed).

--- a/docs/superpowers/specs/2026-06-23-devops-graph-companion-skill-design.md
+++ b/docs/superpowers/specs/2026-06-23-devops-graph-companion-skill-design.md
@@ -68,17 +68,39 @@ offer, and command invocation.
 Detect → offer → confirm. The SKILL.md documents the collision rationale inline
 so a future maintainer does not "helpfully" re-add `graphify claude install`.
 
-## Ambient nudge (added — option B)
+## Enforcement (option B → hardened to a real gate)
 
-The "Build + Query on-demand" core is supplemented by a **devops-owned** ambient
-nudge so the graph is actually *used* during normal coding (the token-saving
-payoff). Rather than installing graphify's colliding hook, the existing
-`pre.tokens.guard` PreToolUse hook is extended: on the first broad search of a
-session it injects a one-line hint (alongside the project-map) steering Claude
-toward `graphify query` — **only when `graphify-out/graph.json` exists**, at most
-once per session. The collision was never "a hook is bad"; it was graphify's
-*uncoordinated* hook beside ours. Logic lives in `hooks/lib/graph-nudge.js`,
-unit-tested independently of the hook's stdin plumbing.
+The "Build + Query on-demand" core was first supplemented by a soft, once-per-
+session **nudge** (devops-owned, via `pre.tokens.guard`). A multi-agent
+verification (research + audit + adversarial red-team) then established two
+load-bearing facts:
+
+1. **graphify's own registration does not force usage.** `graphify claude install`
+   writes a PreToolUse hook that emits `permissionDecision:"allow"` (guarded with
+   `|| true`) plus an advisory CLAUDE.md — a nudge, never a block (graphify issues
+   #249, #83). So "equivalent to registered graphify" (D4) and "forced usage"
+   (D3) are mutually inconsistent; a real gate is *stronger* than graphify.
+2. **A hard block is only safe with two preconditions** — otherwise it forces
+   Claude onto stale data or wedges searches the graph cannot answer.
+
+On the user's explicit choice (hard block + auto-build via git hooks **and**
+SessionStart), the nudge was upgraded to enforcement:
+
+- **Consent** — `.claude/graphify.json` (`consent:true|false`), written only after
+  an explicit opt-in offered by the `ss.graphify` SessionStart hook. Never silent.
+- **Auto-build (D2)** — `ss.graphify` ensures install, runs `graphify hook install`
+  once (git AST rebuild, free), and background-rebuilds when the graph is
+  missing/stale. (`hooks/lib/graphify-state.js`, `graph-nudge.graphIsStale`.)
+- **Hard gate (D3)** — `pre.tokens.guard` blocks (exit 2) a broad raw-file
+  Grep/Glob toward `graphify query`, **only when** the user consented AND the
+  graph is fresh AND no `graphify query` ran yet this session. Precondition 1:
+  staleness guard (`graphIsStale`, mtime vs newest source). Precondition 2:
+  escape hatch — blocks a given search once, a retry falls through;
+  `post.graphify.query` relents the gate for the session once a query runs.
+
+Verified by `graphify-state.test.js`, `graph-nudge.test.js` (staleness), and a
+spawn-based integration test `pre.tokens.guard.graphgate.test.js` (block / retry-
+relent / no-consent / declined / stale / queried).
 
 ## Architecture rationale — the hook collision
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.104.2",
+  "version": "0.105.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/docs/architecture.html
+++ b/plugins/devops/docs/architecture.html
@@ -169,7 +169,7 @@
 <section id="overview">
 <h1>Architecture Documentation <small>devops v0.87.0</small></h1>
 <p class="lead">
-  A comprehensive DevOps automation plugin for Claude Code &mdash; <!--devops:count:hooks-->32<!--/devops:count:hooks--> hooks, <!--devops:count:skills-->19<!--/devops:count:skills--> skills, <!--devops:count:agents-->11<!--/devops:count:agents--> agents,
+  A comprehensive DevOps automation plugin for Claude Code &mdash; <!--devops:count:hooks-->32<!--/devops:count:hooks--> hooks, <!--devops:count:skills-->20<!--/devops:count:skills--> skills, <!--devops:count:agents-->11<!--/devops:count:agents--> agents,
   2 MCP servers, a deterministic completion card engine, and a 3-layer extension system.
 </p>
 <div role="note" style="margin:.4rem 0 1.4rem;padding:.6rem .9rem;background:var(--bg2);border-left:3px solid var(--warn);border-radius:4px;color:var(--text2);font-size:.85rem;">
@@ -189,7 +189,7 @@
     <span class="badge b-hook">Stop &times;<!--devops:count:hooks:stop-->3<!--/devops:count:hooks:stop--></span>
   </div>
   <div class="card">
-    <h4><!--devops:count:skills-->19<!--/devops:count:skills--> Skills</h4>
+    <h4><!--devops:count:skills-->20<!--/devops:count:skills--> Skills</h4>
     <p style="color:var(--text2);font-size:.85rem">Slash commands: ship, commit, flow, new-issue, project-setup, readme, refresh-usage, extend-skill, repo-health, claude-md-lint, concept, agents, plugin-update, autonomous, burn, learn, harden, polish, test-plan</p>
   </div>
   <div class="card">
@@ -235,7 +235,7 @@
 │   ├── render-card.js         <span style="color:var(--warn)"># Completion card template engine</span>
 │   ├── build-id.js            <span style="color:var(--text2)"># Deterministic content hash</span>
 │   └── lib/usage-meter.js     <span style="color:var(--text2)"># Usage bar renderer</span>
-├── skills/                    <span style="color:var(--accent)"># <!--devops:count:skills-->19<!--/devops:count:skills--> skill definitions (SKILL.md + deep-knowledge/)</span>
+├── skills/                    <span style="color:var(--accent)"># <!--devops:count:skills-->20<!--/devops:count:skills--> skill definitions (SKILL.md + deep-knowledge/)</span>
 │   ├── ship/  commit/  flow/  new-issue/  project-setup/  readme/
 │   ├── refresh-usage/  extend-skill/  repo-health/  claude-md-lint/
 │   ├── concept/  agents/  plugin-update/  autonomous/  burn/  learn/

--- a/plugins/devops/docs/architecture.html
+++ b/plugins/devops/docs/architecture.html
@@ -169,7 +169,7 @@
 <section id="overview">
 <h1>Architecture Documentation <small>devops v0.87.0</small></h1>
 <p class="lead">
-  A comprehensive DevOps automation plugin for Claude Code &mdash; <!--devops:count:hooks-->32<!--/devops:count:hooks--> hooks, <!--devops:count:skills-->20<!--/devops:count:skills--> skills, <!--devops:count:agents-->11<!--/devops:count:agents--> agents,
+  A comprehensive DevOps automation plugin for Claude Code &mdash; <!--devops:count:hooks-->34<!--/devops:count:hooks--> hooks, <!--devops:count:skills-->20<!--/devops:count:skills--> skills, <!--devops:count:agents-->11<!--/devops:count:agents--> agents,
   2 MCP servers, a deterministic completion card engine, and a 3-layer extension system.
 </p>
 <div role="note" style="margin:.4rem 0 1.4rem;padding:.6rem .9rem;background:var(--bg2);border-left:3px solid var(--warn);border-radius:4px;color:var(--text2);font-size:.85rem;">
@@ -180,12 +180,12 @@
 
 <div class="card-grid">
   <div class="card">
-    <h4><!--devops:count:hooks-->32<!--/devops:count:hooks--> Hooks</h4>
+    <h4><!--devops:count:hooks-->34<!--/devops:count:hooks--> Hooks</h4>
     <p style="color:var(--text2);font-size:.85rem">Lifecycle guards across SessionStart, UserPromptSubmit, PreToolUse, PostToolUse, Stop</p>
-    <span class="badge b-hook">SessionStart &times;<!--devops:count:hooks:ss-->13<!--/devops:count:hooks:ss--></span>
+    <span class="badge b-hook">SessionStart &times;<!--devops:count:hooks:ss-->14<!--/devops:count:hooks:ss--></span>
     <span class="badge b-hook">Prompt &times;<!--devops:count:hooks:prompt-->7<!--/devops:count:hooks:prompt--></span>
     <span class="badge b-hook">Pre &times;<!--devops:count:hooks:pre-->6<!--/devops:count:hooks:pre--></span>
-    <span class="badge b-hook">Post &times;<!--devops:count:hooks:post-->3<!--/devops:count:hooks:post--></span>
+    <span class="badge b-hook">Post &times;<!--devops:count:hooks:post-->4<!--/devops:count:hooks:post--></span>
     <span class="badge b-hook">Stop &times;<!--devops:count:hooks:stop-->3<!--/devops:count:hooks:stop--></span>
   </div>
   <div class="card">
@@ -217,10 +217,10 @@
 ├── hooks/
 │   ├── hooks.json             <span style="color:var(--purple)"># Hook registry (event &rarr; command mapping)</span>
 │   ├── lib/                   <span style="color:var(--text2)"># plugin-guard, run-once, session-id</span>
-│   ├── session-start/         <span style="color:var(--purple)"># <!--devops:count:hooks:ss-->13<!--/devops:count:hooks:ss--> hooks (ss.*)</span>
+│   ├── session-start/         <span style="color:var(--purple)"># <!--devops:count:hooks:ss-->14<!--/devops:count:hooks:ss--> hooks (ss.*)</span>
 │   ├── user-prompt-submit/    <span style="color:var(--purple)"># <!--devops:count:hooks:prompt-->7<!--/devops:count:hooks:prompt--> hooks (prompt.*)</span>
 │   ├── pre-tool-use/          <span style="color:var(--purple)"># <!--devops:count:hooks:pre-->6<!--/devops:count:hooks:pre--> hooks (pre.*)</span>
-│   ├── post-tool-use/         <span style="color:var(--purple)"># <!--devops:count:hooks:post-->3<!--/devops:count:hooks:post--> hooks (post.*)</span>
+│   ├── post-tool-use/         <span style="color:var(--purple)"># <!--devops:count:hooks:post-->4<!--/devops:count:hooks:post--> hooks (post.*)</span>
 │   └── stop/                  <span style="color:var(--purple)"># <!--devops:count:hooks:stop-->3<!--/devops:count:hooks:stop--> hooks (stop.*)</span>
 ├── mcp-server/
 │   ├── index.js               <span style="color:var(--orange)"># dotclaude-completion MCP</span>

--- a/plugins/devops/hooks/hooks.json
+++ b/plugins/devops/hooks/hooks.json
@@ -14,6 +14,7 @@
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-start/ss.tokens.scan.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-start/ss.git.check.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-start/ss.git.sync.js" },
+          { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-start/ss.graphify.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-start/ss.ship.verify.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-start/ss.concept.resume.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-start/ss.team.changelog.js" },
@@ -57,7 +58,8 @@
       },
       {
         "hooks": [
-          { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/post-tool-use/post.flow.debug.js" }
+          { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/post-tool-use/post.flow.debug.js" },
+          { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/post-tool-use/post.graphify.query.js" }
         ],
         "matcher": "Bash"
       },

--- a/plugins/devops/hooks/lib/graph-nudge.js
+++ b/plugins/devops/hooks/lib/graph-nudge.js
@@ -1,0 +1,45 @@
+'use strict';
+/**
+ * @lib graph-nudge
+ * @version 0.1.0
+ * @plugin devops
+ * @description Pure helpers for the ambient graphify nudge injected by
+ *   pre.tokens.guard on the first broad search of a session. Detects whether a
+ *   graphify knowledge graph exists in the project and builds the one-line hint
+ *   that steers Claude toward `graphify query` instead of grepping raw files.
+ *   Kept separate from the hook so the decision logic is unit-testable without
+ *   stdin plumbing or an installed graphify.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+// graphify's default output location (see the devops-graph skill).
+const GRAPH_JSON_REL = path.join('graphify-out', 'graph.json');
+
+/** Absolute path to the project's graph.json under `cwd`. */
+function graphJsonPath(cwd) {
+  return path.join(cwd, GRAPH_JSON_REL);
+}
+
+/** True iff a graphify graph.json exists for this project. Never throws. */
+function hasGraph(cwd) {
+  try {
+    return fs.statSync(graphJsonPath(cwd)).isFile();
+  } catch {
+    return false;
+  }
+}
+
+/** The ambient hint appended to the session-start injection when a graph exists. */
+function buildGraphNudge() {
+  return [
+    '[graphify] A knowledge graph exists at graphify-out/graph.json.',
+    'For semantic questions (what defines/calls X, how do A and B relate, where is',
+    'Y handled), prefer `graphify query "<question>"` over grepping raw files — it',
+    'reads the graph, not the code, so it is cheaper. Refresh with /devops-graph if',
+    'the code changed meaningfully.',
+  ].join('\n');
+}
+
+module.exports = { GRAPH_JSON_REL, graphJsonPath, hasGraph, buildGraphNudge };

--- a/plugins/devops/hooks/lib/graph-nudge.js
+++ b/plugins/devops/hooks/lib/graph-nudge.js
@@ -42,4 +42,79 @@ function buildGraphNudge() {
   ].join('\n');
 }
 
-module.exports = { GRAPH_JSON_REL, graphJsonPath, hasGraph, buildGraphNudge };
+// Directories whose contents never count toward "newest source file": VCS,
+// dependencies, build output, and graphify's own output. Dot-dirs are skipped
+// too (handled in the walk), so .git/.claude/.venv are covered by both.
+const SKIP_DIRS = new Set([
+  '.git', 'node_modules', 'graphify-out', '.claude', 'dist', 'build',
+  'coverage', '.next', 'out', 'vendor', '.venv', '__pycache__', 'target',
+]);
+
+/**
+ * Scan project source files for the newest mtime, ignoring SKIP_DIRS and
+ * dot-dirs. Symlinked dirs/files ARE followed (resolved via stat) so a newer
+ * file behind a symlink is not invisible. Bounded by `opts.maxFiles` (default
+ * 8000); if the bound is hit the scan is `truncated`. Never throws.
+ * @returns {{newest:number, count:number, truncated:boolean}}
+ */
+function scanSources(cwd, opts = {}) {
+  const maxFiles = opts.maxFiles || 8000;
+  let newest = 0;
+  let count = 0;
+  const stack = [cwd];
+  while (stack.length) {
+    const dir = stack.pop();
+    let entries;
+    try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { continue; }
+    for (const e of entries) {
+      if (count >= maxFiles) return { newest, count, truncated: true };
+      const full = path.join(dir, e.name);
+      let isDir = e.isDirectory();
+      let isFile = e.isFile();
+      if (e.isSymbolicLink()) {
+        // Resolve the link target so symlinked source is not silently skipped.
+        // Loops are bounded by maxFiles → truncated → treated as stale upstream.
+        try { const st = fs.statSync(full); isDir = st.isDirectory(); isFile = st.isFile(); }
+        catch { continue; }
+      }
+      if (isDir) {
+        if (SKIP_DIRS.has(e.name) || e.name.startsWith('.')) continue;
+        stack.push(full);
+      } else if (isFile) {
+        count++;
+        try {
+          const m = fs.statSync(full).mtimeMs;
+          if (m > newest) newest = m;
+        } catch { /* unreadable — skip */ }
+      }
+    }
+  }
+  return { newest, count, truncated: false };
+}
+
+/**
+ * Is the graph stale relative to the working tree? This is the hard
+ * precondition for the PreToolUse graphify-gate — a hard block must NEVER force
+ * Claude onto an out-of-date graph, so it is deliberately fail-safe: when
+ * freshness cannot be PROVEN, return stale (the gate then simply does not fire).
+ * Stale when: graph.json is missing; the scan was truncated (could not see all
+ * files); no source files were found; or any source file is newer than the
+ * graph. Fresh only when the full scan saw ≥1 file and none is newer.
+ */
+function graphIsStale(cwd, opts = {}) {
+  let graphMtime;
+  try { graphMtime = fs.statSync(graphJsonPath(cwd)).mtimeMs; } catch { return true; }
+  const { newest, count, truncated } = scanSources(cwd, opts);
+  if (truncated) return true;   // partial scan → cannot prove freshness
+  if (count === 0) return true; // nothing comparable → do not enforce
+  return newest > graphMtime;
+}
+
+module.exports = {
+  GRAPH_JSON_REL,
+  graphJsonPath,
+  hasGraph,
+  buildGraphNudge,
+  scanSources,
+  graphIsStale,
+};

--- a/plugins/devops/hooks/lib/graph-nudge.test.js
+++ b/plugins/devops/hooks/lib/graph-nudge.test.js
@@ -2,7 +2,7 @@ import { describe, test, expect, beforeAll, afterAll } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { hasGraph, buildGraphNudge, graphJsonPath } from "./graph-nudge.js";
+import { hasGraph, buildGraphNudge, graphJsonPath, graphIsStale } from "./graph-nudge.js";
 
 describe("hasGraph — graph.json detection", () => {
   let dir;
@@ -42,5 +42,99 @@ describe("buildGraphNudge — ambient hint text", () => {
     expect(t).toContain("graphify query");
     expect(t).toContain("graphify-out/graph.json");
     expect(t).toContain("/devops-graph");
+  });
+});
+
+describe("graphIsStale — gate precondition", () => {
+  const OLD = new Date(Date.now() - 60_000);
+  const NOW = new Date();
+
+  function freshTmp() {
+    return fs.mkdtempSync(path.join(os.tmpdir(), "graph-stale-"));
+  }
+  function writeGraph(dir) {
+    const gp = graphJsonPath(dir);
+    fs.mkdirSync(path.dirname(gp), { recursive: true });
+    fs.writeFileSync(gp, "{}");
+    return gp;
+  }
+
+  test("missing graph.json counts as stale", () => {
+    const d = freshTmp();
+    expect(graphIsStale(d)).toBe(true);
+    fs.rmSync(d, { recursive: true, force: true });
+  });
+
+  test("fresh when graph.json is newer than every source", () => {
+    const d = freshTmp();
+    fs.writeFileSync(path.join(d, "a.js"), "x");
+    const gp = writeGraph(d);
+    fs.utimesSync(path.join(d, "a.js"), OLD, OLD);
+    fs.utimesSync(gp, NOW, NOW);
+    expect(graphIsStale(d)).toBe(false);
+    fs.rmSync(d, { recursive: true, force: true });
+  });
+
+  test("stale when a source file is newer than graph.json", () => {
+    const d = freshTmp();
+    const gp = writeGraph(d);
+    fs.writeFileSync(path.join(d, "a.js"), "x");
+    fs.utimesSync(gp, OLD, OLD);
+    fs.utimesSync(path.join(d, "a.js"), NOW, NOW);
+    expect(graphIsStale(d)).toBe(true);
+    fs.rmSync(d, { recursive: true, force: true });
+  });
+
+  test("ignores newer files inside graphify-out / skipped dirs", () => {
+    const d = freshTmp();
+    fs.writeFileSync(path.join(d, "a.js"), "x"); // a real (older) source so count >= 1
+    const gp = writeGraph(d);
+    fs.utimesSync(path.join(d, "a.js"), OLD, OLD);
+    fs.utimesSync(gp, NOW, NOW);
+    const inside = path.join(d, "graphify-out", "cache.bin");
+    fs.writeFileSync(inside, "x");
+    const future = new Date(Date.now() + 60_000);
+    fs.utimesSync(inside, future, future); // newer than the graph, but must be ignored
+    expect(graphIsStale(d)).toBe(false); // graphify-out churn must not mark stale
+    fs.rmSync(d, { recursive: true, force: true });
+  });
+
+  test("fail-safe: a truncated scan (maxFiles hit) is treated as stale", () => {
+    const d = freshTmp();
+    const gp = writeGraph(d);
+    fs.utimesSync(gp, NOW, NOW);
+    fs.writeFileSync(path.join(d, "a.js"), "x");
+    fs.mkdirSync(path.join(d, "sub"));
+    fs.writeFileSync(path.join(d, "sub", "b.js"), "x");
+    // Cannot see every file → must NOT claim fresh.
+    expect(graphIsStale(d, { maxFiles: 1 })).toBe(true);
+    fs.rmSync(d, { recursive: true, force: true });
+  });
+
+  test("fail-safe: a repo with no comparable source files is stale", () => {
+    const d = freshTmp();
+    const gp = writeGraph(d); // only graphify-out/graph.json, no sources
+    fs.utimesSync(gp, NOW, NOW);
+    expect(graphIsStale(d)).toBe(true);
+    fs.rmSync(d, { recursive: true, force: true });
+  });
+
+  test("follows symlinked dirs so newer source behind a link is detected", () => {
+    const d = freshTmp();
+    const gp = writeGraph(d);
+    fs.utimesSync(gp, OLD, OLD);
+    const realDir = fs.mkdtempSync(path.join(os.tmpdir(), "graph-link-target-"));
+    const newer = path.join(realDir, "new.js");
+    fs.writeFileSync(newer, "x");
+    fs.utimesSync(newer, NOW, NOW);
+    let linked = true;
+    try {
+      fs.symlinkSync(realDir, path.join(d, "linked"), process.platform === "win32" ? "junction" : "dir");
+    } catch {
+      linked = false; // no symlink privilege (e.g. Windows non-admin) — skip assert
+    }
+    if (linked) expect(graphIsStale(d)).toBe(true);
+    fs.rmSync(d, { recursive: true, force: true });
+    fs.rmSync(realDir, { recursive: true, force: true });
   });
 });

--- a/plugins/devops/hooks/lib/graph-nudge.test.js
+++ b/plugins/devops/hooks/lib/graph-nudge.test.js
@@ -1,0 +1,46 @@
+import { describe, test, expect, beforeAll, afterAll } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { hasGraph, buildGraphNudge, graphJsonPath } from "./graph-nudge.js";
+
+describe("hasGraph — graph.json detection", () => {
+  let dir;
+  beforeAll(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "graph-nudge-"));
+  });
+  afterAll(() => {
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+  });
+
+  test("false when no graph.json present", () => {
+    expect(hasGraph(dir)).toBe(false);
+  });
+
+  test("true once graphify-out/graph.json exists", () => {
+    const gp = graphJsonPath(dir);
+    fs.mkdirSync(path.dirname(gp), { recursive: true });
+    fs.writeFileSync(gp, "{}");
+    expect(hasGraph(dir)).toBe(true);
+  });
+
+  test("false for a non-existent directory", () => {
+    expect(hasGraph(path.join(dir, "nope"))).toBe(false);
+  });
+
+  test("ignores a directory named graph.json (must be a file)", () => {
+    const d2 = fs.mkdtempSync(path.join(os.tmpdir(), "graph-nudge-dir-"));
+    fs.mkdirSync(graphJsonPath(d2), { recursive: true });
+    expect(hasGraph(d2)).toBe(false);
+    try { fs.rmSync(d2, { recursive: true, force: true }); } catch {}
+  });
+});
+
+describe("buildGraphNudge — ambient hint text", () => {
+  test("names the query command, the graph path, and the refresh skill", () => {
+    const t = buildGraphNudge();
+    expect(t).toContain("graphify query");
+    expect(t).toContain("graphify-out/graph.json");
+    expect(t).toContain("/devops-graph");
+  });
+});

--- a/plugins/devops/hooks/lib/graphify-state.js
+++ b/plugins/devops/hooks/lib/graphify-state.js
@@ -1,0 +1,94 @@
+'use strict';
+/**
+ * @lib graphify-state
+ * @version 0.1.0
+ * @plugin devops
+ * @description Consent + session-state helpers for the graphify enforcement
+ *   layer (devops-graph). The consent record lives at `.claude/graphify.json`
+ *   in the consumer project and is written ONLY after the user explicitly opts
+ *   in (consent:true) or out (consent:false) — hooks never write it silently.
+ *   Also tracks a per-session "graphify query already ran" flag so the
+ *   PreToolUse hard-gate can relent once Claude has consulted the graph.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const crypto = require('node:crypto');
+
+const CONSENT_REL = path.join('.claude', 'graphify.json');
+
+function consentPath(cwd) {
+  return path.join(cwd, CONSENT_REL);
+}
+
+/** Parsed consent record, or null if absent/unreadable. Never throws. */
+function readState(cwd) {
+  try {
+    const obj = JSON.parse(fs.readFileSync(consentPath(cwd), 'utf8'));
+    return obj && typeof obj === 'object' ? obj : null;
+  } catch {
+    return null;
+  }
+}
+
+/** True iff the user explicitly opted IN for this project. */
+function hasConsent(cwd) {
+  const s = readState(cwd);
+  return !!(s && s.consent === true);
+}
+
+/** True iff the user explicitly opted OUT for this project. */
+function isDeclined(cwd) {
+  const s = readState(cwd);
+  return !!(s && s.consent === false);
+}
+
+function queryFlagPath(sessionId, cwd) {
+  const key = crypto.createHash('md5').update(`${sessionId || 'nosid'}:${cwd}`).digest('hex').slice(0, 12);
+  return path.join(os.tmpdir(), `dotclaude-graphq-${key}.flag`);
+}
+
+/** Record that `graphify query` ran this session (relaxes the gate). */
+function markQueryDone(sessionId, cwd) {
+  try {
+    fs.writeFileSync(queryFlagPath(sessionId, cwd), String(Date.now()));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Has `graphify query` already run this session for this project? */
+function queryDone(sessionId, cwd) {
+  try {
+    return fs.existsSync(queryFlagPath(sessionId, cwd));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * True iff `cmd` actually RUNS `graphify query` (not merely mentions it).
+ * Matches only when a command segment STARTS with `graphify query`, so
+ * `echo "graphify query"`, `grep -r "graphify query"`, and commit messages like
+ * `git commit -m "add graphify query"` do NOT falsely relent the gate.
+ */
+function isGraphifyQueryCommand(cmd) {
+  if (typeof cmd !== 'string') return false;
+  return cmd
+    .split(/&&|\|\||[;\n|]/)
+    .some((seg) => /^\s*graphify\s+query\b/.test(seg));
+}
+
+module.exports = {
+  CONSENT_REL,
+  consentPath,
+  readState,
+  hasConsent,
+  isDeclined,
+  queryFlagPath,
+  markQueryDone,
+  queryDone,
+  isGraphifyQueryCommand,
+};

--- a/plugins/devops/hooks/lib/graphify-state.test.js
+++ b/plugins/devops/hooks/lib/graphify-state.test.js
@@ -1,0 +1,92 @@
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  readState,
+  hasConsent,
+  isDeclined,
+  markQueryDone,
+  queryDone,
+  consentPath,
+  isGraphifyQueryCommand,
+} from "./graphify-state.js";
+
+function tmp() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "gstate-"));
+}
+
+describe("consent record", () => {
+  let dir;
+  beforeEach(() => {
+    dir = tmp();
+    fs.mkdirSync(path.join(dir, ".claude"), { recursive: true });
+  });
+  afterEach(() => {
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+  });
+
+  test("no record → null, not consented, not declined", () => {
+    expect(readState(dir)).toBeNull();
+    expect(hasConsent(dir)).toBe(false);
+    expect(isDeclined(dir)).toBe(false);
+  });
+
+  test("consent:true → hasConsent, not declined", () => {
+    fs.writeFileSync(consentPath(dir), JSON.stringify({ consent: true, autoBuild: true }));
+    expect(hasConsent(dir)).toBe(true);
+    expect(isDeclined(dir)).toBe(false);
+  });
+
+  test("consent:false → declined, not consented", () => {
+    fs.writeFileSync(consentPath(dir), JSON.stringify({ consent: false }));
+    expect(hasConsent(dir)).toBe(false);
+    expect(isDeclined(dir)).toBe(true);
+  });
+
+  test("malformed json → null (fail safe, no throw)", () => {
+    fs.writeFileSync(consentPath(dir), "{ not json");
+    expect(readState(dir)).toBeNull();
+    expect(hasConsent(dir)).toBe(false);
+    expect(isDeclined(dir)).toBe(false);
+  });
+});
+
+describe("per-session query flag", () => {
+  test("markQueryDone makes queryDone true; isolated per session + project", () => {
+    const dir = tmp();
+    expect(queryDone("s1", dir)).toBe(false);
+    markQueryDone("s1", dir);
+    expect(queryDone("s1", dir)).toBe(true);
+    expect(queryDone("s2", dir)).toBe(false); // different session
+    expect(queryDone("s1", tmp())).toBe(false); // different project
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+  });
+});
+
+describe("isGraphifyQueryCommand — only real query runs relent the gate", () => {
+  test.each([
+    ['graphify query "x"', true],
+    ['  graphify query "what calls foo"', true],
+    ['cd sub && graphify query "x"', true],
+    ['graphify query "x" | head', true],
+    ['ANTHROPIC_LOG=1 graphify query "x"', false], // env prefix not handled — acceptable, errs safe
+  ])("run detection: %s", (cmd, expected) => {
+    expect(isGraphifyQueryCommand(cmd)).toBe(expected);
+  });
+
+  test.each([
+    ['echo "graphify query"', 'echo mention'],
+    ['grep -r "graphify query" .', 'grep mention'],
+    ['git commit -m "add graphify query support"', 'commit message'],
+    ['# graphify query is great', 'comment'],
+    ['cat graphify-query-notes.md', 'filename'],
+  ])("does NOT relent on mention: %s (%s)", (cmd) => {
+    expect(isGraphifyQueryCommand(cmd)).toBe(false);
+  });
+
+  test("non-string input is safe", () => {
+    expect(isGraphifyQueryCommand(undefined)).toBe(false);
+    expect(isGraphifyQueryCommand(null)).toBe(false);
+  });
+});

--- a/plugins/devops/hooks/post-tool-use/post.graphify.query.js
+++ b/plugins/devops/hooks/post-tool-use/post.graphify.query.js
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+/**
+ * @hook post.graphify.query
+ * @version 0.1.0
+ * @event PostToolUse
+ * @plugin devops
+ * @matcher Bash
+ * @description When Claude runs `graphify query ...`, record a per-session flag
+ *   so the PreToolUse graphify-gate relents for the rest of the session — Claude
+ *   has consulted the graph, so it should not be re-blocked on every broad
+ *   search. Purely a state write; never blocks.
+ */
+
+require('../lib/plugin-guard');
+
+const gstate = require('../lib/graphify-state');
+
+let inputData = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', d => { inputData += d; });
+process.stdin.on('end', () => {
+  let hook;
+  try { hook = JSON.parse(inputData); } catch { process.exit(0); }
+  if ((hook.tool_name || '') !== 'Bash') process.exit(0);
+  const cmd = (hook.tool_input && hook.tool_input.command) || '';
+  if (gstate.isGraphifyQueryCommand(cmd)) {
+    gstate.markQueryDone(hook.session_id || hook.sessionId || 'nosid', process.cwd());
+  }
+  process.exit(0);
+});

--- a/plugins/devops/hooks/pre-tool-use/pre.tokens.guard.graphgate.test.js
+++ b/plugins/devops/hooks/pre-tool-use/pre.tokens.guard.graphgate.test.js
@@ -1,0 +1,106 @@
+import { describe, test, expect } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { markQueryDone } from "../lib/graphify-state.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const HOOK = path.join(__dirname, "pre.tokens.guard.js");
+
+const OLD = new Date(Date.now() - 60_000);
+const NOW = new Date();
+
+// Build a temp project. graph:"fresh"|"stale"|"none", consent:true|false|null.
+function project({ consent, graph }) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "graphgate-"));
+  fs.mkdirSync(path.join(dir, ".claude"), { recursive: true });
+  // Enable the plugin so plugin-guard does not short-circuit.
+  fs.writeFileSync(
+    path.join(dir, ".claude", "settings.json"),
+    JSON.stringify({ enabledPlugins: { "devops@dotclaude": true } })
+  );
+  if (consent !== null) {
+    fs.writeFileSync(
+      path.join(dir, ".claude", "graphify.json"),
+      JSON.stringify({ consent })
+    );
+  }
+  const src = path.join(dir, "a.js");
+  fs.writeFileSync(src, "const x = 1;");
+  if (graph !== "none") {
+    const gp = path.join(dir, "graphify-out", "graph.json");
+    fs.mkdirSync(path.dirname(gp), { recursive: true });
+    fs.writeFileSync(gp, "{}");
+    if (graph === "fresh") {
+      fs.utimesSync(src, OLD, OLD);
+      fs.utimesSync(gp, NOW, NOW);
+    } else { // stale: source newer than graph
+      fs.utimesSync(gp, OLD, OLD);
+      fs.utimesSync(src, NOW, NOW);
+    }
+  }
+  return dir;
+}
+
+function runGrep(dir, sid, pattern) {
+  const res = spawnSync(process.execPath, [HOOK], {
+    cwd: dir,
+    input: JSON.stringify({ tool_name: "Grep", tool_input: { pattern }, session_id: sid }),
+    encoding: "utf8",
+  });
+  return { status: res.status, stderr: res.stderr || "" };
+}
+
+function cleanup(dir) {
+  try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+}
+
+describe("pre.tokens.guard — graphify hard-gate (integration)", () => {
+  test("consent + fresh graph → first broad search is BLOCKED by the graph gate", () => {
+    const dir = project({ consent: true, graph: "fresh" });
+    const r = runGrep(dir, "s-block", "alpha");
+    expect(r.status).toBe(2);
+    expect(r.stderr).toContain("GRAPHIFY GATE");
+    cleanup(dir);
+  });
+
+  test("retry of the same search relents (escape hatch) — no longer the graph gate", () => {
+    const dir = project({ consent: true, graph: "fresh" });
+    const first = runGrep(dir, "s-retry", "beta");
+    expect(first.stderr).toContain("GRAPHIFY GATE");
+    const second = runGrep(dir, "s-retry", "beta");
+    expect(second.stderr).not.toContain("GRAPHIFY GATE"); // fell through to the token guard
+    cleanup(dir);
+  });
+
+  test("no consent → graph gate never fires", () => {
+    const dir = project({ consent: null, graph: "fresh" });
+    const r = runGrep(dir, "s-noconsent", "gamma");
+    expect(r.stderr).not.toContain("GRAPHIFY GATE");
+    cleanup(dir);
+  });
+
+  test("declined (consent:false) → graph gate never fires", () => {
+    const dir = project({ consent: false, graph: "fresh" });
+    const r = runGrep(dir, "s-declined", "delta");
+    expect(r.stderr).not.toContain("GRAPHIFY GATE");
+    cleanup(dir);
+  });
+
+  test("stale graph → NOT blocked (never force onto out-of-date data)", () => {
+    const dir = project({ consent: true, graph: "stale" });
+    const r = runGrep(dir, "s-stale", "epsilon");
+    expect(r.stderr).not.toContain("GRAPHIFY GATE");
+    cleanup(dir);
+  });
+
+  test("after graphify query ran this session → gate relents", () => {
+    const dir = project({ consent: true, graph: "fresh" });
+    markQueryDone("s-queried", dir);
+    const r = runGrep(dir, "s-queried", "zeta");
+    expect(r.stderr).not.toContain("GRAPHIFY GATE");
+    cleanup(dir);
+  });
+});

--- a/plugins/devops/hooks/pre-tool-use/pre.tokens.guard.js
+++ b/plugins/devops/hooks/pre-tool-use/pre.tokens.guard.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * @hook pre.tokens.guard
- * @version 0.3.0
+ * @version 0.4.0
  * @event PreToolUse
  * @plugin devops
  * @description Block Read/Bash/Glob/Grep operations that would consume a
@@ -9,11 +9,15 @@
  *   with the user's Claude plan (pro/max_5/max_20). Uses a flag-file
  *   mechanism: first call blocks with warning, retry allows through.
  *
- *   Project-map injection: on the FIRST broad Grep/Glob (no `path`) of a
- *   session, attaches `.claude/project-map.md` as additionalContext and
- *   ALLOWS the search, so Claude can scope subsequent calls with a `path`
- *   instead of only being nagged after a block. Injected at most once per
- *   session (temp flag); later broad searches still hit the normal block.
+ *   Session-start injection: on the FIRST broad Grep/Glob (no `path`) of a
+ *   session, attaches orientation as additionalContext and ALLOWS the search,
+ *   so Claude can scope subsequent calls with a `path` instead of only being
+ *   nagged after a block. Injected at most once per session (temp flag); later
+ *   broad searches still hit the normal block. The injection combines:
+ *     - `.claude/project-map.md` (file-structure re-scoping hint), and
+ *     - an ambient graphify nudge when `graphify-out/graph.json` exists
+ *       (steer toward `graphify query` over grepping — see hooks/lib/graph-nudge).
+ *   Fires if EITHER source is present.
  */
 
 require('../lib/plugin-guard');
@@ -195,24 +199,34 @@ process.stdin.on('end', () => {
     const sid = hook.session_id || hook.sessionId || 'nosid';
     const mapKey = crypto.createHash('md5').update(`${sid}:${cwd}`).digest('hex').slice(0, 12);
     const mapFlag = path.join(os.tmpdir(), `devops_mapinject_${mapKey}.flag`);
-    if (fs.existsSync(projectMap) && !fs.existsSync(mapFlag)) {
+    const graphNudge = require('../lib/graph-nudge');
+    const hasMap = fs.existsSync(projectMap);
+    const hasGraph = graphNudge.hasGraph(cwd);
+    // Fire once per session if EITHER the project-map or a graphify graph exists.
+    if ((hasMap || hasGraph) && !fs.existsSync(mapFlag)) {
       try {
-        const mapBody = fs.readFileSync(projectMap, 'utf8').trim();
+        const sections = [];
+        if (hasMap) {
+          const mapBody = fs.readFileSync(projectMap, 'utf8').trim();
+          sections.push([
+            `[project-map] Before this broad ${toolName} (no \`path\` set), here is the project's file structure.`,
+            'Use it to re-scope: pick the directory that contains your target and pass it as the `path`',
+            'parameter on this and future Grep/Glob calls instead of scanning the whole repo.',
+            '',
+            mapBody,
+          ].join('\n'));
+        }
+        if (hasGraph) {
+          sections.push(graphNudge.buildGraphNudge());
+        }
         fs.writeFileSync(mapFlag, Date.now().toString());
-        const ctx = [
-          `[project-map] Before this broad ${toolName} (no \`path\` set), here is the project's file structure.`,
-          'Use it to re-scope: pick the directory that contains your target and pass it as the `path`',
-          'parameter on this and future Grep/Glob calls instead of scanning the whole repo.',
-          '',
-          mapBody,
-        ].join('\n');
         process.stdout.write(JSON.stringify({
           hookSpecificOutput: {
             hookEventName: 'PreToolUse',
-            additionalContext: ctx,
+            additionalContext: sections.join('\n\n'),
           },
         }));
-        process.exit(0); // allow the search; map is now in context for the next one
+        process.exit(0); // allow the search; map/graph hint now in context for the next one
       } catch {}
     }
   }

--- a/plugins/devops/hooks/pre-tool-use/pre.tokens.guard.js
+++ b/plugins/devops/hooks/pre-tool-use/pre.tokens.guard.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * @hook pre.tokens.guard
- * @version 0.4.0
+ * @version 0.5.0
  * @event PreToolUse
  * @plugin devops
  * @description Block Read/Bash/Glob/Grep operations that would consume a
@@ -185,6 +185,42 @@ process.stdin.on('end', () => {
 
   else {
     process.exit(0);
+  }
+
+  // ── graphify hard-gate (consented + FRESH graph) ────────────────────
+  // When the user has opted graphify in for this project AND a fresh graph
+  // exists, force a broad raw-file search through the graph first. Two hard
+  // preconditions keep this from being harmful:
+  //   1. Staleness — never block onto an out-of-date graph (graphIsStale).
+  //   2. Escape hatch — block at most once per (session, search); a retry of
+  //      the same search falls through, so a question the graph cannot answer
+  //      (exact string, new/uncommitted file, non-code asset) is never wedged.
+  // Relents entirely once `graphify query` has run this session (queryDone).
+  // Fail-open: any error here must never block a search.
+  if ((toolName === 'Grep' || toolName === 'Glob') && !toolInput.path) {
+    try {
+      const graphNudge = require('../lib/graph-nudge');
+      const gstate = require('../lib/graphify-state');
+      const sid = hook.session_id || hook.sessionId || 'nosid';
+      if (gstate.hasConsent(cwd) && !gstate.queryDone(sid, cwd)
+          && graphNudge.hasGraph(cwd) && !graphNudge.graphIsStale(cwd)) {
+        const gflag = flagPath(`graphgate:${sid}:${cwd}:${toolName}:${JSON.stringify(toolInput)}`);
+        if (!fs.existsSync(gflag)) {
+          try { fs.writeFileSync(gflag, Date.now().toString()); } catch {}
+          console.error('\n⛔  GRAPHIFY GATE — broad search blocked (fresh graph available)');
+          console.error('─'.repeat(54));
+          console.error('Query the knowledge graph instead of grepping raw files:');
+          console.error('  graphify query "<your question>"');
+          console.error('');
+          console.error('If the graph cannot answer THIS search (exact string, a');
+          console.error('new/uncommitted file, or a non-code asset), retry the same');
+          console.error('search to proceed.');
+          console.error('─'.repeat(54));
+          process.exit(2);
+        }
+        // flag present → already gated this search; fall through (escape hatch)
+      }
+    } catch { /* fail open — never block on gate errors */ }
   }
 
   // ── Proactive project-map injection (once per session) ──────────────

--- a/plugins/devops/hooks/session-start/ss.graphify.js
+++ b/plugins/devops/hooks/session-start/ss.graphify.js
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+/**
+ * @hook ss.graphify
+ * @version 0.1.0
+ * @event SessionStart
+ * @plugin devops
+ * @description graphify enforcement — install-check + auto-build wiring for the
+ *   devops-graph feature. Behavior depends on the per-project consent record at
+ *   .claude/graphify.json (written ONLY after the user opts in/out via the
+ *   offer below — never silently):
+ *     - consent:true  → ensure graphify is installed; (once/day) install its git
+ *       hooks; if the graph is missing/stale, kick off a background
+ *       `graphify extract . --update` (AST-only, free). Keeps the graph fresh so
+ *       the PreToolUse graphify-gate enforces against current data.
+ *     - consent:false → stay silent (user declined).
+ *     - no record     → (throttled, weekly) emit a one-time instruction for
+ *       Claude to OFFER enabling graphify via AskUserQuestion.
+ *   Fail-open and non-blocking: every graphify invocation is detached/guarded so
+ *   a missing Python toolchain never degrades session start.
+ */
+
+require('../lib/plugin-guard');
+
+const crypto = require('crypto');
+const { spawn, execSync } = require('child_process');
+const { runOnce } = require('../lib/run-once');
+const gstate = require('../lib/graphify-state');
+const graphNudge = require('../lib/graph-nudge');
+
+const cwd = process.cwd();
+const cwdKey = crypto.createHash('md5').update(cwd).digest('hex').slice(0, 12);
+
+function graphifyInstalled() {
+  try {
+    const { checkTool } = require('../../scripts/check-tool.js');
+    return checkTool('graphify').installed;
+  } catch {
+    return false;
+  }
+}
+
+function isGitRepo() {
+  try {
+    return execSync('git rev-parse --is-inside-work-tree', {
+      cwd, encoding: 'utf8', timeout: 4000, stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim() === 'true';
+  } catch {
+    return false;
+  }
+}
+
+function bg(cmd, args) {
+  // Detached + unref so a 5-10s graphify build never blocks session start.
+  // `shell` on Windows so a `graphify.cmd`/`.bat` shim (what `uv tool install`
+  // produces) actually runs — a bare spawn cannot exec a .cmd and would
+  // silently no-op, leaving the graph un-refreshed. Guarded: a missing
+  // toolchain throws → no-op.
+  try {
+    spawn(cmd, args, {
+      cwd, detached: true, stdio: 'ignore', shell: process.platform === 'win32',
+    }).unref();
+  } catch { /* toolchain absent */ }
+}
+
+const state = gstate.readState(cwd);
+
+if (state && state.consent === true) {
+  // Opted in. Keep the graph fresh so the gate enforces against current code.
+  if (!graphifyInstalled()) {
+    if (runOnce('ss-graphify-reinstall', cwdKey, { cooldownMs: 24 * 60 * 60 * 1000 })) {
+      process.stdout.write(
+        '[graphify] Enabled for this project but the `graphify` CLI is not on PATH. ' +
+        'Offer the user to reinstall (`uv tool install graphifyy && graphify install`), ' +
+        'or to disable graphify here (set .claude/graphify.json {"consent":false}).\n'
+      );
+    }
+    process.exit(0);
+  }
+  if (isGitRepo() && runOnce('ss-graphify-hookinstall', cwdKey, { cooldownMs: 24 * 60 * 60 * 1000 })) {
+    bg('graphify', ['hook', 'install']); // idempotent git post-commit/checkout AST rebuild
+  }
+  // Throttle the rebuild so repeated SessionStart re-entries (multiple agents /
+  // worktrees on the same cwd) cannot stack concurrent `graphify extract`.
+  if ((!graphNudge.hasGraph(cwd) || graphNudge.graphIsStale(cwd))
+      && runOnce('ss-graphify-extract', cwdKey, { cooldownMs: 10 * 60 * 1000 })) {
+    bg('graphify', ['extract', '.', '--update']); // background, AST-only, free
+  }
+  process.exit(0);
+}
+
+if (state && state.consent === false) {
+  process.exit(0); // declined — never nag
+}
+
+// No decision yet → offer ONCE (re-offer at most weekly if ignored).
+// Only in real git projects — never nag in scratch/throwaway folders.
+if (isGitRepo() && runOnce('ss-graphify-offer', cwdKey, { cooldownMs: 7 * 24 * 60 * 60 * 1000 })) {
+  process.stdout.write(
+    '[graphify] No knowledge-graph config for this project. Offer the user (AskUserQuestion) to enable graphify — ' +
+    'it builds a queryable code graph so broad searches use the graph instead of grepping (token saver), kept fresh via git hooks. ' +
+    'On YES: run `uv tool install graphifyy && graphify install && graphify hook install && graphify extract .`, then write .claude/graphify.json {"consent":true,"autoBuild":true}. ' +
+    'On NO: write .claude/graphify.json {"consent":false}. Always confirm before installing — never silently.\n'
+  );
+}
+process.exit(0);

--- a/plugins/devops/scripts/check-tool.js
+++ b/plugins/devops/scripts/check-tool.js
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+/**
+ * @script check-tool
+ * @version 0.1.0
+ * @plugin devops
+ * @description Generic cross-platform CLI availability probe. Resolves whether
+ *   a command is on PATH (manual PATH scan — no shell) and optionally captures
+ *   its version. Prints one JSON line to stdout when run directly:
+ *     {"installed":true,"path":"C:\\...\\node.exe","version":"v22.3.0"}
+ *     {"installed":false}
+ *   Exported for reuse (e.g. the devops-graph skill detecting `graphify`).
+ *   Detection is a pure PATH scan so it is unit-testable without the target
+ *   tool installed. Exit code is always 0 — callers rely on the JSON.
+ *
+ *   CLI: node check-tool.js <command> [versionArg...]
+ *     node check-tool.js graphify --version
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+const IS_WIN = process.platform === 'win32';
+
+/**
+ * Resolve a command to an absolute executable path via a manual PATH scan.
+ * No shell is spawned, so this is safe and deterministic.
+ * @param {string} command bare binary name, e.g. "graphify"
+ * @returns {string|null} absolute path, or null if not found
+ */
+function which(command) {
+  if (!command || typeof command !== 'string') return null;
+  const dirs = (process.env.PATH || '').split(IS_WIN ? ';' : ':').filter(Boolean);
+  const exts = IS_WIN
+    ? (process.env.PATHEXT || '.EXE;.CMD;.BAT;.COM').split(';').filter(Boolean)
+    : [''];
+  const accessMode = IS_WIN ? fs.constants.F_OK : fs.constants.X_OK;
+
+  for (const dir of dirs) {
+    for (const ext of exts) {
+      const candidate = path.join(dir, command + ext);
+      try {
+        fs.accessSync(candidate, accessMode);
+        const st = fs.statSync(candidate);
+        if (st.isFile()) return candidate;
+      } catch { /* not here — keep scanning */ }
+    }
+  }
+  return null;
+}
+
+/**
+ * Capture the first line of a tool's version output. Never throws.
+ * @param {string} exe absolute path to the executable
+ * @param {string[]} versionArgs e.g. ["--version"]
+ * @returns {string|undefined}
+ */
+function probeVersion(exe, versionArgs) {
+  try {
+    const out = execFileSync(exe, versionArgs, {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 5000,
+    });
+    const first = String(out).split('\n')[0].trim();
+    return first || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Probe whether a CLI tool is available, optionally capturing its version.
+ * @param {string} command bare binary name
+ * @param {{versionArgs?: string[]}} [opts]
+ * @returns {{installed: boolean, path?: string, version?: string}}
+ */
+function checkTool(command, opts = {}) {
+  const resolved = which(command);
+  if (!resolved) return { installed: false };
+
+  const result = { installed: true, path: resolved };
+  if (Array.isArray(opts.versionArgs) && opts.versionArgs.length) {
+    const version = probeVersion(resolved, opts.versionArgs);
+    if (version) result.version = version;
+  }
+  return result;
+}
+
+if (require.main === module) {
+  const [, , command, ...versionArgs] = process.argv;
+  if (!command) {
+    process.stderr.write('usage: check-tool <command> [versionArg...]\n');
+    process.exit(2);
+  }
+  const result = checkTool(command, versionArgs.length ? { versionArgs } : {});
+  process.stdout.write(JSON.stringify(result) + '\n');
+  process.exit(0);
+}
+
+module.exports = { checkTool, which, probeVersion };

--- a/plugins/devops/scripts/check-tool.test.js
+++ b/plugins/devops/scripts/check-tool.test.js
@@ -1,0 +1,62 @@
+import { describe, test, expect } from "vitest";
+import { checkTool, which } from "./check-tool.js";
+
+// `node` is guaranteed on PATH (the test runner is node itself); a long random
+// name is guaranteed absent. That makes detection deterministic without the
+// real target tool (graphify) installed.
+const ABSENT = "definitely-not-a-real-binary-xyz-9000";
+
+describe("which — PATH resolution", () => {
+  test("resolves a known binary (node) to an absolute path", () => {
+    const p = which("node");
+    expect(p).toBeTruthy();
+    expect(path_isAbsolute(p)).toBe(true);
+  });
+
+  test("returns null for a binary that does not exist", () => {
+    expect(which(ABSENT)).toBeNull();
+  });
+
+  test.each([
+    ["empty string", ""],
+    ["null", null],
+    ["undefined", undefined],
+    ["non-string", 42],
+  ])("returns null for invalid input (%s)", (_label, input) => {
+    expect(which(input)).toBeNull();
+  });
+});
+
+describe("checkTool — availability probe", () => {
+  test("reports installed:true with a path for node", () => {
+    const r = checkTool("node");
+    expect(r.installed).toBe(true);
+    expect(r.path).toBeTruthy();
+  });
+
+  test("reports installed:false and no path for a missing tool", () => {
+    expect(checkTool(ABSENT)).toEqual({ installed: false });
+  });
+
+  test("captures version when versionArgs probe succeeds", () => {
+    const r = checkTool("node", { versionArgs: ["--version"] });
+    expect(r.installed).toBe(true);
+    expect(r.version).toMatch(/^v?\d+\./);
+  });
+
+  test("missing tool with versionArgs still returns installed:false", () => {
+    const r = checkTool(ABSENT, { versionArgs: ["--version"] });
+    expect(r.installed).toBe(false);
+    expect(r.version).toBeUndefined();
+  });
+
+  test("no version key when versionArgs omitted", () => {
+    const r = checkTool("node");
+    expect(r).not.toHaveProperty("version");
+  });
+});
+
+// Tiny local helper so the test has no import beyond the unit under test.
+function path_isAbsolute(p) {
+  return /^([a-zA-Z]:[\\/]|[\\/])/.test(p);
+}

--- a/plugins/devops/skills/devops-graph/SKILL.md
+++ b/plugins/devops/skills/devops-graph/SKILL.md
@@ -1,33 +1,37 @@
 ---
 name: devops-graph
-version: 0.2.0
+version: 0.3.0
 description: >-
-  On-demand codebase knowledge graph via the external graphify CLI. Detects
-  graphify, offers to install it (with confirmation — never silent), builds or
-  refreshes the graph, then answers codebase questions with `graphify query`.
-  Best for large codebases where querying a graph beats grepping/reading files.
-  Deliberately does NOT install graphify's own PreToolUse hook (would collide
-  with the devops project-map and token-guard hooks). Triggers: "knowledge
-  graph", "graphify", "code graph", "/devops-graph". Do NOT trigger for simple
-  single-file lookups — plain grep/Read is cheaper there.
-allowed-tools: Bash(node *), Bash(graphify *), Bash(uv *), Bash(pipx *), Read, Glob
+  Codebase knowledge graph via the external graphify CLI, with opt-in
+  enforcement. Detects graphify, offers to install it (confirmation — never
+  silent), builds/refreshes the graph, and answers codebase questions with
+  `graphify query`. Once the user opts in per project, the graph is kept fresh
+  automatically (git hooks + SessionStart) and broad raw-file searches are
+  hard-gated toward the graph. Deliberately does NOT install graphify's own
+  PreToolUse hook (would collide with the devops token-guard); the enforcement
+  is devops-owned. Triggers: "knowledge graph", "graphify", "code graph",
+  "/devops-graph". Do NOT trigger for simple single-file lookups.
+allowed-tools: Bash(node *), Bash(graphify *), Bash(uv *), Bash(pipx *), Read, Glob, Write
 ---
 
-# devops-graph — On-Demand Codebase Knowledge Graph
+# devops-graph — Codebase Knowledge Graph (opt-in enforced)
 
 Thin orchestration over the real [`graphify`](https://github.com/safishamsi/graphify)
 CLI. graphify stays the single source of truth — this skill reimplements
-nothing. It only **detects**, **offers to install**, **freshens the graph**, and
-**queries** it. Everything is on-demand; nothing runs in the background.
+nothing. It **detects**, **offers to install**, **freshens the graph**, and
+**queries** it. After a per-project opt-in (recorded in `.claude/graphify.json`)
+the graph is kept fresh automatically and broad searches are hard-gated toward
+it — see [Enforcement](#enforcement-after-opt-in).
 
 ## Hard rules
 
 - **Never install silently.** If graphify is missing, *offer* and wait for an
-  explicit OK before running any install command.
+  explicit OK before running any install command. The consent record
+  (`.claude/graphify.json`) is written only after the user decides.
 - **Never run `graphify claude install`.** That command writes graphify's own
   PreToolUse hook + CLAUDE.md skill, which collides with the devops plugin's
   PreToolUse hooks (the project-map re-scoping hint and `pre.tokens.guard.js`).
-  This skill invokes graphify on-demand instead.
+  Our enforcement is devops-owned instead (single, ordered hook chain).
 - **Do not touch `project-map`.** It is a different layer (cheap always-on
   orientation, not on-demand deep retrieval).
 
@@ -84,27 +88,46 @@ graphify query "<the user's question>"
 Relay the result. For follow-up questions in the same session, reuse the
 existing graph — only re-run Step 3 if the code changed meaningfully.
 
-## Ambient nudge (automatic, once per session)
+## Enforcement (after opt-in)
 
-Once a graph exists, you do not have to remember this skill. The devops
-`pre.tokens.guard` PreToolUse hook injects a one-line hint on the **first broad
-search of a session** (alongside the project-map) that steers Claude toward
-`graphify query` for semantic questions instead of grepping raw files. This is
-the token-saving payoff — the graph gets *used*, not just built. The hint is:
+The user can opt a project in (the `ss.graphify` SessionStart hook offers this
+once). Opt-in is recorded in `.claude/graphify.json`:
 
-- **Silent until a graph exists** — no graph.json, no nudge (no nagging about an
-  unbuilt tool).
-- **Once per session** — Claude is told the graph exists a single time, then
-  decides per question; it does not spam every search.
-- **devops-owned** — it lives in our hook chain, so it never collides with other
-  PreToolUse hooks. We still never run `graphify claude install`.
+- `{"consent":true,"autoBuild":true}` → **enabled**
+- `{"consent":false}` → **declined** (never nagged again)
+- absent → **undecided** (offer shown, throttled weekly)
 
-Logic lives in `hooks/lib/graph-nudge.js` (unit-tested).
+When **enabled**, two things become automatic — no need to invoke this skill:
+
+**1. Auto-build / freshness (D2).** `ss.graphify` ensures graphify is installed,
+installs graphify's git hooks once (`graphify hook install` — post-commit/
+post-checkout AST rebuild, free), and kicks off a background
+`graphify extract . --update` whenever the graph is missing or stale. So the
+graph follows the code via both git hooks *and* SessionStart.
+
+**2. Hard gate (D3).** `pre.tokens.guard` **blocks** a broad raw-file Grep/Glob
+(exit 2) and tells Claude to run `graphify query` instead. Two preconditions
+keep this safe — both enforced in code, never optional:
+
+- **Staleness guard** — the gate only fires when the graph is *fresh*
+  (`graphIsStale` compares graph.json mtime vs the newest source file). A stale
+  graph is never forced onto Claude.
+- **Escape hatch** — the gate blocks a given search at most once per session;
+  *retrying the same search falls through*, so a question the graph cannot
+  answer (exact string, a new/uncommitted file, a non-code asset) is never
+  wedged. Once any `graphify query` runs (tracked by `post.graphify.query`), the
+  gate relents for the rest of the session.
+
+This is stronger than graphify's own registration — graphify's `claude install`
+hook only emits `permissionDecision:"allow"` (a soft nudge), never a block. The
+trade-off: a real gate adds friction the bare nudge does not. Logic lives in
+`hooks/lib/graph-nudge.js` + `hooks/lib/graphify-state.js` (unit + integration
+tested).
 
 ## Out of scope (v1)
 
 - No graphify MCP server (`python -m graphify.serve`) — shell-out per query.
-- No post-commit auto-rebuild hook — graph refresh is on-demand (Step 3) only.
-  A background auto-rebuild could be added later as an explicit opt-in.
-- The nudge piggybacks on the first *broad* search; a session that never runs
-  one won't see it (acceptable for v1 — most sessions do).
+- Auto-build is **code-only** (`--update`, AST). Doc/PDF/image semantic
+  extraction (which costs API tokens) is never enabled automatically.
+- The gate only covers *broad* searches (Grep/Glob with no `path`); targeted,
+  path-scoped reads are intentionally left free.

--- a/plugins/devops/skills/devops-graph/SKILL.md
+++ b/plugins/devops/skills/devops-graph/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: devops-graph
+version: 0.1.0
+description: >-
+  On-demand codebase knowledge graph via the external graphify CLI. Detects
+  graphify, offers to install it (with confirmation — never silent), builds or
+  refreshes the graph, then answers codebase questions with `graphify query`.
+  Best for large codebases where querying a graph beats grepping/reading files.
+  Deliberately does NOT install graphify's own PreToolUse hook (would collide
+  with the devops project-map and token-guard hooks). Triggers: "knowledge
+  graph", "graphify", "code graph", "/devops-graph". Do NOT trigger for simple
+  single-file lookups — plain grep/Read is cheaper there.
+allowed-tools: Bash(node *), Bash(graphify *), Bash(uv *), Bash(pipx *), Read, Glob
+---
+
+# devops-graph — On-Demand Codebase Knowledge Graph
+
+Thin orchestration over the real [`graphify`](https://github.com/safishamsi/graphify)
+CLI. graphify stays the single source of truth — this skill reimplements
+nothing. It only **detects**, **offers to install**, **freshens the graph**, and
+**queries** it. Everything is on-demand; nothing runs in the background.
+
+## Hard rules
+
+- **Never install silently.** If graphify is missing, *offer* and wait for an
+  explicit OK before running any install command.
+- **Never run `graphify claude install`.** That command writes graphify's own
+  PreToolUse hook + CLAUDE.md skill, which collides with the devops plugin's
+  PreToolUse hooks (the project-map re-scoping hint and `pre.tokens.guard.js`).
+  This skill invokes graphify on-demand instead.
+- **Do not touch `project-map`.** It is a different layer (cheap always-on
+  orientation, not on-demand deep retrieval).
+
+## Step 1 — Detect graphify
+
+Probe with the generic helper (resolves the plugin root via the cache path or
+this source repo):
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/check-tool.js" graphify --version
+```
+
+Parse the single JSON line:
+- `{"installed":true,...}` → go to Step 3.
+- `{"installed":false}` → go to Step 2.
+
+## Step 2 — Offer install (confirmation required)
+
+Tell the user graphify is not installed and offer the command. **Do not run it
+until the user confirms.** Recommended:
+
+```bash
+uv tool install graphifyy && graphify install
+```
+
+Fallbacks if `uv` is absent: `pipx install graphifyy` or `pip install graphifyy`
+(pip needs manual PATH setup). On decline, stop here and report that the graph
+features are unavailable until graphify is installed.
+
+After a confirmed install, re-run Step 1 to verify before continuing.
+
+## Step 3 — Ensure the graph is fresh
+
+Check for `graphify-out/graph.json` in the project root (use **Glob**). If it is
+missing or the user expects recent code changes to be reflected, refresh it:
+
+```bash
+graphify extract . --update
+```
+
+`--update` is incremental and AST-only for code, so it costs no API tokens.
+A first-time full build on a large repo may take longer; say so before running.
+Only docs/PDF/image extraction would incur LLM cost — do not enable that unless
+the user asks.
+
+## Step 4 — Query
+
+Answer the user's codebase question against the graph instead of grepping:
+
+```bash
+graphify query "<the user's question>"
+```
+
+Relay the result. For follow-up questions in the same session, reuse the
+existing graph — only re-run Step 3 if the code changed meaningfully.
+
+## Out of scope (v1)
+
+- No graphify MCP server (`python -m graphify.serve`) — shell-out per query.
+- No post-commit auto-rebuild hook — graph refresh is on-demand (Step 3) only.
+  A background auto-rebuild could be added later as an explicit opt-in.

--- a/plugins/devops/skills/devops-graph/SKILL.md
+++ b/plugins/devops/skills/devops-graph/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: devops-graph
-version: 0.1.0
+version: 0.2.0
 description: >-
   On-demand codebase knowledge graph via the external graphify CLI. Detects
   graphify, offers to install it (with confirmation — never silent), builds or
@@ -84,8 +84,27 @@ graphify query "<the user's question>"
 Relay the result. For follow-up questions in the same session, reuse the
 existing graph — only re-run Step 3 if the code changed meaningfully.
 
+## Ambient nudge (automatic, once per session)
+
+Once a graph exists, you do not have to remember this skill. The devops
+`pre.tokens.guard` PreToolUse hook injects a one-line hint on the **first broad
+search of a session** (alongside the project-map) that steers Claude toward
+`graphify query` for semantic questions instead of grepping raw files. This is
+the token-saving payoff — the graph gets *used*, not just built. The hint is:
+
+- **Silent until a graph exists** — no graph.json, no nudge (no nagging about an
+  unbuilt tool).
+- **Once per session** — Claude is told the graph exists a single time, then
+  decides per question; it does not spam every search.
+- **devops-owned** — it lives in our hook chain, so it never collides with other
+  PreToolUse hooks. We still never run `graphify claude install`.
+
+Logic lives in `hooks/lib/graph-nudge.js` (unit-tested).
+
 ## Out of scope (v1)
 
 - No graphify MCP server (`python -m graphify.serve`) — shell-out per query.
 - No post-commit auto-rebuild hook — graph refresh is on-demand (Step 3) only.
   A background auto-rebuild could be added later as an explicit opt-in.
+- The nudge piggybacks on the first *broad* search; a session that never runs
+  one won't see it (acceptable for v1 — most sessions do).

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.104.2",
+  "version": "0.105.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary
Adds the `/devops-graph` skill integrating the external graphify knowledge-graph CLI, with **opt-in per-project enforcement**: after a one-time consent the graph is kept fresh automatically and broad raw-file searches are hard-gated toward `graphify query`.

## What
- New skill `devops-graph` + generic, reusable `scripts/check-tool.js` cross-platform PATH probe.
- **Auto-build** via the new `ss.graphify` SessionStart hook (`graphify hook install` git AST rebuild + background rebuild when stale) — consent-gated, never silent.
- **Hard gate** in `pre.tokens.guard` (0.3.0→0.5.0): blocks a broad Grep/Glob (exit 2) toward the graph, but only when consented **and** the graph is fresh **and** no query ran yet this session. Two safety preconditions enforced in code: fail-safe staleness guard (`graph-nudge.graphIsStale`) + retry escape hatch (`post.graphify.query` relents once a real query runs).
- Verified (multi-agent) that graphify's own `claude install` only *nudges* (`permissionDecision:"allow"` + `|| true`); this gate is intentionally **stronger**.
- Adversarially red-teamed; the false-fresh bug class (maxFiles truncation, empty/unreadable repos, symlinked sources, Windows `.cmd` shims) was closed.

## Tests
549 pass — unit + a spawn-based integration test of the gate (block / retry-relent / no-consent / declined / stale / queried).

Release: v0.105.0