### PR TITLE
fix(autonomous): git-exclude run artifacts (0.107.5)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.107.4"
+    "version": "0.107.5"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.107.4",
+      "version": "0.107.5",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.107.4",
+      "version": "0.107.5",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.107.5] — 2026-07-06
+
+### Fixed
+
+- **Autonomous-run artifacts no longer pollute `git status` — session archiving stops warning about "uncommitted changes that will be permanently discarded" over them.** The `AUTONOMOUS-*` artifact family (`DONE.flag`, `LOG.md`, `REPORT.html`, `RESUME.json`, `STALLED.txt`, `INTERRUPTED.txt`) is deliberately written to the project root: the external watchdog polls `$PWD` for the done-flag, Step 0.2 resume classification scans worktree roots, and the HTML report opens from there — so the files can neither be relocated nor deleted at run end (observed live 2026-07-06: archiving an autonomous-run worktree warned over 3 untracked artifacts as discardable "changes"). `devops-autonomous` Step 3c (skill 0.4.0 → 0.4.1) now registers `/AUTONOMOUS-*` in the repo-local `$(git rev-parse --git-common-dir)/info/exclude` during permission priming, before anything writes them: never committed (no `.gitignore` noise in consumer projects), one entry covers every worktree of the repo, idempotent, and non-fatal on exotic git layouts. This also removes the risk of a blanket `git add -A` sweeping run artifacts into a commit. New `deep-knowledge/autonomous-execution.md` § Artifact Hygiene documents the artifact table (writer/reader per file) and the two hard rules: never relocate/delete mid-run, always git-invisible.
+
 ## [0.107.4] — 2026-07-05
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.107.4**
+**Version: 0.107.5**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.107.4",
+  "version": "0.107.5",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/deep-knowledge/autonomous-execution.md
+++ b/plugins/devops/deep-knowledge/autonomous-execution.md
@@ -75,6 +75,34 @@ Append one timestamped line per autonomous judgment call:
 Format: `[ISO-8601] <category>: <one-line decision + rationale>`. Keep it terse —
 one line each, never prose. This is observability, not a second report.
 
+## Artifact Hygiene
+
+The run drops its artifacts in the **project root** on purpose — every consumer
+polls or scans exactly that path:
+
+| Artifact | Written by | Read by |
+|----------|------------|---------|
+| `AUTONOMOUS-LOG.md` | Steps 4e/5 (decision journal) | user on return; embedded in report |
+| `AUTONOMOUS-REPORT.html` | Step 7b | browser; re-opened post-ship |
+| `AUTONOMOUS-DONE.flag` | Step 8c | external watchdog (`$PWD` poll); Step 0.2 resume scan |
+| `AUTONOMOUS-RESUME.json` | late-permission / bail protocol | Step 0.5 resume detection |
+| `AUTONOMOUS-STALLED.txt` | notify-mode watchdog | user (visible stall signal) |
+| `AUTONOMOUS-INTERRUPTED.txt` | bail protocol (report throttled) | user |
+
+Two hard rules follow:
+
+1. **Never relocate or delete them mid-run or at run end.** The DONE flag is the
+   watchdog handshake, the report is the primary deliverable the user opens after
+   returning, the resume file is the continuation state. They disappear naturally
+   when the worktree is removed (ship cleanup / session archive).
+2. **They must be invisible to git.** Untracked `AUTONOMOUS-*` files make session
+   archiving warn about "uncommitted changes that will be permanently discarded",
+   pollute `git status` in preflight checks, and get swept into commits by
+   `git add -A`. Step 3c therefore registers `/AUTONOMOUS-*` in
+   `$(git rev-parse --git-common-dir)/info/exclude` before execution starts —
+   repo-local, never committed (no `.gitignore` noise in consumer projects), and
+   the common git dir means one entry covers every worktree of the repo.
+
 ## Effort & Token Budget (Soft Cap)
 
 The 8h watchdog (Step 4d) is the hard *outer* limit — it only catches a dead

--- a/plugins/devops/skills/devops-autonomous/SKILL.md
+++ b/plugins/devops/skills/devops-autonomous/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: devops-autonomous
-version: 0.4.0
+version: 0.4.1
 description: >-
   Fully autonomous agent orchestration for when the user is away from the PC.
   Runs agents without supervision (implementation, desktop interaction, live
@@ -253,6 +253,23 @@ signal applies, `$BROWSER_TOOL` must be active before proceeding.
 Run a harmless `Bash` command (e.g., `echo "permission primed"`), `Read` a file,
 and (if `$EXEC_MODE` = `implement`) `Write` a temp file + delete it. This ensures
 file and shell permissions are pre-approved.
+
+**Artifact hygiene (same Bash priming call):** register the run artifacts in the
+repo-local git exclude BEFORE anything writes them, so `AUTONOMOUS-*` files never
+show up as untracked changes — otherwise session archiving warns about
+"uncommitted changes that will be permanently discarded" and a blanket
+`git add -A` would sweep them into a commit:
+
+```bash
+x="$(git rev-parse --path-format=absolute --git-common-dir)/info/exclude"
+mkdir -p "${x%/*}"
+grep -qxF '/AUTONOMOUS-*' "$x" 2>/dev/null || echo '/AUTONOMOUS-*' >> "$x"
+```
+
+Idempotent; `.git/info/exclude` is never committed and one entry covers every
+worktree of the repo. On failure (exotic git layout): log one journal line and
+continue — never block the run. Rationale + full artifact family:
+`deep-knowledge/autonomous-execution.md` § Artifact Hygiene.
 
 ### 3d — MCP Tool Permissions
 If the task uses any MCP tools (completion card, ship preflight, issues, etc.),

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.107.4",
+  "version": "0.107.5",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

Autonomous-run artifacts (`AUTONOMOUS-DONE.flag`, `AUTONOMOUS-LOG.md`, `AUTONOMOUS-REPORT.html`, `AUTONOMOUS-RESUME.json`, `AUTONOMOUS-STALLED.txt`, `AUTONOMOUS-INTERRUPTED.txt`) are deliberately written to the project root — the external watchdog polls `$PWD` for the done-flag, resume classification scans worktree roots, and the HTML report opens from there. As plain untracked files they made session archiving warn about "uncommitted changes that will be permanently discarded" (observed live 2026-07-06) and risked being swept into commits by `git add -A`.

## Fix

- `devops-autonomous` Step 3c (skill 0.4.0 → 0.4.1) registers `/AUTONOMOUS-*` in the repo-local `$(git rev-parse --git-common-dir)/info/exclude` during permission priming, before anything writes the artifacts. Never committed, no `.gitignore` noise in consumer projects, one entry covers every worktree, idempotent, non-fatal on exotic git layouts.
- New `deep-knowledge/autonomous-execution.md` § Artifact Hygiene documents the artifact family (writer/reader per file) and the two hard rules: never relocate/delete mid-run or at run end; always git-invisible.

## Purpose

Session archiving of finished autonomous worktrees must be silent — run artifacts are deliverables and watchdog handshakes, not discardable "changes". Verified live: with the exclude registered, probe artifacts no longer appear in `git status --porcelain` and `git check-ignore` matches them from inside a worktree. 594 tests pass, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)