### PR TITLE
feat(new-issue): user-value gate for issue creation (0.112.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.111.0"
+    "version": "0.112.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.111.0",
+      "version": "0.112.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.111.0",
+      "version": "0.112.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.112.0] — 2026-07-10
+
+### Added
+
+- **Issue creation now enforces a user-value gate — no more swarms of technical tasks that only pay off in combination.** A recent planning run created ~30 file-level tasks that each described a code change but no user-perceivable outcome, flooding the tracker. Every issue must now pass a standalone test before creation: implementing ONLY this issue must already produce a direct (feature, visual, bug fixed, fewer crashes) or indirect (performance, stability, security) user effect. Technical sub-tasks serving one use case are merged into ONE issue scoped by the user value they jointly deliver (sub-tasks as a checklist in the body), and every issue body carries a `**User value:** <effect>` line that the verify step checks. Creating several issues at once stays fine when each passes in isolation; milestones may still aggregate issues into a larger goal but never justify members that fail alone. The gate covers all three creation surfaces: the interactive `/devops-new-issue` flow (new Step 1a + verify check), milestone planning (per-issue gate rule), and the zero-prompt `create-issues` path in `/devops-concept`, which merges combination-only items silently — no `AskUserQuestion`, the zero-prompt invariant holds. (`devops-new-issue` skill 0.1.0 → 0.2.0, `devops-concept` create-issues flow + bridge-server docs.)
+
 ## [0.111.0] — 2026-07-09
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.111.0**
+**Version: 0.112.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.111.0",
+  "version": "0.112.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/skills/devops-concept/SKILL.md
+++ b/plugins/devops/skills/devops-concept/SKILL.md
@@ -618,7 +618,19 @@ interruption is a hard `gh` failure that needs the user's eyes.
    bundles the current disposition state for Step 6 cleanup. Store it
    for use in Step 6a; do NOT apply it now — issue routing and cleanup
    are decoupled so the user can still review the page before closing.
-3. For each selected item, create the GitHub issue **directly via
+3. **User-value gate (silent, mandatory).** Apply the gate from the
+   `devops-new-issue` skill's deep-knowledge/issue-rules.md to the
+   selected items BEFORE creating anything: each issue must deliver a
+   standalone user effect — direct (feature, visual, bug fixed, fewer
+   crashes) or indirect (performance, stability, security). Items that
+   only produce value in combination (file-level / layer-level tasks
+   serving one use case) are **merged into ONE issue**: title = the user
+   value they jointly deliver, original items as a checklist in the
+   body. Merging is a silent sane default under the zero-prompt
+   invariant — never an `AskUserQuestion`. Every resulting body carries
+   a `**User value:** <effect>` line. Never emit a swarm of code-change
+   tasks that only make sense together.
+4. For each gated item, create the GitHub issue **directly via
    `gh issue create`** — do NOT invoke the `devops-new-issue` skill,
    which runs an interactive `AskUserQuestion` Step 1. Build the
    command from the payload + concept-extension labels (see § Project
@@ -636,7 +648,7 @@ interruption is a hard `gh` failure that needs the user's eyes.
    abort this item, surface the error to the user, and continue with
    the remaining items — partial success beats silent loss.
 
-4. **Project label enrichment (role / module).** Before calling `gh`,
+5. **Project label enrichment (role / module).** Before calling `gh`,
    resolve project-specific labels in this order:
    - If `item.role` / `item.module` is set in the payload → use directly.
    - Else, check the project's `devops-new-issue` extension
@@ -647,20 +659,22 @@ interruption is a hard `gh` failure that needs the user's eyes.
    - Else → omit the label silently. NEVER ask. A minimal `type:*`-only
      issue is preferable to interrupting the user.
 
-5. **Issue body composition.** Always end the body with a backlink:
+6. **Issue body composition.** Always end the body with a backlink:
    `_Created from concept: docs/concepts/{date}-{slug}.html_`. This is
    how the human reader (and future Claude session) recovers the
    originating context months later. Prepend whatever richer body the
    payload's `item.description` carries.
 
-6. Update the final-report HTML: in the open-questions section, replace
+7. Update the final-report HTML: in the open-questions section, replace
    each created item's label with `[Issue #NNN] {title}` (linked to the
-   issue URL), disable the checkbox, and add a small ✓ badge.
-7. POST `/reload` so the browser shows the updated state. If every item
+   issue URL), disable the checkbox, and add a small ✓ badge. For items
+   that were merged by the user-value gate, link ALL source items to the
+   one merged issue.
+8. POST `/reload` so the browser shows the updated state. If every item
    was processed, the "Issues erstellen" button auto-hides on reload
    (panel JS gates it on the presence of un-created checkable items).
-8. Then POST `/reset` with the captured `_version` as usual.
-9. The concept session stays open — the user may still review previous
+9. Then POST `/reset` with the captured `_version` as usual.
+10. The concept session stays open — the user may still review previous
    iteration tabs but cannot trigger further iterate/implement actions
    from the final report.
 

--- a/plugins/devops/skills/devops-concept/deep-knowledge/bridge-server.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/bridge-server.md
@@ -141,8 +141,10 @@ AND provides HTTP endpoints for heartbeat and decision exchange.
            one of FOUR values, each with its own SKILL.md Step 5b branch:
              - "iterate"        → next iteration on the concept page only
              - "implement"      → apply real code changes + final-report
-             - "create-issues"  → autonomously run `gh issue create` for each
-                                  payload item; NO AskUserQuestion, the user
+             - "create-issues"  → apply the user-value gate (SKILL.md Step 5b,
+                                  merges combination-only items silently), then
+                                  autonomously run `gh issue create` for each
+                                  gated item; NO AskUserQuestion, the user
                                   already committed by clicking the button
              - "dispose-concept"→ record disposition, advance to Step 6
            Process per Step 5 (Live Feedback Loop) — act on the user's choices

--- a/plugins/devops/skills/devops-new-issue/SKILL.md
+++ b/plugins/devops/skills/devops-new-issue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: devops-new-issue
-version: 0.1.0
+version: 0.2.0
 description: >-
   Create GitHub issues with enforced title format, labels, and optional milestone
   and project board integration. Also handles milestone creation and naming. Use
@@ -40,11 +40,30 @@ Determine from user input or ask via AskUserQuestion:
 
 If project extension defines additional required fields (roles, modules), ask for those too.
 
+## Step 1a — User-value gate (mandatory)
+
+Apply the gate from deep-knowledge/issue-rules.md to EVERY issue before
+creating it: implementing this one issue alone must already produce a
+positive user effect — direct (feature, visual, bug fixed, fewer crashes)
+or indirect (performance, stability, security).
+
+- Fails the gate ("only valuable together with other issues") → do NOT
+  create it. Bundle the technical sub-tasks into ONE issue scoped by the
+  user value they jointly deliver, sub-tasks as a checklist in the body.
+- Multiple issues in one request: gate each one in isolation. If several
+  only pass together, propose the merged issue(s) to the user instead of
+  creating the originals.
+- Milestones may aggregate issues into a larger goal, but never use a
+  milestone to justify member issues that fail the gate individually.
+
 ## Step 2 — Create the issue
 
 ```bash
 gh issue create --title "[TYPE] Title" --body "Description" --label "type:X"
 ```
+
+The body MUST include the user-value line (see deep-knowledge/issue-rules.md):
+`**User value:** <direct or indirect effect>`
 
 Add optional flags based on project extension:
 - `--label "role:Y,module:Z"` — if project defines these label categories
@@ -61,9 +80,10 @@ Set custom fields (e.g., "Agent Role") via GraphQL if field IDs are provided in 
 ## Step 4 — Verify
 
 Confirm all required parameters are set:
-1. Labels: at least `type:*` (plus any project-specific requirements)
-2. Milestone: if configured
-3. Project board item: if configured
+1. User-value gate passed and body contains the `**User value:**` line
+2. Labels: at least `type:*` (plus any project-specific requirements)
+3. Milestone: if configured
+4. Project board item: if configured
 
 Missing required items = hard error. Fix before reporting success.
 
@@ -83,6 +103,8 @@ Output the markdown VERBATIM as the LAST thing in the response.
 
 ## Rules
 
+- Every issue passes the user-value gate on its own (deep-knowledge/issue-rules.md) —
+  never create file-level/layer-level tasks that only deliver value in combination
 - Never use `[FIX]` — bugs are always `[BUG]`
 - Always link PRs to issues via `Closes #NNN` in PR body
 - Re-evaluate milestone level prefix when issues are added/removed

--- a/plugins/devops/skills/devops-new-issue/deep-knowledge/issue-rules.md
+++ b/plugins/devops/skills/devops-new-issue/deep-knowledge/issue-rules.md
@@ -1,5 +1,38 @@
 # GitHub Issue Rules
 
+## User-value gate (mandatory — checked BEFORE creating any issue)
+
+Every issue must deliver a positive user-experience effect **on its own**.
+The test: *"If ONLY this issue is implemented and shipped — nothing else —
+does the user notice a positive difference?"*
+
+Accepted value, either kind:
+- **Direct**: visible feature, UI improvement, bug fixed, fewer crashes
+- **Indirect**: performance, stability, security, lower resource usage
+
+If the honest answer is *"only in combination with other issues"* → do NOT
+create it as its own issue.
+
+**Bundling rule:** Technical sub-tasks that only produce value together
+(e.g. "change file A", "adapt module B", "extend schema C" — all serving one
+use case) become **ONE issue**, titled and scoped by the user value they
+jointly deliver. List the sub-tasks as a checklist in the issue body.
+
+**Body requirement:** every issue body states the user value in one line:
+`**User value:** <direct or indirect effect>`. If you cannot write that
+line honestly, the issue fails the gate.
+
+**What remains fine:**
+- Creating multiple issues at once — as long as EACH passes the gate in isolation
+- Milestones bundling issues into a larger goal — the milestone aggregates
+  value, but each member issue must still pass the gate on its own
+- `type:chore` / `type:refactor` issues — IF the body names the indirect
+  user effect (e.g. "removes crash-prone code path", "cuts startup time")
+
+**Anti-pattern (never):** decomposing one use case into many file-level or
+layer-level issues that each describe a code change but no user-perceivable
+outcome. That floods the tracker without adding plannable value.
+
 ## Title format
 
 `[TYPE] Short imperative description`

--- a/plugins/devops/skills/devops-new-issue/deep-knowledge/milestone-rules.md
+++ b/plugins/devops/skills/devops-new-issue/deep-knowledge/milestone-rules.md
@@ -5,6 +5,10 @@
 - "Plan a milestone" = **planning mode only**: create GitHub milestone + issues, ask questions, set labels. No code.
 - Implementation begins only when the user explicitly says to implement.
 - Milestones are **not time-boxed** — done when all issues are closed.
+- **User-value gate applies per issue** (see issue-rules.md): the milestone
+  aggregates value, but every member issue must still deliver standalone
+  user value. Never decompose a milestone into file-level tasks — cut it
+  into the smallest slices that each produce a user-perceivable effect.
 
 ## Naming convention
 

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.111.0",
+  "version": "0.112.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

Every GitHub issue created via the plugin must now pass a **user-value gate**: implementing ONLY that issue must already produce a direct (feature, visual, bug fixed, fewer crashes) or indirect (performance, stability, security) user effect. Technical sub-tasks that only deliver value in combination are merged into ONE issue scoped by the user value they jointly deliver, with the sub-tasks as a checklist in the body.

**Why:** a recent planning run created ~30 file-level tasks that each described a code change but no user-perceivable outcome — flooding the tracker with issues that only make sense together.

## Changes

- `devops-new-issue` skill (0.1.0 → 0.2.0): new **Step 1a — User-value gate** (mandatory, before creation), body requirement `**User value:** <effect>`, verify-step check, rules bullet.
- `devops-new-issue/deep-knowledge/issue-rules.md`: canonical gate definition — the standalone test, bundling rule, what remains fine (multiple gated issues, milestones as aggregates, chores/refactors naming their indirect effect), anti-pattern.
- `devops-new-issue/deep-knowledge/milestone-rules.md`: milestones aggregate value, but every member issue must pass the gate individually — never decompose into file-level tasks.
- `devops-concept` create-issues path (zero-prompt): silent gate + merge of combination-only items before `gh issue create` — no `AskUserQuestion`, zero-prompt invariant holds; merged source items all link to the one merged issue in the final report.
- `devops-concept/deep-knowledge/bridge-server.md`: action summary updated to reflect the gate.

## Validation

- `npm run lint` clean, 669/669 tests green.
- Gate covers all three issue-creation surfaces (interactive skill, milestone planning, concept zero-prompt path); `devops-learn` delegates to `/devops-new-issue` and inherits it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)