### PR TITLE
docs(agents): agent orchestration by default (0.107.3)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.107.2"
+    "version": "0.107.3"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.107.2",
+      "version": "0.107.3",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.107.2",
+      "version": "0.107.3",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.107.3] — 2026-07-04
+
+### Changed
+
+- **Proactive agent orchestration is now the default mode of work, not a per-task judgment about *whether* to involve agents.** `deep-knowledge/agent-proactivity.md` reframes the Core Rule: the devops agents are spun up automatically in the background for any task that isn't an explicit carve-out — the decision left to Claude is only *which* agents fit, and skipping them is what now needs justification. The `When NOT to Orchestrate` carve-outs (single-file/single-domain edits, pure Q&A, explicit "just fix it") are preserved unchanged, so trivial tasks stay inline without agent overhead.
+
 ## [0.107.2] — 2026-07-04
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.107.2**
+**Version: 0.107.3**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.107.2",
+  "version": "0.107.3",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/deep-knowledge/agent-proactivity.md
+++ b/plugins/devops/deep-knowledge/agent-proactivity.md
@@ -4,8 +4,12 @@ Cross-cutting rule for when to involve specialized agents without explicit user 
 
 ## Core Rule
 
-**Proactively evaluate whether specialized agents add value for the current task.**
-Do not wait for the user to say "use agents" — assess this yourself based on task signals.
+**Orchestrating specialized agents is the default mode of work — not the exception.**
+Involve the relevant devops agents automatically, in the background, without waiting for
+the user to say "use agents". For any task that isn't an explicit carve-out below, spin up
+the fitting agents by default; the decision is never "should I use agents?" but "which
+agents fit?". The only tasks that stay fully inline are the exceptions in
+[When NOT to Orchestrate](#when-not-to-orchestrate).
 
 ## When to Orchestrate Agents
 
@@ -71,7 +75,9 @@ integrations) is canonical there. For higher-stakes work, escalate to the
 
 ## Rules
 
-- This is a **judgment call**, not a mechanical trigger — use context and common sense
+- **Orchestrate by default.** The judgment call is not *whether* to use agents but
+  *which* ones fit — and whether a carve-out applies. Skipping agents is the decision
+  that needs justification, not using them.
 - When in doubt about complexity: orchestrate. The cost of an unnecessary agent is low;
   the cost of a missed perspective is high.
 - Never orchestrate silently — always tell the user which agents you're spinning up

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.107.2",
+  "version": "0.107.3",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

Reframes the proactive-agent-orchestration concept so the devops agents are used **by default, automatically in the background** — not decided per task. The judgment call is now only *which* agents fit; skipping them is what needs justification.

## Changes

- `deep-knowledge/agent-proactivity.md`: Core Rule + Rules section rewritten to "orchestrate by default"
- `When NOT to Orchestrate` carve-outs (trivial single-file edits, pure Q&A, explicit "just fix it") preserved unchanged — trivial tasks stay inline

## Verification

- lint clean · 584 tests pass