### PR TITLE
feat(rethink): strategic-reset skill with code-blind lens fan-out

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.105.0"
+    "version": "0.106.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.105.0",
+      "version": "0.106.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.105.0",
+      "version": "0.106.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.106.0] — 2026-07-02
+
+### Added
+
+- **New `/devops-rethink` skill — a strategic reset for stuck development, closing the gap above `/devops-flow` (tactical debugging) and `/devops-harden`/`/devops-polish` (incremental passes).** When iterations circle without reaching the goal, or a named section of the app is functionally/visually not where it should be, the skill first re-derives the original goals itself (repo evidence: git log, issues, concept pages, docs — plus a live look at the running app per `test-autonomy.md`/`preview-testing.md`), presents a hypothesis dossier, and validates it in a short question round that also **jointly calibrates a demolition corridor** (how much may be torn down: nothing / section / everything). Fresh ideation is **structurally un-anchored**: three parallel instances of the new code-blind `devops:rethinker` agent (tools: WebSearch/WebFetch only — no Read/Grep/Glob, so the current implementation cannot leak in) each receive ONLY a code-free Rethink Brief plus one lens — product-value, ux-design, enduser-feel (architecture swap for backend-only targets); prompt blocks live in the skill's `deep-knowledge/lenses.md` with a fixed `RETHINK_APPROACH` output contract. A reconciliation step then re-introduces reality: migration path, effort, risks, and blast-radius labels relative to the corridor (over-corridor ideas stay visible as flagged outliers but are never implemented without explicit corridor widening). The decision happens on a `devops-concept` decision page — **Iterate** loops back, only an explicit **Implement** starts work — and the handoff goes to `devops-autonomous` with a `devops-test-plan` test mandate. Artifacts persist under `.claude/rethink/<date>-<slug>/` for later resume. Design spec: `docs/superpowers/specs/2026-07-02-devops-rethink-design.md` (PR #230). (552 tests pass.)
+
 ## [0.105.0] — 2026-06-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.105.0**
+**Version: 0.106.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/README.md
+++ b/README.md
@@ -168,8 +168,8 @@ For the full extension guide with examples per skill, see `deep-knowledge/skill-
 ## Features
 
 - **<!--devops:count:hooks-->34<!--/devops:count:hooks--> Hooks** — automated guards and triggers across the full session lifecycle
-- **<!--devops:count:skills-->20<!--/devops:count:skills--> Skills** — devops-ship, devops-commit, devops-flow, devops-new-issue, devops-project-setup, devops-readme, devops-refresh-usage, devops-extend-skill, devops-repo-health, devops-claude-md-lint, devops-concept, devops-agents, devops-plugin-update, devops-autonomous, devops-burn, devops-learn, devops-harden, devops-polish, devops-test-plan
-- **<!--devops:count:agents-->11<!--/devops:count:agents--> Agents** — AI, Core, Designer, Feature, Frontend, Gamer, PO, QA, Redteam, Research, Windows
+- **<!--devops:count:skills-->21<!--/devops:count:skills--> Skills** — devops-ship, devops-commit, devops-flow, devops-new-issue, devops-project-setup, devops-readme, devops-refresh-usage, devops-extend-skill, devops-repo-health, devops-claude-md-lint, devops-concept, devops-agents, devops-plugin-update, devops-autonomous, devops-burn, devops-learn, devops-harden, devops-polish, devops-test-plan
+- **<!--devops:count:agents-->12<!--/devops:count:agents--> Agents** — AI, Core, Designer, Feature, Frontend, Gamer, PO, QA, Redteam, Research, Windows
 - **Completion Flow** — mandatory card after every task (8 variants), visual verification, ship recommendation
 - **Ship Enforcement** — intent detection, PR command blocking, automatic /devops-ship skill routing
 - **3-Layer Extension Model** — customize any skill or agent per-project without forking
@@ -320,6 +320,7 @@ SessionStart  ──>  UserPromptSubmit  ──>  PreToolUse  ──>  PostToolU
 | `/devops-polish` | Explicit | UI refinement: visual consistency, state-visuals, UI-side functionality checks |
 | `/devops-test-plan` | Explicit + Hook | Detect test profile, deterministic tool-chain recommendations per test request |
 | `/devops-graph` | Explicit + Hook | On-demand code knowledge graph via graphify, with opt-in auto-build + hard-gate enforcement |
+| `/devops-rethink` | Explicit | Strategic reset for stuck development: code-blind fresh approaches, concept decision, autonomous implementation |
 
 ### Agents (spawned for parallel work)
 
@@ -335,6 +336,7 @@ SessionStart  ──>  UserPromptSubmit  ──>  PreToolUse  ──>  PostToolU
 | **qa** | Test, verify, screenshot |
 | **redteam** | Adversarial review: failure modes, blind spots, hidden risks |
 | **research** | Deep-dive investigations |
+| **rethinker** | Code-blind fresh-approach ideation through one lens |
 | **windows** | Platform-specific features |
 
 ## Completion Cards
@@ -648,8 +650,8 @@ devops/
 ├── .claude-plugin/plugin.json     ← Plugin manifest
 ├── CONVENTIONS.md                 ← Naming, versioning, extension rules
 ├── hooks/                         ← <!--devops:count:hooks-->34<!--/devops:count:hooks--> hooks (JS) registered in hooks.json
-├── skills/                        ← <!--devops:count:skills-->20<!--/devops:count:skills--> skill definitions (SKILL.md)
-├── agents/                        ← <!--devops:count:agents-->11<!--/devops:count:agents--> agent definitions
+├── skills/                        ← <!--devops:count:skills-->21<!--/devops:count:skills--> skill definitions (SKILL.md)
+├── agents/                        ← <!--devops:count:agents-->12<!--/devops:count:agents--> agent definitions
 ├── deep-knowledge/                ← Cross-cutting reference docs
 ├── templates/                     ← Output format templates
 └── scripts/                       ← Utility scripts (build-id, usage)

--- a/docs/superpowers/specs/2026-07-02-devops-rethink-design.md
+++ b/docs/superpowers/specs/2026-07-02-devops-rethink-design.md
@@ -1,0 +1,192 @@
+# Design Spec — `/devops-rethink`
+
+**Date:** 2026-07-02
+**Status:** Draft (awaiting user review)
+**Plugin:** devops (MINOR bump on release)
+
+## Problem
+
+Development gets stuck: Claude iterates in circles, progress needs many
+prompts, and the named part of the app (or the whole app) is neither
+functionally nor visually where it should be. Existing skills don't cover
+this: `devops-flow` is tactical debugging ("something is broken"),
+`devops-harden`/`devops-polish` are incremental improvement passes on the
+existing approach. What's missing is a strategic reset: fresh, un-anchored
+approaches that still respect the original goals and hard constraints.
+
+## Goals
+
+- Re-derive the original goals and the stuck state — largely self-served by
+  Claude (repo evidence + live look at the running app), validated by a short
+  question round with the user.
+- Generate genuinely fresh approaches: ideation that is technically isolated
+  from the current implementation, not merely asked to "think fresh".
+- Integrate existing knowledge in a second, separate step (reconciliation).
+- Let the user pick/steer on an interactive concept page, then implement the
+  chosen approach fully autonomously, including test verification.
+
+## Non-Goals
+
+- Not a debugging tool (that is `devops-flow`).
+- Not a micro-polish pass (button radius etc. → `devops-polish`).
+- No implementation without an explicit "Implement" decision on the concept
+  page.
+
+## Skill Definition
+
+- **Name:** `devops-rethink` — directory `plugins/devops/skills/devops-rethink/`
+- **Version:** 0.1.0
+- **Triggers:** "festgefahren", "stuck", "unstuck", "wir drehen uns im Kreis",
+  "neu denken", "rethink", "frischer Ansatz", "fresh approach"
+- **Do NOT trigger:** debugging/errors (→ `devops-flow`), incremental
+  consistency or UI passes (→ `devops-harden`/`devops-polish`), normal feature
+  work, README/doc tasks.
+- **Frontmatter:** `description: >-` folded scalar (YAML-safety convention),
+  `argument-hint: "[app or section that is stuck, e.g. 'the onboarding flow']"`.
+- **Extension paths (Step 0):** `~/.claude/skills/rethink/` and
+  `{project}/.claude/skills/rethink/` (SKILL.md + reference.md,
+  project > global > plugin).
+
+## Pipeline
+
+### Step 0 — Load Extensions
+
+Standard three-layer load per CONVENTIONS.md. Silent on missing files.
+
+### Step 1 — Intake & Scope
+
+`$ARGUMENTS` names the target (whole app or a section). The skill states the
+scope boundary explicitly ("in scope: X incl. Y; out of scope: Z") and keeps
+it in the brief. If `$ARGUMENTS` is empty, ask one question to name the
+target before anything else.
+
+### Step 2 — Evidence Mining (self-served)
+
+Two source classes, gathered before any question is asked:
+
+1. **Repo evidence:** git log for the target area, issues (open/closed),
+   existing concept pages, docs, CHANGELOG, CLAUDE.md — reconstruct: intended
+   goal, what was already tried, where iterations circled.
+2. **Live evidence:** per deep-knowledge `test-autonomy.md` /
+   `preview-testing.md` / `responsive-testing.md`: start the app (Claude
+   Preview preferred), view the named area at multiple viewports, click
+   through its core flows, capture screenshots/snapshots.
+
+Output: a **hypothesis dossier** — "this was the goal, this is today's state,
+here is the gap, this was tried". Explicitly marked as hypotheses.
+
+Fallbacks: no repo evidence → question round carries more weight (more
+questions allowed). App not startable → static evidence only; the dossier
+notes "no live look possible".
+
+### Step 3 — Question Round (validate + calibrate)
+
+`AskUserQuestion`, one question per round, ~3–5 rounds, multiple-choice
+preferred. Mandatory contents:
+
+1. Confirm/correct the hypothesis dossier (goal, gap, tried-before).
+2. Success criteria: "what does *good* look like?" for this target.
+3. Biggest frustration / most-missed outcome.
+4. Hard no-gos: stack, data model, deadlines, budget — non-negotiables.
+5. **Demolition corridor (joint calibration):** how much may be torn down at
+   the large scale — nothing / the named section / everything. This is agreed
+   together, not assumed.
+
+Output: the **Rethink Brief** — one completely code-free document containing
+scope, goal, gap, success criteria, no-gos, corridor. Persisted to
+`.claude/rethink/<date>-<slug>/brief.md` in the consumer project.
+
+### Step 4 — Fresh Phase (code-blind fan-out)
+
+**New agent:** `plugins/devops/agents/rethinker.md` (`devops:rethinker`).
+Tools: **WebSearch, WebFetch only** — no Read/Grep/Glob/Bash. Code-blindness
+is enforced by the tool set, not by a prompt request.
+
+Three instances run in parallel; each receives ONLY the Rethink Brief plus
+one lens (lens prompts live in `skills/devops-rethink/deep-knowledge/lenses.md`):
+
+| Lens | Question it owns |
+|------|------------------|
+| Product/Value (PO view) | Does the approach achieve the purpose? What is the simplest thing that reaches the goal? |
+| UX/Design | Structure, flow, layout idea, visual direction. |
+| End-user feel | Journey, friction, "does it feel good?" |
+
+For backend-only targets the End-user lens is swapped for an
+**Architecture lens** (boundaries, data flow, simplification).
+
+Each agent returns one approach: core idea, structure sketch, why it reaches
+the success criteria, rough blast-radius estimate. Web research for
+inspiration/best practices is allowed (per `fact-verification.md`).
+
+Failure handling: if a lens agent dies, continue with the surviving
+approaches (min. 1) and note the gap on the concept page.
+
+### Step 5 — Reconciliation (the "second step")
+
+Back in the main context, now WITH codebase access: evaluate each fresh
+approach against reality — migration path, what survives, effort, risks.
+Merge near-duplicates. Label every approach with its blast radius relative
+to the corridor:
+
+- **in-corridor** — eligible for implementation.
+- **over-corridor** — shown as a flagged outlier for information; NEVER
+  implemented without an explicit user decision that widens the corridor.
+
+### Step 6 — Concept Page
+
+Invoke `devops-concept` (decision template). Each approach is a variant with:
+pros/cons, blast-radius label, effort estimate, migration sketch, and which
+success criteria it serves. Two decision actions:
+
+- **Iterate:** feedback flows back → revise approaches (Step 5, or a new
+  fresh round if the user's feedback changes direction fundamentally) →
+  re-render. No implementation starts.
+- **Implement:** locks the chosen approach and proceeds to Step 7.
+
+Decision snapshot persisted to `.claude/rethink/<date>-<slug>/decision.md`.
+
+### Step 7 — Autonomous Handoff
+
+Only after an explicit **Implement** click. The skill assembles a task
+briefing:
+
+- chosen approach (full concept content),
+- scope boundary, success criteria, no-gos, corridor,
+- test mandate: pin the profile via `devops-test-plan`, verify per its
+  recommendation,
+- pointer to `.claude/rethink/<date>-<slug>/` artifacts.
+
+Then invoke `devops-autonomous` with this briefing as the task. Autonomous
+owns permission priming, confirmation, worktree, implementation, testing,
+report — unchanged. `devops-rethink` does not re-implement any of that.
+
+## Deliverables (implementation checklist)
+
+1. `plugins/devops/skills/devops-rethink/SKILL.md` (lean; Step 0 extensions;
+   steps as above)
+2. `plugins/devops/skills/devops-rethink/deep-knowledge/lenses.md`
+3. `plugins/devops/agents/rethinker.md` (WebSearch/WebFetch only; YAML-safe
+   frontmatter; `<example>` tags per agent conventions)
+4. README curated table row + generator run (`gen-readme-sections.js`)
+5. Plugin MINOR version bump at ship time
+
+## Error Handling Summary
+
+| Situation | Behavior |
+|-----------|----------|
+| Empty `$ARGUMENTS` | One intake question first |
+| No repo evidence | Heavier question round |
+| App not startable | Static evidence; dossier notes it |
+| Lens agent failure | Continue with ≥1 approach, gap noted |
+| User picks over-corridor approach | Explicit corridor-widening question before handoff |
+| No decision on concept page | Nothing is implemented; artifacts remain for a later resume |
+
+## Testing
+
+- `scripts/frontmatter-yaml.test.js` guards SKILL.md + agent frontmatter
+  automatically.
+- Roster/README markers verified by `gen-readme-sections.js --check`
+  (existing ship gate).
+- Behavioral dry-run: invoke `/devops-rethink` on a consumer project section
+  and walk the pipeline to the concept page (handoff smoke-tested with a
+  trivial target).

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.105.0",
+  "version": "0.106.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/agents/rethinker.md
+++ b/plugins/devops/agents/rethinker.md
@@ -1,0 +1,66 @@
+---
+name: rethinker
+description: >-
+  Code-blind fresh-approach ideation agent — rethinks a stuck app or section
+  from scratch through one lens (product-value, ux-design, enduser-feel, or
+  architecture). Receives ONLY a code-free Rethink Brief; has no file tools
+  by design, so the current implementation cannot anchor its thinking.
+  Spawned in parallel (one per lens) by /devops-rethink Step 4.
+  <example>Rethink the onboarding flow through the ux-design lens</example>
+  <example>Fresh product-value approach for the stuck reporting section</example>
+model: opus
+effort: high
+color: purple
+tools: ["WebSearch", "WebFetch"]
+---
+
+# Rethinker Agent
+
+Fresh thinking, structurally un-anchored. You rethink a target from scratch
+through one lens — and you cannot read the codebase, on purpose.
+
+## Why you are code-blind
+
+The target has been iterated on many times without reaching its goal. Every
+context that contains the current implementation gets anchored by it — the
+same half-solutions keep coming back. Your value is that you have never seen
+the code. Do not ask for it, do not request file contents, do not assume the
+current structure. Fresh means un-anchored from the implementation — NOT
+uninformed about the goal: the brief gives you scope, goal, success
+criteria, no-gos, and the demolition corridor. Honor all of them.
+
+## Input contract
+
+Your prompt contains:
+
+1. The **Rethink Brief** — the only project context you get. Treat it as
+   complete; gaps are design freedom, not questions to send back.
+2. One **lens block** (from the skill's `deep-knowledge/lenses.md`) — the
+   question you own. Stay in your lens; the other lenses run in parallel
+   as separate agents.
+
+## How to work
+
+- Think from the goal backwards, not from "what is probably there today"
+  forwards.
+- Use WebSearch/WebFetch for inspiration and current best-practice patterns
+  when helpful (respect `deep-knowledge/fact-verification.md` — verify
+  claims you rely on). Cite what inspired you.
+- Stay inside the demolition corridor from the brief. If your single best
+  idea exceeds it, return it anyway with an honest `blast_radius` — the
+  orchestrator flags it as an outlier; it is never silently implemented.
+- One sharp approach beats three vague ones. Commit to a core idea.
+
+## Output
+
+Return exactly one `RETHINK_APPROACH` block as specified in the lens prompt
+(fields: lens, title, core_idea, structure, why_it_reaches_the_goal,
+kills_the_frustration, not_built, blast_radius, inspiration). No preamble,
+no code, no file paths.
+
+## What You Do NOT Do
+
+- Read, request, or speculate in detail about the current implementation.
+- Produce implementation-level artifacts (code, file trees, migrations) —
+  the reconciliation step and later the implementing agents own that.
+- Water down your lens to cover everything; the fan-out provides breadth.

--- a/plugins/devops/docs/architecture.html
+++ b/plugins/devops/docs/architecture.html
@@ -169,7 +169,7 @@
 <section id="overview">
 <h1>Architecture Documentation <small>devops v0.87.0</small></h1>
 <p class="lead">
-  A comprehensive DevOps automation plugin for Claude Code &mdash; <!--devops:count:hooks-->34<!--/devops:count:hooks--> hooks, <!--devops:count:skills-->20<!--/devops:count:skills--> skills, <!--devops:count:agents-->11<!--/devops:count:agents--> agents,
+  A comprehensive DevOps automation plugin for Claude Code &mdash; <!--devops:count:hooks-->34<!--/devops:count:hooks--> hooks, <!--devops:count:skills-->21<!--/devops:count:skills--> skills, <!--devops:count:agents-->12<!--/devops:count:agents--> agents,
   2 MCP servers, a deterministic completion card engine, and a 3-layer extension system.
 </p>
 <div role="note" style="margin:.4rem 0 1.4rem;padding:.6rem .9rem;background:var(--bg2);border-left:3px solid var(--warn);border-radius:4px;color:var(--text2);font-size:.85rem;">
@@ -189,11 +189,11 @@
     <span class="badge b-hook">Stop &times;<!--devops:count:hooks:stop-->3<!--/devops:count:hooks:stop--></span>
   </div>
   <div class="card">
-    <h4><!--devops:count:skills-->20<!--/devops:count:skills--> Skills</h4>
+    <h4><!--devops:count:skills-->21<!--/devops:count:skills--> Skills</h4>
     <p style="color:var(--text2);font-size:.85rem">Slash commands: ship, commit, flow, new-issue, project-setup, readme, refresh-usage, extend-skill, repo-health, claude-md-lint, concept, agents, plugin-update, autonomous, burn, learn, harden, polish, test-plan</p>
   </div>
   <div class="card">
-    <h4><!--devops:count:agents-->11<!--/devops:count:agents--> Agents</h4>
+    <h4><!--devops:count:agents-->12<!--/devops:count:agents--> Agents</h4>
     <p style="color:var(--text2);font-size:.85rem">Specialized subagents: ai, core, designer, feature, frontend, gamer, po, qa, redteam, research, windows</p>
   </div>
   <div class="card">
@@ -212,7 +212,7 @@
 ├── .claude-plugin/
 │   ├── plugin.json            <span style="color:var(--text2)"># Plugin manifest (name, version, mcpServers, hooks)</span>
 │   └── marketplace.json       <span style="color:var(--text2)"># Marketplace registration</span>
-├── agents/                    <span style="color:var(--accent2)"># <!--devops:count:agents-->11<!--/devops:count:agents--> agent definitions (*.md with YAML frontmatter)</span>
+├── agents/                    <span style="color:var(--accent2)"># <!--devops:count:agents-->12<!--/devops:count:agents--> agent definitions (*.md with YAML frontmatter)</span>
 ├── deep-knowledge/            <span style="color:var(--warn)"># <!--devops:count:dk-->31<!--/devops:count:dk--> cross-cutting reference docs</span>
 ├── hooks/
 │   ├── hooks.json             <span style="color:var(--purple)"># Hook registry (event &rarr; command mapping)</span>
@@ -235,7 +235,7 @@
 │   ├── render-card.js         <span style="color:var(--warn)"># Completion card template engine</span>
 │   ├── build-id.js            <span style="color:var(--text2)"># Deterministic content hash</span>
 │   └── lib/usage-meter.js     <span style="color:var(--text2)"># Usage bar renderer</span>
-├── skills/                    <span style="color:var(--accent)"># <!--devops:count:skills-->20<!--/devops:count:skills--> skill definitions (SKILL.md + deep-knowledge/)</span>
+├── skills/                    <span style="color:var(--accent)"># <!--devops:count:skills-->21<!--/devops:count:skills--> skill definitions (SKILL.md + deep-knowledge/)</span>
 │   ├── ship/  commit/  flow/  new-issue/  project-setup/  readme/
 │   ├── refresh-usage/  extend-skill/  repo-health/  claude-md-lint/
 │   ├── concept/  agents/  plugin-update/  autonomous/  burn/  learn/

--- a/plugins/devops/skills/devops-rethink/SKILL.md
+++ b/plugins/devops/skills/devops-rethink/SKILL.md
@@ -1,0 +1,193 @@
+---
+name: devops-rethink
+version: 0.1.0
+description: >-
+  Strategic reset for stuck development: iterations circle without reaching
+  the goal, or a named part of the app (or the whole app) is functionally and
+  visually not where it should be and incremental fixes stopped helping.
+  Re-derives the original goals from repo + live-app evidence, validates them
+  in a short question round (incl. jointly calibrating how much may be torn
+  down), generates genuinely fresh approaches via code-blind lens agents,
+  reconciles them against the codebase, lets the user decide on a
+  devops-concept page, then hands the chosen approach to devops-autonomous
+  for implementation with devops-test-plan verification.
+  Triggers on: "festgefahren", "stuck", "unstuck", "wir drehen uns im Kreis",
+  "neu denken", "rethink", "frischer Ansatz", "fresh approach",
+  "komplett neu denken", "das führt zu nichts".
+  Do NOT trigger for: debugging/errors (use /devops-flow), incremental
+  consistency or UI passes (/devops-harden, /devops-polish), or normal
+  feature work.
+argument-hint: "[app or section that is stuck, e.g. 'the onboarding flow']"
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash, Agent, AskUserQuestion, CronCreate, CronDelete, mcp__Claude_Preview__*, mcp__plugin_playwright_playwright__*, mcp__plugin_devops_dotclaude-completion__*
+---
+
+# Rethink — Strategic Reset
+
+Break out of a stuck development loop for `$ARGUMENTS`: rebuild the goal
+picture, think fresh without being anchored by the current implementation,
+then reconcile, decide, and implement autonomously.
+
+**Why this skill exists:** when the same area has been iterated on many times
+without reaching the goal, the current implementation itself anchors every
+new attempt. This skill enforces un-anchored ideation *structurally* — the
+ideation agents cannot read the code — and re-introduces existing knowledge
+only in a second, explicit step.
+
+## Step 0 — Load Extensions
+
+Check for optional overrides. Use **Glob** to verify each path exists before
+reading. Skip missing files silently.
+
+1. Global: `~/.claude/skills/rethink/SKILL.md` + `reference.md`
+2. Project: `{project}/.claude/skills/rethink/SKILL.md` + `reference.md`
+3. Merge order: project > global > plugin defaults
+
+## Step 1 — Intake & Scope
+
+`$ARGUMENTS` names the target — the whole app or a section of it. The rethink
+is holistic for the named target (not a micro-polish of one control).
+
+- If `$ARGUMENTS` is empty: ask ONE question (AskUserQuestion) to name the
+  target before anything else.
+- State the scope boundary explicitly: "In scope: X including Y. Out of
+  scope: Z." This boundary travels with the brief through every later step.
+
+## Step 2 — Evidence Mining (self-served)
+
+Build your own picture BEFORE asking the user anything. Two source classes:
+
+1. **Repo evidence:** git log for the target area, open/closed issues,
+   existing concept pages, docs, CHANGELOG, CLAUDE.md. Reconstruct: what was
+   the intended goal, what was already tried, where did iterations circle.
+2. **Live evidence:** look at the running app — this is the only honest
+   source for "it doesn't look/feel right". Follow
+   `{PLUGIN_ROOT}/deep-knowledge/test-autonomy.md` and
+   `preview-testing.md`: start the app (Claude Preview preferred), view the
+   target at the profile viewports (`responsive-testing.md`), click through
+   its core flows, capture snapshots.
+
+Output: a **hypothesis dossier**, explicitly marked as hypotheses —
+"this was the goal, this is today's state, here is the gap, this was tried".
+
+Fallbacks: no repo evidence → the question round carries more weight (more
+questions allowed). App not startable → static evidence only; note
+"no live look possible" in the dossier.
+
+## Step 3 — Question Round (validate + calibrate)
+
+AskUserQuestion, ONE question per round, ~3–5 rounds, multiple-choice
+preferred. Mandatory contents, in this order:
+
+1. Confirm/correct the hypothesis dossier (goal, gap, tried-before).
+2. Success criteria: what does *good* look like for this target?
+3. Biggest frustration / most-missed outcome.
+4. Hard no-gos: stack, data model, deadlines — non-negotiables.
+5. **Demolition corridor — calibrated together, never assumed:** how much
+   may be torn down at the large scale (nothing / the named section /
+   everything). The corridor bounds what gets seriously developed; it is
+   agreed jointly so radical options don't surprise the user later.
+
+Output: the **Rethink Brief** — ONE completely code-free document containing
+scope, goal, gap, success criteria, no-gos, corridor. Persist it to
+`.claude/rethink/<YYYY-MM-DD>-<slug>/brief.md`. The brief is the ONLY project
+context the fresh-phase agents receive, so it must stand alone.
+
+## Step 4 — Fresh Phase (code-blind fan-out)
+
+Spawn **three `devops:rethinker` agents in parallel** (one message, three
+Agent calls). Each prompt = the full Rethink Brief + ONE lens block from
+`deep-knowledge/lenses.md`:
+
+| Lens | Owns the question |
+|---|---|
+| `product-value` | Does the approach achieve the purpose — simplest thing that reaches the goal? |
+| `ux-design` | Structure, flow, layout idea, visual direction |
+| `enduser-feel` | Journey, friction, "does it feel good?" |
+
+For backend-only targets (no UI surface in scope), replace `enduser-feel`
+with the `architecture` lens.
+
+The rethinker agent has **no file tools** — code-blindness is enforced by
+its tool set, not by a polite request. Do NOT paste code, file paths, or
+implementation details into its prompt; that would defeat the isolation.
+
+Naming per `deep-knowledge/agent-conventions.md`:
+`[role:rethinker · Ideation] <lens> approach for <target>`.
+
+Each agent returns one `RETHINK_APPROACH` block (format in `lenses.md`).
+If an agent dies, continue with the survivors (minimum 1) and note the gap
+on the concept page.
+
+## Step 5 — Reconciliation (the second step)
+
+Back in the main context, now WITH codebase access, integrate what is
+already known:
+
+- Evaluate each approach against reality: migration path, what survives,
+  effort, risks, which success criteria it serves.
+- Merge near-duplicate approaches.
+- Label every approach with its blast radius **relative to the corridor**:
+  - `in-corridor` — eligible for implementation.
+  - `over-corridor` — shown as a flagged outlier for information; NEVER
+    implemented without the user explicitly widening the corridor first.
+
+Persist the reconciled set to `.claude/rethink/<date>-<slug>/approaches.md`.
+
+## Step 6 — Concept Page
+
+Invoke `devops-concept` (decision template). Each approach is a variant
+with: pros/cons, blast-radius label, effort estimate, migration sketch, and
+which success criteria it serves. The page offers two decision actions:
+
+- **Iterate** — feedback flows back: revise via Step 5, or run a new fresh
+  round (Step 4) when the feedback changes direction fundamentally. Then
+  re-render. Nothing is implemented.
+- **Implement** — locks the chosen approach and proceeds to Step 7. Only
+  this explicit action starts implementation.
+
+Persist the decision to `.claude/rethink/<date>-<slug>/decision.md`.
+
+## Step 7 — Autonomous Handoff
+
+Only after an explicit **Implement** decision. Assemble the task briefing:
+
+- the chosen approach (full concept content),
+- scope boundary, success criteria, no-gos, corridor,
+- test mandate: pin the profile via `devops-test-plan` and verify per its
+  recommendation,
+- pointer to the `.claude/rethink/<date>-<slug>/` artifacts.
+
+Then invoke `devops-autonomous` with this briefing as the task. Autonomous
+owns permission priming, confirmation, worktree, implementation, testing,
+and the report — do not re-implement any of that here.
+
+If the user chose an `over-corridor` approach: ask ONE explicit
+corridor-widening question before the handoff.
+
+## Completion
+
+- Handoff happened (Step 7) → `devops-autonomous` owns the completion card.
+- Run ends earlier (no decision yet, or user stops at the concept page) →
+  render a completion card yourself (`analysis` if nothing was written,
+  `ready` if brief/approaches were persisted). Artifacts remain on disk for
+  a later resume.
+
+## Error Handling
+
+| Situation | Behavior |
+|---|---|
+| Empty `$ARGUMENTS` | One intake question first |
+| No repo evidence | Heavier question round |
+| App not startable | Static evidence; dossier notes it |
+| Lens agent failure | Continue with ≥1 approach, gap noted on page |
+| User picks over-corridor approach | Explicit corridor-widening question before handoff |
+| No decision on concept page | Nothing implemented; artifacts kept for resume |
+
+## Rules
+
+- Never skip the question round — evidence hypotheses are validated, not
+  assumed correct.
+- Never feed code, file paths, or current-implementation details to the
+  fresh-phase agents.
+- Never start implementation without the explicit Implement decision.
+- The corridor is agreed with the user, never assumed.

--- a/plugins/devops/skills/devops-rethink/deep-knowledge/lenses.md
+++ b/plugins/devops/skills/devops-rethink/deep-knowledge/lenses.md
@@ -1,0 +1,105 @@
+# Rethink Lenses — Fresh-Phase Prompt Blocks
+
+Used by `/devops-rethink` Step 4. Each `devops:rethinker` agent receives the
+full Rethink Brief plus exactly ONE lens block below. The lens focuses the
+agent's divergence — three agents with the same prompt produce three similar
+answers; three agents with different lenses produce genuinely different ones.
+
+## Shared prompt scaffold
+
+Compose each agent prompt as:
+
+```
+[role:rethinker · Ideation] <lens> approach for <target>
+
+You are rethinking <target> from scratch. You have deliberately NOT been
+given the current implementation — do not ask for it, do not assume its
+structure. Everything you know is in this brief:
+
+<full Rethink Brief text>
+
+<lens block — one of the four below>
+
+Return exactly one RETHINK_APPROACH block (format at the end of this prompt).
+Stay inside the demolition corridor from the brief. If your single best idea
+exceeds the corridor, you may return it anyway — but set blast_radius
+honestly so it gets flagged as an outlier.
+```
+
+## Lens: product-value
+
+```
+LENS: product-value (the PO view)
+Own this question: what is the SIMPLEST thing that fully reaches the goal?
+- Judge every idea against the success criteria in the brief, nothing else.
+- Cut scope aggressively: which parts of the stated gap actually matter to
+  the outcome, which are decoration?
+- Prefer one sharp core mechanism over three mediocre features.
+- Name explicitly what you would NOT build and why that is acceptable.
+```
+
+## Lens: ux-design
+
+```
+LENS: ux-design (structure and visual direction)
+Own this question: what structure, flow, and visual idea makes the target
+feel coherent and obvious?
+- Propose the information architecture and screen/section flow from zero.
+- Give a concrete visual direction (layout pattern, hierarchy, density,
+  one signature design idea) — not a token-level style guide.
+- Design for the success criteria and the frustration named in the brief.
+- WebSearch for current best-practice patterns of this kind of surface is
+  encouraged; cite what inspired you.
+```
+
+## Lens: enduser-feel
+
+```
+LENS: enduser-feel (journey and friction)
+Own this question: does it feel good — from first contact to goal reached?
+- Walk the user journey step by step as a first-time user AND a daily user.
+- Hunt friction: waiting, confusion, dead ends, needless decisions.
+- Name the emotional beat of the experience (confidence, delight, control)
+  and how the approach produces it.
+- Judge against the "biggest frustration" from the brief — your approach
+  must visibly kill it.
+```
+
+## Lens: architecture (backend-only swap)
+
+Used instead of `enduser-feel` when the target has no UI surface in scope.
+
+```
+LENS: architecture (boundaries and data flow)
+Own this question: what module boundaries and data flow make this simple,
+testable, and hard to break?
+- Propose the component split and ownership from zero — ignore how it is
+  cut today (you don't know anyway).
+- Trace the main data flow end to end; name every boundary it crosses.
+- Optimize for: fewest moving parts that still meet the success criteria,
+  clear failure isolation, easy verification.
+```
+
+## Output contract — RETHINK_APPROACH
+
+Every rethinker returns exactly this block:
+
+```
+RETHINK_APPROACH:
+  lens: product-value | ux-design | enduser-feel | architecture
+  title: <3-6 word name for the approach>
+  core_idea: <2-4 sentences — the one idea that makes this approach work>
+  structure: <bullet sketch of the parts/screens/modules and how they connect>
+  why_it_reaches_the_goal: <map to the brief's success criteria, point by point>
+  kills_the_frustration: <how the brief's biggest frustration disappears>
+  not_built: <what is deliberately left out, one line each>
+  blast_radius: rework | section-rewrite | new-approach
+  inspiration: <optional — external patterns/products found via WebSearch>
+```
+
+Rules for the orchestrator (Step 5):
+- `blast_radius` is the agent's estimate from the brief alone; re-label it
+  against the actual codebase during reconciliation (in-corridor /
+  over-corridor).
+- Do not average approaches into mush. If two are near-identical, merge
+  them; otherwise keep them distinct on the concept page.

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.105.0",
+  "version": "0.106.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary
Implements `/devops-rethink` per the approved design spec (PR #230): a strategic reset for stuck development.

- **New skill `devops-rethink`** — evidence mining (repo + live app) → hypothesis dossier → question round with joint demolition-corridor calibration → code-blind lens fan-out → reconciliation with blast-radius labels → `devops-concept` decision page (Iterate/Implement) → `devops-autonomous` handoff with `devops-test-plan` mandate. Artifacts under `.claude/rethink/<date>-<slug>/`.
- **New agent `devops:rethinker`** — code-blind ideation (WebSearch/WebFetch only, no file tools by design), one lens per instance; prompt blocks + `RETHINK_APPROACH` contract in the skill's `deep-knowledge/lenses.md`.
- README curated rows (skill + agent) + regenerated roster markers/architecture.html.
- Version 0.105.0 → 0.106.0 (MINOR: new skill + new agent), CHANGELOG entry.

## Verification
- npm test: 552/552 passed (35 files) — incl. frontmatter-YAML guard over the new SKILL.md/agent and README-marker check
- npm run lint: clean
- Codex review gate: skipped (CLI not on PATH, rc=127)

## Intermediate PRs
- #230 — docs(spec): add devops-rethink design spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)