### PR TITLE
feat(ship): purpose alignment gate — cross-branch purpose checks

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.106.0"
+    "version": "0.107.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.106.0",
+      "version": "0.107.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.106.0",
+      "version": "0.107.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.107.0] — 2026-07-03
+
+### Added
+
+- **`/devops-ship` now verifies every ship against the *purposes* of recently merged branches, not just their code — the new Purpose Alignment Gate (Step 1d).** Code-level merge safety (rebase gates, conflict classification, tests) cannot catch a purpose-level defect: branch A ships "hotkeys on ALL interactive elements", branch B — developed in parallel — ships a new element with a conflict-free rebase and green tests, yet the merged result violates A's convention (no hotkey on B's element) and may silently break A's feature. The gate gathers the purposes of the last 3–5 merged PRs into the base (≥3 when available, discretionary up to ~8; Claude-authored PR bodies preferred, fallback merge commits/CHANGELOG; reverts and mechanical bumps excluded), distills **cross-cutting conventions** from **local purposes**, and audits **bidirectionally**: forward — conventions from merged branches must cover artifacts this branch introduces; reverse — a convention THIS branch introduces is retro-applied to the existing artifacts on base as part of the same ship (never silently demoted to a "follow-up"). When a rebase/merge actually happened (incl. `baseAdvancedDuringChecks` re-entry), a **regression audit** additionally verifies the merged content still delivers its purposes in both directions. Resolution is autonomous-first: mechanical fixes ship with the PR; only high-impact conflicts (contradicting purposes, per-site design decisions, a retro-migration dwarfing the branch's own diff) go into ONE batched AskUserQuestion — low-confidence findings (title-only sources) never block and surface as `userFinalTest` items at most. Intermediate ships audit sibling sub-branch PRs (parallel role agents propagate conventions to each other). Full P1–P6 protocol in the skill's `deep-knowledge/purpose-alignment.md`; referenced from `merge-safety.md` Step 5 and the ship data-flow diagrams; project-tunable via a `purpose_alignment:` block (depth / disable / standing conventions) in the ship extension's `reference.md`. Skill version 0.5.0 → 0.6.0. Design spec: `docs/superpowers/specs/2026-07-03-ship-purpose-alignment-design.md`. (552 tests pass.)
+
 ## [0.106.0] — 2026-07-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.106.0**
+**Version: 0.107.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/docs/superpowers/specs/2026-07-03-ship-purpose-alignment-design.md
+++ b/docs/superpowers/specs/2026-07-03-ship-purpose-alignment-design.md
@@ -1,0 +1,130 @@
+# Design Spec — Ship Purpose Alignment Gate
+
+**Date:** 2026-07-03
+**Status:** Implemented on branch (autonomous, per user request)
+**Plugin:** devops (MINOR bump on release)
+
+## Problem
+
+`/devops-ship` handles merges safely at the **code level**: rebase gates,
+conflict classification, semantic verification, tests
+(`deep-knowledge/merge-safety.md`). What it does not check is the
+**purpose level**. Two branches developed in parallel:
+
+- Branch A: "add hotkeys to ALL interactive elements" — ships first.
+- Branch B: "add a new export button" — ships second, rebase is
+  conflict-free, tests green.
+
+The merged result still violates A's purpose: B's new button has no hotkey,
+because B was written before A's convention existed. Conversely B's change
+can silently break the *functionality* A delivered without any textual
+conflict. Neither defect is visible in the diff; both are visible against
+the branches' stated purposes. The same applies to branches merged long ago
+whose purposes established standing conventions.
+
+## Goals
+
+- On every ship, gather the purposes of the last N merged branches
+  (N = 5 default, ≥ 3 when available, discretionary) from Claude-authored
+  PR bodies, merge commits, or CHANGELOG.
+- **Propagation audit:** verify the current diff honors cross-cutting
+  conventions established by those branches (hotkey example).
+- **Regression audit** (only when a merge/rebase actually happened during
+  this ship): verify the merged content still delivers its purposes, in
+  both directions (theirs intact under ours, ours intact under theirs).
+- Autonomous resolution by default; a single batched AskUserQuestion only
+  for high-impact conflicts (contradicting purposes, design decisions,
+  large rework).
+- Project-tunable via the existing ship extension mechanism
+  (`purpose_alignment:` block in reference.md, incl. standing conventions).
+
+## Non-Goals
+
+- No new MCP tool — the gate is judgment work (reading purposes, assessing
+  compliance) and lives in the skill layer, not in `ship/tools/`.
+- No retro-application of the *current* branch's new conventions to the rest
+  of the repo (flagged as follow-up instead — keeps ship scope bounded).
+- No blocking on low-confidence purposes (title-only sources → the finding
+  becomes a `userFinalTest` item, not a gate).
+- git-sync cron merges are out of scope (pointer added in merge-safety.md;
+  the cron resolves code-level conflicts only).
+
+## Design
+
+### Placement: Step 1d in `/devops-ship`
+
+Runs after the preflight/rebase loop stabilizes (`ready: true`), before
+Step 2 (build). Two intensities:
+
+| Trigger | Intensity |
+|---|---|
+| Every ship (direct + intermediate) | **Light** — gather purposes + propagation audit |
+| Rebase/merge happened in 1b, or `ship_release` bounced with `baseAdvancedDuringChecks` | **Full** — light + regression audit |
+| `mode: "file-only"`, no sources, diff out of scope for all purposes | **Skip** silently |
+
+The `rebaseRequired`/`baseAdvancedDuringChecks` bounce in Step 4 re-enters
+Step 1b and then re-runs Step 1d as **full** — a parallel ship just landed,
+which is exactly the A/B scenario.
+
+Intermediate ships use sibling sub-branch PRs merged into the feature
+branch as sources (parallel role agents propagate conventions to each
+other).
+
+### Protocol (deep-knowledge/purpose-alignment.md)
+
+- **P1 Gather** — `gh pr list --base <base> --state merged` (bodies
+  truncated, ~3K token cap); exclusions: own PRs, reverts, mechanical
+  bumps. Fallbacks: merge commits → squash log grouped by `(#NNN)` →
+  silent skip.
+- **P2 Distill** — per source one purpose record; separate **local
+  purposes** (regression-relevant only) from **cross-cutting conventions**
+  (propagation-relevant); confidence tier by source quality.
+- **P3 Propagation audit** — does the current diff introduce artifacts
+  inside a convention's scope? Violations recorded with fix size.
+- **P4 Regression audit** (full only) — intersect diff with each record's
+  surfaces; no overlap → intact, done; overlap → tests or targeted semantic
+  read (merge-safety Step 5 patterns), both directions.
+- **P5 Resolve & escalate** — mechanical fixes and merge-caused regressions
+  fixed autonomously (committed into the ship); contradictions, design
+  decisions, high-impact rework → ONE batched AskUserQuestion.
+- **P6 Report** — fixes → card `changes`; open items → `userFinalTest`;
+  silent when clean.
+
+### Internal references
+
+- `merge-safety.md` Step 5 gains a purpose-level pointer (code-semantic
+  verification ≠ purpose verification).
+- `data-flow.md` diagrams show the Claude-side gate between preflight and
+  build.
+- Ship `reference.md` documents the `purpose_alignment:` extension block.
+
+## Deliverables
+
+1. `plugins/devops/skills/devops-ship/deep-knowledge/purpose-alignment.md` (new)
+2. `plugins/devops/skills/devops-ship/SKILL.md` — new Step 1d, Step 4
+   bounce-back note, Step 6 reporting note, version 0.5.0 → 0.6.0
+3. `plugins/devops/deep-knowledge/merge-safety.md` — Step 5 pointer
+4. `plugins/devops/skills/devops-ship/deep-knowledge/data-flow.md` — gate in
+   both flow diagrams
+5. `plugins/devops/skills/devops-ship/reference.md` — `purpose_alignment:`
+   extension example
+6. This spec.
+
+## Error Handling Summary
+
+| Situation | Behavior |
+|---|---|
+| No gh / no remote | Fallback to merge commits / CHANGELOG; else silent skip |
+| < 3 merged branches exist | Use what exists (no fabrication) |
+| Purpose only derivable from title | Low confidence → never blocks, `userFinalTest` at most |
+| Contradicting purposes | Batched AskUserQuestion |
+| Fix requires design decision / large rework | Batched AskUserQuestion |
+| Gate finds nothing | Silent — no card noise |
+
+## Testing
+
+- `npm test` (vitest) — frontmatter YAML guard covers the SKILL.md edit.
+- `node plugins/devops/scripts/gen-readme-sections.js --check` — roster
+  markers unaffected (no new skill/agent).
+- Behavioral: next real ship on this repo exercises the light path; a
+  parallel-ship rebase exercises the full path.

--- a/docs/superpowers/specs/2026-07-03-ship-purpose-alignment-design.md
+++ b/docs/superpowers/specs/2026-07-03-ship-purpose-alignment-design.md
@@ -27,8 +27,10 @@ whose purposes established standing conventions.
 - On every ship, gather the purposes of the last N merged branches
   (N = 5 default, ≥ 3 when available, discretionary) from Claude-authored
   PR bodies, merge commits, or CHANGELOG.
-- **Propagation audit:** verify the current diff honors cross-cutting
-  conventions established by those branches (hotkey example).
+- **Propagation audit (bidirectional):** verify the current diff honors
+  cross-cutting conventions established by those branches (hotkey example),
+  AND retro-apply a convention the current branch introduces to the existing
+  artifacts on base — as part of the same ship.
 - **Regression audit** (only when a merge/rebase actually happened during
   this ship): verify the merged content still delivers its purposes, in
   both directions (theirs intact under ours, ours intact under theirs).
@@ -42,8 +44,11 @@ whose purposes established standing conventions.
 
 - No new MCP tool — the gate is judgment work (reading purposes, assessing
   compliance) and lives in the skill layer, not in `ship/tools/`.
-- No retro-application of the *current* branch's new conventions to the rest
-  of the repo (flagged as follow-up instead — keeps ship scope bounded).
+- ~~No retro-application of the current branch's new conventions~~ — revised
+  2026-07-03 per user decision: retro-application IS in scope (P3 reverse
+  propagation). Scope stays bounded via escalation: a retro-migration that
+  dwarfs the branch's own diff goes into the batched AskUserQuestion instead
+  of landing silently.
 - No blocking on low-confidence purposes (title-only sources → the finding
   becomes a `userFinalTest` item, not a gate).
 - git-sync cron merges are out of scope (pointer added in merge-safety.md;
@@ -79,8 +84,10 @@ other).
 - **P2 Distill** — per source one purpose record; separate **local
   purposes** (regression-relevant only) from **cross-cutting conventions**
   (propagation-relevant); confidence tier by source quality.
-- **P3 Propagation audit** — does the current diff introduce artifacts
-  inside a convention's scope? Violations recorded with fix size.
+- **P3 Propagation audit (bidirectional)** — forward: does the current diff
+  introduce artifacts inside a merged convention's scope? Reverse: does a
+  convention introduced on this branch obligate existing artifacts on base
+  (retro-application, ships with the PR)? Violations recorded with fix size.
 - **P4 Regression audit** (full only) — intersect diff with each record's
   surfaces; no overlap → intact, done; overlap → tests or targeted semantic
   read (merge-safety Step 5 patterns), both directions.

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.106.0",
+  "version": "0.107.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/deep-knowledge/merge-safety.md
+++ b/plugins/devops/deep-knowledge/merge-safety.md
@@ -170,6 +170,14 @@ After all textual conflicts are resolved (or after a clean merge):
    - Import added on one side + the module was moved/renamed on the other
 3. **If the project has build/lint/typecheck** → run it to catch compilation errors
 4. If semantic issues found → fix them as part of the merge resolution
+5. **Purpose-level verification (ship flow only):** code-semantic checks catch
+   broken wiring, not broken *intent*. During `/devops-ship`, the Purpose
+   Alignment Gate additionally verifies that the merged result honors the
+   goals and cross-cutting conventions of recently merged branches (e.g. "all
+   elements get hotkeys" must also cover an element the other branch added).
+   See `skills/devops-ship/deep-knowledge/purpose-alignment.md`. The git-sync
+   cron resolves code-level conflicts only — purpose alignment runs at ship
+   time.
 
 ### Step 6 — Complete the merge
 

--- a/plugins/devops/deep-knowledge/merge-safety.md
+++ b/plugins/devops/deep-knowledge/merge-safety.md
@@ -173,8 +173,10 @@ After all textual conflicts are resolved (or after a clean merge):
 5. **Purpose-level verification (ship flow only):** code-semantic checks catch
    broken wiring, not broken *intent*. During `/devops-ship`, the Purpose
    Alignment Gate additionally verifies that the merged result honors the
-   goals and cross-cutting conventions of recently merged branches (e.g. "all
-   elements get hotkeys" must also cover an element the other branch added).
+   goals and cross-cutting conventions of recently merged branches — in both
+   directions (e.g. "all elements get hotkeys" must cover an element the
+   other branch added, and a convention introduced on the shipping branch is
+   retro-applied to existing artifacts).
    See `skills/devops-ship/deep-knowledge/purpose-alignment.md`. The git-sync
    cron resolves code-level conflicts only — purpose alignment runs at ship
    time.

--- a/plugins/devops/skills/devops-ship/SKILL.md
+++ b/plugins/devops/skills/devops-ship/SKILL.md
@@ -151,9 +151,11 @@ the **purposes** of recently merged work — not just its code. Full protocol:
 - **Light check (every ship, direct + intermediate):** gather the purposes of
   the last 3–5 merged PRs into `<base>` (Claude-authored bodies preferred;
   fallback: merge commits / CHANGELOG), extract cross-cutting conventions, and
-  audit the current diff for violations — e.g. a prior branch's convention
-  "all elements get hotkeys" must also cover an element added on THIS branch,
-  even though the hotkey task never belonged to this branch.
+  audit **in both directions**: (a) the current diff honors prior conventions —
+  e.g. a prior branch's "all elements get hotkeys" must also cover an element
+  added on THIS branch, even though the hotkey task never belonged to it; and
+  (b) a convention THIS branch introduces is retro-applied to the existing
+  artifacts on `<base>` as part of this ship (reverse propagation).
 - **Full check (a rebase/merge happened in 1b, or re-entry after
   `baseAdvancedDuringChecks`):** additionally verify the merged content still
   delivers its purposes in **both directions** — their features intact under

--- a/plugins/devops/skills/devops-ship/SKILL.md
+++ b/plugins/devops/skills/devops-ship/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: devops-ship
-version: 0.5.0
+version: 0.6.0
 description: >-
   Full end-to-end shipping pipeline using MCP tools: ship_preflight, ship_build,
   ship_version_bump, ship_release, ship_cleanup, render_completion_card,
@@ -142,6 +142,34 @@ After rebase + push + tests pass, **re-run `ship_preflight`** with the same para
 
 This loop naturally terminates — each iteration brings the branch closer to base.
 
+### 1d. Purpose Alignment Gate
+
+After the preflight loop stabilizes (`ready: true`), verify the ship against
+the **purposes** of recently merged work — not just its code. Full protocol:
+`deep-knowledge/purpose-alignment.md`.
+
+- **Light check (every ship, direct + intermediate):** gather the purposes of
+  the last 3–5 merged PRs into `<base>` (Claude-authored bodies preferred;
+  fallback: merge commits / CHANGELOG), extract cross-cutting conventions, and
+  audit the current diff for violations — e.g. a prior branch's convention
+  "all elements get hotkeys" must also cover an element added on THIS branch,
+  even though the hotkey task never belonged to this branch.
+- **Full check (a rebase/merge happened in 1b, or re-entry after
+  `baseAdvancedDuringChecks`):** additionally verify the merged content still
+  delivers its purposes in **both directions** — their features intact under
+  our changes, our features intact under theirs.
+
+Findings: fix autonomously when the fix is mechanical and clearly implied by
+the convention (it ships with this PR). Ask via AskUserQuestion ONLY for
+high-impact conflicts (contradicting purposes, design decisions, substantial
+rework) — all batched into ONE question.
+
+Skip silently when: `mode: "file-only"`, no purpose sources found, or the diff
+is clearly out of scope for every gathered purpose.
+
+Feed results into Step 6: fixed violations → `changes`; open/unverifiable
+items → `userFinalTest`. Silent when clean.
+
 ### Merge strategy decision
 
 Based on the `file-overlap` check from the **final** preflight run:
@@ -219,7 +247,7 @@ Returns: `{ branch, commit, rebased, pushed, pr: {number, url}, checks: {status,
 - Tune timeout per call: `checksTimeoutSec: <30..3600>`.
 - See `deep-knowledge/quality-gates.md → Pre-Merge CI Checks Gate` for the full state matrix.
 
-**If `rebaseRequired: true`**: the branch is not rebased onto base. Go back to Step 1b and rebase before retrying. This also fires as `baseAdvancedDuringChecks: true` when a **parallel ship landed on base while we waited for CI** — the PR is left open and unmerged (no silent overwrite). Same action: rebase + retry. See `deep-knowledge/merge-safety.md → How ship_release Prevents Overwrites`.
+**If `rebaseRequired: true`**: the branch is not rebased onto base. Go back to Step 1b and rebase before retrying. This also fires as `baseAdvancedDuringChecks: true` when a **parallel ship landed on base while we waited for CI** — the PR is left open and unmerged (no silent overwrite). Same action: rebase + retry, then re-run the **Step 1d full check** before the retry: a parallel ship just landed, and its purpose may impose obligations on this branch (see `deep-knowledge/purpose-alignment.md`). See `deep-knowledge/merge-safety.md → How ship_release Prevents Overwrites`.
 
 **If `postMergeTreeMatch: false`** (merge succeeded but `postMergeWarning` is set): a concurrent ship was three-way merged into base during the merge — its changes are preserved, but surface `postMergeWarning` as a `userFinalTest` item ("Verify main is consistent — a parallel ship merged in concurrently") so the user double-checks. Do NOT treat it as a ship failure — the merge landed.
 

--- a/plugins/devops/skills/devops-ship/deep-knowledge/data-flow.md
+++ b/plugins/devops/skills/devops-ship/deep-knowledge/data-flow.md
@@ -9,6 +9,8 @@ deterministic data flow.
 ```
 ship_preflight → { ready, branch, base: "main", intermediate: false }
       ↓
+[purpose alignment gate — Claude-side, no MCP tool; see purpose-alignment.md]
+      ↓
 ship_build → { success, buildId, steps }
       ↓
 ship_version_bump → { vOld, vNew, filesUpdated, verified }
@@ -28,6 +30,8 @@ render_completion_card → card markdown (VERBATIM)
 
 ```
 ship_preflight → { ready, branch, base: "feat/42", intermediate: true, autoDetectedBase: "feat/42" }
+      ↓
+[purpose alignment gate — sources: sibling sub-branch PRs merged into feat/42]
       ↓
 ship_build → { success, buildId, steps }
       ↓

--- a/plugins/devops/skills/devops-ship/deep-knowledge/purpose-alignment.md
+++ b/plugins/devops/skills/devops-ship/deep-knowledge/purpose-alignment.md
@@ -1,0 +1,207 @@
+# Purpose Alignment Gate — Cross-Branch Purpose & Regression Check
+
+Referenced by `/devops-ship` Step 1d. Verifies that a ship honors not only the
+**code** of recently merged branches (that is `deep-knowledge/merge-safety.md`)
+but their **purposes**: the goals and conventions each branch established.
+
+## Why code-level merge safety is not enough
+
+Two branches developed in parallel:
+
+- **Branch A** — "Add hotkeys to all interactive elements." Ships first.
+- **Branch B** — "Add a new export button." Ships second; the rebase onto main
+  succeeds without a single textual conflict.
+
+Every merge-safety check passes — no overlapping files, tests green. Yet the
+merged result violates A's purpose: the new export button has no hotkey,
+because B was written before A's convention existed. Conversely, B's button
+may sit in a container A's hotkey handler re-renders, silently breaking A's
+feature. Neither problem is visible at the diff level. Both are visible at the
+**purpose** level.
+
+The same holds for branches merged long ago and no longer "relevant" to any
+conflict: their purposes may still impose obligations on new work (a standing
+convention does not expire when its PR leaves the git log's first page).
+
+## When it runs
+
+| Situation | Intensity |
+|---|---|
+| Every ship (direct or intermediate) once preflight reports `ready: true` | **Light** — purpose gathering + propagation audit (P1–P3, P5–P6) |
+| A rebase/merge happened in Step 1b, or `ship_release` bounced with `baseAdvancedDuringChecks` | **Full** — light + regression audit (adds P4) |
+| `mode: "file-only"`, zero purpose sources, or every purpose clearly out of scope for the diff | **Skip** silently |
+
+Intermediate ships (sub-branch → feature branch) use the sibling sub-branches
+merged into the feature branch as sources — parallel role agents (core,
+frontend, ai) are precisely the scenario where one agent's convention must
+propagate to another agent's work.
+
+## Step P1 — Gather purpose sources
+
+Select the last **N merged branches** into `<base>`, newest first.
+
+**N:** default 5. Use at least 3 when available; fewer only when fewer exist.
+Discretionary widening (up to ~8) when several recent merges carry no purpose
+(see exclusions); narrowing to 3 when PR bodies are unusually large.
+
+Primary source — merged PRs (richest, usually Claude-authored):
+
+```bash
+gh pr list --base <base> --state merged --limit 15 \
+  --json number,title,body,mergedAt,headRefName,author
+```
+
+Exclude, then keep the newest N:
+
+- PRs of the **current branch** itself (own intermediate ships)
+- Reverts, version-bump-only, changelog-only, and other purely mechanical PRs
+- PRs whose changes lie fully outside the active codebase (vendored deps)
+
+Fallbacks, in order:
+
+1. No `gh` / no remote → merge commits:
+   `git log <base> --merges -n 15 --format='%h %s%n%b'` plus matching
+   `CHANGELOG.md` entries.
+2. Squash-only history (no merge commits) →
+   `git log <base> -n 30 --format='%h %s'`, grouped by the PR reference
+   `(#NNN)` in the subjects.
+3. Nothing usable → skip the gate silently. **Never fabricate purposes.**
+
+Claude-authored PR bodies (structured `## Summary` sections, "Generated with
+Claude Code" trailer) are the preferred purpose statements — the user's task
+briefs usually survive there. Human PRs without a body contribute only their
+title + commit subjects; mark those purposes **low-confidence**.
+
+**Cost control:** do NOT read PR diffs during gathering. Truncate each body
+after ~40 lines. Total purpose material stays under ~3K tokens.
+
+## Step P2 — Distill purpose records
+
+For each source, produce one record:
+
+```
+{ branch, pr, mergedAt,
+  purpose:     <1–2 sentences — what the branch was FOR>,
+  conventions: [ <cross-cutting obligations it established — may be empty> ],
+  surfaces:    [ <files / areas / features it delivered> ],
+  confidence:  high | low }
+```
+
+The key judgment is separating two kinds of intent:
+
+- **Local purpose** — "add export button", "fix crash in parser". Imposes no
+  obligation on other branches; relevant only for the regression audit (P4).
+- **Cross-cutting convention** — a rule the branch established that future and
+  parallel code must follow: "ALL interactive elements get hotkeys", "every
+  API call goes through the retry wrapper", "all dialogs close on ESC",
+  "every skill loads extensions in Step 0". Relevant for the propagation
+  audit (P3).
+
+Markers of a convention: universal quantifiers in the purpose ("alle",
+"every", "überall", "konsistent"), a migration applied across many files,
+lint-rule or guard additions, template changes.
+
+## Step P3 — Propagation audit
+
+*Does OUR diff honor THEIR conventions?*
+
+For each convention:
+
+1. Determine whether the current diff (`git diff origin/<base>...HEAD`)
+   introduces anything inside the convention's scope (a new element, a new
+   API call, a new dialog, a new skill, …).
+2. If yes → check the introduced artifact against the convention. When
+   compliance is unclear, read ONE reference implementation from the source
+   branch's surface to see what compliance looks like.
+3. Violation found → record `{ convention, artifact, fixSize }`.
+
+This audit is **directional**: conventions flow from already-merged branches
+into the current one. The current branch's own new conventions are NOT
+retro-applied to the rest of the repo here — flag them as follow-up work
+instead of widening this ship's scope.
+
+## Step P4 — Regression audit (full check only)
+
+*Does the merged result still deliver ALL purposes — theirs and ours?*
+
+Runs only when a rebase/merge actually happened during this ship.
+
+For each purpose record (local purposes included):
+
+1. **Intersection check:** does the current diff touch the record's surfaces?
+   Use preflight's `file-overlap` result plus a targeted
+   `git log --oneline origin/<base> -n 20 -- <surface paths>`.
+2. **No intersection** → mark `intact (no overlap)`. Done — do not deep-read.
+3. **Intersection** → verify the delivered feature still works:
+   - Tests covering the surface exist → confirm they run (Step 1b/6, Step 2)
+     and are green.
+   - No test coverage → read the merged result at the intersection and verify
+     the feature's mechanism is still wired (merge-safety.md Step 5 semantic
+     patterns: signatures, config keys, imports, render paths).
+   - **Symmetric direction:** check OUR feature still works where THEIR
+     merged code touched our surfaces — a rebase replays our commits on top
+     of theirs, so our side can silently lose too.
+4. Broken → treat as a **merge defect**: fix as part of the ship. This is not
+   scope creep — the ship caused the breakage.
+
+## Step P5 — Resolve & escalate
+
+| Finding | Action |
+|---|---|
+| Violation with a mechanical, clearly-implied fix (add the missing hotkey, wrap the call, register the handler) | Fix autonomously, commit on the current branch, re-run affected tests |
+| Regression caused by the merge/rebase | Fix autonomously (merge defect) |
+| Two gathered purposes contradict each other as applied to this diff | **AskUserQuestion** |
+| Compliance needs a design decision (where the hotkey goes, which UX pattern) and no reference implementation exists to copy | **AskUserQuestion** |
+| Fix would require substantial rework of this branch's approach, or changes user-visible behavior beyond this branch's own scope (high impact) | **AskUserQuestion** |
+| Low-confidence purpose (title-only source) with an ambiguous violation | Do NOT block; surface as `userFinalTest` item |
+
+**Batching rule** (same as merge-safety): resolve all autonomous findings
+first, then present ALL user decisions in a single AskUserQuestion — never
+one question per finding. Each option shows: the purpose (with PR number),
+the violating artifact, and a recommendation.
+
+After autonomous fixes: they ship with this PR; re-run the test suite if any
+code changed.
+
+## Step P6 — Report
+
+Feed into the completion card (ship Step 6):
+
+- Fixed violations/regressions → `changes` entries phrased as behavior
+  ("Export-Button folgt jetzt der Hotkey-Konvention aus #47").
+- Open or unverifiable items (low-confidence, user-deferred) →
+  `userFinalTest` items, most critical first.
+- Gate found nothing → stay silent. No "purpose check passed" noise on the
+  card.
+
+## Configuration (project extension)
+
+Projects can tune the gate in `{project}/.claude/skills/ship/reference.md`:
+
+```yaml
+purpose_alignment:
+  depth: 5          # merged branches to gather (min 3 is enforced)
+  disable: false    # true = skip the gate entirely
+  conventions:      # standing conventions checked on EVERY ship,
+    - "All interactive elements have hotkeys"    # independent of history depth
+    - "Every dialog closes on ESC"
+```
+
+Standing `conventions:` entries behave like P2 conventions with **high**
+confidence — the escape hatch once a convention is older than the gathering
+window.
+
+## Anti-patterns
+
+- **Reading full PR diffs during gathering.** Purposes come from
+  titles/bodies; code is consulted per-finding in P3/P4 only.
+- **Retro-applying the current branch's new convention to the whole repo.**
+  Follow-up work — flag it, don't ship it here.
+- **Blocking the ship on low-confidence violations.** Title-only purposes
+  produce `userFinalTest` items, not gates.
+- **"Tests pass, so purposes hold."** Tests cover what was written; a missing
+  hotkey on a new element has no failing test. The propagation audit is a
+  judgment pass, not a test run.
+- **Asking the user per finding.** One batched question, autonomous-first.
+- **Fabricating purposes from thin sources.** A branch with no recoverable
+  intent contributes nothing — skip it.

--- a/plugins/devops/skills/devops-ship/deep-knowledge/purpose-alignment.md
+++ b/plugins/devops/skills/devops-ship/deep-knowledge/purpose-alignment.md
@@ -103,9 +103,11 @@ lint-rule or guard additions, template changes.
 
 ## Step P3 — Propagation audit
 
-*Does OUR diff honor THEIR conventions?*
+*Does OUR diff honor THEIR conventions — and does the existing repo honor OURS?*
 
-For each convention:
+### Forward propagation
+
+For each convention from a merged branch:
 
 1. Determine whether the current diff (`git diff origin/<base>...HEAD`)
    introduces anything inside the convention's scope (a new element, a new
@@ -115,10 +117,23 @@ For each convention:
    branch's surface to see what compliance looks like.
 3. Violation found → record `{ convention, artifact, fixSize }`.
 
-This audit is **directional**: conventions flow from already-merged branches
-into the current one. The current branch's own new conventions are NOT
-retro-applied to the rest of the repo here — flag them as follow-up work
-instead of widening this ship's scope.
+### Reverse propagation (retro-application)
+
+The audit runs in **both directions**. When the CURRENT branch establishes a
+new cross-cutting convention (distill it from the branch's own diff + task
+context, same P2 markers), the artifacts that already exist on `<base>` fall
+inside its scope too — a convention "all elements get hotkeys" introduced on
+THIS branch obligates the elements the repo already has, not only future ones.
+
+1. Enumerate existing in-scope artifacts on `origin/<base>` — targeted
+   Grep/Glob over the convention's surface, not a full-repo read.
+2. Apply the convention to each site **as part of this ship** when the fix is
+   mechanical (same escalation rules as P5). The retro-fixes commit on the
+   current branch and ship with the PR.
+3. When the retro-migration would dwarf the branch's own diff, or individual
+   sites need per-site design decisions → include it in the ONE batched
+   AskUserQuestion with a recommendation (apply now vs. explicit user call).
+   Never drop it silently and never demote it to an unasked "follow-up".
 
 ## Step P4 — Regression audit (full check only)
 
@@ -150,6 +165,7 @@ For each purpose record (local purposes included):
 |---|---|
 | Violation with a mechanical, clearly-implied fix (add the missing hotkey, wrap the call, register the handler) | Fix autonomously, commit on the current branch, re-run affected tests |
 | Regression caused by the merge/rebase | Fix autonomously (merge defect) |
+| Retro-application of a convention THIS branch introduces (existing sites on `<base>`, see P3 reverse propagation) | Apply autonomously when mechanical — ships with this PR. If it dwarfs the branch's own diff or needs per-site design decisions → **AskUserQuestion** (batched, with recommendation) |
 | Two gathered purposes contradict each other as applied to this diff | **AskUserQuestion** |
 | Compliance needs a design decision (where the hotkey goes, which UX pattern) and no reference implementation exists to copy | **AskUserQuestion** |
 | Fix would require substantial rework of this branch's approach, or changes user-visible behavior beyond this branch's own scope (high impact) | **AskUserQuestion** |
@@ -195,8 +211,9 @@ window.
 
 - **Reading full PR diffs during gathering.** Purposes come from
   titles/bodies; code is consulted per-finding in P3/P4 only.
-- **Retro-applying the current branch's new convention to the whole repo.**
-  Follow-up work — flag it, don't ship it here.
+- **Demoting retro-application to a silent "follow-up".** A convention this
+  branch introduces obligates existing artifacts NOW — apply it mechanically
+  or put it in the batched question; never defer it unasked.
 - **Blocking the ship on low-confidence violations.** Title-only purposes
   produce `userFinalTest` items, not gates.
 - **"Tests pass, so purposes hold."** Tests cover what was written; a missing

--- a/plugins/devops/skills/devops-ship/reference.md
+++ b/plugins/devops/skills/devops-ship/reference.md
@@ -53,4 +53,19 @@ Without a `verify:` block the watcher only confirms the GitHub Actions
 run on the merge commit. Failures (CI or verify) surface at the next
 SessionStart and via Windows toast.
 
+## Purpose alignment tuning (opt-out / standing conventions)
+
+The Purpose Alignment Gate (ship Step 1d) checks every ship against the
+purposes of recently merged branches. Tune it via a `purpose_alignment:`
+block in **this** `reference.md` — see
+[`deep-knowledge/purpose-alignment.md`](deep-knowledge/purpose-alignment.md):
+
+```yaml
+purpose_alignment:
+  depth: 5          # merged branches to gather (min 3 is enforced)
+  disable: false    # true = skip the gate entirely
+  conventions:      # standing conventions checked on EVERY ship,
+    - "All interactive elements have hotkeys"    # independent of history depth
+```
+
 This pattern applies to ALL plugin skills, not just ship.

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.106.0",
+  "version": "0.107.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary
`/devops-ship` now verifies every ship against the **purposes** of recently merged branches, not just their code — new **Purpose Alignment Gate** (Step 1d).

- **Why:** code-level merge safety cannot catch purpose-level defects. Branch A ships "hotkeys on ALL elements", parallel branch B ships a new element — conflict-free rebase, green tests, yet B's element has no hotkey and A's feature may be silently broken.
- **Gathering (P1/P2):** last 3–5 merged PRs into base (≥3 when available, discretionary; Claude-authored bodies preferred, fallback merge commits/CHANGELOG; reverts/mechanical bumps excluded). Distills cross-cutting **conventions** vs. local purposes, with confidence tiers.
- **Propagation audit (P3, bidirectional):** forward — merged conventions must cover artifacts this branch introduces; reverse — a convention THIS branch introduces is retro-applied to existing artifacts on base as part of the same ship (never silently demoted to follow-up).
- **Regression audit (P4, only when a rebase/merge happened, incl. `baseAdvancedDuringChecks` re-entry):** merged content must still deliver its purposes in both directions.
- **Escalation (P5):** autonomous-first; ONE batched AskUserQuestion only for high-impact conflicts (contradicting purposes, per-site design decisions, retro-migration dwarfing the branch diff). Low-confidence findings never block.
- **Wiring:** full P1–P6 protocol in `skills/devops-ship/deep-knowledge/purpose-alignment.md`; referenced from SKILL.md Step 1d + Step 4 bounce-back, `merge-safety.md` Step 5, data-flow diagrams; project-tunable via `purpose_alignment:` block (depth/disable/standing conventions) in the ship extension `reference.md`. Skill 0.5.0 → 0.6.0.
- Design spec: `docs/superpowers/specs/2026-07-03-ship-purpose-alignment-design.md`.

## Verification
- npm test: 552/552 passed (35 files), lint clean, README markers current
- Gate dogfooded on this very ship: 5 purpose sources (#231, #229, #227, #226, #224) audited, no violations
- Codex review gate: skipped (CLI not on PATH, rc=127)

🤖 Generated with [Claude Code](https://claude.com/claude-code)