### PR TITLE
feat(graphify): bounded staleness gate + adoption telemetry (0.111.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.110.0"
+    "version": "0.111.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.110.0",
+      "version": "0.111.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.110.0",
+      "version": "0.111.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.111.0] — 2026-07-09
+
+### Fixed
+
+- **The graphify gate now fires during real development — bounded staleness tolerance replaces the binary fresh/stale check that kept it disarmed.** A transcript audit (744 sessions) found 634 graphify mentions but only ~5 real `graphify query` executions (~0.8% conversion, all of them verification probes): the 0.109.0 self-heal kept the graph *converging*, but the gate itself still required a *provably fresh* graph, and in an actively-edited repo any file save re-disarmed it — the enforcement chain was well-built and practically inert. The gate now enforces while the graph lags ≤25 files behind the working tree (`GRAPHIFY_STALE_TOLERANCE`, single `scanSources` walk — no extra filesystem pass), disclosing the lag in the block message and kicking the throttled background refresh in parallel; only unbounded staleness (>25 files, truncated scan, missing graph) falls through to silent self-heal. All safety properties preserved: fail-open on errors, one-shot escape hatch per search, session relent after a query. (`pre.tokens.guard` → 0.7.0, `graph-nudge` → 0.2.0.)
+- **Background graphify builds can no longer fail invisibly — and the failure sentinel actually works on Windows.** All `graphify extract` spawns were detached with `stdio:'ignore'` and try/catch-swallowed: a consented project whose build kept failing showed no graph AND no error, indistinguishable from "never built". Builds now run through a sentinel-tracked spawn (`bgWithSentinel`) and the next SessionStart reports a failed build as one line. Two Windows traps were fixed on the way, both caught by new real-shell end-to-end tests: node's manual `cmd.exe` arg quoting escaped the inner quotes as `\"` (cmd cannot parse that — no sentinel was ever written), and `%errorlevel%` expands at cmd parse time while leaving a digit before `>` that cmd eats as a file-handle redirection — win32 now writes a bare `fail` marker instead. (`graphify-state` → 0.2.0, `ss.graphify` → 0.2.0.)
+
+### Added
+
+- **Query-adoption telemetry — the graphify funnel is now measurable instead of requiring transcript archaeology.** New fail-silent JSONL event sink at `~/.claude/graphify-metrics.jsonl` (2 MB cap, keeps newest half): `gate_fired`, `gate_bypassed`, `self_heal_kicked`, `query_ran`, `offer_shown` (session-start vs. value-moment), `nudge_injected`, plus a `consent_written` event the devops-graph skill records on opt-in/out — so offer→consent→query conversion is measurable end to end. A metrics failure can never break a hook. (new `graphify-metrics` lib, `post.graphify.query` → 0.2.0.)
+- **The gate block message now proposes a ready-to-run query derived from the blocked search** (e.g. Grep `foo.*bar` → `graphify query "What defines or uses foo bar?"`) instead of a generic placeholder, and the opt-in offers instruct verifying `graphify-out/graph.json` exists (node count reported) after install instead of claiming success blind. `hasGraph()` gained a 512-byte validity floor and SessionStart a once-daily deep JSON validity check, so a truncated/corrupt graph triggers a rebuild instead of enforcement against garbage. (25 new tests, 669 total.)
+
 ## [0.110.0] — 2026-07-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.110.0**
+**Version: 0.111.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.110.0",
+  "version": "0.111.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/hooks/lib/graph-nudge.js
+++ b/plugins/devops/hooks/lib/graph-nudge.js
@@ -1,7 +1,7 @@
 'use strict';
 /**
  * @lib graph-nudge
- * @version 0.1.0
+ * @version 0.2.0
  * @plugin devops
  * @description Pure helpers for the ambient graphify nudge injected by
  *   pre.tokens.guard on the first broad search of a session. Detects whether a

--- a/plugins/devops/hooks/lib/graph-nudge.js
+++ b/plugins/devops/hooks/lib/graph-nudge.js
@@ -22,10 +22,18 @@ function graphJsonPath(cwd) {
   return path.join(cwd, GRAPH_JSON_REL);
 }
 
-/** True iff a graphify graph.json exists for this project. Never throws. */
+// Cheap validity floor for the PreToolUse hot path: a 0-byte or near-empty
+// graph.json (partial write, truncated extract) must not count as present.
+// Deliberately NOT a JSON.parse here — this runs on every broad search, so it
+// stays a statSync-only check. A deeper (JSON-parsing) validity check belongs
+// to the SessionStart hook, which runs once per session (see ss.graphify.js).
+const MIN_GRAPH_BYTES = 512;
+
+/** True iff a graphify graph.json exists AND clears the size floor. Never throws. */
 function hasGraph(cwd) {
   try {
-    return fs.statSync(graphJsonPath(cwd)).isFile();
+    const st = fs.statSync(graphJsonPath(cwd));
+    return st.isFile() && st.size > MIN_GRAPH_BYTES;
   } catch {
     return false;
   }
@@ -54,9 +62,33 @@ function buildGraphifyOffer() {
     '💡 [graphify] Broad searches like this are exactly what a code knowledge graph makes cheap.',
     'This project has no graphify decision yet — offer the user (AskUserQuestion) to enable it.',
     'On YES: `uv tool install graphifyy && graphify install && graphify hook install && graphify extract .`,',
-    'then write .claude/graphify.json {"consent":true,"autoBuild":true}. On NO: write {"consent":false}.',
+    'then write .claude/graphify.json {"consent":true,"autoBuild":true}. After extract completes, verify',
+    'graphify-out/graph.json exists and report its node count to the user; if it is missing, report the',
+    'failure instead of claiming success. On NO: write {"consent":false}.',
     'Never install without confirmation.',
   ].join('\n');
+}
+
+/**
+ * Derive a concrete `graphify query` suggestion from the actual blocked
+ * search (Gap #3) so the gate message is actionable instead of the generic
+ * `<your question>` placeholder. Deliberately dumb and predictable: strip
+ * regex metacharacters/escapes, collapse separators to spaces, and wrap the
+ * remaining words in a fixed "What defines or uses X?" template. Never
+ * throws; falls back to the generic placeholder when nothing usable remains.
+ */
+function suggestQuery(pattern) {
+  if (typeof pattern !== 'string' || !pattern.trim()) {
+    return 'graphify query "<your question>"';
+  }
+  const words = pattern
+    .replace(/\\[a-zA-Z]/g, ' ')          // \d \w \s \b etc.
+    .replace(/[.*+?^${}()|[\]\\]/g, ' ')  // regex metacharacters
+    .replace(/[_-]/g, ' ')                // snake/kebab separators → words
+    .split(/\s+/)
+    .filter(Boolean);
+  if (!words.length) return 'graphify query "<your question>"';
+  return `graphify query "What defines or uses ${words.join(' ')}?"`;
 }
 
 // Directories whose contents never count toward "newest source file": VCS,
@@ -68,23 +100,29 @@ const SKIP_DIRS = new Set([
 ]);
 
 /**
- * Scan project source files for the newest mtime, ignoring SKIP_DIRS and
- * dot-dirs. Symlinked dirs/files ARE followed (resolved via stat) so a newer
- * file behind a symlink is not invisible. Bounded by `opts.maxFiles` (default
- * 8000); if the bound is hit the scan is `truncated`. Never throws.
- * @returns {{newest:number, count:number, truncated:boolean}}
+ * Scan project source files for the newest mtime (and, when `opts.newerThan`
+ * is given, how many files are newer than that reference mtime), ignoring
+ * SKIP_DIRS and dot-dirs. Symlinked dirs/files ARE followed (resolved via
+ * stat) so a newer file behind a symlink is not invisible. Bounded by
+ * `opts.maxFiles` (default 8000); if the bound is hit the scan is
+ * `truncated`. Single walk — both `graphIsStale` and `stalenessInfo` reuse it,
+ * so bounded-tolerance staleness never costs a second filesystem pass. Never
+ * throws.
+ * @returns {{newest:number, count:number, truncated:boolean, newerCount:number}}
  */
 function scanSources(cwd, opts = {}) {
   const maxFiles = opts.maxFiles || 8000;
+  const newerThan = opts.newerThan || 0;
   let newest = 0;
   let count = 0;
+  let newerCount = 0;
   const stack = [cwd];
   while (stack.length) {
     const dir = stack.pop();
     let entries;
     try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { continue; }
     for (const e of entries) {
-      if (count >= maxFiles) return { newest, count, truncated: true };
+      if (count >= maxFiles) return { newest, count, truncated: true, newerCount };
       const full = path.join(dir, e.name);
       let isDir = e.isDirectory();
       let isFile = e.isFile();
@@ -102,37 +140,57 @@ function scanSources(cwd, opts = {}) {
         try {
           const m = fs.statSync(full).mtimeMs;
           if (m > newest) newest = m;
+          if (m > newerThan) newerCount++;
         } catch { /* unreadable — skip */ }
       }
     }
   }
-  return { newest, count, truncated: false };
+  return { newest, count, truncated: false, newerCount };
 }
 
 /**
- * Is the graph stale relative to the working tree? This is the hard
- * precondition for the PreToolUse graphify-gate — a hard block must NEVER force
- * Claude onto an out-of-date graph, so it is deliberately fail-safe: when
- * freshness cannot be PROVEN, return stale (the gate then simply does not fire).
- * Stale when: graph.json is missing; the scan was truncated (could not see all
- * files); no source files were found; or any source file is newer than the
- * graph. Fresh only when the full scan saw ≥1 file and none is newer.
+ * Bounded-staleness read for the PreToolUse graphify-gate. Rather than a
+ * binary fresh/stale verdict, reports HOW MANY source files are newer than
+ * the graph (`newerCount`) so the gate can apply a tolerance band: a graph
+ * that lags a handful of files behind is still useful and worth enforcing
+ * (with a disclosure + a kicked background refresh), while a graph that
+ * cannot be trusted at all (missing, or the scan was truncated / found
+ * nothing comparable) must never be enforced. `newerCount` is reported as
+ * `Infinity` in the "cannot be trusted at all" cases so any tolerance
+ * threshold naturally treats them as fully stale. Reuses the single
+ * `scanSources` walk. Never throws.
+ * @returns {{newerCount:number, truncated:boolean, graphMtime:number}}
+ */
+function stalenessInfo(cwd, opts = {}) {
+  let graphMtime;
+  try { graphMtime = fs.statSync(graphJsonPath(cwd)).mtimeMs; } catch { return { newerCount: Infinity, truncated: false, graphMtime: 0 }; }
+  const { count, truncated, newerCount } = scanSources(cwd, { ...opts, newerThan: graphMtime });
+  if (truncated) return { newerCount: Infinity, truncated: true, graphMtime };
+  if (count === 0) return { newerCount: Infinity, truncated: false, graphMtime }; // nothing comparable
+  return { newerCount, truncated: false, graphMtime };
+}
+
+/**
+ * Is the graph stale relative to the working tree? Binary convenience wrapper
+ * over `stalenessInfo` (newerCount > 0), kept for callers that only need a
+ * yes/no answer. The PreToolUse gate itself uses `stalenessInfo` directly so
+ * it can apply a bounded-tolerance policy instead of this strict boundary —
+ * see the `GRAPHIFY_STALE_TOLERANCE` policy in pre.tokens.guard.js.
  */
 function graphIsStale(cwd, opts = {}) {
-  let graphMtime;
-  try { graphMtime = fs.statSync(graphJsonPath(cwd)).mtimeMs; } catch { return true; }
-  const { newest, count, truncated } = scanSources(cwd, opts);
-  if (truncated) return true;   // partial scan → cannot prove freshness
-  if (count === 0) return true; // nothing comparable → do not enforce
-  return newest > graphMtime;
+  const info = stalenessInfo(cwd, opts);
+  return info.truncated || info.newerCount > 0;
 }
 
 module.exports = {
   GRAPH_JSON_REL,
+  MIN_GRAPH_BYTES,
   graphJsonPath,
   hasGraph,
   buildGraphNudge,
   buildGraphifyOffer,
+  suggestQuery,
   scanSources,
+  stalenessInfo,
   graphIsStale,
 };

--- a/plugins/devops/hooks/lib/graph-nudge.test.js
+++ b/plugins/devops/hooks/lib/graph-nudge.test.js
@@ -2,7 +2,7 @@ import { describe, test, expect, beforeAll, afterAll } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { hasGraph, buildGraphNudge, buildGraphifyOffer, graphJsonPath, graphIsStale } from "./graph-nudge.js";
+import { hasGraph, buildGraphNudge, buildGraphifyOffer, graphJsonPath, graphIsStale, stalenessInfo, suggestQuery } from "./graph-nudge.js";
 
 describe("hasGraph — graph.json detection", () => {
   let dir;
@@ -17,10 +17,17 @@ describe("hasGraph — graph.json detection", () => {
     expect(hasGraph(dir)).toBe(false);
   });
 
-  test("true once graphify-out/graph.json exists", () => {
+  test("false when graph.json exists but is under the size floor", () => {
     const gp = graphJsonPath(dir);
     fs.mkdirSync(path.dirname(gp), { recursive: true });
     fs.writeFileSync(gp, "{}");
+    expect(hasGraph(dir)).toBe(false);
+  });
+
+  test("true once graphify-out/graph.json exists and clears the size floor", () => {
+    const gp = graphJsonPath(dir);
+    fs.mkdirSync(path.dirname(gp), { recursive: true });
+    fs.writeFileSync(gp, JSON.stringify({ nodes: Array(50).fill({ id: "x" }) }));
     expect(hasGraph(dir)).toBe(true);
   });
 
@@ -145,5 +152,102 @@ describe("graphIsStale — gate precondition", () => {
     if (linked) expect(graphIsStale(d)).toBe(true);
     fs.rmSync(d, { recursive: true, force: true });
     fs.rmSync(realDir, { recursive: true, force: true });
+  });
+});
+
+describe("stalenessInfo — bounded-tolerance gate precondition", () => {
+  const OLD = new Date(Date.now() - 60_000);
+  const NOW = new Date();
+
+  function freshTmp() {
+    return fs.mkdtempSync(path.join(os.tmpdir(), "graph-stalenessinfo-"));
+  }
+  function writeGraph(dir) {
+    const gp = graphJsonPath(dir);
+    fs.mkdirSync(path.dirname(gp), { recursive: true });
+    fs.writeFileSync(gp, "{}");
+    return gp;
+  }
+  function newSourceFile(dir, name) {
+    const p = path.join(dir, name);
+    fs.writeFileSync(p, "x");
+    fs.utimesSync(p, NOW, NOW);
+    return p;
+  }
+
+  test("missing graph.json → newerCount Infinity, not truncated", () => {
+    const d = freshTmp();
+    const info = stalenessInfo(d);
+    expect(info.newerCount).toBe(Infinity);
+    expect(info.truncated).toBe(false);
+    fs.rmSync(d, { recursive: true, force: true });
+  });
+
+  test("newerCount 0 when graph is newer than every source", () => {
+    const d = freshTmp();
+    fs.writeFileSync(path.join(d, "a.js"), "x");
+    fs.utimesSync(path.join(d, "a.js"), OLD, OLD);
+    const gp = writeGraph(d);
+    fs.utimesSync(gp, NOW, NOW);
+    expect(stalenessInfo(d).newerCount).toBe(0);
+    fs.rmSync(d, { recursive: true, force: true });
+  });
+
+  test("newerCount reflects exactly how many files are newer (boundary: 1)", () => {
+    const d = freshTmp();
+    const gp = writeGraph(d);
+    fs.utimesSync(gp, OLD, OLD);
+    newSourceFile(d, "a.js");
+    expect(stalenessInfo(d).newerCount).toBe(1);
+    fs.rmSync(d, { recursive: true, force: true });
+  });
+
+  test("newerCount at the tolerance boundary (25) and one past it (26)", () => {
+    const TOLERANCE = 25;
+    const d = freshTmp();
+    const gp = writeGraph(d);
+    fs.utimesSync(gp, OLD, OLD);
+    for (let i = 0; i < TOLERANCE; i++) newSourceFile(d, `f${i}.js`);
+    expect(stalenessInfo(d).newerCount).toBe(TOLERANCE);
+    newSourceFile(d, "one-more.js");
+    expect(stalenessInfo(d).newerCount).toBe(TOLERANCE + 1);
+    fs.rmSync(d, { recursive: true, force: true });
+  });
+
+  test("truncated scan → newerCount Infinity, truncated true", () => {
+    const d = freshTmp();
+    const gp = writeGraph(d);
+    fs.utimesSync(gp, NOW, NOW);
+    fs.writeFileSync(path.join(d, "a.js"), "x");
+    fs.mkdirSync(path.join(d, "sub"));
+    fs.writeFileSync(path.join(d, "sub", "b.js"), "x");
+    const info = stalenessInfo(d, { maxFiles: 1 });
+    expect(info.newerCount).toBe(Infinity);
+    expect(info.truncated).toBe(true);
+    fs.rmSync(d, { recursive: true, force: true });
+  });
+
+  test("no comparable source files → newerCount Infinity", () => {
+    const d = freshTmp();
+    const gp = writeGraph(d);
+    fs.utimesSync(gp, NOW, NOW);
+    expect(stalenessInfo(d).newerCount).toBe(Infinity);
+    fs.rmSync(d, { recursive: true, force: true });
+  });
+});
+
+describe("suggestQuery — Gap #3 concrete gate suggestion", () => {
+  test("strips regex metachars and collapses into a plain-English question", () => {
+    expect(suggestQuery("foo.*bar")).toBe('graphify query "What defines or uses foo bar?"');
+  });
+
+  test("collapses snake/kebab separators into words", () => {
+    expect(suggestQuery("foo_bar-baz")).toBe('graphify query "What defines or uses foo bar baz?"');
+  });
+
+  test("falls back to the generic placeholder for empty/non-string patterns", () => {
+    expect(suggestQuery("")).toBe('graphify query "<your question>"');
+    expect(suggestQuery(undefined)).toBe('graphify query "<your question>"');
+    expect(suggestQuery("...")).toBe('graphify query "<your question>"');
   });
 });

--- a/plugins/devops/hooks/lib/graphify-metrics.js
+++ b/plugins/devops/hooks/lib/graphify-metrics.js
@@ -1,0 +1,74 @@
+'use strict';
+/**
+ * @lib graphify-metrics
+ * @version 0.1.0
+ * @plugin devops
+ * @description Append-only usage telemetry for the graphify enforcement chain.
+ *   Audit finding: 634 graphify mentions across session transcripts but only 5
+ *   real `graphify query` executions (~0.8%) — and zero telemetry existed to
+ *   even measure that. This lib gives the enforcement chain a single,
+ *   fail-silent event sink so query-adoption can be measured going forward.
+ *   Writes one JSON line per event to `~/.claude/graphify-metrics.jsonl`
+ *   (override via `opts.path` — tests MUST inject a temp path, never the real
+ *   home dir). Every write is wrapped so a metrics failure can NEVER break the
+ *   hook that called it — record() never throws.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const DEFAULT_METRICS_PATH = path.join(os.homedir(), '.claude', 'graphify-metrics.jsonl');
+
+// Growth cap: once the file exceeds this size, keep only the newest half of
+// lines on the next write. Simple truncate-rewrite, not a rotating log —
+// good enough for a diagnostic stream nobody rotates by hand.
+const MAX_BYTES = 2 * 1024 * 1024;
+
+function metricsPath(opts = {}) {
+  return opts.path || DEFAULT_METRICS_PATH;
+}
+
+/** Keep only the newest half of lines if `file` is over the size cap. Fail-silent. */
+function capIfNeeded(file) {
+  try {
+    const st = fs.statSync(file);
+    if (st.size <= MAX_BYTES) return;
+    const lines = fs.readFileSync(file, 'utf8').split('\n').filter(Boolean);
+    const kept = lines.slice(Math.floor(lines.length / 2));
+    fs.writeFileSync(file, kept.length ? kept.join('\n') + '\n' : '');
+  } catch { /* never break the caller over a cap failure */ }
+}
+
+/**
+ * Append one telemetry event. `extra` is merged into the record (event-
+ * specific fields, e.g. `{ source: 'value_moment' }` or `{ newerCount: 3 }`).
+ * `opts.path` overrides the metrics file (tests only). `opts.cwd`/`opts.sid`
+ * populate `project`/`sid`; both default sensibly. Never throws — a metrics
+ * failure (unwritable path, full disk, etc.) is swallowed so it can never
+ * break the hook that is recording the event.
+ */
+function record(event, extra = {}, opts = {}) {
+  try {
+    const file = metricsPath(opts);
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    const entry = Object.assign(
+      {
+        ts: new Date().toISOString(),
+        event,
+        project: opts.cwd || process.cwd(),
+        sid: opts.sid || 'nosid',
+      },
+      extra
+    );
+    fs.appendFileSync(file, JSON.stringify(entry) + '\n');
+    capIfNeeded(file);
+  } catch { /* fail-silent — telemetry must never break a hook */ }
+}
+
+module.exports = {
+  DEFAULT_METRICS_PATH,
+  MAX_BYTES,
+  metricsPath,
+  record,
+};

--- a/plugins/devops/hooks/lib/graphify-metrics.test.js
+++ b/plugins/devops/hooks/lib/graphify-metrics.test.js
@@ -1,0 +1,85 @@
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { record, metricsPath, DEFAULT_METRICS_PATH } from "./graphify-metrics.js";
+
+describe("graphify-metrics — event telemetry", () => {
+  let dir;
+  let file;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "graphify-metrics-"));
+    file = path.join(dir, "sub", "graphify-metrics.jsonl");
+  });
+
+  afterEach(() => {
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+  });
+
+  test("metricsPath defaults to ~/.claude/graphify-metrics.jsonl", () => {
+    expect(metricsPath()).toBe(DEFAULT_METRICS_PATH);
+    expect(DEFAULT_METRICS_PATH).toContain(os.homedir());
+  });
+
+  test("appends one JSON line per event with ts/event/project/sid", () => {
+    record("gate_fired", { newerCount: 3 }, { path: file, cwd: "/proj", sid: "s1" });
+    const lines = fs.readFileSync(file, "utf8").trim().split("\n");
+    expect(lines.length).toBe(1);
+    const entry = JSON.parse(lines[0]);
+    expect(entry.event).toBe("gate_fired");
+    expect(entry.project).toBe("/proj");
+    expect(entry.sid).toBe("s1");
+    expect(entry.newerCount).toBe(3);
+    expect(typeof entry.ts).toBe("string");
+  });
+
+  test("multiple record() calls append (not overwrite)", () => {
+    record("gate_fired", {}, { path: file });
+    record("query_ran", {}, { path: file });
+    const lines = fs.readFileSync(file, "utf8").trim().split("\n");
+    expect(lines.length).toBe(2);
+    expect(JSON.parse(lines[1]).event).toBe("query_ran");
+  });
+
+  test("creates parent directories on demand", () => {
+    expect(fs.existsSync(path.dirname(file))).toBe(false);
+    record("offer_shown", { source: "session_start" }, { path: file });
+    expect(fs.existsSync(file)).toBe(true);
+  });
+
+  test("caps the file to the newest half once it exceeds the byte cap", () => {
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    const bigLine = "x".repeat(200);
+    const lines = [];
+    // Write enough lines to exceed a small synthetic cap by writing directly,
+    // then let one more record() call trigger the cap check with a tiny
+    // override — the module's real MAX_BYTES is 2MB, too slow to exercise
+    // directly, so we assert the truncate-rewrite mechanics via capIfNeeded's
+    // observable effect: after crossing the module's cap the file should
+    // never throw and should remain valid JSONL. We approximate by writing
+    // ~2.1MB of lines directly, then confirming the next record() call still
+    // succeeds and produces a smaller, valid file.
+    let size = 0;
+    while (size < 2.1 * 1024 * 1024) {
+      const l = JSON.stringify({ ts: "t", event: "gate_fired", i: lines.length, pad: bigLine });
+      lines.push(l);
+      size += l.length + 1;
+    }
+    fs.writeFileSync(file, lines.join("\n") + "\n");
+    const beforeCount = fs.readFileSync(file, "utf8").trim().split("\n").length;
+    record("query_ran", {}, { path: file });
+    const after = fs.readFileSync(file, "utf8").trim().split("\n");
+    // Capped: fewer lines than before + 1 (the new one), and every line still
+    // valid JSON (no corruption from the truncate-rewrite).
+    expect(after.length).toBeLessThan(beforeCount + 1);
+    for (const l of after) expect(() => JSON.parse(l)).not.toThrow();
+  });
+
+  test("fail-silent: never throws when the path is unwritable", () => {
+    const bogus = path.join(dir, "not-a-dir.txt");
+    fs.writeFileSync(bogus, "x"); // a FILE, so path.join(bogus, 'metrics.jsonl') dir creation fails
+    const badPath = path.join(bogus, "graphify-metrics.jsonl");
+    expect(() => record("gate_fired", {}, { path: badPath })).not.toThrow();
+  });
+});

--- a/plugins/devops/hooks/lib/graphify-state.js
+++ b/plugins/devops/hooks/lib/graphify-state.js
@@ -1,7 +1,7 @@
 'use strict';
 /**
  * @lib graphify-state
- * @version 0.1.0
+ * @version 0.2.0
  * @plugin devops
  * @description Consent + session-state helpers for the graphify enforcement
  *   layer (devops-graph). The consent record lives at `.claude/graphify.json`

--- a/plugins/devops/hooks/lib/graphify-state.js
+++ b/plugins/devops/hooks/lib/graphify-state.js
@@ -141,16 +141,23 @@ function bgWithSentinel(cmd, args, cwd) {
   const sentinel = sentinelPath(cwd);
   try { fs.unlinkSync(sentinel); } catch { /* no previous sentinel */ }
   const quoted = args.map((a) => `"${String(a).replace(/"/g, '""')}"`).join(' ');
+  // Two Windows traps shape this implementation:
+  //   1. No exit code on win32: %errorlevel% expands at cmd PARSE time (before
+  //      the command runs → always 0), and once expanded the token ends in a
+  //      digit directly before `>` (`echo fail:0>"…"`), which cmd parses as a
+  //      file-handle redirection — the sentinel then contains neither `ok` nor
+  //      `fail`. A bare `fail` (ends in a letter) has neither problem.
+  //   2. Quoting: a manual spawn('cmd.exe', ['/c', inner]) makes node escape
+  //      the inner quotes as \" — cmd.exe does not understand backslash
+  //      escapes, the redirect path breaks, and NO sentinel is ever written.
+  //      `shell: true` lets node compose the platform shell line verbatim.
+  const inner = process.platform === 'win32'
+    ? `${cmd} ${quoted} && (echo ok>"${sentinel}") || (echo fail>"${sentinel}")`
+    : `${cmd} ${quoted} && echo ok > "${sentinel}" || echo "fail:$?" > "${sentinel}"`;
   try {
-    if (process.platform === 'win32') {
-      const inner = `${cmd} ${quoted} && (echo ok>"${sentinel}") || (echo fail:%errorlevel%>"${sentinel}")`;
-      spawn('cmd.exe', ['/d', '/s', '/c', inner], {
-        cwd, detached: true, stdio: 'ignore', windowsHide: true,
-      }).unref();
-    } else {
-      const inner = `${cmd} ${quoted} && echo ok > "${sentinel}" || echo "fail:$?" > "${sentinel}"`;
-      spawn('/bin/sh', ['-c', inner], { cwd, detached: true, stdio: 'ignore' }).unref();
-    }
+    spawn(inner, [], {
+      cwd, detached: true, stdio: 'ignore', windowsHide: true, shell: true,
+    }).unref();
     return true;
   } catch {
     return false; // toolchain / shell absent
@@ -159,13 +166,16 @@ function bgWithSentinel(cmd, args, cwd) {
 
 /**
  * Read the last background-build sentinel for `cwd`. Returns null when no
- * sentinel exists yet (never ran, or still running). Never throws.
- * @returns {null|{status:'ok'}|{status:'fail', code:number}|{status:'unknown'}}
+ * sentinel exists yet (never ran, or still running). `code` is null when the
+ * platform shell could not report one (win32 — see bgWithSentinel).
+ * Never throws.
+ * @returns {null|{status:'ok'}|{status:'fail', code:number|null}|{status:'unknown'}}
  */
 function readSentinel(cwd) {
   try {
     const content = fs.readFileSync(sentinelPath(cwd), 'utf8').trim();
     if (content === 'ok') return { status: 'ok' };
+    if (content === 'fail') return { status: 'fail', code: null };
     const m = /^fail:(-?\d+)$/.exec(content);
     if (m) return { status: 'fail', code: Number(m[1]) };
     return { status: 'unknown' };

--- a/plugins/devops/hooks/lib/graphify-state.js
+++ b/plugins/devops/hooks/lib/graphify-state.js
@@ -8,13 +8,18 @@
  *   in the consumer project and is written ONLY after the user explicitly opts
  *   in (consent:true) or out (consent:false) — hooks never write it silently.
  *   Also tracks a per-session "graphify query already ran" flag so the
- *   PreToolUse hard-gate can relent once Claude has consulted the graph.
+ *   PreToolUse hard-gate can relent once Claude has consulted the graph, and
+ *   provides `bgWithSentinel`/`readSentinel` — a shared detached-spawn wrapper
+ *   that records background `graphify extract`/`hook install` outcomes to a
+ *   per-project sentinel file so a silent failure (stdio:'ignore') can be
+ *   surfaced at the next SessionStart instead of vanishing.
  */
 
 const fs = require('node:fs');
 const path = require('node:path');
 const os = require('node:os');
 const crypto = require('node:crypto');
+const { spawn } = require('node:child_process');
 
 const CONSENT_REL = path.join('.claude', 'graphify.json');
 
@@ -116,6 +121,64 @@ function isGraphifyQueryCommand(cmd) {
     .some((seg) => /^\s*graphify\s+query\b/.test(seg));
 }
 
+function sentinelPath(cwd) {
+  const key = crypto.createHash('md5').update(`sentinel:${cwd}`).digest('hex').slice(0, 12);
+  return path.join(os.tmpdir(), `dotclaude-graphbuild-${key}.sentinel`);
+}
+
+/**
+ * Detached background spawn with a completion sentinel (Gap #5). Plain bg()
+ * spawns (detached + stdio:'ignore') make a failing `graphify extract`
+ * completely invisible — this wraps the command in a platform shell that
+ * writes `ok` or `fail:<code>` to a per-project sentinel file once the
+ * command exits, so a LATER SessionStart can detect and surface the failure
+ * (see readSentinel + ss.graphify.js). git-invisible (os.tmpdir(), not the
+ * project). Fail-open: any spawn error is swallowed, matching the shape of
+ * the plain bg() helpers in ss.graphify.js / pre.tokens.guard.js.
+ * @returns {boolean} true iff the spawn was issued (not whether it succeeds)
+ */
+function bgWithSentinel(cmd, args, cwd) {
+  const sentinel = sentinelPath(cwd);
+  try { fs.unlinkSync(sentinel); } catch { /* no previous sentinel */ }
+  const quoted = args.map((a) => `"${String(a).replace(/"/g, '""')}"`).join(' ');
+  try {
+    if (process.platform === 'win32') {
+      const inner = `${cmd} ${quoted} && (echo ok>"${sentinel}") || (echo fail:%errorlevel%>"${sentinel}")`;
+      spawn('cmd.exe', ['/d', '/s', '/c', inner], {
+        cwd, detached: true, stdio: 'ignore', windowsHide: true,
+      }).unref();
+    } else {
+      const inner = `${cmd} ${quoted} && echo ok > "${sentinel}" || echo "fail:$?" > "${sentinel}"`;
+      spawn('/bin/sh', ['-c', inner], { cwd, detached: true, stdio: 'ignore' }).unref();
+    }
+    return true;
+  } catch {
+    return false; // toolchain / shell absent
+  }
+}
+
+/**
+ * Read the last background-build sentinel for `cwd`. Returns null when no
+ * sentinel exists yet (never ran, or still running). Never throws.
+ * @returns {null|{status:'ok'}|{status:'fail', code:number}|{status:'unknown'}}
+ */
+function readSentinel(cwd) {
+  try {
+    const content = fs.readFileSync(sentinelPath(cwd), 'utf8').trim();
+    if (content === 'ok') return { status: 'ok' };
+    const m = /^fail:(-?\d+)$/.exec(content);
+    if (m) return { status: 'fail', code: Number(m[1]) };
+    return { status: 'unknown' };
+  } catch {
+    return null;
+  }
+}
+
+/** Clear the sentinel so a stale result is not re-reported next SessionStart. */
+function clearSentinel(cwd) {
+  try { fs.unlinkSync(sentinelPath(cwd)); } catch { /* absent already */ }
+}
+
 module.exports = {
   CONSENT_REL,
   consentPath,
@@ -129,4 +192,8 @@ module.exports = {
   markQueryDone,
   queryDone,
   isGraphifyQueryCommand,
+  sentinelPath,
+  bgWithSentinel,
+  readSentinel,
+  clearSentinel,
 };

--- a/plugins/devops/hooks/lib/graphify-state.test.js
+++ b/plugins/devops/hooks/lib/graphify-state.test.js
@@ -13,6 +13,10 @@ import {
   queryDone,
   consentPath,
   isGraphifyQueryCommand,
+  sentinelPath,
+  bgWithSentinel,
+  readSentinel,
+  clearSentinel,
 } from "./graphify-state.js";
 
 function tmp() {
@@ -139,4 +143,75 @@ describe("isGraphifyQueryCommand — only real query runs relent the gate", () =
     expect(isGraphifyQueryCommand(undefined)).toBe(false);
     expect(isGraphifyQueryCommand(null)).toBe(false);
   });
+});
+
+describe("background-build sentinel — read/clear", () => {
+  let dir;
+  beforeEach(() => { dir = tmp(); });
+  afterEach(() => {
+    clearSentinel(dir);
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+  });
+
+  test("no sentinel → null", () => {
+    expect(readSentinel(dir)).toBeNull();
+  });
+
+  test.each([
+    ["ok\r\n", { status: "ok" }],
+    ["fail\r\n", { status: "fail", code: null }], // win32 shape — no exit code available
+    ["fail:9\n", { status: "fail", code: 9 }],    // POSIX shape
+    ["fail:\r\n", { status: "unknown" }],          // garbage stays distinguishable
+  ])("parses %j", (content, expected) => {
+    fs.writeFileSync(sentinelPath(dir), content);
+    expect(readSentinel(dir)).toEqual(expected);
+  });
+
+  test("clearSentinel removes and is a no-op when absent", () => {
+    fs.writeFileSync(sentinelPath(dir), "ok");
+    clearSentinel(dir);
+    expect(readSentinel(dir)).toBeNull();
+    expect(() => clearSentinel(dir)).not.toThrow();
+  });
+
+  test("sentinelPath is stable per cwd and distinct across cwds", () => {
+    expect(sentinelPath(dir)).toBe(sentinelPath(dir));
+    expect(sentinelPath(dir)).not.toBe(sentinelPath(tmp()));
+  });
+});
+
+// End-to-end through the REAL platform shell — exactly the path that silently
+// broke on cmd.exe (%errorlevel% parse-time expansion + trailing-digit handle
+// redirection made the fail-sentinel unparseable). Detached spawn → poll.
+describe("background-build sentinel — bgWithSentinel end-to-end", () => {
+  const waitForSentinel = async (cwd, timeoutMs = 5000) => {
+    const start = Date.now();
+    for (;;) {
+      const s = readSentinel(cwd);
+      if (s !== null) return s;
+      if (Date.now() - start > timeoutMs) return null;
+      await new Promise((r) => setTimeout(r, 100));
+    }
+  };
+
+  test("successful command → 'ok' sentinel", async () => {
+    const dir = tmp();
+    const okCmd = process.platform === "win32" ? "ver" : "true";
+    expect(bgWithSentinel(okCmd, [], dir)).toBe(true);
+    expect(await waitForSentinel(dir)).toEqual({ status: "ok" });
+    clearSentinel(dir);
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+  }, 10000);
+
+  test("failing command → parseable 'fail' sentinel (not 'unknown')", async () => {
+    const dir = tmp();
+    const failCmd = process.platform === "win32" ? "findstr" : "false";
+    const failArgs = process.platform === "win32" ? ["/x", "nomatch", "nul"] : [];
+    expect(bgWithSentinel(failCmd, failArgs, dir)).toBe(true);
+    const s = await waitForSentinel(dir);
+    expect(s).not.toBeNull();
+    expect(s.status).toBe("fail"); // the regression this guards against
+    clearSentinel(dir);
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+  }, 10000);
 });

--- a/plugins/devops/hooks/post-tool-use/post.graphify.query.js
+++ b/plugins/devops/hooks/post-tool-use/post.graphify.query.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * @hook post.graphify.query
- * @version 0.1.0
+ * @version 0.2.0
  * @event PostToolUse
  * @plugin devops
  * @matcher Bash

--- a/plugins/devops/hooks/post-tool-use/post.graphify.query.js
+++ b/plugins/devops/hooks/post-tool-use/post.graphify.query.js
@@ -8,12 +8,16 @@
  * @description When Claude runs `graphify query ...`, record a per-session flag
  *   so the PreToolUse graphify-gate relents for the rest of the session — Claude
  *   has consulted the graph, so it should not be re-blocked on every broad
- *   search. Purely a state write; never blocks.
+ *   search. Also records a `query_ran` telemetry event (hooks/lib/
+ *   graphify-metrics) — this is the numerator of the query-adoption metric
+ *   (real `graphify query` runs vs. gate fires/mentions). Purely a state
+ *   write + metrics append; never blocks.
  */
 
 require('../lib/plugin-guard');
 
 const gstate = require('../lib/graphify-state');
+const metrics = require('../lib/graphify-metrics');
 
 let inputData = '';
 process.stdin.setEncoding('utf8');
@@ -24,7 +28,9 @@ process.stdin.on('end', () => {
   if ((hook.tool_name || '') !== 'Bash') process.exit(0);
   const cmd = (hook.tool_input && hook.tool_input.command) || '';
   if (gstate.isGraphifyQueryCommand(cmd)) {
-    gstate.markQueryDone(hook.session_id || hook.sessionId || 'nosid', process.cwd());
+    const sid = hook.session_id || hook.sessionId || 'nosid';
+    gstate.markQueryDone(sid, process.cwd());
+    metrics.record('query_ran', {}, { cwd: process.cwd(), sid });
   }
   process.exit(0);
 });

--- a/plugins/devops/hooks/pre-tool-use/pre.tokens.guard.graphgate.test.js
+++ b/plugins/devops/hooks/pre-tool-use/pre.tokens.guard.graphgate.test.js
@@ -32,7 +32,8 @@ function project({ consent, graph }) {
   if (graph !== "none") {
     const gp = path.join(dir, "graphify-out", "graph.json");
     fs.mkdirSync(path.dirname(gp), { recursive: true });
-    fs.writeFileSync(gp, "{}");
+    // Must clear hasGraph()'s size floor (MIN_GRAPH_BYTES) to count as present.
+    fs.writeFileSync(gp, JSON.stringify({ nodes: Array(50).fill({ id: "x" }) }));
     if (graph === "fresh") {
       fs.utimesSync(src, OLD, OLD);
       fs.utimesSync(gp, NOW, NOW);
@@ -89,10 +90,13 @@ describe("pre.tokens.guard — graphify hard-gate (integration)", () => {
     cleanup(dir);
   });
 
-  test("stale graph → NOT blocked (never force onto out-of-date data)", () => {
+  test("stale graph within tolerance (1 newer file) → STILL blocked, with a lag disclosure", () => {
     const dir = project({ consent: true, graph: "stale" });
     const r = runGrep(dir, "s-stale", "epsilon");
-    expect(r.stderr).not.toContain("GRAPHIFY GATE");
+    expect(r.status).toBe(2);
+    expect(r.stderr).toContain("GRAPHIFY GATE");
+    expect(r.stderr).toContain("graph lags");
+    expect(fs.existsSync(refreshFlagPath(dir))).toBe(true); // refresh kicked alongside the block
     cleanup(dir);
   });
 
@@ -104,10 +108,16 @@ describe("pre.tokens.guard — graphify hard-gate (integration)", () => {
     cleanup(dir);
   });
 
-  test("stale graph + consent → self-heal refresh requested, still not gated", () => {
+  test("stale graph BEYOND tolerance → self-heal refresh requested, not gated", () => {
     const dir = project({ consent: true, graph: "stale" });
+    // Push well past GRAPHIFY_STALE_TOLERANCE (25) with more newer files.
+    for (let i = 0; i < 30; i++) {
+      const p = path.join(dir, `extra${i}.js`);
+      fs.writeFileSync(p, "x");
+      fs.utimesSync(p, NOW, NOW);
+    }
     const r = runGrep(dir, "s-heal", "omega");
-    expect(r.stderr).not.toContain("GRAPHIFY GATE"); // never block onto stale
+    expect(r.stderr).not.toContain("GRAPHIFY GATE"); // never block beyond tolerance
     expect(fs.existsSync(refreshFlagPath(dir))).toBe(true); // background refresh kicked
     cleanup(dir);
   });

--- a/plugins/devops/hooks/pre-tool-use/pre.tokens.guard.js
+++ b/plugins/devops/hooks/pre-tool-use/pre.tokens.guard.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * @hook pre.tokens.guard
- * @version 0.5.0
+ * @version 0.7.0
  * @event PreToolUse
  * @plugin devops
  * @description Block Read/Bash/Glob/Grep operations that would consume a

--- a/plugins/devops/hooks/pre-tool-use/pre.tokens.guard.js
+++ b/plugins/devops/hooks/pre-tool-use/pre.tokens.guard.js
@@ -26,22 +26,17 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 const crypto = require('crypto');
-const { spawn, execSync } = require('child_process');
+const { execSync } = require('child_process');
 
 const cwd = process.cwd();
 const CONFIG_DIR = path.join(cwd, '.claude');
 const CONFIG_PATH = path.join(CONFIG_DIR, 'token-config.json');
 
-// Detached, fail-open background spawn (mirrors ss.graphify). `shell` on Windows
-// so a `graphify.cmd` shim from `uv tool install` actually runs. A missing
-// toolchain throws → no-op; never affects the guard's block/allow decision.
-function bg(cmd, args) {
-  try {
-    spawn(cmd, args, {
-      cwd, detached: true, stdio: 'ignore', shell: process.platform === 'win32',
-    }).unref();
-  } catch { /* toolchain absent */ }
-}
+// Note: background graphify spawns (self-heal refresh) go through
+// `gstate.bgWithSentinel` (hooks/lib/graphify-state.js) rather than a local
+// bg() helper — it wraps the same detached/stdio:'ignore' spawn shape but
+// also records ok/fail to a sentinel file so a silent failure (Gap #5) can
+// be surfaced at the next SessionStart instead of vanishing.
 
 function isGitRepo() {
   try {
@@ -209,46 +204,76 @@ process.stdin.on('end', () => {
     process.exit(0);
   }
 
-  // ── graphify hard-gate (consented + FRESH graph) ────────────────────
-  // When the user has opted graphify in for this project AND a fresh graph
-  // exists, force a broad raw-file search through the graph first. Two hard
-  // preconditions keep this from being harmful:
-  //   1. Staleness — never block onto an out-of-date graph (graphIsStale).
-  //   2. Escape hatch — block at most once per (session, search); a retry of
+  // ── graphify hard-gate (consented + graph within staleness tolerance) ────
+  // When the user has opted graphify in for this project AND a usable graph
+  // exists, force a broad raw-file search through the graph first. This is a
+  // BOUNDED-tolerance gate, not a strict fresh/stale one: a graph that lags a
+  // small number of files behind the working tree is still useful, so the
+  // gate still enforces on it (with a disclosure line + a kicked background
+  // refresh) — see GRAPHIFY_STALE_TOLERANCE below. It must NEVER force Claude
+  // onto a graph whose staleness cannot be bounded at all (missing, truncated
+  // scan, nothing comparable — stalenessInfo reports newerCount:Infinity for
+  // all of these); that self-heals silently instead. Two more safety
+  // properties are preserved:
+  //   1. Escape hatch — block at most once per (session, search); a retry of
   //      the same search falls through, so a question the graph cannot answer
   //      (exact string, new/uncommitted file, non-code asset) is never wedged.
-  // Relents entirely once `graphify query` has run this session (queryDone).
+  //   2. Relents entirely once `graphify query` has run this session (queryDone).
   // Fail-open: any error here must never block a search.
+  //
+  // Tolerance is a file COUNT, not a time window, because scanSources already
+  // walks the tree per-search — comparing counts costs nothing extra and is
+  // robust to editors touching files without changing them meaningfully.
+  const GRAPHIFY_STALE_TOLERANCE = 25;
   if ((toolName === 'Grep' || toolName === 'Glob') && !toolInput.path) {
     try {
       const graphNudge = require('../lib/graph-nudge');
       const gstate = require('../lib/graphify-state');
+      const metrics = require('../lib/graphify-metrics');
       const sid = hook.session_id || hook.sessionId || 'nosid';
       if (gstate.hasConsent(cwd) && graphNudge.hasGraph(cwd)) {
-        if (graphNudge.graphIsStale(cwd)) {
-          // Demand-driven self-heal: a broad search arrived but the graph is
-          // stale (the common case mid-development — any edit outdates it), so
-          // the gate below cannot fire and the graph would just rot until the
-          // next SessionStart. Kick a throttled background AST refresh (free) so
-          // the graph converges to fresh and the gate can enforce on LATER
-          // searches this session. Never blocks; falls through to allow.
-          if (gstate.markRefresh(cwd, 2 * 60 * 1000)) bg('graphify', ['extract', '.', '--update']);
+        const info = graphNudge.stalenessInfo(cwd);
+        const withinTolerance = !info.truncated && info.newerCount <= GRAPHIFY_STALE_TOLERANCE;
+        if (!withinTolerance) {
+          // Demand-driven self-heal: a broad search arrived but the graph lags
+          // too far behind (or its staleness cannot be bounded at all), so the
+          // gate below must not fire and the graph would just rot until the
+          // next SessionStart. Kick a throttled background AST refresh (free,
+          // sentinel-tracked — see Gap #5) so the graph converges and the gate
+          // can enforce on LATER searches this session. Never blocks.
+          if (gstate.markRefresh(cwd, 2 * 60 * 1000)) {
+            gstate.bgWithSentinel('graphify', ['extract', '.', '--update'], cwd);
+            metrics.record('self_heal_kicked', { newerCount: info.newerCount, truncated: info.truncated }, { cwd, sid });
+          }
         } else if (!gstate.queryDone(sid, cwd)) {
           const gflag = flagPath(`graphgate:${sid}:${cwd}:${toolName}:${JSON.stringify(toolInput)}`);
           if (!fs.existsSync(gflag)) {
             try { fs.writeFileSync(gflag, Date.now().toString()); } catch {}
-            console.error('\n⛔  GRAPHIFY GATE — broad search blocked (fresh graph available)');
+            // Within tolerance but still lagging by >0 files — enforce AND kick
+            // a refresh in parallel so it converges toward newerCount 0.
+            if (info.newerCount > 0 && gstate.markRefresh(cwd, 2 * 60 * 1000)) {
+              gstate.bgWithSentinel('graphify', ['extract', '.', '--update'], cwd);
+              metrics.record('self_heal_kicked', { newerCount: info.newerCount, truncated: false }, { cwd, sid });
+            }
+            const suggestion = graphNudge.suggestQuery(toolInput.pattern);
+            console.error('\n⛔  GRAPHIFY GATE — broad search blocked (graph available)');
             console.error('─'.repeat(54));
             console.error('Query the knowledge graph instead of grepping raw files:');
-            console.error('  graphify query "<your question>"');
+            console.error(`  ${suggestion}`);
+            if (info.newerCount > 0) {
+              console.error('');
+              console.error(`note: graph lags ${info.newerCount} file(s) behind — background refresh started`);
+            }
             console.error('');
             console.error('If the graph cannot answer THIS search (exact string, a');
             console.error('new/uncommitted file, or a non-code asset), retry the same');
             console.error('search to proceed.');
             console.error('─'.repeat(54));
+            metrics.record('gate_fired', { newerCount: info.newerCount }, { cwd, sid });
             process.exit(2);
           }
           // flag present → already gated this search; fall through (escape hatch)
+          metrics.record('gate_bypassed', {}, { cwd, sid });
         }
       }
     } catch { /* fail open — never block on gate errors */ }
@@ -285,6 +310,7 @@ process.stdin.on('end', () => {
         }
         if (hasGraph) {
           sections.push(graphNudge.buildGraphNudge());
+          try { require('../lib/graphify-metrics').record('nudge_injected', {}, { cwd, sid }); } catch {}
         }
         fs.writeFileSync(mapFlag, Date.now().toString());
         process.stdout.write(JSON.stringify({
@@ -364,6 +390,7 @@ process.stdin.on('end', () => {
         if (runOnce('graphify-block-offer', cwdKey, { cooldownMs: 7 * 24 * 60 * 60 * 1000 })) {
           console.error('');
           console.error(graphNudge.buildGraphifyOffer());
+          try { require('../lib/graphify-metrics').record('offer_shown', { source: 'value_moment' }, { cwd }); } catch {}
         }
       }
     } catch { /* never let the offer break the block */ }

--- a/plugins/devops/hooks/pre-tool-use/pre.tokens.guard.js
+++ b/plugins/devops/hooks/pre-tool-use/pre.tokens.guard.js
@@ -243,7 +243,9 @@ process.stdin.on('end', () => {
           // can enforce on LATER searches this session. Never blocks.
           if (gstate.markRefresh(cwd, 2 * 60 * 1000)) {
             gstate.bgWithSentinel('graphify', ['extract', '.', '--update'], cwd);
-            metrics.record('self_heal_kicked', { newerCount: info.newerCount, truncated: info.truncated }, { cwd, sid });
+            // Infinity is JSON-null; -1 keeps "unbounded" distinguishable in the log.
+            const newerCount = Number.isFinite(info.newerCount) ? info.newerCount : -1;
+            metrics.record('self_heal_kicked', { newerCount, truncated: info.truncated }, { cwd, sid });
           }
         } else if (!gstate.queryDone(sid, cwd)) {
           const gflag = flagPath(`graphgate:${sid}:${cwd}:${toolName}:${JSON.stringify(toolInput)}`);

--- a/plugins/devops/hooks/session-start/ss.graphify.js
+++ b/plugins/devops/hooks/session-start/ss.graphify.js
@@ -46,8 +46,9 @@ const cwdKey = crypto.createHash('md5').update(cwd).digest('hex').slice(0, 12);
 function reportBgFailureIfAny() {
   const sentinel = gstate.readSentinel(cwd);
   if (sentinel && sentinel.status === 'fail') {
+    const codeInfo = sentinel.code == null ? '' : ` (exit ${sentinel.code})`;
     process.stdout.write(
-      `⚠ graphify background build failed (exit ${sentinel.code}) — run \`graphify extract . --update\` manually or /devops-graph\n`
+      `⚠ graphify background build failed${codeInfo} — run \`graphify extract . --update\` manually or /devops-graph\n`
     );
     gstate.clearSentinel(cwd); // one report per failure, not every session
   }

--- a/plugins/devops/hooks/session-start/ss.graphify.js
+++ b/plugins/devops/hooks/session-start/ss.graphify.js
@@ -9,26 +9,65 @@
  *   .claude/graphify.json (written ONLY after the user opts in/out via the
  *   offer below — never silently):
  *     - consent:true  → ensure graphify is installed; (once/day) install its git
- *       hooks; if the graph is missing/stale, kick off a background
- *       `graphify extract . --update` (AST-only, free). Keeps the graph fresh so
- *       the PreToolUse graphify-gate enforces against current data.
+ *       hooks; if the graph is missing/stale/invalid (once/day JSON.parse
+ *       validity check), kick off a background `graphify extract . --update`
+ *       (AST-only, free) via a sentinel-tracked spawn. Keeps the graph fresh so
+ *       the PreToolUse graphify-gate enforces against current data. If the
+ *       PREVIOUS background build failed, surface it as one line before doing
+ *       anything else (see reportBgFailureIfAny / hooks/lib/graphify-state's
+ *       readSentinel — bg spawns are stdio:'ignore', so without this a failing
+ *       build is otherwise invisible).
  *     - consent:false → stay silent (user declined).
  *     - no record     → (throttled, weekly) emit a one-time instruction for
- *       Claude to OFFER enabling graphify via AskUserQuestion.
+ *       Claude to OFFER enabling graphify via AskUserQuestion, and record an
+ *       `offer_shown` metrics event (see hooks/lib/graphify-metrics).
  *   Fail-open and non-blocking: every graphify invocation is detached/guarded so
  *   a missing Python toolchain never degrades session start.
  */
 
 require('../lib/plugin-guard');
 
+const fs = require('fs');
 const crypto = require('crypto');
 const { spawn, execSync } = require('child_process');
 const { runOnce } = require('../lib/run-once');
 const gstate = require('../lib/graphify-state');
 const graphNudge = require('../lib/graph-nudge');
+const metrics = require('../lib/graphify-metrics');
 
 const cwd = process.cwd();
 const cwdKey = crypto.createHash('md5').update(cwd).digest('hex').slice(0, 12);
+
+/**
+ * Gap #5/#6: surface a background-build failure or a graph that looks
+ * present but is invalid (0 nodes / unparsable) as ONE line to the user, and
+ * report whether a rebuild is warranted. Deliberately does not throw.
+ */
+function reportBgFailureIfAny() {
+  const sentinel = gstate.readSentinel(cwd);
+  if (sentinel && sentinel.status === 'fail') {
+    process.stdout.write(
+      `⚠ graphify background build failed (exit ${sentinel.code}) — run \`graphify extract . --update\` manually or /devops-graph\n`
+    );
+    gstate.clearSentinel(cwd); // one report per failure, not every session
+  }
+}
+
+/**
+ * Deeper (once/24h) validity check beyond the cheap size-floor in hasGraph():
+ * a graph.json that parses but has no "nodes" is as useless as a missing one.
+ * JSON.parse only runs here (once per day, SessionStart) — never on the
+ * PreToolUse hot path.
+ */
+function graphLooksValid() {
+  try {
+    const raw = fs.readFileSync(graphNudge.graphJsonPath(cwd), 'utf8');
+    const parsed = JSON.parse(raw);
+    return !!(parsed && typeof parsed === 'object' && Array.isArray(parsed.nodes) && parsed.nodes.length > 0);
+  } catch {
+    return false;
+  }
+}
 
 function graphifyInstalled() {
   try {
@@ -65,6 +104,7 @@ function bg(cmd, args) {
 const state = gstate.readState(cwd);
 
 if (state && state.consent === true) {
+  reportBgFailureIfAny();
   // Opted in. Keep the graph fresh so the gate enforces against current code.
   if (!graphifyInstalled()) {
     if (runOnce('ss-graphify-reinstall', cwdKey, { cooldownMs: 24 * 60 * 60 * 1000 })) {
@@ -79,11 +119,15 @@ if (state && state.consent === true) {
   if (isGitRepo() && runOnce('ss-graphify-hookinstall', cwdKey, { cooldownMs: 24 * 60 * 60 * 1000 })) {
     bg('graphify', ['hook', 'install']); // idempotent git post-commit/checkout AST rebuild
   }
+  // Once/24h deeper validity check (JSON.parse) beyond hasGraph()'s cheap size
+  // floor — a present-but-empty/corrupt graph.json must trigger a rebuild too.
+  const needsRebuild = !graphNudge.hasGraph(cwd)
+    || graphNudge.graphIsStale(cwd)
+    || (runOnce('ss-graphify-validate', cwdKey, { cooldownMs: 24 * 60 * 60 * 1000 }) && !graphLooksValid());
   // Throttle the rebuild so repeated SessionStart re-entries (multiple agents /
   // worktrees on the same cwd) cannot stack concurrent `graphify extract`.
-  if ((!graphNudge.hasGraph(cwd) || graphNudge.graphIsStale(cwd))
-      && runOnce('ss-graphify-extract', cwdKey, { cooldownMs: 10 * 60 * 1000 })) {
-    bg('graphify', ['extract', '.', '--update']); // background, AST-only, free
+  if (needsRebuild && runOnce('ss-graphify-extract', cwdKey, { cooldownMs: 10 * 60 * 1000 })) {
+    gstate.bgWithSentinel('graphify', ['extract', '.', '--update'], cwd); // background, AST-only, free
   }
   process.exit(0);
 }
@@ -95,10 +139,12 @@ if (state && state.consent === false) {
 // No decision yet → offer ONCE (re-offer at most weekly if ignored).
 // Only in real git projects — never nag in scratch/throwaway folders.
 if (isGitRepo() && runOnce('ss-graphify-offer', cwdKey, { cooldownMs: 7 * 24 * 60 * 60 * 1000 })) {
+  metrics.record('offer_shown', { source: 'session_start' }, { cwd });
   process.stdout.write(
     '[graphify] No knowledge-graph config for this project. Offer the user (AskUserQuestion) to enable graphify — ' +
     'it builds a queryable code graph so broad searches use the graph instead of grepping (token saver), kept fresh via git hooks. ' +
     'On YES: run `uv tool install graphifyy && graphify install && graphify hook install && graphify extract .`, then write .claude/graphify.json {"consent":true,"autoBuild":true}. ' +
+    'After extract completes, verify graphify-out/graph.json exists and report its node count to the user; if missing, report the failure instead of claiming success. ' +
     'On NO: write .claude/graphify.json {"consent":false}. Always confirm before installing — never silently.\n'
   );
 }

--- a/plugins/devops/hooks/session-start/ss.graphify.js
+++ b/plugins/devops/hooks/session-start/ss.graphify.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * @hook ss.graphify
- * @version 0.1.0
+ * @version 0.2.0
  * @event SessionStart
  * @plugin devops
  * @description graphify enforcement — install-check + auto-build wiring for the

--- a/plugins/devops/skills/devops-graph/SKILL.md
+++ b/plugins/devops/skills/devops-graph/SKILL.md
@@ -28,6 +28,15 @@ it — see [Enforcement](#enforcement-after-opt-in).
 - **Never install silently.** If graphify is missing, *offer* and wait for an
   explicit OK before running any install command. The consent record
   (`.claude/graphify.json`) is written only after the user decides.
+- **After writing the consent record, log the decision.** Immediately after
+  writing `.claude/graphify.json` (either `{"consent":true,...}` or
+  `{"consent":false}`), append one telemetry line so offer→conversion is
+  measurable end to end:
+  ```bash
+  node -e "require('${CLAUDE_PLUGIN_ROOT}/hooks/lib/graphify-metrics').record('consent_written', {consent: <true|false>}, {cwd: process.cwd()})"
+  ```
+  This never blocks anything and is best-effort — if it errors, ignore it and
+  continue.
 - **Never run `graphify claude install`.** That command writes graphify's own
   PreToolUse hook + CLAUDE.md skill, which collides with the devops plugin's
   PreToolUse hooks (the project-map re-scoping hint and `pre.tokens.guard.js`).
@@ -109,9 +118,13 @@ graph follows the code via both git hooks *and* SessionStart.
 (exit 2) and tells Claude to run `graphify query` instead. Two preconditions
 keep this safe — both enforced in code, never optional:
 
-- **Staleness guard** — the gate only fires when the graph is *fresh*
-  (`graphIsStale` compares graph.json mtime vs the newest source file). A stale
-  graph is never forced onto Claude.
+- **Bounded staleness tolerance** — the gate does not require perfect
+  freshness. `stalenessInfo` counts how many source files are newer than
+  graph.json; the gate still fires (with a "graph lags N file(s) behind —
+  background refresh started" disclosure) up to a small tolerance, and only
+  falls back to self-heal (no block) when the lag is large or cannot be
+  bounded at all (missing graph, truncated scan, nothing comparable). A graph
+  whose staleness cannot be proven is never forced onto Claude.
 - **Escape hatch** — the gate blocks a given search at most once per session;
   *retrying the same search falls through*, so a question the graph cannot
   answer (exact string, a new/uncommitted file, a non-code asset) is never

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.110.0",
+  "version": "0.111.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

Makes the graphify enforcement chain actually drive query adoption instead of sitting disarmed:

- **Bounded staleness tolerance** (`GRAPHIFY_STALE_TOLERANCE = 25`): the gate now enforces while the graph lags ≤25 files behind the working tree (lag disclosed in the block message, throttled background refresh kicked in parallel). The previous binary fresh/stale precondition was re-disarmed by every file save — a 744-session audit found 634 graphify mentions but only ~5 real `graphify query` executions (~0.8%), all verification probes.
- **Adoption telemetry**: fail-silent JSONL sink at `~/.claude/graphify-metrics.jsonl` (2 MB cap) recording `gate_fired`, `gate_bypassed`, `self_heal_kicked`, `query_ran`, `offer_shown`, `nudge_injected`, plus `consent_written` from the devops-graph skill — offer→consent→query conversion is measurable end to end.
- **Silent background-build failures surfaced**: `graphify extract` spawns are sentinel-tracked (`bgWithSentinel`); a failed build is reported as one line at the next SessionStart. Fixes two Windows traps that made the sentinel path inoperative (node cmd.exe quoting escaping inner quotes as `\"`; `%errorlevel%` parse-time expansion + trailing-digit handle redirection) — caught by new real-shell end-to-end tests.
- **Lower query friction**: block message proposes a ready-to-run `graphify query "…"` derived from the blocked search pattern; opt-in offers must verify `graphify-out/graph.json` exists (node count reported) after install; `hasGraph()` gained a 512-byte floor plus a once-daily deep JSON validity check.

Safety properties preserved: fail-open on all gate errors, one-shot escape hatch per search, session relent after a query, metrics can never break a hook.

## Evidence

- 669/669 vitest green, eslint clean; 25 new tests (staleness boundaries, metrics sink, suggested-query heuristic, sentinel read/clear + real-shell e2e ok/fail).
- Wave pipeline: research (transcript audit) → core (implementation) → adversarial review (found + fixed the Windows sentinel defects) → QA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)