### PR TITLE
feat(graphify): gate self-heal + value-moment opt-in offer (0.109.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.108.0"
+    "version": "0.109.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.108.0",
+      "version": "0.109.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.108.0",
+      "version": "0.109.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ memory/
 package-lock.json
 .claude/devops-concept/
 __pycache__/
+
+# graphify knowledge-graph output (generated, per-project, not distributable)
+graphify-out/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.109.0] — 2026-07-07
+
+### Fixed
+
+- **The graphify token-saver gate now actually fires during development instead of sitting silently disarmed.** A 3-day / 108-session audit found zero real `graphify query` retrievals and only one project ever opted in — the enforcement was running in the void. Root cause: the PreToolUse graphify-gate only fires against a **fresh** graph (a deliberate fail-safe — never force Claude onto stale data), but any source-file edit outdates the graph, so mid-development the graph is almost always stale and the gate is off; the background rebuild only ran at SessionStart (throttled 10 min) or on commit. Now a broad `Grep`/`Glob` on a consented project with a **stale** graph kicks a throttled (2 min) background `graphify extract . --update` (AST-only, free), so the graph self-heals mid-session and the gate can enforce on later searches — while still never blocking onto stale data. (`pre.tokens.guard` 0.5.0 → 0.6.0, `graphify-state` `isUndecided`/`markRefresh`.)
+
+### Added
+
+- **Undecided projects now get the graphify opt-in offer at the moment it pays off — a blocked broad search — not just as passive session-start context.** The SessionStart auto-offer converted ~0% (1 of 12 audited projects reacted) because it competes with the user's first prompt and loses. The SessionStart proposal is unchanged; additionally, when a broad search is blocked by the token guard in a git project that has no graphify decision yet, the block message now carries a throttled (weekly) enable offer where the token cost is concrete. Two independent weekly throttles → at most two low-cost offers per project per week. (`graph-nudge` `buildGraphifyOffer`; 6 new tests, 626 total.)
+
 ## [0.108.0] — 2026-07-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.108.0**
+**Version: 0.109.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.108.0",
+  "version": "0.109.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/hooks/lib/graph-nudge.js
+++ b/plugins/devops/hooks/lib/graph-nudge.js
@@ -42,6 +42,23 @@ function buildGraphNudge() {
   ].join('\n');
 }
 
+/**
+ * One-line offer surfaced at the moment a broad search is blocked in a project
+ * that has no graphify decision yet — the point where the token cost is concrete
+ * and the value proposition lands hardest (much higher conversion than the
+ * passive SessionStart offer). Steers Claude to offer enabling graphify via
+ * AskUserQuestion. Kept short so it rides an existing block message.
+ */
+function buildGraphifyOffer() {
+  return [
+    '💡 [graphify] Broad searches like this are exactly what a code knowledge graph makes cheap.',
+    'This project has no graphify decision yet — offer the user (AskUserQuestion) to enable it.',
+    'On YES: `uv tool install graphifyy && graphify install && graphify hook install && graphify extract .`,',
+    'then write .claude/graphify.json {"consent":true,"autoBuild":true}. On NO: write {"consent":false}.',
+    'Never install without confirmation.',
+  ].join('\n');
+}
+
 // Directories whose contents never count toward "newest source file": VCS,
 // dependencies, build output, and graphify's own output. Dot-dirs are skipped
 // too (handled in the walk), so .git/.claude/.venv are covered by both.
@@ -115,6 +132,7 @@ module.exports = {
   graphJsonPath,
   hasGraph,
   buildGraphNudge,
+  buildGraphifyOffer,
   scanSources,
   graphIsStale,
 };

--- a/plugins/devops/hooks/lib/graph-nudge.test.js
+++ b/plugins/devops/hooks/lib/graph-nudge.test.js
@@ -2,7 +2,7 @@ import { describe, test, expect, beforeAll, afterAll } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { hasGraph, buildGraphNudge, graphJsonPath, graphIsStale } from "./graph-nudge.js";
+import { hasGraph, buildGraphNudge, buildGraphifyOffer, graphJsonPath, graphIsStale } from "./graph-nudge.js";
 
 describe("hasGraph — graph.json detection", () => {
   let dir;
@@ -42,6 +42,15 @@ describe("buildGraphNudge — ambient hint text", () => {
     expect(t).toContain("graphify query");
     expect(t).toContain("graphify-out/graph.json");
     expect(t).toContain("/devops-graph");
+  });
+});
+
+describe("buildGraphifyOffer — value-moment offer text", () => {
+  test("names graphify, AskUserQuestion, and the consent file", () => {
+    const t = buildGraphifyOffer();
+    expect(t).toContain("graphify");
+    expect(t).toContain("AskUserQuestion");
+    expect(t).toContain("graphify.json");
   });
 });
 

--- a/plugins/devops/hooks/lib/graphify-state.js
+++ b/plugins/devops/hooks/lib/graphify-state.js
@@ -44,6 +44,41 @@ function isDeclined(cwd) {
   return !!(s && s.consent === false);
 }
 
+/**
+ * True iff there is NO consent record yet — the project is undecided, so a
+ * one-time offer to enable graphify is appropriate. (consent:true / consent:false
+ * both return false — the user has already chosen.)
+ */
+function isUndecided(cwd) {
+  return readState(cwd) === null;
+}
+
+function refreshFlagPath(cwd) {
+  const key = crypto.createHash('md5').update(`refresh:${cwd}`).digest('hex').slice(0, 12);
+  return path.join(os.tmpdir(), `dotclaude-graphrefresh-${key}.flag`);
+}
+
+/**
+ * Throttle gate for the demand-driven stale-graph refresh triggered from the
+ * PreToolUse graphify-gate. Returns true (and stamps the flag) at most once per
+ * `cooldownMs` per project, so a burst of broad searches cannot stack concurrent
+ * `graphify extract` runs. Keyed on cwd (not session) so parallel agents/
+ * worktrees on the same project share one throttle. Never throws.
+ */
+function markRefresh(cwd, cooldownMs) {
+  const file = refreshFlagPath(cwd);
+  try {
+    const age = Date.now() - fs.statSync(file).mtimeMs;
+    if (age < cooldownMs) return false;
+  } catch { /* absent → first run */ }
+  try {
+    fs.writeFileSync(file, String(Date.now()));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function queryFlagPath(sessionId, cwd) {
   const key = crypto.createHash('md5').update(`${sessionId || 'nosid'}:${cwd}`).digest('hex').slice(0, 12);
   return path.join(os.tmpdir(), `dotclaude-graphq-${key}.flag`);
@@ -87,6 +122,9 @@ module.exports = {
   readState,
   hasConsent,
   isDeclined,
+  isUndecided,
+  refreshFlagPath,
+  markRefresh,
   queryFlagPath,
   markQueryDone,
   queryDone,

--- a/plugins/devops/hooks/lib/graphify-state.test.js
+++ b/plugins/devops/hooks/lib/graphify-state.test.js
@@ -6,6 +6,9 @@ import {
   readState,
   hasConsent,
   isDeclined,
+  isUndecided,
+  markRefresh,
+  refreshFlagPath,
   markQueryDone,
   queryDone,
   consentPath,
@@ -49,6 +52,53 @@ describe("consent record", () => {
     expect(readState(dir)).toBeNull();
     expect(hasConsent(dir)).toBe(false);
     expect(isDeclined(dir)).toBe(false);
+  });
+});
+
+describe("isUndecided — offer eligibility", () => {
+  let dir;
+  beforeEach(() => {
+    dir = tmp();
+    fs.mkdirSync(path.join(dir, ".claude"), { recursive: true });
+  });
+  afterEach(() => {
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+  });
+
+  test("no record → undecided", () => {
+    expect(isUndecided(dir)).toBe(true);
+  });
+  test("consent:true → decided (not undecided)", () => {
+    fs.writeFileSync(consentPath(dir), JSON.stringify({ consent: true }));
+    expect(isUndecided(dir)).toBe(false);
+  });
+  test("consent:false → decided (not undecided)", () => {
+    fs.writeFileSync(consentPath(dir), JSON.stringify({ consent: false }));
+    expect(isUndecided(dir)).toBe(false);
+  });
+});
+
+describe("markRefresh — stale-graph refresh throttle", () => {
+  test("first call true then throttled; independent per project", () => {
+    const d = tmp();
+    expect(markRefresh(d, 60_000)).toBe(true);   // first → allowed, stamps flag
+    expect(markRefresh(d, 60_000)).toBe(false);  // within cooldown → throttled
+    expect(fs.existsSync(refreshFlagPath(d))).toBe(true);
+    const d2 = tmp();
+    expect(markRefresh(d2, 60_000)).toBe(true);  // different project → independent
+    try { fs.rmSync(d, { recursive: true, force: true }); } catch {}
+    try { fs.rmSync(d2, { recursive: true, force: true }); } catch {}
+  });
+
+  test("allowed again once the cooldown has elapsed", () => {
+    const d = tmp();
+    expect(markRefresh(d, 60_000)).toBe(true);
+    expect(markRefresh(d, 60_000)).toBe(false); // throttled
+    // Backdate the flag past the cooldown → next call allowed again.
+    const past = new Date(Date.now() - 120_000);
+    fs.utimesSync(refreshFlagPath(d), past, past);
+    expect(markRefresh(d, 60_000)).toBe(true);
+    try { fs.rmSync(d, { recursive: true, force: true }); } catch {}
   });
 });
 

--- a/plugins/devops/hooks/pre-tool-use/pre.tokens.guard.graphgate.test.js
+++ b/plugins/devops/hooks/pre-tool-use/pre.tokens.guard.graphgate.test.js
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
-import { markQueryDone } from "../lib/graphify-state.js";
+import { markQueryDone, refreshFlagPath } from "../lib/graphify-state.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const HOOK = path.join(__dirname, "pre.tokens.guard.js");
@@ -101,6 +101,48 @@ describe("pre.tokens.guard — graphify hard-gate (integration)", () => {
     markQueryDone("s-queried", dir);
     const r = runGrep(dir, "s-queried", "zeta");
     expect(r.stderr).not.toContain("GRAPHIFY GATE");
+    cleanup(dir);
+  });
+
+  test("stale graph + consent → self-heal refresh requested, still not gated", () => {
+    const dir = project({ consent: true, graph: "stale" });
+    const r = runGrep(dir, "s-heal", "omega");
+    expect(r.stderr).not.toContain("GRAPHIFY GATE"); // never block onto stale
+    expect(fs.existsSync(refreshFlagPath(dir))).toBe(true); // background refresh kicked
+    cleanup(dir);
+  });
+});
+
+describe("pre.tokens.guard — value-moment graphify offer (undecided projects)", () => {
+  function gitProject() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "graphoffer-"));
+    fs.mkdirSync(path.join(dir, ".claude"), { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, ".claude", "settings.json"),
+      JSON.stringify({ enabledPlugins: { "devops@dotclaude": true } })
+    );
+    fs.writeFileSync(path.join(dir, "a.js"), "const x = 1;");
+    spawnSync("git", ["init", "-q"], { cwd: dir });
+    return dir;
+  }
+
+  test("undecided + no graph + git → broad search block carries the offer, throttled", () => {
+    const dir = gitProject();
+    const first = runGrep(dir, "s-offer", "needle");
+    expect(first.status).toBe(2); // still blocked by the token guard
+    expect(first.stderr).toContain("[graphify]");
+    expect(first.stderr).toContain("AskUserQuestion");
+    // Weekly throttle: a second broad search this week does NOT re-offer.
+    const second = runGrep(dir, "s-offer", "haystack");
+    expect(second.stderr).not.toContain("[graphify]");
+    cleanup(dir);
+  });
+
+  test("declined project → no offer", () => {
+    const dir = gitProject();
+    fs.writeFileSync(path.join(dir, ".claude", "graphify.json"), JSON.stringify({ consent: false }));
+    const r = runGrep(dir, "s-declined-offer", "needle");
+    expect(r.stderr).not.toContain("[graphify]");
     cleanup(dir);
   });
 });

--- a/plugins/devops/hooks/pre-tool-use/pre.tokens.guard.js
+++ b/plugins/devops/hooks/pre-tool-use/pre.tokens.guard.js
@@ -26,10 +26,32 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 const crypto = require('crypto');
+const { spawn, execSync } = require('child_process');
 
 const cwd = process.cwd();
 const CONFIG_DIR = path.join(cwd, '.claude');
 const CONFIG_PATH = path.join(CONFIG_DIR, 'token-config.json');
+
+// Detached, fail-open background spawn (mirrors ss.graphify). `shell` on Windows
+// so a `graphify.cmd` shim from `uv tool install` actually runs. A missing
+// toolchain throws → no-op; never affects the guard's block/allow decision.
+function bg(cmd, args) {
+  try {
+    spawn(cmd, args, {
+      cwd, detached: true, stdio: 'ignore', shell: process.platform === 'win32',
+    }).unref();
+  } catch { /* toolchain absent */ }
+}
+
+function isGitRepo() {
+  try {
+    return execSync('git rev-parse --is-inside-work-tree', {
+      cwd, encoding: 'utf8', timeout: 4000, stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim() === 'true';
+  } catch {
+    return false;
+  }
+}
 
 const PLAN_DEFAULTS = require('../lib/plan-defaults');
 
@@ -202,23 +224,32 @@ process.stdin.on('end', () => {
       const graphNudge = require('../lib/graph-nudge');
       const gstate = require('../lib/graphify-state');
       const sid = hook.session_id || hook.sessionId || 'nosid';
-      if (gstate.hasConsent(cwd) && !gstate.queryDone(sid, cwd)
-          && graphNudge.hasGraph(cwd) && !graphNudge.graphIsStale(cwd)) {
-        const gflag = flagPath(`graphgate:${sid}:${cwd}:${toolName}:${JSON.stringify(toolInput)}`);
-        if (!fs.existsSync(gflag)) {
-          try { fs.writeFileSync(gflag, Date.now().toString()); } catch {}
-          console.error('\n⛔  GRAPHIFY GATE — broad search blocked (fresh graph available)');
-          console.error('─'.repeat(54));
-          console.error('Query the knowledge graph instead of grepping raw files:');
-          console.error('  graphify query "<your question>"');
-          console.error('');
-          console.error('If the graph cannot answer THIS search (exact string, a');
-          console.error('new/uncommitted file, or a non-code asset), retry the same');
-          console.error('search to proceed.');
-          console.error('─'.repeat(54));
-          process.exit(2);
+      if (gstate.hasConsent(cwd) && graphNudge.hasGraph(cwd)) {
+        if (graphNudge.graphIsStale(cwd)) {
+          // Demand-driven self-heal: a broad search arrived but the graph is
+          // stale (the common case mid-development — any edit outdates it), so
+          // the gate below cannot fire and the graph would just rot until the
+          // next SessionStart. Kick a throttled background AST refresh (free) so
+          // the graph converges to fresh and the gate can enforce on LATER
+          // searches this session. Never blocks; falls through to allow.
+          if (gstate.markRefresh(cwd, 2 * 60 * 1000)) bg('graphify', ['extract', '.', '--update']);
+        } else if (!gstate.queryDone(sid, cwd)) {
+          const gflag = flagPath(`graphgate:${sid}:${cwd}:${toolName}:${JSON.stringify(toolInput)}`);
+          if (!fs.existsSync(gflag)) {
+            try { fs.writeFileSync(gflag, Date.now().toString()); } catch {}
+            console.error('\n⛔  GRAPHIFY GATE — broad search blocked (fresh graph available)');
+            console.error('─'.repeat(54));
+            console.error('Query the knowledge graph instead of grepping raw files:');
+            console.error('  graphify query "<your question>"');
+            console.error('');
+            console.error('If the graph cannot answer THIS search (exact string, a');
+            console.error('new/uncommitted file, or a non-code asset), retry the same');
+            console.error('search to proceed.');
+            console.error('─'.repeat(54));
+            process.exit(2);
+          }
+          // flag present → already gated this search; fall through (escape hatch)
         }
-        // flag present → already gated this search; fall through (escape hatch)
       }
     } catch { /* fail open — never block on gate errors */ }
   }
@@ -318,6 +349,24 @@ process.stdin.on('end', () => {
     if (fs.existsSync(projectMap)) {
       console.error(`\nHint: Read .claude/project-map.md to find the right path first.`);
     }
+
+    // Value-moment graphify offer: a broad search just got blocked in a git
+    // project that has no graphify decision yet and no graph. This is where the
+    // token cost is concrete, so conversion is far higher than the passive
+    // SessionStart offer. Throttled once per week per project (shares nothing
+    // with the SessionStart offer key, so at most two low-cost offers/week).
+    try {
+      const gstate = require('../lib/graphify-state');
+      const graphNudge = require('../lib/graph-nudge');
+      if (gstate.isUndecided(cwd) && !graphNudge.hasGraph(cwd) && isGitRepo()) {
+        const { runOnce } = require('../lib/run-once');
+        const cwdKey = crypto.createHash('md5').update(cwd).digest('hex').slice(0, 12);
+        if (runOnce('graphify-block-offer', cwdKey, { cooldownMs: 7 * 24 * 60 * 60 * 1000 })) {
+          console.error('');
+          console.error(graphNudge.buildGraphifyOffer());
+        }
+      }
+    } catch { /* never let the offer break the block */ }
   }
 
   console.error(line);

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.108.0",
+  "version": "0.109.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

The graphify token-saver was running in the void: a 3-day / 108-session audit found **zero** real `graphify query` retrievals and only one project (dotclaude) ever opted in. Two root causes fixed.

**1. Gate never fired (Fixed).** The PreToolUse graphify-gate only enforces against a *fresh* graph (a deliberate fail-safe — never force Claude onto stale data). But any source edit outdates the graph, so mid-development it is almost always stale and the gate is silently off; the rebuild only ran at SessionStart (10-min throttle) or on commit. Now a broad `Grep`/`Glob` on a consented project with a **stale** graph kicks a throttled (2 min) background `graphify extract . --update` (AST, free) — the graph self-heals mid-session so the gate can enforce on later searches, while still never blocking onto stale data.

**2. Auto-offer converted ~0% (Added).** The passive SessionStart offer loses to the user's first prompt (1 of 12 audited projects reacted). The SessionStart auto-proposal is unchanged; additionally the **block-moment** of a broad search in undecided git projects now carries a throttled (weekly) enable offer, where the token cost is concrete.

Retracted a false finding along the way: the "offer spam" was a grep artifact — the real offer string appears exactly once per session (weekly `runOnce` throttle works correctly).

## Changes
- `pre.tokens.guard.js` 0.5.0 → 0.6.0 — stale-graph self-heal + value-moment offer + `bg`/`isGitRepo` helpers
- `graphify-state.js` — `isUndecided`, `markRefresh`, `refreshFlagPath`
- `graph-nudge.js` — `buildGraphifyOffer`
- `.gitignore` — ignore generated `graphify-out/`

## Tests
- 626/626 vitest green (+6 new: 3 lib unit, 3 gate integration), eslint clean
- Real-hook smoke on the worktree confirmed correct routing

🤖 Generated with [Claude Code](https://claude.com/claude-code)