### PR TITLE
feat(ship): gate out-of-band infra deploys (0.110.0) (#243)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.109.0"
+    "version": "0.110.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.109.0",
+      "version": "0.110.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.109.0",
+      "version": "0.110.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.110.0] — 2026-07-08
+
+### Added
+
+- **Ship now detects out-of-band deploy artifacts and refuses to report "all done" while they are undeployed (#243).** A `/devops-ship` run merges code and rendered a `ship-successful` "Alles ERLEDIGT" card the moment the PR merged + tagged — but a plain merge does **not** apply DB migrations or deploy edge/serverless functions. When a diff touched those paths, the merged code referenced infra that was never applied, so the change was silently NOT live while the card claimed done. `ship_preflight` now scans the branch diff against stack-agnostic globs (`**/migrations/**`, `supabase/migrations/**`, `supabase/functions/**`, overridable per project via the ship-extension `reference.md` `outOfBandDeploy:` field) and returns `outOfBandDeploys: { detected, files, kinds }` (non-blocking — never gates the merge). New ship Step 4d turns that into either an actual deploy (when the extension registers a `deploy:` handler) or a mandatory, loud completion-card gate: the card gains a `deployGate` block naming each undeployed artifact + its required deploy action, and `state.deployPending` flips the ship-successful CTA from "Alles ERLEDIGT" to "🚨 DEPLOY erforderlich (noch nicht live)". Concrete deploy automation stays project-specific; the plugin ships only the generic detection + gate. (`ship_preflight` + new `ship/lib/infra-deploy.js`, completion MCP `0.6.0 → 0.7.0`, `devops-ship` skill `0.6.1 → 0.7.0`; 19 new tests, 644 total.)
+
 ## [0.109.0] — 2026-07-07
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.109.0**
+**Version: 0.110.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.109.0",
+  "version": "0.110.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/mcp-server/index.card.test.js
+++ b/plugins/devops/mcp-server/index.card.test.js
@@ -1,0 +1,96 @@
+import { describe, test, expect, vi, beforeAll } from "vitest";
+
+// index.js boots an MCP server over stdio at import time and pulls in the
+// @modelcontextprotocol SDK + zod (neither is a devDependency of this repo).
+// Mock all three so the module imports cleanly and we can capture the
+// render_completion_card handler to exercise the pure card renderer.
+// Never spawn the real headless usage scraper (Edge) from a unit test — it is
+// slow and flaky under parallel load. The card renders without a usage meter.
+process.env.DEVOPS_COMPLETION_NO_USAGE = "1";
+
+const captured = vi.hoisted(() => ({ handlers: {} }));
+
+vi.mock("@modelcontextprotocol/sdk/server/mcp.js", () => ({
+  McpServer: class {
+    registerTool(name, _cfg, handler) { captured.handlers[name] = handler; }
+    async connect() {}
+  },
+}));
+vi.mock("@modelcontextprotocol/sdk/server/stdio.js", () => ({
+  StdioServerTransport: class {},
+}));
+vi.mock("zod", () => {
+  const node = new Proxy(() => node, { get: () => () => node });
+  const z = new Proxy({}, { get: () => () => node });
+  return { z };
+});
+
+let render;
+
+beforeAll(async () => {
+  await import("./index.js");
+  render = captured.handlers["render_completion_card"];
+});
+
+async function cardText(params) {
+  const res = await render(params);
+  // content[0] is the DO-NOT-OUTPUT instruction; content[1] is the card markdown.
+  return res.content.map((c) => c.text).join("\n");
+}
+
+describe("render_completion_card — out-of-band deploy gate (#243)", () => {
+  const baseParams = {
+    variant: "ship-successful",
+    summary: "Test ship",
+    lang: "de",
+    buildId: "abc1234",
+    session_id: "test-oob",
+    state: { branch: "main", pushed: true, merged: "main", commit: "abc1234" },
+  };
+
+  test("no deployGate → renders 'Alles ERLEDIGT', no deploy warning", async () => {
+    const text = await cardText(baseParams);
+    expect(text).toMatch(/Alles ERLEDIGT/);
+    expect(text).not.toMatch(/DEPLOY erforderlich/);
+    expect(text).not.toMatch(/noch NICHT live/);
+  });
+
+  test("deployGate + deployPending → loud deploy block AND CTA flips off 'all done'", async () => {
+    const text = await cardText({
+      ...baseParams,
+      state: { ...baseParams.state, deployPending: true },
+      deployGate: [
+        { artifact: "supabase/migrations/20260708_token_revoked.sql", kind: "migration", action: "apply_migration" },
+        { artifact: "supabase/functions/desktop-latest/index.ts", kind: "function", action: "deploy_edge_function desktop-latest" },
+      ],
+    });
+    // Loud gate block names each artifact + its deploy action.
+    expect(text).toMatch(/DEPLOY erforderlich — noch NICHT live/);
+    expect(text).toMatch(/migration · supabase\/migrations\/20260708_token_revoked\.sql — apply_migration/);
+    expect(text).toMatch(/function · supabase\/functions\/desktop-latest\/index\.ts — deploy_edge_function desktop-latest/);
+    // CTA must NOT read as finished.
+    expect(text).toMatch(/DEPLOY erforderlich \(noch nicht live\)/);
+    expect(text).not.toMatch(/Alles ERLEDIGT/);
+  });
+
+  test("English deploy gate localizes header + CTA", async () => {
+    const text = await cardText({
+      ...baseParams,
+      lang: "en",
+      state: { ...baseParams.state, deployPending: true },
+      deployGate: [{ artifact: "db/migrations/1.sql", kind: "migration", action: "run migration" }],
+    });
+    expect(text).toMatch(/DEPLOY required — NOT live yet/);
+    expect(text).toMatch(/DEPLOY REQUIRED \(not live yet\)/);
+    expect(text).not.toMatch(/All DONE/);
+  });
+
+  test("plain-string deploy items render as bullets", async () => {
+    const text = await cardText({
+      ...baseParams,
+      state: { ...baseParams.state, deployPending: true },
+      deployGate: ["Apply the token_revoked migration to prod"],
+    });
+    expect(text).toMatch(/Apply the token_revoked migration to prod/);
+  });
+});

--- a/plugins/devops/mcp-server/index.js
+++ b/plugins/devops/mcp-server/index.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * @module dotclaude-completion-mcp
- * @version 0.6.0
+ * @version 0.7.0
  * @plugin devops
  * @description MCP server with two tools:
  *   - `get_usage`              — live usage via the claude.ai internal API
@@ -254,15 +254,15 @@ function renderUsageMeterForCard(usageData, delta5h, deltaWk, healthLine) {
 // ---------------------------------------------------------------------------
 
 const VARIANTS = {
-  'ship-successful': { usage: true,  changes: true,  tests: true,  state: true,  userTest: false, userFinalTest: true  },
-  ready:             { usage: true,  changes: true,  tests: true,  state: true,  userTest: false, userFinalTest: true  },
-  'ready-files':     { usage: true,  changes: true,  tests: true,  state: true,  userTest: false, userFinalTest: true  },
-  'ship-blocked':    { usage: true,  changes: true,  tests: true,  state: true,  userTest: false, userFinalTest: true  },
-  test:              { usage: true,  changes: true,  tests: true,  state: true,  userTest: true,  userFinalTest: false },
-  'test-minimal':    { usage: false, changes: false, tests: false, state: false, userTest: false, userFinalTest: false },
-  analysis:          { usage: true,  changes: true,  tests: false, state: true,  userTest: false, userFinalTest: true  },
-  aborted:           { usage: true,  changes: true,  tests: false, state: true,  userTest: false, userFinalTest: true  },
-  fallback:          { usage: true,  changes: true,  tests: false, state: true,  userTest: false, userFinalTest: true  },
+  'ship-successful': { usage: true,  changes: true,  tests: true,  state: true,  userTest: false, userFinalTest: true,  deployGate: true  },
+  ready:             { usage: true,  changes: true,  tests: true,  state: true,  userTest: false, userFinalTest: true,  deployGate: true  },
+  'ready-files':     { usage: true,  changes: true,  tests: true,  state: true,  userTest: false, userFinalTest: true,  deployGate: true  },
+  'ship-blocked':    { usage: true,  changes: true,  tests: true,  state: true,  userTest: false, userFinalTest: true,  deployGate: true  },
+  test:              { usage: true,  changes: true,  tests: true,  state: true,  userTest: true,  userFinalTest: false, deployGate: false },
+  'test-minimal':    { usage: false, changes: false, tests: false, state: false, userTest: false, userFinalTest: false, deployGate: false },
+  analysis:          { usage: true,  changes: true,  tests: false, state: true,  userTest: false, userFinalTest: true,  deployGate: true  },
+  aborted:           { usage: true,  changes: true,  tests: false, state: true,  userTest: false, userFinalTest: true,  deployGate: true  },
+  fallback:          { usage: true,  changes: true,  tests: false, state: true,  userTest: false, userFinalTest: true,  deployGate: true  },
 };
 
 const CTA = {
@@ -271,6 +271,8 @@ const CTA = {
     'ship-successful-merged-kept': '## \ud83d\ude80 SHIPPED. merged \u2192 origin/{merged} \u2014 KEEP CODING in `{branch}`',
     'ship-successful-plain':       '## \ud83d\ude80 SHIPPED \u2014 All DONE',
     'ship-successful-plain-kept':  '## \ud83d\ude80 SHIPPED \u2014 KEEP CODING in `{branch}`',
+    'ship-successful-deploy-merged': '## \ud83d\ude80 MERGED \u2192 origin/{merged} \u2014 \ud83d\udea8 DEPLOY REQUIRED (not live yet)',
+    'ship-successful-deploy-plain':  '## \ud83d\ude80 SHIPPED \u2014 \ud83d\udea8 DEPLOY REQUIRED (not live yet)',
     ready:                    '## \ud83d\udce6 READY \u2014 SHIP or CHANGE?',
     'ship-blocked':           '## \u26d4 BLOCKED. {reason} \u2014 FIX or SKIP?',
     test:                     '## \ud83e\uddea DONE \u2014 SHIP after your TEST?',
@@ -284,6 +286,8 @@ const CTA = {
     'ship-successful-merged-kept': '## \ud83d\ude80 SHIPPED. merged \u2192 origin/{merged} \u2014 WEITER in `{branch}`',
     'ship-successful-plain':       '## \ud83d\ude80 SHIPPED \u2014 Alles ERLEDIGT',
     'ship-successful-plain-kept':  '## \ud83d\ude80 SHIPPED \u2014 WEITER in `{branch}`',
+    'ship-successful-deploy-merged': '## \ud83d\ude80 GEMERGED \u2192 origin/{merged} \u2014 \ud83d\udea8 DEPLOY erforderlich (noch nicht live)',
+    'ship-successful-deploy-plain':  '## \ud83d\ude80 SHIPPED \u2014 \ud83d\udea8 DEPLOY erforderlich (noch nicht live)',
     ready:                    '## \ud83d\udce6 READY \u2014 SHIP oder ÄNDERN?',
     'ship-blocked':           '## \u26d4 BLOCKED. {reason} \u2014 FIX oder SKIP?',
     test:                     '## \ud83e\uddea DONE \u2014 SHIP nach deinem TEST?',
@@ -508,16 +512,49 @@ function renderUserFinalTest(items, lang) {
   return labels.header + '\n' + bullets.join('\n');
 }
 
+// Out-of-band deploy gate (#243). A code merge does NOT apply DB migrations or
+// deploy edge/serverless functions — so a card for such a ship must NOT read as
+// "all done". This block is deliberately loud: it names each artifact that is
+// still NOT live and what deploy action it needs, so the user cannot mistake a
+// merged-but-undeployed ship for a finished one.
+const DEPLOY_GATE_LABEL = {
+  de: { header: '🚨 **DEPLOY erforderlich — noch NICHT live:**', hint: 'Ein Merge deployt diese Artefakte nicht. Ohne diesen Schritt bleibt die Änderung in Produktion unwirksam.' },
+  en: { header: '🚨 **DEPLOY required — NOT live yet:**',        hint: 'A merge does not deploy these artifacts. Until you deploy them, the change stays inactive in production.' },
+};
+
+function renderDeployGate(items, lang) {
+  if (!items || items.length === 0) return '';
+  const labels = DEPLOY_GATE_LABEL[lang] || DEPLOY_GATE_LABEL.de;
+  const bullets = items.map(it => {
+    if (typeof it === 'string') return '* ' + it;
+    const artifact = (it && it.artifact) || '';
+    const kind = it && it.kind;
+    const action = it && it.action;
+    // "migration · supabase/migrations/1.sql — apply_migration"
+    const head = [kind, artifact].filter(Boolean).join(' · ');
+    return '* ' + head + (action ? ' — ' + action : '');
+  });
+  return labels.header + '\n' + bullets.join('\n') + '\n\n_' + labels.hint + '_';
+}
+
 function renderCTA(variant, cta, lang, state) {
   const templates = CTA[lang] || CTA.de;
   cta = cta || {};
 
   let key;
   if (variant === 'ship-successful') {
-    // Show merge target in CTA if actually merged; "-kept" suffix when keep-mode
-    // kept the worktree/branch alive for follow-up work.
-    const base = (state && state.merged) ? 'ship-successful-merged' : 'ship-successful-plain';
-    key = (state && state.kept) ? `${base}-kept` : base;
+    // Out-of-band deploy pending (#243): the code merged but infra (migrations /
+    // functions) is NOT deployed. The CTA must NOT say "All DONE" — flip it to a
+    // deploy-required call to action so a merged-but-undeployed ship is never
+    // mistaken for finished. Takes precedence over merged/kept wording.
+    if (state && state.deployPending) {
+      key = (state && state.merged) ? 'ship-successful-deploy-merged' : 'ship-successful-deploy-plain';
+    } else {
+      // Show merge target in CTA if actually merged; "-kept" suffix when keep-mode
+      // kept the worktree/branch alive for follow-up work.
+      const base = (state && state.merged) ? 'ship-successful-merged' : 'ship-successful-plain';
+      key = (state && state.kept) ? `${base}-kept` : base;
+    }
   } else {
     key = variant;
   }
@@ -704,6 +741,18 @@ function renderCard(input, meterText, buildId) {
     }
   }
 
+  // Out-of-band deploy gate (#243) — rendered BEFORE userFinalTest so the
+  // "not live yet" warning is the first thing after the change/test blocks. A
+  // merged-but-undeployed ship (DB migration, edge function) must never read as
+  // done. Same variant availability as userFinalTest (skipped in test/-minimal).
+  if (config.deployGate) {
+    const deployBlock = renderDeployGate(input.deployGate, lang);
+    if (deployBlock) {
+      parts.push(deployBlock);
+      parts.push('');
+    }
+  }
+
   // User-final-test flag (Electron without takeover, 3rd-party integrations)
   // Available in all variants except test-minimal and test — so e.g. a
   // ship-successful card can still flag "test the real Stripe integration in
@@ -832,6 +881,13 @@ function refreshUsage() {
   //    cache fallback (it stamps _cached/_failureReason into the file instead),
   //    so a zero exit code is NOT proof of a live fetch — the freshness of the
   //    re-read file is.
+  // Escape hatch — skip the external headless fetch entirely. Set in tests (so
+  // the card renderer never spawns Edge) and usable offline/CI. The card still
+  // renders; it just omits the usage meter (data === null).
+  if (process.env.DEVOPS_COMPLETION_NO_USAGE === "1") {
+    return { success: false, data: null, delta5h: null, deltaWk: null };
+  }
+
   const scraperScript = resolveScraperScript();
   let scrapeErr = null;
   if (scraperScript) {
@@ -1009,6 +1065,7 @@ server.registerTool(
           merged: z.string().nullable().optional(),
           appStatus: z.enum(["running", "not-started"]).nullable().optional(),
           kept: z.boolean().optional().describe("Ship cleanup was skipped — branch + worktree preserved for follow-up work. Switches the ship-successful CTA from 'All DONE' to 'KEEP CODING in {branch}'."),
+          deployPending: z.boolean().optional().describe("Out-of-band deploy artifacts (DB migrations / edge functions) were merged but NOT deployed (#243). Flips the ship-successful CTA from 'All DONE' to '🚨 DEPLOY erforderlich (noch nicht live)'. Pair with the top-level `deployGate` list naming each artifact."),
         }).optional(),
       ).describe("Repository state"),
       cta: z.preprocess(
@@ -1037,6 +1094,17 @@ server.registerTool(
           }),
         ])).optional(),
       ).describe("User-final-test items — for changes where automation cannot cover the last step (packaged Electron/Tauri without desktop takeover, 3rd-party integrations). Pass strings for local final tests; pass { action, afterDeployment: true } for 3rd-party items that require deployment first. Available in all variants except test-minimal and test — in the test variant all manual steps go into userTest (single test section, no duplicate)."),
+      deployGate: z.preprocess(
+        v => typeof v === 'string' ? tryParse(v) : v,
+        z.array(z.union([
+          z.string(),
+          z.object({
+            artifact: z.string().describe("The out-of-band deploy artifact path, e.g. 'supabase/migrations/1.sql'."),
+            kind: z.string().optional().describe("Deploy kind — 'migration', 'function', or 'infra'."),
+            action: z.string().optional().describe("The concrete deploy action still required, e.g. 'apply_migration' or 'deploy_edge_function desktop-latest'."),
+          }),
+        ])).optional(),
+      ).describe("Out-of-band deploy gate (#243) — artifacts a code merge did NOT deploy (DB migrations, edge/serverless functions) and that are therefore NOT live yet. Renders a loud '🚨 DEPLOY erforderlich — noch NICHT live' block naming each artifact + its deploy action, so a merged-but-undeployed ship never reads as done. Pair with state.deployPending to also flip the CTA. Available in all variants except test-minimal and test. Populate from ship_preflight.outOfBandDeploys when the project has no deploy handler that already applied them."),
       validation: z.preprocess(
         v => typeof v === 'string' ? tryParse(v) : v,
         z.array(z.object({

--- a/plugins/devops/mcp-server/ship/lib/infra-deploy.js
+++ b/plugins/devops/mcp-server/ship/lib/infra-deploy.js
@@ -1,0 +1,118 @@
+/**
+ * @module ship/lib/infra-deploy
+ * @description Detect out-of-band deploy artifacts in a branch diff (#243).
+ *
+ * A plain code merge to `main` does NOT apply DB migrations or deploy
+ * serverless/edge functions — those are deployed out-of-band (a separate
+ * `supabase db push`, a function deploy, a manual `apply_migration`). When a
+ * ship's diff touches such paths, merging the code leaves it referencing infra
+ * that was never applied: the change is silently NOT live even though ship
+ * reported "all done". This module flags those paths so the pipeline can raise
+ * a mandatory post-merge deploy gate instead of a clean completion card.
+ *
+ * Stack-agnostic by design: only the default globs mention Supabase paths.
+ * Consumers override the globs via the project ship-extension `reference.md`.
+ */
+
+// Sensible, stack-agnostic defaults. `**/migrations/**` covers Rails/Django/
+// Prisma/Supabase/Flyway layouts; the two `supabase/` entries cover the
+// most common serverless target. Override per-project via reference.md.
+export const DEFAULT_OUT_OF_BAND_GLOBS = [
+  "**/migrations/**",
+  "supabase/migrations/**",
+  "supabase/functions/**",
+];
+
+/**
+ * Compile a minimal path glob to a RegExp anchored at both ends.
+ *
+ * Supported syntax (POSIX-forward-slash paths, repo-root-relative):
+ *   - `**` between slashes (`a/&#42;&#42;/b`) or leading (`&#42;&#42;/b`) matches zero or
+ *     more full path segments.
+ *   - `**` elsewhere (`a/&#42;&#42;`) matches the rest of the path, crossing slashes.
+ *   - `*` matches within a single segment (no slash).
+ *   - every other character is matched literally (regex metachars escaped).
+ *
+ * Backslashes are normalized to forward slashes so Windows-style diff paths
+ * (rare, but git can emit them via some tooling) still match.
+ */
+export function globToRegExp(glob) {
+  const g = String(glob).replace(/\\/g, "/");
+  let re = "";
+  let i = 0;
+  while (i < g.length) {
+    const c = g[i];
+    if (c === "*") {
+      if (g[i + 1] === "*") {
+        // `**` — a globstar. When bounded by a slash on the right (or at the
+        // start), it spans whole segments including zero: `(?:[^/]*/)*`.
+        if (g[i + 2] === "/") {
+          re += "(?:[^/]*/)*";
+          i += 3;
+        } else if (i + 2 === g.length && (i === 0 || g[i - 1] === "/")) {
+          // trailing `/**` (or bare `**`) — match the remainder incl. slashes.
+          re += ".*";
+          i += 2;
+        } else {
+          // `**` not slash-delimited — treat as "cross anything".
+          re += ".*";
+          i += 2;
+        }
+      } else {
+        // single `*` — within a segment only.
+        re += "[^/]*";
+        i += 1;
+      }
+    } else if (".+?^${}()|[]\\".includes(c)) {
+      re += "\\" + c;
+      i += 1;
+    } else {
+      re += c;
+      i += 1;
+    }
+  }
+  return new RegExp("^" + re + "$");
+}
+
+/**
+ * Categorize a matched path into a human-readable deploy kind. Generic keyword
+ * heuristics only (no stack lock-in): the gate names WHAT needs deploying.
+ */
+function categorize(file) {
+  const f = file.toLowerCase();
+  if (f.includes("/migrations/") || f.startsWith("migrations/")) return "migration";
+  if (f.includes("/functions/") || f.startsWith("functions/")) return "function";
+  return "infra";
+}
+
+/**
+ * Scan a list of branch-changed files for out-of-band deploy artifacts.
+ *
+ * @param {string[]} files - repo-root-relative paths changed on the branch.
+ * @param {string[]} [globs] - override globs; falls back to the defaults.
+ * @returns {{ detected: boolean, globs: string[], files: string[],
+ *             matched: Array<{ file: string, glob: string, kind: string }>,
+ *             kinds: string[] }}
+ */
+export function detectOutOfBandDeploys(files, globs = DEFAULT_OUT_OF_BAND_GLOBS) {
+  const activeGlobs = Array.isArray(globs) && globs.length ? globs : DEFAULT_OUT_OF_BAND_GLOBS;
+  const compiled = activeGlobs.map((glob) => ({ glob, re: globToRegExp(glob) }));
+  const matched = [];
+  for (const file of Array.isArray(files) ? files : []) {
+    if (!file) continue;
+    for (const { glob, re } of compiled) {
+      if (re.test(file)) {
+        matched.push({ file, glob, kind: categorize(file) });
+        break;
+      }
+    }
+  }
+  const kinds = [...new Set(matched.map((m) => m.kind))];
+  return {
+    detected: matched.length > 0,
+    globs: activeGlobs,
+    files: matched.map((m) => m.file),
+    matched,
+    kinds,
+  };
+}

--- a/plugins/devops/mcp-server/ship/lib/infra-deploy.test.js
+++ b/plugins/devops/mcp-server/ship/lib/infra-deploy.test.js
@@ -1,0 +1,87 @@
+import { describe, test, expect } from "vitest";
+import {
+  DEFAULT_OUT_OF_BAND_GLOBS,
+  globToRegExp,
+  detectOutOfBandDeploys,
+} from "./infra-deploy.js";
+
+describe("globToRegExp", () => {
+  test("**/migrations/** matches a nested migration under any prefix", () => {
+    const re = globToRegExp("**/migrations/**");
+    expect(re.test("supabase/migrations/20260708_add_col.sql")).toBe(true);
+    expect(re.test("db/migrations/001.sql")).toBe(true);
+  });
+
+  test("**/migrations/** matches a root-level migrations dir (zero prefix segments)", () => {
+    expect(globToRegExp("**/migrations/**").test("migrations/001.sql")).toBe(true);
+  });
+
+  test("supabase/functions/** matches a function file but not a sibling", () => {
+    const re = globToRegExp("supabase/functions/**");
+    expect(re.test("supabase/functions/desktop-latest/index.ts")).toBe(true);
+    expect(re.test("supabase/config.toml")).toBe(false);
+  });
+
+  test("single * stays within a segment", () => {
+    const re = globToRegExp("src/*.ts");
+    expect(re.test("src/app.ts")).toBe(true);
+    expect(re.test("src/nested/app.ts")).toBe(false);
+  });
+
+  test("regex metacharacters in the glob are escaped", () => {
+    const re = globToRegExp("a.b/c+d/**");
+    expect(re.test("a.b/c+d/x")).toBe(true);
+    expect(re.test("aXb/cYd/x")).toBe(false);
+  });
+});
+
+describe("detectOutOfBandDeploys — defaults", () => {
+  test("plain code diff → not detected", () => {
+    const r = detectOutOfBandDeploys(["src/app.ts", "README.md", "package.json"]);
+    expect(r.detected).toBe(false);
+    expect(r.files).toEqual([]);
+    expect(r.kinds).toEqual([]);
+  });
+
+  test("migration + edge function → detected, categorized, first-match glob recorded", () => {
+    const r = detectOutOfBandDeploys([
+      "src/app.ts",
+      "supabase/migrations/20260708_token_revoked.sql",
+      "supabase/functions/desktop-latest/index.ts",
+    ]);
+    expect(r.detected).toBe(true);
+    expect(r.files).toEqual([
+      "supabase/migrations/20260708_token_revoked.sql",
+      "supabase/functions/desktop-latest/index.ts",
+    ]);
+    expect(r.kinds.sort()).toEqual(["function", "migration"]);
+  });
+
+  test("a path is counted once even if two globs would match it", () => {
+    const r = detectOutOfBandDeploys(["supabase/migrations/1.sql"]);
+    expect(r.matched).toHaveLength(1);
+  });
+
+  test("empty / non-array input is safe", () => {
+    expect(detectOutOfBandDeploys([]).detected).toBe(false);
+    expect(detectOutOfBandDeploys(undefined).detected).toBe(false);
+    expect(detectOutOfBandDeploys(null).detected).toBe(false);
+  });
+});
+
+describe("detectOutOfBandDeploys — override globs", () => {
+  test("custom globs replace the defaults", () => {
+    const r = detectOutOfBandDeploys(
+      ["infra/terraform/main.tf", "supabase/migrations/1.sql"],
+      ["infra/**"]
+    );
+    expect(r.files).toEqual(["infra/terraform/main.tf"]);
+    expect(r.globs).toEqual(["infra/**"]);
+  });
+
+  test("empty override array falls back to defaults", () => {
+    const r = detectOutOfBandDeploys(["supabase/migrations/1.sql"], []);
+    expect(r.detected).toBe(true);
+    expect(r.globs).toEqual(DEFAULT_OUT_OF_BAND_GLOBS);
+  });
+});

--- a/plugins/devops/mcp-server/ship/tools/preflight.js
+++ b/plugins/devops/mcp-server/ship/tools/preflight.js
@@ -13,9 +13,11 @@ import { dirtySessionWorktrees } from "../lib/worktree.js";
 import { readVersion, verifyVersionFiles } from "../lib/version.js";
 import { writeSentinel } from "../lib/sentinel.js";
 import { detectRepoMode } from "../lib/repo-mode.js";
+import { detectOutOfBandDeploys, DEFAULT_OUT_OF_BAND_GLOBS } from "../lib/infra-deploy.js";
 
 export const schema = z.object({
   base: z.string().optional().describe("Base branch to ship into. Omit to auto-detect: parent branch (from sub-branch naming) or the repository's default branch (origin/HEAD, typically 'main' or 'master')."),
+  outOfBandGlobs: z.array(z.string()).nullable().default(null).describe("Override globs for out-of-band deploy detection (#243). Paths that a code merge does NOT deploy — DB migrations, edge/serverless functions. Omit/null to use the stack-agnostic defaults (**/migrations/**, supabase/migrations/**, supabase/functions/**). The ship skill passes these from the project ship-extension reference.md `outOfBandDeploy:` field."),
   cwd: z.string().describe("Working directory of the target repo (required — must be passed by the caller)"),
 });
 
@@ -127,6 +129,7 @@ export async function handler(params) {
       needsRebase: false,
       version: null,
       projectType: null,
+      outOfBandDeploys: { detected: false, globs: [], files: [], matched: [], kinds: [] },
       checks: [{ name: "repo-mode", value: "none", ok: true }],
       warnings: [],
       errors: [],
@@ -229,8 +232,11 @@ export async function handler(params) {
   }
 
   // 9. File overlap detection (skip when no remote — no origin ref to compare)
+  // Captured for reuse by 9b so the branch diff is computed once, not twice.
+  let step9Overlap = null;
   if (!noRemote) {
     const overlap = fileOverlap(originBase, opts);
+    step9Overlap = overlap;
     if (overlap.overlap.length > 0) {
       checks.push({
         name: "file-overlap",
@@ -247,6 +253,36 @@ export async function handler(params) {
     }
   } else {
     checks.push({ name: "file-overlap", ok: true, count: 0, skipped: true, reason: "no-remote" });
+  }
+
+  // 9b. Out-of-band deploy detection (#243). A code merge does NOT apply DB
+  //     migrations or deploy edge/serverless functions — so when the diff
+  //     touches those paths, the shipped code references infra that was never
+  //     applied and the change is silently NOT live. Detect it here (non-blocking)
+  //     so Step 4d/Step 6 can raise a mandatory post-merge deploy gate instead of
+  //     a clean "all done" card. Uses the same merge-base diff as file-overlap.
+  const infraBase = !noRemote && (baseExists === "remote" || baseExists === "local") ? originBase : base;
+  // Reuse the Step 9 diff when it already targeted the same ref; else compute it.
+  const branchFilesForInfra = (step9Overlap && infraBase === originBase)
+    ? step9Overlap.branchFiles
+    : fileOverlap(infraBase, opts).branchFiles;
+  const oobGlobs = Array.isArray(params.outOfBandGlobs) && params.outOfBandGlobs.length
+    ? params.outOfBandGlobs
+    : DEFAULT_OUT_OF_BAND_GLOBS;
+  const outOfBandDeploys = detectOutOfBandDeploys(branchFilesForInfra, oobGlobs);
+  if (outOfBandDeploys.detected) {
+    checks.push({
+      name: "out-of-band-deploys",
+      ok: true, // non-blocking: the merge still proceeds; the gate is post-merge
+      deploy: true,
+      count: outOfBandDeploys.files.length,
+      kinds: outOfBandDeploys.kinds,
+      files: outOfBandDeploys.files.slice(0, 20),
+      globs: oobGlobs,
+      warning: `${outOfBandDeploys.files.length} out-of-band deploy artifact(s) touched (${outOfBandDeploys.kinds.join(", ")}) — a code merge does NOT deploy these. A post-merge deploy gate is required; the completion card must not report "all done".`,
+    });
+  } else {
+    checks.push({ name: "out-of-band-deploys", ok: true, deploy: false });
   }
 
   // 10. Git config check (warning — auto-fixed by ship skill)
@@ -346,6 +382,7 @@ export async function handler(params) {
     needsRebase,
     version: versionInfo.version,
     projectType: versionInfo.type,
+    outOfBandDeploys,
     checks,
     warnings,
     errors,

--- a/plugins/devops/mcp-server/ship/tools/preflight.test.js
+++ b/plugins/devops/mcp-server/ship/tools/preflight.test.js
@@ -6,7 +6,7 @@ import { describe, test, expect, vi, beforeEach } from "vitest";
 // does — so a minimal chainable stub is enough to load the module.
 vi.mock("zod", () => {
   const node = new Proxy(() => node, { get: () => () => node });
-  return { z: { object: () => node, string: () => node, boolean: () => node } };
+  return { z: { object: () => node, string: () => node, boolean: () => node, array: () => node } };
 });
 
 // Mock every lib the handler touches so we can drive a deterministic "ready"
@@ -44,7 +44,7 @@ vi.mock("../lib/worktree.js", () => ({
 }));
 
 import { handler } from "./preflight.js";
-import { isWorktree } from "../lib/git.js";
+import { isWorktree, fileOverlap } from "../lib/git.js";
 import { dirtySessionWorktrees } from "../lib/worktree.js";
 
 const CWD = "/fake/consumer-repo";
@@ -54,6 +54,9 @@ beforeEach(() => {
   // Re-apply defaults cleared by clearAllMocks.
   isWorktree.mockReturnValue(false);
   dirtySessionWorktrees.mockReturnValue([]);
+  // Default: empty diff (no overlap, no out-of-band artifacts). Tests that need
+  // a populated diff override this — resetting here keeps them isolated.
+  fileOverlap.mockReturnValue({ mergeBase: "abc", branchFiles: [], baseFiles: [], overlap: [] });
 });
 
 function checkByName(result, name) {
@@ -133,5 +136,44 @@ describe("ship_preflight — session-worktree-clean gate", () => {
     // When in-worktree we must NOT scan siblings (clean-tree already covers cwd).
     expect(dirtySessionWorktrees).not.toHaveBeenCalled();
     expect(result.ready).toBe(true);
+  });
+});
+
+describe("ship_preflight — out-of-band deploy detection (#243)", () => {
+  test("plain code diff → not detected, non-blocking ok check, ready", async () => {
+    fileOverlap.mockReturnValue({ mergeBase: "abc", branchFiles: ["src/app.ts", "README.md"], baseFiles: [], overlap: [] });
+    const result = await handler({ cwd: CWD });
+    expect(result.outOfBandDeploys.detected).toBe(false);
+    expect(checkByName(result, "out-of-band-deploys")).toEqual({ name: "out-of-band-deploys", ok: true, deploy: false });
+    expect(result.ready).toBe(true);
+  });
+
+  test("migration + edge function in diff → detected, warned, still ready (non-blocking)", async () => {
+    fileOverlap.mockReturnValue({
+      mergeBase: "abc",
+      branchFiles: ["src/app.ts", "supabase/migrations/1.sql", "supabase/functions/f/index.ts"],
+      baseFiles: [],
+      overlap: [],
+    });
+    const result = await handler({ cwd: CWD });
+    expect(result.outOfBandDeploys.detected).toBe(true);
+    expect(result.outOfBandDeploys.kinds.sort()).toEqual(["function", "migration"]);
+    const check = checkByName(result, "out-of-band-deploys");
+    expect(check).toMatchObject({ ok: true, deploy: true, count: 2 });
+    expect(result.warnings.some((w) => /out-of-band deploy/i.test(w))).toBe(true);
+    // Detection must NOT block the ship — the gate is post-merge.
+    expect(result.ready).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  test("custom override globs replace the defaults", async () => {
+    fileOverlap.mockReturnValue({
+      mergeBase: "abc",
+      branchFiles: ["infra/terraform/main.tf", "supabase/migrations/1.sql"],
+      baseFiles: [],
+      overlap: [],
+    });
+    const result = await handler({ cwd: CWD, outOfBandGlobs: ["infra/**"] });
+    expect(result.outOfBandDeploys.files).toEqual(["infra/terraform/main.tf"]);
   });
 });

--- a/plugins/devops/skills/devops-ship/SKILL.md
+++ b/plugins/devops/skills/devops-ship/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: devops-ship
-version: 0.6.1
+version: 0.7.0
 description: >-
   Full end-to-end shipping pipeline using MCP tools: ship_preflight, ship_build,
   ship_version_bump, ship_release, ship_cleanup, render_completion_card,
@@ -52,6 +52,14 @@ Do NOT call Read on files that may not exist — skip missing files silently (no
 
 Project extensions define: quality gate commands, deploy targets, version files, CI specifics.
 
+Also capture, if present in the merged `reference.md`, for use later in this run:
+- `outOfBandDeploy:` — a list of path globs for artifacts a code merge does NOT
+  deploy (DB migrations, edge/serverless functions). Pass them to `ship_preflight`
+  in Step 1a. Omit when absent — the tool applies stack-agnostic defaults.
+- `deploy:` — a deploy handler (e.g. `supabase`) that can actually APPLY those
+  artifacts post-merge. Used by Step 4d. When absent, Step 4d raises the deploy
+  gate instead of deploying.
+
 4. Codex context: Read `{PLUGIN_ROOT}/deep-knowledge/codex-integration.md` — this skill has a **mandatory** Codex review gate (§1 in that doc), which MUST be called via `{PLUGIN_ROOT}/scripts/codex-safe.sh` (5-min hard timeout, see "Hard Timeout & Failure-Tolerance" section), NEVER via the `/codex:rescue` Agent tool. Detect Codex availability now so Step 2 can act on it.
 
 ## Step 0.5 — Load Deferred MCP Schemas
@@ -85,6 +93,14 @@ Omit `base` to let the tool auto-detect it.
 ```
 ship_preflight({ cwd: "<current working directory>" })
 ```
+
+If Step 0 captured an `outOfBandDeploy:` glob list from the extension, pass it:
+`ship_preflight({ cwd: "<cwd>", outOfBandGlobs: ["**/migrations/**", ...] })`.
+Otherwise omit it — the tool uses stack-agnostic defaults.
+
+The result carries `outOfBandDeploys: { detected, files, kinds, globs }` — artifacts
+this diff touches that a code merge will NOT deploy (#243). **Carry this value
+forward to Step 4d.** It is informational, never a hard gate (`ready` is unaffected).
 
 The tool **auto-detects** the correct base branch:
 - If on a sub-branch like `feat/42-video-filters/core`, it detects `feat/42-video-filters` as the parent and uses it as base.
@@ -402,6 +418,48 @@ same path a user does. Gaps this catches that pass CI:
 
 Pass `state.surfaceVerify = { checked: N, live: M, lagging: [...] }` into the card.
 
+## Step 4d — Out-of-Band Deploy Gate (final ship only)
+
+**A code merge does NOT apply DB migrations or deploy edge/serverless functions.**
+When the shipped diff touches such artifacts, merging the PR leaves the code
+referencing infra that was never applied — the change is silently NOT live even
+though every prior step went green. This step turns `ship_preflight`'s detection
+into either an actual deploy (when a handler is configured) or a mandatory,
+loud completion-card gate. (#243)
+
+**Skip this step entirely when:**
+- `intermediate: true` (no deploy target for intermediate merges), or
+- `ship_preflight.outOfBandDeploys.detected` is `false` (the common case — skip
+  silently, nothing changed).
+
+**When `outOfBandDeploys.detected` is `true`:**
+
+1. **If Step 0 captured a `deploy:` handler** that can apply these artifacts
+   (e.g. `supabase` → `apply_migration` + `deploy_edge_function` via the Supabase
+   MCP): run it now, after the merge landed. Deploy each detected artifact.
+   - **All deployed successfully** → the change is live. Do NOT set the gate;
+     instead add a `userFinalTest` item to **verify** the deployed infra behaves
+     (e.g. "Verify the migration applied: query the new column in prod").
+   - **Any deploy failed / handler errored** → fall through to step 2 for the
+     artifacts that did not deploy, naming the failure.
+
+   Keep concrete deploy automation in the **project** extension — the plugin
+   ships detection + the gate, never a stack-specific deployer.
+
+2. **Otherwise (no handler, or a deploy failed)** — raise the deploy gate. This
+   is mandatory: the completion card MUST NOT read as "all done" while merged
+   infra is undeployed. Carry into Step 6:
+   - `state.deployPending: true` — flips the ship-successful CTA from
+     "Alles ERLEDIGT" to "🚨 DEPLOY erforderlich (noch nicht live)".
+   - `deployGate: [...]` — one item per detected artifact, each
+     `{ artifact: "<path>", kind: "<migration|function|infra>", action: "<the concrete deploy step still required>" }`.
+     Derive `artifact`/`kind` from `outOfBandDeploys.matched`; write `action` as
+     the smallest true next step (e.g. "apply_migration", "deploy edge function
+     desktop-latest", or "run your migration + function deploy").
+
+Never downgrade the variant — the merge DID happen (per the Step 6 variant rule).
+The gate lives in `deployGate` + `state.deployPending`, not in the variant.
+
 ## Step 5a — Continue-Intent Check (auto-detect keep-mode)
 
 Before cleanup, decide whether **follow-up work** is expected in this same branch/worktree.
@@ -606,6 +664,21 @@ The MCP variant guard already auto-corrects `ship-successful`→`ready` when
 is: merged ⇒ `ship-successful`, downstream-still-pending ⇒ `userFinalTest`,
 never a variant downgrade. (Project ship-extensions: keep project-specific
 downstream surfaces, but don't re-encode this variant rule.)
+
+**Out-of-band deploy gate (from Step 4d).** When Step 4d raised the gate, pass
+`state.deployPending: true` and the `deployGate` array to `render_completion_card`.
+This is stronger than a `userFinalTest` item: the CTA itself flips to
+"🚨 DEPLOY erforderlich (noch nicht live)" and a loud gate block names each
+undeployed artifact — so a merged-but-undeployed ship is never mistaken for done.
+Undeployed infra is the ONE thing that must not hide behind a green card.
+Example:
+```
+deployGate: [
+  { artifact: "supabase/migrations/20260708_token_revoked.sql", kind: "migration", action: "apply_migration" },
+  { artifact: "supabase/functions/desktop-latest/index.ts",     kind: "function",  action: "deploy edge function desktop-latest" }
+],
+state: { branch: "main", pushed: true, merged: "main", commit: "<sha>", deployPending: true }
+```
 
 **Keep-mode variant** (Step 5a chose keep, Step 5c ran):
 ```

--- a/plugins/devops/skills/devops-ship/reference.md
+++ b/plugins/devops/skills/devops-ship/reference.md
@@ -69,3 +69,37 @@ purpose_alignment:
 ```
 
 This pattern applies to ALL plugin skills, not just ship.
+
+## Out-of-band deploy gate (#243)
+
+A code merge does **not** apply DB migrations or deploy edge/serverless
+functions. When a ship's diff touches such artifacts, the merged code references
+infra that was never applied — the change is silently NOT live. Ship detects
+this (Step 1a) and, for a final ship to main, either deploys it (if a handler is
+configured) or raises a loud completion-card gate (Step 4d) so the card never
+reads "all done" over undeployed infra.
+
+### Override the detection globs
+
+Detection uses stack-agnostic defaults (`**/migrations/**`,
+`supabase/migrations/**`, `supabase/functions/**`). Override them per project:
+
+```yaml
+outOfBandDeploy:
+  - "**/migrations/**"
+  - "supabase/functions/**"
+  - "infra/terraform/**"       # add your own out-of-band paths
+```
+
+### Register a deploy handler (optional)
+
+Without a handler, Step 4d raises the gate and the user deploys manually. To make
+ship actually apply the artifacts post-merge, register a `deploy:` handler:
+
+```yaml
+deploy: supabase        # e.g. apply_migration + deploy_edge_function via the Supabase MCP
+```
+
+Concrete deploy automation is **project-specific** and lives here in the
+extension — the plugin ships only the generic detection + gate, never a
+stack-specific deployer.

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.109.0",
+  "version": "0.110.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
Closes #243

## Summary
A `/devops-ship` run rendered a `ship-successful` "all done" card the moment the PR merged + tagged — but a plain merge does not apply DB migrations or deploy edge/serverless functions. When a diff touched those paths, the merged code referenced infra that was never applied, so the change was silently NOT live while the card claimed done.

## Changes
- `ship_preflight` scans the branch diff against stack-agnostic globs (`**/migrations/**`, `supabase/migrations/**`, `supabase/functions/**`), overridable per project via the ship-extension `reference.md` `outOfBandDeploy:` field, and returns `outOfBandDeploys: { detected, files, kinds }` — non-blocking, never gates the merge.
- New ship **Step 4d** deploys the artifacts (when the extension registers a `deploy:` handler) or raises a mandatory completion-card gate.
- Completion card gains a loud `deployGate` block naming each undeployed artifact + its deploy action; `state.deployPending` flips the ship-successful CTA from "all done" to "🚨 DEPLOY required (not live yet)".
- Concrete deploy automation stays project-specific; the plugin ships only the generic detection + gate.

New `ship/lib/infra-deploy.js`; completion MCP `0.6.0 → 0.7.0`; `devops-ship` skill `0.6.1 → 0.7.0`. 19 new tests, 644 total; lint clean.