### PR TITLE
feat(ship): release channels alpha/beta/stable (ring model)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.112.0"
+    "version": "0.113.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.112.0",
+      "version": "0.113.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.112.0",
+      "version": "0.113.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # Full history + tags: `git describe`/`git log <range>` below need
+          # them (the fetch-depth:1 default silently broke release notes).
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Extract version from tag
         id: version
@@ -22,8 +27,9 @@ jobs:
       - name: Generate release notes
         id: notes
         run: |
-          # Get previous tag
-          PREV_TAG=$(git describe --tags --abbrev=0 HEAD~1 2>/dev/null || echo "")
+          # Previous STABLE tag only — channel tags (alpha/*, beta/*) share
+          # commits with bare tags and would corrupt the range (ring model).
+          PREV_TAG=$(git describe --tags --match 'v[0-9]*' --abbrev=0 HEAD~1 2>/dev/null || echo "")
 
           if [ -n "$PREV_TAG" ]; then
             COMMITS=$(git log ${PREV_TAG}..HEAD --pretty=format:"- %s" | head -20)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.113.0] — 2026-07-11
+
+### Added
+
+- **Release channels (alpha/beta/stable) — ship stays autonomous, promotion becomes a deliberate step.** Every `/devops-ship` to main now publishes to the earliest channel automatically: `ship_release` creates the ANNOTATED tag `alpha/vX.Y.Z` on the merge commit and no longer creates a GitHub Release at ship time. The new `/devops-release` skill + `ship_promote` MCP tool move an already-shipped version up the ring (alpha→beta→stable, or fast-track alpha→stable as two sequential promotions) by re-tagging the SAME commit — bit-identical by construction, no rebuild, no version bump. Guards: monotonicity (never tag a version older than the target channel's latest; equal-version re-runs are idempotent success for partial-failure recovery), ancestry (only commits reachable from origin/main), immutability (published tags are never moved or deleted — rollback = roll forward). Stable promotion additionally creates the bare `vX.Y.Z` tag (backward-compat alias) which triggers the Release workflow; the tool polls for the Release and creates it via `gh` as an idempotent fallback. Beta stays tags-only until an external beta audience exists. The ship completion card now carries a promotion-gap nudge ("alpha is N versions ahead of stable — /devops-release") with escalation past 3 versions / 7 days, so deliberate promotion has a heartbeat. Design spec with redteam findings + PO review: `docs/superpowers/specs/2026-07-11-tag-channel-system-design.md`. (`ship_release` alpha tagging, new `ship_promote` + `ship/lib/channels.js`, new `devops-release` skill, 25 new tests.)
+- **Consumers pin a channel — the update hook resolves tags instead of tracking main.** `ss.plugin.update` (and `/devops-plugin-update`, incl. new `--channel <alpha|beta|stable>` flag) now reads a per-marketplace channel pin from `~/.claude/plugins/.channels.json` (default: stable; one channel per marketplace — a single clone cannot serve two plugins on different channels) and pins the marketplace clone to the highest version visible to that channel (own channel ∪ all more-stable ∪ bare pre-channel tags, numeric version comparison) via a detached tag checkout with a reset/clean repair guard. Bootstrap fallback keeps the legacy `git pull --ff-only` behavior until the repo's FIRST `stable/*` tag exists, making the migration oscillation-free: nothing changes for any consumer until a version is deliberately promoted to stable. The registry entry gains an informational `channel` field. (`ss.plugin.update` 0.9.1 → 0.10.0, new CJS `hooks/lib/channels.js`.)
+
+### Fixed
+
+- **`release.yml` release notes were silently broken — `actions/checkout` fetched no history and no tags.** `git describe --tags HEAD~1` failed on the fetch-depth:1 checkout ever since the workflow existed (swallowed by `2>/dev/null`, notes degraded to `git log -20` on a single-commit checkout). Checkout now uses `fetch-depth: 0` + `fetch-tags: true`, and the previous-tag lookup filters to stable tags (`--match 'v[0-9]*'`) so same-commit channel tags never corrupt the release-notes range.
+
 ## [0.112.0] — 2026-07-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ SessionStart  ──>  UserPromptSubmit  ──>  PreToolUse  ──>  PostToolU
 | Skill | Invocation | Purpose |
 |---|---|---|
 | `/devops-ship` | Explicit + Hook | Full shipping pipeline: build, version, PR, merge, cleanup |
+| `/devops-release` | Explicit | Channel promotion (alpha→beta→stable): re-tag the same SHA, no rebuild |
 | `/devops-commit` | Explicit | Conventional commits with smart staging |
 | `/devops-flow` (alias: `/debug`) | Explicit + Hook | Root-cause analysis, diagnostics, and fix cycle |
 | `/devops-new-issue` | Explicit | GitHub issue creation with labels and milestones |

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ For the full extension guide with examples per skill, see `deep-knowledge/skill-
 ## Features
 
 - **<!--devops:count:hooks-->35<!--/devops:count:hooks--> Hooks** — automated guards and triggers across the full session lifecycle
-- **<!--devops:count:skills-->21<!--/devops:count:skills--> Skills** — devops-ship, devops-commit, devops-flow, devops-new-issue, devops-project-setup, devops-readme, devops-refresh-usage, devops-extend-skill, devops-repo-health, devops-claude-md-lint, devops-concept, devops-agents, devops-plugin-update, devops-autonomous, devops-burn, devops-learn, devops-harden, devops-polish, devops-test-plan
+- **<!--devops:count:skills-->22<!--/devops:count:skills--> Skills** — devops-ship, devops-commit, devops-flow, devops-new-issue, devops-project-setup, devops-readme, devops-refresh-usage, devops-extend-skill, devops-repo-health, devops-claude-md-lint, devops-concept, devops-agents, devops-plugin-update, devops-autonomous, devops-burn, devops-learn, devops-harden, devops-polish, devops-test-plan
 - **<!--devops:count:agents-->12<!--/devops:count:agents--> Agents** — AI, Core, Designer, Feature, Frontend, Gamer, PO, QA, Redteam, Research, Windows
 - **Completion Flow** — mandatory card after every task (8 variants), visual verification, ship recommendation
 - **Ship Enforcement** — intent detection, PR command blocking, automatic /devops-ship skill routing
@@ -651,7 +651,7 @@ devops/
 ├── .claude-plugin/plugin.json     ← Plugin manifest
 ├── CONVENTIONS.md                 ← Naming, versioning, extension rules
 ├── hooks/                         ← <!--devops:count:hooks-->35<!--/devops:count:hooks--> hooks (JS) registered in hooks.json
-├── skills/                        ← <!--devops:count:skills-->21<!--/devops:count:skills--> skill definitions (SKILL.md)
+├── skills/                        ← <!--devops:count:skills-->22<!--/devops:count:skills--> skill definitions (SKILL.md)
 ├── agents/                        ← <!--devops:count:agents-->12<!--/devops:count:agents--> agent definitions
 ├── deep-knowledge/                ← Cross-cutting reference docs
 ├── templates/                     ← Output format templates

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.112.0**
+**Version: 0.113.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/docs/superpowers/plans/2026-07-11-tag-channel-system.md
+++ b/docs/superpowers/plans/2026-07-11-tag-channel-system.md
@@ -1,0 +1,117 @@
+# Tag-Based Release Channels Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the alpha/beta/stable ring model from `docs/superpowers/specs/2026-07-11-tag-channel-system-design.md`: ship tags `alpha/vX.Y.Z` autonomously, `ship_promote` + `/devops-release` promote the same SHA, the consumer hook pins a channel via tag resolution.
+
+**Architecture:** Shared pure helpers exist twice by necessity — ESM (`mcp-server/ship/lib/channels.js`, imported by tools) and CJS (`hooks/lib/channels.js`, hooks must stay dependency-free standalone scripts). Both are small and tested independently. All git effects go through existing `lib/git.js` / `lib/github.js` patterns.
+
+**Tech Stack:** Node ESM (mcp-server) + CJS (hooks), vitest with the repo's zod-stub mock pattern, no new dependencies.
+
+## Global Constraints
+
+- Version files NEVER carry a channel suffix (spec §2) — `ship_version_bump` untouched.
+- All channel tags are ANNOTATED (`git tag -a`) with a JSON message payload (spec §2/R4).
+- Never move/delete published tags; all tag creation is skip-if-exists idempotent (spec §4.1).
+- Cross-prefix tag resolution MUST compare versions numerically — `--sort=v:refname` across prefixes is forbidden (spec §5.2/R9).
+- Bootstrap fallback: no `stable/*` tag ⇒ hook behaves exactly like today (spec §5.2/R1).
+- Beta promotions create NO GitHub Release at launch (PO/O2). Stable creates bare `vX.Y.Z` + Release.
+- Chat language German, artifacts English.
+
+---
+
+### Task 1: ESM channel helpers (`lib/channels.js`)
+
+**Files:**
+- Create: `plugins/devops/mcp-server/ship/lib/channels.js`
+- Test: `plugins/devops/mcp-server/ship/lib/channels.test.js`
+
+**Interfaces:**
+- Produces: `parseChannelTag(ref) -> {channel:'alpha'|'beta'|'stable'|'bare', version:string}|null`, `compareVersions(a,b) -> -1|0|1`, `visibleChannels(pin) -> string[]`, `latestVisible(tagNames, pin) -> {tag, version, channel}|null`, `CHANNELS = ['alpha','beta','stable']`
+
+- [ ] **Step 1: Write failing tests** — cases: parse `alpha/v0.113.0`, bare `v0.113.0`, reject `foo/v1`, `v1.2` (needs x.y.z), numeric compare `0.9.0 < 0.10.0`, cross-prefix `alpha/v0.113.0 > stable/v0.112.0` via latestVisible, union rules per pin (stable pin ignores alpha tags; alpha pin sees all), empty list → null.
+- [ ] **Step 2: Run** `npx vitest run plugins/devops/mcp-server/ship/lib/channels.test.js` — expect FAIL (module missing).
+- [ ] **Step 3: Implement** pure functions, no I/O.
+- [ ] **Step 4: Run again** — expect PASS.
+- [ ] **Step 5: Commit** `feat(ship): channel tag helpers (parse/compare/resolve)`
+
+### Task 2: `ship_promote` MCP tool
+
+**Files:**
+- Create: `plugins/devops/mcp-server/ship/tools/promote.js`
+- Test: `plugins/devops/mcp-server/ship/tools/promote.test.js`
+- Modify: `plugins/devops/mcp-server/ship/index.js` (register tool)
+- Modify: `plugins/devops/mcp-server/ship/lib/github.js` (add `releaseExists(tag, opts)`)
+
+**Interfaces:**
+- Consumes: Task 1 helpers; `git`/`gitStrict` from `lib/git.js`; `createRelease`/`releaseExists` from `lib/github.js`.
+- Produces: tool result `{ success, version, from, to, sha, tag, bareTag?, alreadyPromoted?, release?, pushed?, missing? }`. Schema: `{ version, from: enum(alpha,beta), to: enum(beta,stable), cwd }`.
+
+Handler logic (spec §4.1): ls-remote source tag → SHA; monotonicity guard (empty target ⇒ allow; `==` + same SHA ⇒ `alreadyPromoted:true`; `<` ⇒ refuse); ancestry guard `merge-base --is-ancestor <sha> origin/main`; annotated tag via `execFileSync("git",["tag","-a",tag,sha,"-m",payload])`, push, ls-remote verify, skip-if-exists; stable ⇒ additionally bare tag (stable-first ordering, both-verified gate, `pushed`/`missing` on partial); stable ⇒ poll `releaseExists(bareTag)` (6×10s), fallback `createRelease` with CHANGELOG notes passed in via param `releaseNotes`; beta ⇒ NO release.
+
+- [ ] **Step 1: Write failing tests** (mirror `release.test.js` mock pattern: zod stub, mock `node:child_process`, `../lib/git.js`, `../lib/github.js`, `../lib/channels.js` NOT mocked — pure). Cases: happy alpha→beta; missing source tag; downgrade refused; equal+same-SHA idempotent; empty target allowed; stable creates stable+bare in order; partial bare failure → `success:false, missing:["v0.113.0"]`; re-run completes; beta creates no release; stable falls back to createRelease when poll never sees it.
+- [ ] **Step 2: Run** — FAIL.
+- [ ] **Step 3: Implement** `promote.js` + `releaseExists` + register in `index.js` (description: "Promote a shipped version to a higher channel by re-tagging the same SHA (alpha→beta→stable). Never rebuilds.").
+- [ ] **Step 4: Run** — PASS.
+- [ ] **Step 5: Commit** `feat(ship): ship_promote tool — ring promotion via annotated tags`
+
+### Task 3: `ship_release` ships to alpha
+
+**Files:**
+- Modify: `plugins/devops/mcp-server/ship/tools/release.js:241-269`
+- Test: `plugins/devops/mcp-server/ship/tools/release.test.js`
+
+**Interfaces:**
+- Consumes: existing params (`tag` stays bare `vX.Y.Z`).
+- Produces: result `tag: "alpha/vX.Y.Z"`, `channel: "alpha"`, `releaseDeferred: true`; no `createRelease` call at ship time.
+
+- [ ] **Step 1: Adjust/extend tests**: expect annotated `alpha/v1.0.0` created+pushed; `createRelease` NOT called; idempotency check against `alpha/v1.0.0`; intermediate merges still skip tags.
+- [ ] **Step 2: Run** — FAIL on new expectations.
+- [ ] **Step 3: Implement**: prefix `alpha/`, `execFileSync` annotated tag (`-m {"channel":"alpha"}`), drop createRelease block (keep params accepted; set `releaseDeferred: true` when releaseNotes given).
+- [ ] **Step 4: Run full ship tool tests** — PASS.
+- [ ] **Step 5: Commit** `feat(ship): ship_release publishes to alpha channel`
+
+### Task 4: CJS channel helpers + consumer hook rewrite
+
+**Files:**
+- Create: `plugins/devops/hooks/lib/channels.js` (CJS twin of Task 1 + `readChannelPin(pluginsDir, marketplace)`)
+- Test: `plugins/devops/hooks/lib/channels.test.js`
+- Modify: `plugins/devops/hooks/session-start/ss.plugin.update.js:334-345` (pull → pin), `:264-292` (registry `channel` field)
+
+**Interfaces:**
+- Consumes: `.channels.json` sidecar at `~/.claude/plugins/.channels.json` (`{"<marketplace>": "beta"}`), default `stable`.
+- Produces: pin sequence — `git fetch origin --tags` + fetch branch; if NO `stable/*` tag → legacy pull path unchanged (bootstrap fallback); else resolve `latestVisible`, and when target SHA ≠ HEAD: `reset --hard` + `clean -fd` + `checkout --detach <tag>`. `headChanged` stays SHA-based (localHead vs newHead) — versionChanged logic untouched (bit-identical channels ⇒ same version ⇒ same dir).
+
+- [ ] **Step 1: Write failing tests** for the CJS lib (same cases as Task 1 + pin file read: missing file ⇒ stable, invalid JSON ⇒ stable, valid pin).
+- [ ] **Step 2: Run** — FAIL.
+- [ ] **Step 3: Implement lib**, then rewrite the hook's pull block per the spec table (§5.2): legacy path preserved verbatim under the fallback condition; dirty-retry inside the pin path re-pins (never pulls).
+- [ ] **Step 4: Run lib tests + `node -c`-style smoke** (`node --check ss.plugin.update.js`) — PASS.
+- [ ] **Step 5: Commit** `feat(hooks): channel-aware plugin updates (tag pinning + bootstrap fallback)`
+
+### Task 5: `/devops-release` skill
+
+**Files:**
+- Create: `plugins/devops/skills/devops-release/SKILL.md`
+
+Content per spec §4.2: frontmatter (name devops-release, triggers "release", "promote", "promotion", "channel release", explicit-invocation bias), one-line channel state via `git ls-remote --tags origin`, AskUserQuestion with precomputed meaningful promotions (recommended first), fast-track = two `ship_promote` calls with retry semantics, completion card. Document `cwd` requirement like devops-ship does.
+
+- [ ] **Step 1: Write SKILL.md** (skills have no unit tests; validate against `plugins/devops/CONVENTIONS.md` skill structure).
+- [ ] **Step 2: Commit** `feat(skills): /devops-release — deliberate channel promotion`
+
+### Task 6: Ship skill nudge + plugin-update channel UX + docs
+
+**Files:**
+- Modify: `plugins/devops/skills/devops-ship/SKILL.md` (Step 4: tag is `alpha/vX.Y.Z`; Step 6: promotion-gap nudge — compute drift via `git ls-remote --tags origin 'refs/tags/stable/*' 'refs/tags/v*'`, escalate ≥3 versions/≥7 days, add as card `userFinalTest`/summary line)
+- Modify: `plugins/devops/skills/devops-plugin-update/SKILL.md` (`--channel` flag → writes sidecar; drift line "latest visible vN (alpha has vM available)")
+- Modify: `plugins/devops/CONVENTIONS.md` (ring-model tagging convention)
+- Modify: `plugins/devops/skills/devops-ship/deep-knowledge/versioning.md` + `release-flow.md` (channel section)
+- Modify: `.github/workflows/release.yml` (checkout `fetch-depth: 0` + `fetch-tags: true`; `git describe --tags --match 'v[0-9]*' --abbrev=0 HEAD~1`)
+
+- [ ] **Step 1: Apply all edits.**
+- [ ] **Step 2: Commit** `feat(ship): promotion-gap nudge, channel docs, release.yml tag fixes`
+
+### Task 7: Full verification + ship
+
+- [ ] **Step 1:** `npm test` — all green (expect existing suite + new tests).
+- [ ] **Step 2:** `npm run lint` — clean.
+- [ ] **Step 3:** CHANGELOG entry for the feature version; then `/devops-ship` (minor bump). Rollout checklist §5.4 note: steps 2–5 of the checklist (release.yml live check, content-identity, fast-track stable promotion, consumer verify) happen POST-ship via `/devops-release` — the bootstrap fallback keeps consumers safe until then.

--- a/docs/superpowers/specs/2026-07-11-tag-channel-system-design.md
+++ b/docs/superpowers/specs/2026-07-11-tag-channel-system-design.md
@@ -1,0 +1,258 @@
+# Tag-Based Release Channels (alpha / beta / stable) — Design
+
+**Status:** DRAFT v3 — redteam-hardened + PO-trimmed; pending user approval
+**Date:** 2026-07-11
+**Scope:** devops plugin distribution (producer: ship pipeline; consumer: plugin update hook)
+
+## 1. Goal & Principles
+
+Introduce three release channels — **alpha → beta → stable** — for the devops plugin, following the **ring model**:
+
+- **Ship stays autonomous.** Every `/devops-ship` to `main` publishes to the *earliest* channel (alpha) with zero prompts. The channel question never interrupts the ship pipeline.
+- **Promotion is bit-identical.** Moving a version alpha→beta→stable re-tags the *same commit SHA*. No rebuild, no new commit, no version-file change. What was tested in alpha is byte-for-byte what stable consumers get.
+- **Promotion is deliberate.** A separate `/devops-release` skill promotes, with an explicit user decision (alpha→beta, beta→stable, or fast-track alpha→stable).
+- **Consumers pin a channel.** Each consumer machine follows one channel **per marketplace**; the update hook resolves "latest version visible to my channel" from git tags.
+
+Industry basis (research-verified): npm dist-tag decoupling (version = immutable identity, channel = pointer), Rust release-train (channel as label, not version), container digest promotion (promote the tested artifact), Obsidian BRAT (GitHub-hosted plugin beta channels).
+
+## 2. Tag Scheme
+
+**Namespaced immutable tags**, one per (channel, version), all pointing at the same merge commit:
+
+```
+alpha/v0.113.0     ← created by ship_release (automatic, every ship)
+beta/v0.113.0      ← created by promotion (same SHA)
+stable/v0.113.0    ← created by promotion (same SHA)
+v0.113.0           ← created ONLY at stable promotion (same SHA) — backward-compat alias
+```
+
+Rules:
+
+- **All channel tags are ANNOTATED tags** (`git tag -a`), not lightweight. Rationale (redteam R4): lightweight tags carry no tagger/date — since all channel tags share one commit, promotion time and actor would be unrecoverable. Annotated tags make the promotion log fully derivable from git (`for-each-ref --format='%(taggerdate) %(taggername)'` + a JSON payload in the tag message: `{"from":"alpha","to":"beta"}`). No committed log file, no extra commit per promotion (resolves former O1).
+- **Never move, never delete** a published tag (git re-tagging is unsafe across clones; fetch won't overwrite without `--force`). Rollback = roll forward (§7).
+- **Version stays frozen across channels.** `plugin.json` / `marketplace.json` / `package.json` carry bare `X.Y.Z` — no channel suffix, ever. The channel lives *only* in the tag namespace. This is what makes promotion a pure re-tag (verified: `ship_version_bump` is never called during promotion). Note: `ship_version_bump` forces devops AND local-llm to the same version each ship (version.js:118-136, 199-206), so one repo tag ⇒ one consistent version for both plugins (redteam-verified).
+- The **bare `vX.Y.Z` tag doubles as the stable marker** and keeps existing conventions intact: `CONVENTIONS.md`, the `.github/workflows/release.yml` trigger (`v[0-9]+.[0-9]+.[0-9]+` matches bare tags only — verified: GHA glob `+` is supported; channel-prefixed tags never match), and GitHub's `/releases/latest` semantics.
+- **Tag accumulation is accepted** (redteam R10): one `alpha/*` tag per ship, add-only forever. Documented trade-off; a retention policy (e.g. prune alpha tags older than latest stable) is a possible future exception to "never delete" — deferred, not launch-relevant.
+
+### Not chosen (and why)
+
+- **Moving channel tags** (`beta` re-pointed): documented git anti-pattern; consumers silently stay on stale SHAs without `fetch --force`.
+- **Channel branches** (`alpha`/`beta`/`main`): user decision for tags; branches add ff-only discipline burden and a second long-lived-ref maintenance surface.
+- **SemVer prerelease suffixes** (`v1.2.3-beta.1`): would force a version-file change per channel → new commit → breaks bit-identity.
+
+## 3. Producer Side — Ship Pipeline Changes
+
+### 3.1 `ship_release` (mcp-server/ship/tools/release.js)
+
+Today (release.js:241-259): creates lightweight bare `v{X.Y.Z}` on `origin/<base>` + GitHub Release.
+
+Change:
+
+- Tag name becomes **`alpha/v{X.Y.Z}`**, created **annotated** with message payload `{"channel":"alpha","ship":true}`. Idempotency check (`ls-remote --tags origin <tag>`) keys on the full namespaced string — unique per (channel, version).
+- **No GitHub Release at ship time.** Releases are created at promotion (beta = prerelease, stable = full). Rationale: alpha ships happen on every merge; a Release per alpha is noise. The `createRelease` call (release.js:261-269) moves into the promote tool.
+- Result fields: `tag: "alpha/v0.113.0"`, `channel: "alpha"` added.
+- **Post-merge watcher note** (redteam needs-info): release.yml no longer fires at ship time (it triggers on bare tags only). The watcher spawned in ship Step 4b keys on push-to-main workflow runs — currently none exist, so it reports benign `no-run` (unchanged behavior). The release-verification duty moves into `ship_promote` step 6, which polls the Release inline. No watcher change required now; if a push-to-main CI workflow is ever added, the watcher covers it as designed.
+
+### 3.2 `/devops-ship` skill
+
+- Step 3 (version bump) unchanged — every ship to main still bumps `X.Y.Z` and writes one CHANGELOG entry. CHANGELOG remains **one entry per version** regardless of how many channels the version reaches.
+- Step 4/6 texts + completion card: show `alpha/vX.Y.Z` as the created tag.
+- **Promotion-gap nudge (MUST-HAVE, PO #4):** every `ship-successful` card shows the channel drift — "alpha is N versions ahead of stable — `/devops-release` to promote" (one `ls-remote 'refs/tags/stable/*'` + bare at card time). Escalated wording past a threshold (≥3 versions **or** ≥7 days since last stable promotion): "stable is 5 versions / 9 days behind alpha." Rationale: with multi-ships/week and a solo maintainer, deliberate promotion has no heartbeat without a forcing function — invisible lag is the failure mode that kills the feature; visible lag is the feature working.
+- deep-knowledge (`versioning.md`, `release-flow.md`) and `CONVENTIONS.md`: document the ring model.
+
+### 3.3 `.github/workflows/release.yml`
+
+- Trigger pattern stays `v[0-9]+.[0-9]+.[0-9]+` → fires only on the bare stable tag (redteam-verified; also verified: `ship_promote` pushes with the user's git credential, not `GITHUB_TOKEN`, so the tag push DOES trigger the workflow).
+- **Fix 1 (pre-existing bug, redteam R5):** `actions/checkout@v4` defaults to `fetch-depth: 1` without tags — `git describe --tags HEAD~1` fails silently TODAY (release notes degrade to `git log -20` on a 1-commit checkout). Add `fetch-depth: 0` and `fetch-tags: true`.
+- **Fix 2:** `PREV_TAG=$(git describe --tags --abbrev=0 HEAD~1)` must become `git describe --tags --match 'v[0-9]*' --abbrev=0 HEAD~1` so channel tags on the same commits never pollute the release-notes range.
+- The double-release-producer overlap resolves: ship no longer creates Releases; the workflow fires on stable tags; `ship_promote` polls before creating (idempotent both ways).
+
+## 4. Promotion — `/devops-release` skill + `ship_promote` MCP tool
+
+### 4.1 New MCP tool `ship_promote` (deterministic git work)
+
+```
+ship_promote({ version: "0.113.0", from: "alpha", to: "beta", cwd })
+```
+
+Steps (all against `origin`, never local state):
+
+1. Resolve source tag `"{from}/v{version}"` via `ls-remote` → SHA. Missing → error `source-tag-not-found`.
+2. **Monotonicity guard** (amended per redteam R6): let `L` = latest version in `{to}` channel.
+   - `{to}` empty → allow (first promotion into the channel).
+   - `version > L` → allow.
+   - `version == L` **and target tag exists on the same SHA** → **idempotent success** (`alreadyPromoted: true`), NOT an error — this is what makes partial-failure retries work.
+   - `version < L` → refuse (would be invisible under latest-resolution). No `--force` escape hatch.
+3. **Ancestry guard:** verify the SHA is reachable from `origin/main` (`merge-base --is-ancestor`).
+4. Create **annotated** tag `"{to}/v{version}"` (message payload `{"from":"{from}","to":"{to}"}`) on the SHA; push; verify via `ls-remote`. Skip-if-exists (idempotent).
+5. If `to === "stable"`: additionally create annotated bare `v{version}` on the same SHA. **Transactionality** (redteam R7): push `stable/v{version}` FIRST, then bare `v{version}`; each step skip-if-exists; `success: true` only when BOTH verified via `ls-remote`. On partial failure, return `{ success: false, pushed: [...], missing: [...] }` — a re-run completes the missing pushes (guaranteed by skip-if-exists + guard rule `version == L` → idempotent).
+6. GitHub Release:
+   - `to === "beta"` → **no GitHub Release at launch** (PO decision on O2: tags are the canonical channel truth; there is no beta audience using the GitHub UI yet — presentation for zero viewers is deferred, re-added as a single idempotent `gh release create --prerelease` call the day an external beta tester exists).
+   - `to === "stable"` → the bare tag triggers release.yml; poll for the Release (timeout 60s), create via `gh` as fallback (skip if exists).
+7. Promotion log: **derived, not stored** — annotated tag metadata (taggerdate, taggername, message payload) IS the audit trail. `ship_promote` returns it; `/devops-release` renders it.
+
+Returns `{ success, version, from, to, sha, tag, bareTag?, alreadyPromoted?, release?, pushed?, missing? }`.
+
+### 4.2 `/devops-release` skill (interactive gate)
+
+1. Gather state: latest version per channel via per-channel globs (`git for-each-ref --sort=-v:refname --count=1 'refs/tags/{ch}/*'` — safe within ONE prefix; see §5.2 for why cross-prefix sorting must never use this). Render a **one-line channel state** ("alpha v0.117 / beta v0.114 / stable v0.112") — PO trim: no rich table at current scale; the annotated-tag metadata plumbing stays (it is free) but elaborate rendering is deferred.
+2. AskUserQuestion with the **meaningful promotions precomputed**:
+   - `alpha/v0.115.0 → beta` (Recommended, if alpha is ahead of beta)
+   - `beta/v0.113.0 → stable`
+   - `alpha/v0.115.0 → stable (fast-track)` — legitimate skip; beta is optional per user decision
+   - Abbrechen
+3. Fast-track alpha→stable executes as TWO `ship_promote` calls (alpha→beta, then beta→stable) so the ring invariant "stable ⊆ beta ⊆ alpha" always holds. **Partial-failure recovery** (redteam R6): if step 2 fails after step 1 succeeded, re-running the fast-track is safe — step 1 returns `alreadyPromoted: true` and step 2 retries.
+4. Render completion card (summary "promoted vX to <channel>").
+
+No autonomous promotion anywhere. Ship never calls this.
+
+## 5. Consumer Side — Channel-Aware Updates
+
+### 5.1 Channel pin — per MARKETPLACE, not per plugin (redteam R3)
+
+One marketplace clone = one working tree = one checked-out SHA — it **cannot** serve two plugins on different channels. Divergent per-plugin pins are therefore structurally unsatisfiable and forbidden by design:
+
+- **Authoritative store:** `~/.claude/plugins/.channels.json` — plugin-owned sidecar, `{ "<marketplace>": "alpha" | "beta" | "stable" }`. Lives OUTSIDE the clones (survives `reset --hard`/`clean -fd` and native registry rewrites; redeam needs-info: Claude Code native tooling may strip unknown fields from `installed_plugins.json`, so that file cannot be authoritative).
+- `installed_plugins.json` entries additionally get an informational `channel` field (kept in sync by the hook; tolerated if stripped).
+- Default when absent: **`stable`**. Set via `/devops-plugin-update --channel <ch>` (updates the sidecar for the whole marketplace). The plugin-source dev machine pins `alpha`.
+
+### 5.2 Resolution rule (the core rewrite in `ss.plugin.update.js`)
+
+**Every branch-pull site is replaced** (redteam R2 — the spec explicitly enumerates ALL of them):
+
+| Site | Today | New |
+|---|---|---|
+| ss.plugin.update.js:336 (main pull) | `git pull --ff-only origin main \|\| master` | fetch-tags + resolve + pin (below) |
+| ss.plugin.update.js:339-345 (dirty-tree retry) | `checkout -- . && clean -fd` then **pull again** | `reset --hard && clean -fd` then **re-pin to resolved tag** (never pull — a detached HEAD that is an ancestor of main would silently fast-forward to alpha tip) |
+| devops-plugin-update/SKILL.md:52 (docs) | describes `git pull --ff-only` | describes tag resolution |
+
+New pin sequence per marketplace clone:
+
+```
+git fetch origin --tags                              # add-only; immutable tags need no --force
+resolve: highest SemVer version among tags in
+         UNION(own channel, all more-stable channels)
+         alpha → alpha ∪ beta ∪ stable ∪ bare
+         beta  → beta ∪ stable ∪ bare
+         stable→ stable ∪ bare
+git reset --hard && git clean -fd                    # guard: dirty/half-merged clone (redteam R8)
+git checkout --detach <resolved-tag>
+```
+
+- **Bootstrap fallback** (redteam R1 — kills the migration oscillation): **if no `stable/*` tag exists at all**, the hook falls back to legacy behavior (`git pull --ff-only origin main`). This makes the hook swap self-gating: until the first stable promotion exists, consumers behave exactly as today; the moment `stable/vN` is pushed, every consumer pins to it on next SessionStart. No oscillation window, because the fallback and the pin converge on the same content once N is stable (see §5.4 rollout).
+- **Union resolution** guarantees a channel never lags a more-stable channel (covers fast-track promotions). **Hard requirement** (redteam R9): the union resolver parses versions from tag names and compares **numerically**. `git for-each-ref --sort=-v:refname` over a cross-prefix glob is FORBIDDEN for the union — the refname sort would rank the `alpha/` vs `stable/` prefix above the version. Required test: `alpha/v0.113.0 > stable/v0.112.0` and `0.9.0 < 0.10.0`.
+- **Change detection** (`versionChanged`, line 355): switch from "HEAD moved && version string differs" to **"resolved tag SHA ≠ current HEAD SHA"**.
+- Cache path stays **version-keyed** (`cache/dotclaude/devops/<version>/`) — safe because channels are content-identical per version by construction. Registry entry gains informational `channel`; `gitCommitSha` = the resolved tag's SHA.
+- `.mcp-stale.json` sentinel logic unchanged — redteam-verified: same-version promotion ⇒ same SHA ⇒ no rebuild ⇒ no sentinel; no hook keys on tag strings.
+
+### 5.3 `/devops-plugin-update` skill
+
+- New Step: read/print current channel + resolved target **including drift** ("Channel: stable — latest visible: v0.113.0 (alpha has v0.117.0 available)"). Drift visibility on the consumer side mirrors the producer-side ship-card nudge (PO acceptance criterion #5). `--channel` flag re-pins (sidecar write) then updates.
+- Step 3a version-alignment check unchanged (three sources still must match — promotion never touches files).
+
+### 5.4 Migration & rollout (rewritten per redteam R1)
+
+The naive rollout oscillates: old hook pulls main (alpha-quality tip N, contains new hook) → new hook pins `stable` = last bare tag (old content, old hook) → old hook pulls main again → loop. **Two measures kill this:**
+
+1. **Bootstrap fallback** (§5.2): the new hook only switches to tag-pinning once a `stable/*` tag exists; before that it behaves exactly like the old hook (pull main). No behavioral flip-flop is possible — both hook versions do the same thing until stable exists.
+2. **Mandatory rollout step:** the release that ships this feature (version N) is **immediately fast-track promoted to stable** as part of its rollout checklist. From that moment, `stable/vN` exists, contains the new hook, and every consumer converges on it. The window in which consumers ran alpha-quality main-tip is the same window that exists today (they always ran main tip) — no regression.
+
+**Rollout checklist (ordered — PO additions marked):**
+
+1. Ship the feature version N (`/devops-ship` → `alpha/vN`).
+2. **Sequencing guard (PO):** verify release.yml on `main` contains `fetch-depth: 0` + `fetch-tags: true` + `--match 'v[0-9]*'` (§3.3) BEFORE any stable promotion — otherwise the first `stable/vN` triggers the still-broken `git describe` and corrupts the launch Release notes.
+3. **Content-identity check (PO):** verify the SHA of `alpha/vN` contains the rewritten `ss.plugin.update.js` (the rollout's correctness depends on the new hook being INSIDE stable/vN; promoting an older SHA strands consumers on the old hook).
+4. Fast-track promote N to stable (`/devops-release`).
+5. Verify on one consumer machine: next SessionStart pins to `stable/vN`, subsequent SessionStart does NOT flip back (oscillation check).
+
+- Existing bare tags (`v0.112.0` and older) are treated as `stable` — automatic, since bare is in every union.
+- Native `git pull` interference (Desktop App/CLI touching the clone): on a detached HEAD a plain `pull` fails or leaves a dirty state — the pin sequence's `reset --hard && clean -fd` (§5.2) repairs it every SessionStart (self-healing, same philosophy as today's dirty-tree reset).
+
+## 6. Merge Strategy Impact
+
+**None.** Branching, PRs, squash-merge to `main`, hierarchical sub-branch merges, git-sync (`scripts/git-sync.js` hardcoding `MAIN='main'`) — all unchanged. `main` remains the only long-lived branch and the single source of truth; channels are a *distribution* concept layered on tags, not a development concept. This was the decisive argument for tags over channel-branches.
+
+## 7. Rollback Policy — Roll Forward
+
+Published tags are never moved or deleted. A bad promotion is corrected by:
+
+1. **Bad stable:** fix on a branch → `/devops-ship` (new version, alpha) → `/devops-release` fast-track to stable. Consumers resolve the higher version and move on.
+2. **Bad beta:** same, promote the fixed version to beta.
+3. Optional marker: `gh release edit <tag> --prerelease` demotion or a `[YANKED]` note in CHANGELOG — cosmetic; resolution ignores it (monotone latest-wins).
+
+There is deliberately **no demote operation** — it cannot work under immutable tags + latest-resolution; npm/cargo converge on the same yank-not-delete answer.
+
+## 8. Error Handling & Races
+
+| Failure | Behavior |
+|---|---|
+| Tag push race (two ships) | Impossible per version: version bump is serialized through the PR merge; idempotency check skips existing tags. |
+| Promotion of unmerged/foreign SHA | Ancestry guard (§4.1.3) refuses. |
+| Promote older-than-current version | Monotonicity guard refuses (`<` only; `==` on same SHA is idempotent success). |
+| Partial fast-track (beta ok, stable fails) | Re-run fast-track: step 1 returns `alreadyPromoted`, step 2 retries. Deterministic recovery, no manual state surgery. |
+| Partial stable (stable/vN pushed, bare vN fails) | `success: false` with `missing: ["vN"]`; re-run pushes only the missing tag (skip-if-exists). Both-verified gate prevents "half-stable" success. |
+| release.yml + promote both create stable Release | Promote polls first, creates only if absent (idempotent both ways). |
+| Consumer fetches mid-promotion | Sees previous latest — harmless staleness, corrected next SessionStart. Tags are add-only; no clobber states exist. |
+| Dirty/half-merged consumer clone | `reset --hard && clean -fd` before every pin (§5.2). |
+| GitHub Release creation fails | `release: false` in result; card flags it; tags (the canonical channel truth) are already pushed — Releases are presentation. |
+
+## 9. Testing Strategy
+
+- **Unit (vitest):** promote guards (monotonicity incl. empty-channel + idempotent-equal, ancestry, missing source), union resolver (numeric sort, cross-prefix `alpha/v0.113.0 > stable/v0.112.0`, `0.9.0 < 0.10.0`, bare-as-stable), change detection (SHA-based), bootstrap fallback (no stable/* ⇒ legacy pull), partial-failure retry (beta-then-stable resume; stable-then-bare resume).
+- **Integration (local bare-repo fixture):** ship→alpha tag; promote alpha→beta→stable; fast-track; per-channel consumer resolution; migration sequence (bare-tags-only state → first stable promotion → pin flips); dirty-clone repair.
+- **Manual (userFinalTest in card):** one real ship + one real promotion + `/devops-plugin-update --channel beta` from a consumer machine; verify GitHub Release appears exactly once.
+
+## 10. Acceptance Criteria (PO — post-launch gates)
+
+1. **Ship autonomy preserved:** 5 consecutive `/devops-ship` runs create `alpha/vX.Y.Z` tags with zero channel prompts and zero GitHub Releases at ship time.
+2. **Bit-identical promotion:** for any promoted version, `git rev-parse alpha/vN == beta/vN == stable/vN == vN` (same SHA), and `plugin.json` version is unchanged between alpha tag and stable tag.
+3. **Idempotent recovery:** a `ship_promote` re-run after a simulated mid-promotion failure completes the missing tag/Release and returns `success: true` with no manual git surgery (gated on §9 partial-failure tests).
+4. **Rollout converges without oscillation:** after the mandatory fast-track of version N, a default-channel consumer pins to `stable/vN` on next SessionStart and does NOT flip back on the subsequent SessionStart.
+5. **Drift is visible (operational-health criterion):** when alpha leads stable by ≥1 version, the ship card shows the gap (§3.2 nudge) and `/devops-plugin-update` shows "latest visible vN (alpha has vM available)" (§5.3).
+
+Criteria 1–4 are ship-blocking; degraded #5 means the feature will rot even if 1–4 pass.
+
+## 11. Out of Scope
+
+- `scripts/git-sync.js` (dev-time branch sync — no channel relevance, verified).
+- **Divergent per-plugin channels** — structurally impossible with one shared clone (§5.1); would require per-plugin marketplace clones. Explicitly forbidden, not just deferred.
+- local-llm plugin versioning (lockstep-versioned with devops by `ship_version_bump`; follows the same repo tags).
+- **Beta GitHub prerelease Releases** (former O2 — PO: deferred until a real external beta tester exists; 10-minute follow-up, not architecture).
+- Rich channel-state table in `/devops-release` (PO trim: one-liner suffices at current scale).
+- Auto-promotion policies ("alpha→beta after 7 days") — possible later on top of `ship_promote`, deliberately not now.
+- Alpha-tag retention/pruning (accepted growth, §2).
+
+## 12. Review Resolution Map
+
+### PO review (verdict: trim-scope, then ship)
+
+| PO recommendation | Resolution |
+|---|---|
+| #4 Promotion-gap nudge = MUST-HAVE | §3.2 ship-card nudge with escalation threshold |
+| #5 Defer beta GitHub prereleases (O2) | §4.1.6 no beta Release at launch; §11 out-of-scope |
+| #6 Trim channel table | §4.2.1 one-liner state |
+| Rollout: sequencing guard + content-identity check | §5.4 checklist steps 2-3 |
+| Acceptance criteria | §10 |
+| O3 default stable | Confirmed (§5.1) |
+| Operational rhythm: forcing function, not calendar; fast-track as default path; visible lag = feature working | Adopted as design stance (§3.2 rationale) |
+
+### Redteam findings (verdict after rework: resolved)
+
+| Finding | Resolution |
+|---|---|
+| R1 migration oscillation (blocker) | §5.2 bootstrap fallback + §5.4 mandatory stable promotion at rollout |
+| R2 incomplete pull-site rewrite (blocker) | §5.2 enumerated site table; retry path re-pins, never pulls |
+| R3 divergent per-plugin pins (major) | §5.1 pin per marketplace; sidecar authoritative; divergence forbidden |
+| R4 lightweight tags break derived log (major) | §2 all channel tags annotated; log derived from tag metadata |
+| R5 release.yml already broken (major) | §3.3 fetch-depth 0 + fetch-tags + `--match` |
+| R6 monotonicity blocks retry (major) | §4.1.2 `==`+same-SHA ⇒ idempotent success; empty ⇒ allow |
+| R7 non-transactional stable+bare (major) | §4.1.5 ordered pushes, skip-if-exists, both-verified gate |
+| R8 no dirty-clone guard (major) | §5.2 reset --hard + clean -fd before pin |
+| R9 cross-prefix refname sort trap (minor) | §5.2 numeric union resolver mandatory; for-each-ref forbidden cross-prefix; test required |
+| R10 unbounded alpha tags (minor) | §2 accepted + documented; retention deferred |
+| NI post-merge-watcher voided | §3.1 note: release verification moved into ship_promote step 6 |
+| NI registry field stripping | §5.1 sidecar outside registry is authoritative |
+
+## Open Questions
+
+None — O1 resolved by annotated tags (§2), O2 decided by PO (deferred, §11), O3 confirmed (stable default, §5.1).

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.112.0",
+  "version": "0.113.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/CONVENTIONS.md
+++ b/plugins/devops/CONVENTIONS.md
@@ -13,7 +13,14 @@ PATCH  → Bug fixes, doc updates, internal improvements
 ```
 
 Current version is tracked in `.claude-plugin/plugin.json` → `"version"`.
-Each release gets a git tag: `v0.1.0`, `v0.2.0`, etc.
+
+**Release channels (ring model):** every ship to main creates the annotated
+tag `alpha/vX.Y.Z` automatically. Promotion (`/devops-release`) re-tags the
+SAME commit as `beta/vX.Y.Z`, then `stable/vX.Y.Z` + bare `vX.Y.Z` (stable
+alias, triggers the Release workflow). Version files never carry a channel;
+published tags are never moved or deleted. Consumers pin a channel per
+marketplace in `~/.claude/plugins/.channels.json` (default `stable`).
+Spec: `docs/superpowers/specs/2026-07-11-tag-channel-system-design.md`.
 
 ## Hook Conventions
 

--- a/plugins/devops/docs/architecture.html
+++ b/plugins/devops/docs/architecture.html
@@ -169,7 +169,7 @@
 <section id="overview">
 <h1>Architecture Documentation <small>devops v0.87.0</small></h1>
 <p class="lead">
-  A comprehensive DevOps automation plugin for Claude Code &mdash; <!--devops:count:hooks-->35<!--/devops:count:hooks--> hooks, <!--devops:count:skills-->21<!--/devops:count:skills--> skills, <!--devops:count:agents-->12<!--/devops:count:agents--> agents,
+  A comprehensive DevOps automation plugin for Claude Code &mdash; <!--devops:count:hooks-->35<!--/devops:count:hooks--> hooks, <!--devops:count:skills-->22<!--/devops:count:skills--> skills, <!--devops:count:agents-->12<!--/devops:count:agents--> agents,
   2 MCP servers, a deterministic completion card engine, and a 3-layer extension system.
 </p>
 <div role="note" style="margin:.4rem 0 1.4rem;padding:.6rem .9rem;background:var(--bg2);border-left:3px solid var(--warn);border-radius:4px;color:var(--text2);font-size:.85rem;">
@@ -189,7 +189,7 @@
     <span class="badge b-hook">Stop &times;<!--devops:count:hooks:stop-->3<!--/devops:count:hooks:stop--></span>
   </div>
   <div class="card">
-    <h4><!--devops:count:skills-->21<!--/devops:count:skills--> Skills</h4>
+    <h4><!--devops:count:skills-->22<!--/devops:count:skills--> Skills</h4>
     <p style="color:var(--text2);font-size:.85rem">Slash commands: ship, commit, flow, new-issue, project-setup, readme, refresh-usage, extend-skill, repo-health, claude-md-lint, concept, agents, plugin-update, autonomous, burn, learn, harden, polish, test-plan</p>
   </div>
   <div class="card">
@@ -235,7 +235,7 @@
 │   ├── render-card.js         <span style="color:var(--warn)"># Completion card template engine</span>
 │   ├── build-id.js            <span style="color:var(--text2)"># Deterministic content hash</span>
 │   └── lib/usage-meter.js     <span style="color:var(--text2)"># Usage bar renderer</span>
-├── skills/                    <span style="color:var(--accent)"># <!--devops:count:skills-->21<!--/devops:count:skills--> skill definitions (SKILL.md + deep-knowledge/)</span>
+├── skills/                    <span style="color:var(--accent)"># <!--devops:count:skills-->22<!--/devops:count:skills--> skill definitions (SKILL.md + deep-knowledge/)</span>
 │   ├── ship/  commit/  flow/  new-issue/  project-setup/  readme/
 │   ├── refresh-usage/  extend-skill/  repo-health/  claude-md-lint/
 │   ├── concept/  agents/  plugin-update/  autonomous/  burn/  learn/

--- a/plugins/devops/hooks/lib/channels.js
+++ b/plugins/devops/hooks/lib/channels.js
@@ -1,0 +1,85 @@
+/**
+ * @module hooks/lib/channels
+ * @description CJS twin of mcp-server/ship/lib/channels.js — pure helpers for
+ *   the alpha/beta/stable ring model plus the consumer-side channel pin.
+ *   Hooks are standalone CommonJS scripts and cannot import the ESM original;
+ *   keep the two files in sync (spec: docs/superpowers/specs/
+ *   2026-07-11-tag-channel-system-design.md).
+ *
+ *   The channel pin lives in `~/.claude/plugins/.channels.json` — a
+ *   plugin-owned sidecar OUTSIDE the marketplace clones and OUTSIDE
+ *   installed_plugins.json: clones get reset/cleaned by the pin sequence, and
+ *   Claude Code's native tooling may rewrite the registry and strip unknown
+ *   fields (spec §5.1/R3). One channel per MARKETPLACE — a single clone
+ *   cannot serve two plugins on different channels.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const CHANNELS = ['alpha', 'beta', 'stable'];
+
+// Strict x.y.z — prerelease suffixes are deliberately NOT channel carriers.
+const TAG_RE = /^(?:refs\/tags\/)?(?:(alpha|beta|stable)\/)?v(\d+)\.(\d+)\.(\d+)(?:\^\{\})?$/;
+
+function parseChannelTag(ref) {
+  const m = TAG_RE.exec(ref);
+  if (!m) return null;
+  return { channel: m[1] || 'bare', version: `${m[2]}.${m[3]}.${m[4]}` };
+}
+
+function compareVersions(a, b) {
+  const pa = a.split('.').map(Number);
+  const pb = b.split('.').map(Number);
+  for (let i = 0; i < 3; i++) {
+    if (pa[i] !== pb[i]) return pa[i] < pb[i] ? -1 : 1;
+  }
+  return 0;
+}
+
+function visibleChannels(pin) {
+  const idx = CHANNELS.indexOf(pin);
+  const start = idx === -1 ? CHANNELS.length - 1 : idx;
+  return [...CHANNELS.slice(start), 'bare'];
+}
+
+/**
+ * Resolve the highest version among tags visible to `pin`. Numeric-parse
+ * resolver — cross-prefix refname sorting is forbidden (spec §5.2/R9).
+ * On a version tie the non-bare tag wins.
+ */
+function latestVisible(tagNames, pin) {
+  const visible = new Set(visibleChannels(pin));
+  let best = null;
+  for (const name of tagNames) {
+    const parsed = parseChannelTag(name);
+    if (!parsed || !visible.has(parsed.channel)) continue;
+    const cleanTag = name.replace(/^refs\/tags\//, '').replace(/\^\{\}$/, '');
+    if (!best) {
+      best = { tag: cleanTag, version: parsed.version, channel: parsed.channel };
+      continue;
+    }
+    const cmp = compareVersions(parsed.version, best.version);
+    if (cmp > 0 || (cmp === 0 && best.channel === 'bare' && parsed.channel !== 'bare')) {
+      best = { tag: cleanTag, version: parsed.version, channel: parsed.channel };
+    }
+  }
+  return best;
+}
+
+/**
+ * Read the channel pin for a marketplace from `<pluginsDir>/.channels.json`.
+ * Missing file, unreadable JSON, or an unknown channel value all degrade to
+ * the safest ring: stable.
+ */
+function readChannelPin(pluginsDir, marketplace) {
+  try {
+    const raw = fs.readFileSync(path.join(pluginsDir, '.channels.json'), 'utf8');
+    const pin = JSON.parse(raw)[marketplace];
+    return CHANNELS.includes(pin) ? pin : 'stable';
+  } catch {
+    return 'stable';
+  }
+}
+
+module.exports = { CHANNELS, parseChannelTag, compareVersions, visibleChannels, latestVisible, readChannelPin };

--- a/plugins/devops/hooks/lib/channels.test.js
+++ b/plugins/devops/hooks/lib/channels.test.js
@@ -1,0 +1,67 @@
+import { describe, test, expect } from "vitest";
+import os from "node:os";
+import fs from "node:fs";
+import path from "node:path";
+// channels.js is CommonJS (hooks are standalone CJS scripts) — default interop.
+import channels from "./channels.js";
+
+const { CHANNELS, parseChannelTag, compareVersions, visibleChannels, latestVisible, readChannelPin } = channels;
+
+describe("channels (CJS twin — keep in sync with mcp-server/ship/lib/channels.js)", () => {
+  test("parseChannelTag", () => {
+    expect(parseChannelTag("alpha/v0.113.0")).toEqual({ channel: "alpha", version: "0.113.0" });
+    expect(parseChannelTag("v0.112.0")).toEqual({ channel: "bare", version: "0.112.0" });
+    expect(parseChannelTag("refs/tags/beta/v1.2.3")).toEqual({ channel: "beta", version: "1.2.3" });
+    expect(parseChannelTag("foo/v1.0.0")).toBeNull();
+    expect(parseChannelTag("v1.2.3-beta.1")).toBeNull();
+  });
+
+  test("compareVersions is numeric", () => {
+    expect(compareVersions("0.9.0", "0.10.0")).toBe(-1);
+    expect(compareVersions("0.113.0", "0.113.0")).toBe(0);
+  });
+
+  test("visibleChannels union", () => {
+    expect(visibleChannels("alpha")).toEqual(["alpha", "beta", "stable", "bare"]);
+    expect(visibleChannels("stable")).toEqual(["stable", "bare"]);
+    expect(visibleChannels("bogus")).toEqual(["stable", "bare"]);
+    expect(CHANNELS).toEqual(["alpha", "beta", "stable"]);
+  });
+
+  test("latestVisible cross-prefix numeric resolution", () => {
+    const tags = ["v0.112.0", "alpha/v0.113.0", "stable/v0.112.0"];
+    expect(latestVisible(tags, "alpha")).toEqual({ tag: "alpha/v0.113.0", version: "0.113.0", channel: "alpha" });
+    expect(latestVisible(tags, "stable")).toEqual({ tag: "stable/v0.112.0", version: "0.112.0", channel: "stable" });
+    expect(latestVisible([], "stable")).toBeNull();
+  });
+});
+
+describe("readChannelPin", () => {
+  function tmpPluginsDir(contents) {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "channels-test-"));
+    if (contents !== undefined) {
+      fs.writeFileSync(path.join(dir, ".channels.json"), contents);
+    }
+    return dir;
+  }
+
+  test("missing sidecar → stable", () => {
+    expect(readChannelPin(tmpPluginsDir(), "dotclaude")).toBe("stable");
+  });
+
+  test("invalid JSON → stable", () => {
+    expect(readChannelPin(tmpPluginsDir("{nope"), "dotclaude")).toBe("stable");
+  });
+
+  test("valid pin is returned", () => {
+    expect(readChannelPin(tmpPluginsDir('{"dotclaude":"beta"}'), "dotclaude")).toBe("beta");
+  });
+
+  test("unknown channel value degrades to stable", () => {
+    expect(readChannelPin(tmpPluginsDir('{"dotclaude":"nightly"}'), "dotclaude")).toBe("stable");
+  });
+
+  test("other marketplace unaffected", () => {
+    expect(readChannelPin(tmpPluginsDir('{"other":"alpha"}'), "dotclaude")).toBe("stable");
+  });
+});

--- a/plugins/devops/hooks/session-start/ss.plugin.update.js
+++ b/plugins/devops/hooks/session-start/ss.plugin.update.js
@@ -1,13 +1,19 @@
 #!/usr/bin/env node
 /**
  * @hook ss.plugin.update
- * @version 0.9.1
+ * @version 0.10.0
  * @event SessionStart
  * @plugin devops
  * @description Auto-update plugin marketplace clones, rebuild cache, and update registry.
  *   Workaround for anthropics/claude-code#14061 — Desktop never runs git pull
  *   on marketplace clones and never rebuilds the plugin cache.
  *   Shares the same update logic as /devops-plugin-update (see SKILL.md).
+ *
+ *   CHANNEL-AWARE (ring model): once the repo has a stable/* tag, the clone is
+ *   pinned to the highest version visible to the marketplace's channel pin
+ *   (~/.claude/plugins/.channels.json, default stable) via a detached tag
+ *   checkout instead of branch-tip pulling. Until then a bootstrap fallback
+ *   keeps the legacy pull behavior (migration safety — spec §5.2/§5.4).
  *
  *   When a plugin with an MCP server is upgraded mid-session, the running
  *   MCP processes point at the now-deleted old installPath. A sentinel file
@@ -32,6 +38,7 @@ const { execSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 const { t } = require('../lib/locale');
+const { latestVisible, readChannelPin } = require('../lib/channels');
 
 // Translations for user-facing output. SessionStart fires before any user
 // prompt — there is no detected locale yet and no session_id in hook input
@@ -192,7 +199,7 @@ function copyDir(src, dst) {
   return fs.existsSync(path.join(dst, '.claude-plugin', 'plugin.json'));
 }
 
-function rebuildCache(marketplace, pluginName, pluginDir, version, sha, { versionChanged = true } = {}) {
+function rebuildCache(marketplace, pluginName, pluginDir, version, sha, { versionChanged = true, channel = 'stable' } = {}) {
   const pluginCache = path.join(cacheDir, marketplace, pluginName);
   const newCache = path.join(pluginCache, version);
 
@@ -271,6 +278,9 @@ function rebuildCache(marketplace, pluginName, pluginDir, version, sha, { versio
       entry.version = version;
       entry.lastUpdated = new Date().toISOString();
       entry.gitCommitSha = sha;
+      // Informational only — the authoritative pin is ~/.claude/plugins/
+      // .channels.json (native tooling may strip unknown registry fields).
+      entry.channel = channel;
     } else {
       // New install — create entry
       registry.plugins[key] = [{
@@ -280,6 +290,7 @@ function rebuildCache(marketplace, pluginName, pluginDir, version, sha, { versio
         installedAt: new Date().toISOString(),
         lastUpdated: new Date().toISOString(),
         gitCommitSha: sha,
+        channel,
       }];
     }
 
@@ -331,17 +342,48 @@ for (const marketplace of fs.readdirSync(marketplacesDir)) {
     beforeVersions[name] = getVersion(dir);
   }
 
-  // Pull latest — reset dirty state first to prevent pull failures
+  // Update strategy (ring model, spec §5.2): resolve the marketplace's channel
+  // pin against channel tags. Bootstrap fallback: until the FIRST stable/* tag
+  // exists, behave exactly like the legacy hook (branch pull) — this is what
+  // makes the migration oscillation-free (R1): old and new hook versions do
+  // the same thing until a stable promotion exists, then every consumer
+  // converges on the resolved tag.
+  const channel = readChannelPin(path.join(home, '.claude', 'plugins'), marketplace);
   const localHead = run('git rev-parse HEAD', mDir);
-  const pullResult = run('git pull --ff-only origin main 2>&1 || git pull --ff-only origin master 2>&1', mDir);
-  let newHead = run('git rev-parse HEAD', mDir);
+  run('git fetch origin --tags 2>&1', mDir);
+  const tagList = run('git tag --list', mDir).split('\n').filter(Boolean);
+  const hasStableTag = tagList.some((tag) => tag.startsWith('stable/'));
+  let newHead = localHead;
 
-  // If pull failed (dirty tree), reset and retry
-  if (localHead === newHead && !pullResult) {
-    run('git checkout -- .', mDir);
-    run('git clean -fd', mDir);
-    run('git pull --ff-only origin main 2>&1 || git pull --ff-only origin master 2>&1', mDir);
+  if (!hasStableTag) {
+    // Legacy path (pre-channel repo state): branch-tip tracking.
+    const pullResult = run('git pull --ff-only origin main 2>&1 || git pull --ff-only origin master 2>&1', mDir);
     newHead = run('git rev-parse HEAD', mDir);
+
+    // If pull failed (dirty tree), reset and retry
+    if (localHead === newHead && !pullResult) {
+      run('git checkout -- .', mDir);
+      run('git clean -fd', mDir);
+      run('git pull --ff-only origin main 2>&1 || git pull --ff-only origin master 2>&1', mDir);
+      newHead = run('git rev-parse HEAD', mDir);
+    }
+  } else {
+    // Channel pin: highest version visible to the pinned channel
+    // (own channel ∪ all more-stable ∪ bare pre-channel tags).
+    const resolved = latestVisible(tagList, channel);
+    const targetSha = resolved ? run(`git rev-list -n 1 "${resolved.tag}"`, mDir) : '';
+    if (targetSha && targetSha !== localHead) {
+      // Repair-then-pin: a dirty or half-merged clone (e.g. a native `git pull`
+      // that failed on the detached HEAD) must never block the pin (R8). NEVER
+      // pull in this path — on a detached HEAD that is an ancestor of main,
+      // --ff-only would silently fast-forward to the alpha tip and defeat the
+      // pin (R2). Re-resolving + re-pinning every SessionStart is the
+      // self-healing property.
+      run('git reset --hard', mDir);
+      run('git clean -fd', mDir);
+      run(`git checkout --detach "${resolved.tag}" 2>&1`, mDir);
+      newHead = run('git rev-parse HEAD', mDir);
+    }
   }
 
   const newSha = newHead.substring(0, 7);
@@ -393,7 +435,7 @@ for (const marketplace of fs.readdirSync(marketplacesDir)) {
     } catch { /* registry unreadable — rebuild to be safe */ cacheMissing = true; }
 
     if (versionChanged || cacheMissing || cacheStale) {
-      const result = rebuildCache(marketplace, name, dir, after, newSha, { versionChanged });
+      const result = rebuildCache(marketplace, name, dir, after, newSha, { versionChanged, channel });
       updated.push({
         name,
         from: beforeVersions[name] || '?',

--- a/plugins/devops/mcp-server/ship/index.js
+++ b/plugins/devops/mcp-server/ship/index.js
@@ -22,6 +22,7 @@ import { schema as preflightSchema, handler as preflightHandler } from "./tools/
 import { schema as buildSchema, handler as buildHandler } from "./tools/build.js";
 import { schema as versionBumpSchema, handler as versionBumpHandler } from "./tools/version-bump.js";
 import { schema as releaseSchema, handler as releaseHandler } from "./tools/release.js";
+import { schema as promoteSchema, handler as promoteHandler } from "./tools/promote.js";
 import { schema as cleanupSchema, handler as cleanupHandler } from "./tools/cleanup.js";
 
 const server = new McpServer({
@@ -84,6 +85,16 @@ registerTool(
   "Handles the full git + GitHub flow deterministically. Returns PR number, merge sha, tag status.",
   releaseSchema,
   releaseHandler,
+);
+
+registerTool(
+  "ship_promote",
+  "Ship Promote",
+  "Promote a shipped version to a higher channel (alpha→beta→stable) by re-tagging the SAME commit SHA. " +
+  "Never rebuilds, never bumps versions — bit-identical ring promotion via annotated tags. " +
+  "Idempotent: re-run after partial failure completes the missing steps. Used by /devops-release, never by /devops-ship.",
+  promoteSchema,
+  promoteHandler,
 );
 
 registerTool(

--- a/plugins/devops/mcp-server/ship/lib/channels.js
+++ b/plugins/devops/mcp-server/ship/lib/channels.js
@@ -1,0 +1,75 @@
+/**
+ * @module ship/lib/channels
+ * @description Pure helpers for the alpha/beta/stable ring model
+ *   (spec: docs/superpowers/specs/2026-07-11-tag-channel-system-design.md).
+ *   Channel identity lives ONLY in the tag namespace (`alpha/vX.Y.Z`,
+ *   `beta/vX.Y.Z`, `stable/vX.Y.Z`, bare `vX.Y.Z` = stable alias) — version
+ *   files stay channel-free so promotion is a pure re-tag of the same SHA.
+ *
+ *   CJS twin: plugins/devops/hooks/lib/channels.js (hooks are standalone
+ *   CommonJS scripts and cannot import this ESM module — keep both in sync).
+ */
+
+export const CHANNELS = ["alpha", "beta", "stable"];
+
+// Strict x.y.z — prerelease suffixes are deliberately NOT channel carriers.
+const TAG_RE = /^(?:refs\/tags\/)?(?:(alpha|beta|stable)\/)?v(\d+)\.(\d+)\.(\d+)(?:\^\{\})?$/;
+
+/**
+ * Parse a tag name (or full ref) into { channel, version }.
+ * Bare `vX.Y.Z` tags report channel "bare" (stable alias).
+ * Returns null for anything outside the channel tag grammar.
+ */
+export function parseChannelTag(ref) {
+  const m = TAG_RE.exec(ref);
+  if (!m) return null;
+  return { channel: m[1] || "bare", version: `${m[2]}.${m[3]}.${m[4]}` };
+}
+
+/** Numeric x.y.z comparison — never lexicographic (0.9.0 < 0.10.0). */
+export function compareVersions(a, b) {
+  const pa = a.split(".").map(Number);
+  const pb = b.split(".").map(Number);
+  for (let i = 0; i < 3; i++) {
+    if (pa[i] !== pb[i]) return pa[i] < pb[i] ? -1 : 1;
+  }
+  return 0;
+}
+
+/**
+ * Channels visible to a pin: own channel plus every more-stable one.
+ * Bare tags are always included (pre-channel releases are stable).
+ * Unknown pins degrade to the safest ring (stable).
+ */
+export function visibleChannels(pin) {
+  const idx = CHANNELS.indexOf(pin);
+  const start = idx === -1 ? CHANNELS.length - 1 : idx;
+  return [...CHANNELS.slice(start), "bare"];
+}
+
+/**
+ * Resolve the highest version among tags visible to `pin`.
+ * MUST stay a numeric-parse resolver — sorting refnames across channel
+ * prefixes (git for-each-ref --sort=v:refname over a cross-prefix glob)
+ * ranks the prefix above the version and is forbidden (spec §5.2 / R9).
+ * On a version tie the more specific (non-bare) tag wins so the resolved
+ * ref names its channel explicitly.
+ */
+export function latestVisible(tagNames, pin) {
+  const visible = new Set(visibleChannels(pin));
+  let best = null;
+  for (const name of tagNames) {
+    const parsed = parseChannelTag(name);
+    if (!parsed || !visible.has(parsed.channel)) continue;
+    const cleanTag = name.replace(/^refs\/tags\//, "").replace(/\^\{\}$/, "");
+    if (!best) {
+      best = { tag: cleanTag, version: parsed.version, channel: parsed.channel };
+      continue;
+    }
+    const cmp = compareVersions(parsed.version, best.version);
+    if (cmp > 0 || (cmp === 0 && best.channel === "bare" && parsed.channel !== "bare")) {
+      best = { tag: cleanTag, version: parsed.version, channel: parsed.channel };
+    }
+  }
+  return best;
+}

--- a/plugins/devops/mcp-server/ship/lib/channels.test.js
+++ b/plugins/devops/mcp-server/ship/lib/channels.test.js
@@ -1,0 +1,106 @@
+import { describe, test, expect } from "vitest";
+import {
+  CHANNELS,
+  parseChannelTag,
+  compareVersions,
+  visibleChannels,
+  latestVisible,
+} from "./channels.js";
+
+describe("parseChannelTag", () => {
+  test("parses namespaced channel tags", () => {
+    expect(parseChannelTag("alpha/v0.113.0")).toEqual({ channel: "alpha", version: "0.113.0" });
+    expect(parseChannelTag("beta/v1.2.3")).toEqual({ channel: "beta", version: "1.2.3" });
+    expect(parseChannelTag("stable/v10.20.30")).toEqual({ channel: "stable", version: "10.20.30" });
+  });
+
+  test("parses bare tags as channel 'bare'", () => {
+    expect(parseChannelTag("v0.112.0")).toEqual({ channel: "bare", version: "0.112.0" });
+  });
+
+  test("accepts full ref paths", () => {
+    expect(parseChannelTag("refs/tags/alpha/v0.113.0")).toEqual({ channel: "alpha", version: "0.113.0" });
+    expect(parseChannelTag("refs/tags/v0.112.0")).toEqual({ channel: "bare", version: "0.112.0" });
+  });
+
+  test("rejects non-channel tags", () => {
+    expect(parseChannelTag("foo/v1.0.0")).toBeNull();
+    expect(parseChannelTag("v1.2")).toBeNull();
+    expect(parseChannelTag("alpha/v1.2")).toBeNull();
+    expect(parseChannelTag("v1.2.3-beta.1")).toBeNull();
+    expect(parseChannelTag("release-1.0.0")).toBeNull();
+    expect(parseChannelTag("alpha/v0.113.0^{}")).toEqual({ channel: "alpha", version: "0.113.0" });
+  });
+});
+
+describe("compareVersions", () => {
+  test("numeric comparison, not lexicographic", () => {
+    expect(compareVersions("0.9.0", "0.10.0")).toBe(-1);
+    expect(compareVersions("0.10.0", "0.9.0")).toBe(1);
+    expect(compareVersions("1.0.0", "1.0.0")).toBe(0);
+    expect(compareVersions("0.112.0", "0.113.0")).toBe(-1);
+    expect(compareVersions("2.0.0", "1.99.99")).toBe(1);
+  });
+});
+
+describe("visibleChannels", () => {
+  test("union of own channel and all more-stable channels", () => {
+    expect(visibleChannels("alpha")).toEqual(["alpha", "beta", "stable", "bare"]);
+    expect(visibleChannels("beta")).toEqual(["beta", "stable", "bare"]);
+    expect(visibleChannels("stable")).toEqual(["stable", "bare"]);
+  });
+
+  test("unknown pin falls back to stable", () => {
+    expect(visibleChannels("nightly")).toEqual(["stable", "bare"]);
+  });
+});
+
+describe("latestVisible", () => {
+  const tags = [
+    "v0.111.0",
+    "v0.112.0",
+    "alpha/v0.113.0",
+    "alpha/v0.114.0",
+    "beta/v0.113.0",
+    "stable/v0.113.0",
+    "some-random-tag",
+  ];
+
+  test("stable pin ignores alpha/beta tags", () => {
+    expect(latestVisible(tags, "stable")).toEqual({ tag: "stable/v0.113.0", version: "0.113.0", channel: "stable" });
+  });
+
+  test("alpha pin sees everything — cross-prefix numeric winner", () => {
+    expect(latestVisible(tags, "alpha")).toEqual({ tag: "alpha/v0.114.0", version: "0.114.0", channel: "alpha" });
+  });
+
+  test("beta pin sees beta+stable+bare but not alpha", () => {
+    expect(latestVisible(tags, "beta")).toEqual({ tag: "beta/v0.113.0", version: "0.113.0", channel: "beta" });
+  });
+
+  test("cross-prefix: alpha/v0.113.0 > stable/v0.112.0 for alpha pin", () => {
+    const t = ["stable/v0.112.0", "alpha/v0.113.0"];
+    expect(latestVisible(t, "alpha")).toEqual({ tag: "alpha/v0.113.0", version: "0.113.0", channel: "alpha" });
+  });
+
+  test("bare tags count as stable for every pin", () => {
+    const t = ["v0.112.0", "alpha/v0.110.0"];
+    expect(latestVisible(t, "stable")).toEqual({ tag: "v0.112.0", version: "0.112.0", channel: "bare" });
+    expect(latestVisible(t, "alpha")).toEqual({ tag: "v0.112.0", version: "0.112.0", channel: "bare" });
+  });
+
+  test("same version in multiple visible channels prefers the more specific (non-bare) tag deterministically", () => {
+    const t = ["v0.113.0", "stable/v0.113.0"];
+    const r = latestVisible(t, "stable");
+    expect(r.version).toBe("0.113.0");
+  });
+
+  test("empty or channel-free list returns null", () => {
+    expect(latestVisible([], "alpha")).toBeNull();
+    expect(latestVisible(["some-random-tag"], "stable")).toBeNull();
+  });
+
+  test("CHANNELS constant order", () => {
+    expect(CHANNELS).toEqual(["alpha", "beta", "stable"]);
+  });
+});

--- a/plugins/devops/mcp-server/ship/lib/github.js
+++ b/plugins/devops/mcp-server/ship/lib/github.js
@@ -259,3 +259,23 @@ export function createRelease({ tag, title, notes, prerelease = false }, opts) {
     stdio: ["pipe", "pipe", "pipe"],
   });
 }
+
+/**
+ * Whether a GitHub release exists for a tag. Used by ship_promote to stay
+ * idempotent against release.yml (which creates the stable release when the
+ * bare tag push triggers it — promote only creates one as a fallback).
+ */
+export function releaseExists(tag, opts) {
+  const cwd = opts?.cwd || process.cwd();
+  try {
+    execFileSync("gh", ["release", "view", tag], {
+      cwd,
+      encoding: "utf8",
+      timeout: DEFAULT_TIMEOUT,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/plugins/devops/mcp-server/ship/tools/promote.js
+++ b/plugins/devops/mcp-server/ship/tools/promote.js
@@ -1,0 +1,189 @@
+/**
+ * @tool ship_promote
+ * @description Promote a shipped version to a higher channel by re-tagging the
+ *   SAME commit SHA (alpha→beta→stable). Never rebuilds, never bumps versions —
+ *   promotion is bit-identical by construction (spec §4.1). All tags are
+ *   annotated (promotion time/actor derivable from tag metadata) and every
+ *   step is skip-if-exists idempotent so partial failures recover by re-run.
+ */
+
+import { z } from "zod";
+import { execFileSync } from "node:child_process";
+import { git, gitStrict } from "../lib/git.js";
+import { createRelease, releaseExists } from "../lib/github.js";
+import { parseChannelTag, compareVersions } from "../lib/channels.js";
+
+export const schema = z.object({
+  version: z.string().describe("Bare version to promote, e.g. 0.113.0 (no v prefix, no channel)"),
+  from: z.enum(["alpha", "beta"]).describe("Source channel the version currently lives in"),
+  to: z.enum(["beta", "stable"]).describe("Target channel (must be more stable than source)"),
+  releaseNotes: z.string().nullable().default(null).describe("CHANGELOG entry for the stable GitHub Release fallback — ignored for beta"),
+  releasePollAttempts: z.number().int().min(1).max(30).default(6).describe("How often to poll for the release.yml-created GitHub Release before falling back"),
+  releasePollDelayMs: z.number().int().min(0).max(60_000).default(10_000).describe("Delay between release polls"),
+  cwd: z.string().describe("Working directory of the target repo (required — must be passed by the caller)"),
+});
+
+const ORDER = { alpha: 0, beta: 1, stable: 2 };
+
+function lsRemoteTag(tag, opts) {
+  const out = git(`ls-remote --tags origin ${tag}`, opts);
+  if (!out || !out.includes(`refs/tags/${tag}`)) return null;
+  return out.trim().split(/\s+/)[0] || null;
+}
+
+function listRemoteChannelTags(opts) {
+  const out = git(`ls-remote --tags origin`, opts) || "";
+  const tags = [];
+  for (const line of out.split("\n")) {
+    const [sha, ref] = line.trim().split(/\s+/);
+    if (!sha || !ref) continue;
+    const parsed = parseChannelTag(ref);
+    if (!parsed) continue;
+    tags.push({ sha, tag: ref.replace(/^refs\/tags\//, "").replace(/\^\{\}$/, ""), ...parsed });
+  }
+  return tags;
+}
+
+/**
+ * Create + push one annotated tag, skip-if-exists. Returns
+ * { ok: true } | { ok: true, existed: true } | { ok: false, error }.
+ * An existing remote tag on a DIFFERENT SHA is a hard error — published
+ * tags are immutable, never moved (spec §2).
+ */
+function ensureTag(tag, sha, payload, opts) {
+  const existing = lsRemoteTag(tag, opts);
+  if (existing) {
+    if (existing !== sha) {
+      return { ok: false, error: `tag ${tag} already exists on remote at ${existing.slice(0, 12)} (expected ${sha.slice(0, 12)}) — published tags are immutable` };
+    }
+    return { ok: true, existed: true };
+  }
+  try {
+    // Annotated (-a): promotion timestamp/actor live in the tag object —
+    // lightweight tags would collapse all channels onto the commit date (R4).
+    execFileSync("git", ["tag", "-a", tag, sha, "-m", JSON.stringify(payload)], {
+      cwd: opts.cwd,
+      encoding: "utf8",
+      timeout: 15_000,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    gitStrict(`push origin ${tag}`, { ...opts, timeout: 60_000 });
+    const verify = lsRemoteTag(tag, opts);
+    if (verify !== sha) return { ok: false, error: `tag ${tag} not verifiable on remote after push` };
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, error: e.message?.slice(0, 300) || "tag creation failed" };
+  }
+}
+
+export async function handler(params) {
+  const { version, from, to, releaseNotes, releasePollAttempts, releasePollDelayMs } = params;
+  const cwd = params.cwd;
+  if (!cwd) throw new Error("cwd is required — MCP server runs in the plugin directory, not the target repo");
+  const opts = { cwd };
+
+  const result = { version, from, to };
+
+  if (ORDER[to] <= ORDER[from]) {
+    return { ...result, success: false, error: `invalid promotion direction: ${from} → ${to}` };
+  }
+
+  // 1. Resolve source tag → SHA (remote is the source of truth, never local state)
+  const sourceTag = `${from}/v${version}`;
+  const sha = lsRemoteTag(sourceTag, opts);
+  if (!sha) {
+    return { ...result, success: false, error: `source-tag-not-found: ${sourceTag} does not exist on origin` };
+  }
+  result.sha = sha;
+
+  // 2. Monotonicity guard (spec §4.1.2, amended per R6):
+  //    empty target → allow; version > latest → allow;
+  //    version == latest on the same SHA → idempotent path (re-run recovery);
+  //    version < latest → refuse (invisible under latest-resolution).
+  const remoteTags = listRemoteChannelTags(opts);
+  const targetTags = remoteTags.filter((t) => t.channel === to);
+  let targetLatest = null;
+  for (const t of targetTags) {
+    if (!targetLatest || compareVersions(t.version, targetLatest.version) > 0) targetLatest = t;
+  }
+  const targetExisting = targetTags.find((t) => t.version === version) || null;
+  if (targetLatest && compareVersions(version, targetLatest.version) < 0) {
+    return {
+      ...result,
+      success: false,
+      error: `monotonicity: ${to} is already at v${targetLatest.version} — promoting v${version} would be invisible to consumers (latest-resolution). Roll forward instead.`,
+    };
+  }
+  if (targetExisting && targetExisting.sha !== sha) {
+    return { ...result, success: false, error: `tag ${to}/v${version} already exists on a different SHA — published tags are immutable` };
+  }
+
+  // 3. Ancestry guard: only commits reachable from origin/main are promotable.
+  try {
+    gitStrict(`fetch origin main`, { ...opts, timeout: 30_000 });
+    gitStrict(`merge-base --is-ancestor ${sha} origin/main`, opts);
+  } catch {
+    return { ...result, success: false, error: `ancestry: ${sha.slice(0, 12)} is not an ancestor of origin/main — refusing to promote an unmerged/foreign commit` };
+  }
+
+  // 4./5. Create tags — target first, then (stable only) the bare alias.
+  //       Ordered + individually idempotent = deterministic partial-failure
+  //       recovery (spec §4.1.5 / R7).
+  const plan = [{ tag: `${to}/v${version}`, payload: { from, to, version } }];
+  if (to === "stable") {
+    plan.push({ tag: `v${version}`, payload: { from: "stable", to: "bare", version } });
+  }
+
+  const pushed = [];
+  const missing = [];
+  let anyCreated = false;
+  for (const step of plan) {
+    const r = ensureTag(step.tag, sha, step.payload, opts);
+    if (r.ok) {
+      pushed.push(step.tag);
+      if (!r.existed) anyCreated = true;
+    } else {
+      missing.push(step.tag);
+      result.error = r.error;
+      break; // keep ordering guarantee — don't create bare before stable succeeded
+    }
+  }
+  result.tag = plan[0].tag;
+  if (to === "stable") result.bareTag = `v${version}`;
+  result.pushed = pushed;
+  if (missing.length) {
+    // Remaining plan steps that were never attempted are also missing.
+    const attempted = new Set([...pushed, ...missing]);
+    for (const step of plan) if (!attempted.has(step.tag)) missing.push(step.tag);
+    return { ...result, success: false, missing };
+  }
+
+  // 6. GitHub Release — stable only (beta is tags-only at launch, PO/O2).
+  //    The bare tag push triggers release.yml; poll for its Release, create
+  //    as fallback. Skip-if-exists keeps both producers idempotent.
+  if (to === "stable") {
+    const bareTag = `v${version}`;
+    let exists = false;
+    for (let i = 0; i < releasePollAttempts; i++) {
+      if (releaseExists(bareTag, opts)) { exists = true; break; }
+      if (i < releasePollAttempts - 1 && releasePollDelayMs > 0) {
+        await new Promise((r) => setTimeout(r, releasePollDelayMs));
+      }
+    }
+    if (!exists) {
+      try {
+        createRelease({ tag: bareTag, title: bareTag, notes: releaseNotes || `Release ${bareTag}`, prerelease: false }, opts);
+        exists = true;
+      } catch (e) {
+        result.releaseError = e.message?.slice(0, 200);
+      }
+    }
+    result.release = exists;
+  }
+
+  if (!anyCreated && (to !== "stable" || result.release)) {
+    result.alreadyPromoted = true;
+  }
+  result.success = true;
+  return result;
+}

--- a/plugins/devops/mcp-server/ship/tools/promote.test.js
+++ b/plugins/devops/mcp-server/ship/tools/promote.test.js
@@ -1,0 +1,180 @@
+import { describe, test, expect, vi, beforeEach } from "vitest";
+
+// Same zod-stub pattern as release.test.js — the handler never invokes the
+// schema, only the MCP registration does.
+vi.mock("zod", () => {
+  const node = new Proxy(() => node, { get: () => () => node });
+  return { z: { object: () => node, string: () => node, boolean: () => node, enum: () => node, number: () => node } };
+});
+
+vi.mock("node:child_process", () => ({
+  execFileSync: vi.fn(() => ""),
+}));
+
+vi.mock("../lib/git.js", () => ({
+  git: vi.fn(() => ""),
+  gitStrict: vi.fn(() => ""),
+}));
+
+vi.mock("../lib/github.js", () => ({
+  createRelease: vi.fn(() => undefined),
+  releaseExists: vi.fn(() => true),
+}));
+
+import { handler } from "./promote.js";
+import { execFileSync } from "node:child_process";
+import * as gitLib from "../lib/git.js";
+import * as ghLib from "../lib/github.js";
+
+const SHA = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2";
+
+function params(overrides = {}) {
+  return {
+    version: "0.113.0",
+    from: "alpha",
+    to: "beta",
+    releaseNotes: null,
+    cwd: "/repo",
+    // Keep tests fast — production defaults are 6 × 10s.
+    releasePollAttempts: 1,
+    releasePollDelayMs: 0,
+    ...overrides,
+  };
+}
+
+// Build a STATEFUL remote mock: ls-remote answers from a tag map, and a
+// `git tag -a <tag> <sha>` via execFileSync registers the tag so the
+// post-push ls-remote verification sees it (mirrors real remote behavior).
+function mockRemote(tags, { existingTarget = {} } = {}) {
+  const all = { ...tags, ...existingTarget };
+  execFileSync.mockImplementation((cmd, args) => {
+    if (cmd === "git" && Array.isArray(args) && args[0] === "tag") {
+      all[args[2]] = args[3];
+    }
+    return "";
+  });
+  gitLib.git.mockImplementation((cmd) => {
+    if (cmd.startsWith("ls-remote --tags origin")) {
+      // Specific-tag query: `ls-remote --tags origin <tag>`
+      const m = /ls-remote --tags origin (\S+)$/.exec(cmd);
+      if (m && m[1] !== "origin") {
+        const tag = m[1];
+        return all[tag] ? `${all[tag]}\trefs/tags/${tag}` : "";
+      }
+      // Full listing
+      return Object.entries(all)
+        .map(([t, sha]) => `${sha}\trefs/tags/${t}`)
+        .join("\n");
+    }
+    return "";
+  });
+  gitLib.gitStrict.mockImplementation(() => "");
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  ghLib.releaseExists.mockReturnValue(true);
+});
+
+function tagCreateCalls() {
+  return execFileSync.mock.calls.filter((c) => c[0] === "git" && c[1][0] === "tag");
+}
+
+describe("ship_promote — guards", () => {
+  test("missing source tag → source-tag-not-found", async () => {
+    mockRemote({});
+    const r = await handler(params());
+    expect(r.success).toBe(false);
+    expect(r.error).toMatch(/source-tag-not-found/);
+  });
+
+  test("downgrade (version < target latest) refused", async () => {
+    mockRemote({ "alpha/v0.113.0": SHA, "beta/v0.114.0": "f".repeat(40) });
+    const r = await handler(params());
+    expect(r.success).toBe(false);
+    expect(r.error).toMatch(/monotonicity/);
+    expect(tagCreateCalls()).toHaveLength(0);
+  });
+
+  test("equal version + same SHA → idempotent success (alreadyPromoted)", async () => {
+    mockRemote({ "alpha/v0.113.0": SHA, "beta/v0.113.0": SHA });
+    const r = await handler(params());
+    expect(r.success).toBe(true);
+    expect(r.alreadyPromoted).toBe(true);
+    expect(tagCreateCalls()).toHaveLength(0);
+  });
+
+  test("empty target channel allowed (first promotion)", async () => {
+    mockRemote({ "alpha/v0.113.0": SHA });
+    const r = await handler(params());
+    expect(r.success).toBe(true);
+    expect(r.tag).toBe("beta/v0.113.0");
+  });
+
+  test("ancestry guard failure refuses", async () => {
+    mockRemote({ "alpha/v0.113.0": SHA });
+    gitLib.gitStrict.mockImplementation((cmd) => {
+      if (cmd.startsWith("merge-base --is-ancestor")) throw new Error("not an ancestor");
+      return "";
+    });
+    const r = await handler(params());
+    expect(r.success).toBe(false);
+    expect(r.error).toMatch(/ancestor/);
+  });
+});
+
+describe("ship_promote — tagging", () => {
+  test("alpha→beta creates ONE annotated tag on the source SHA, pushes, no release", async () => {
+    mockRemote({ "alpha/v0.113.0": SHA });
+    const r = await handler(params());
+    expect(r.success).toBe(true);
+    expect(r.sha).toBe(SHA);
+    const creates = tagCreateCalls();
+    expect(creates).toHaveLength(1);
+    expect(creates[0][1]).toEqual(["tag", "-a", "beta/v0.113.0", SHA, "-m", expect.stringContaining('"to":"beta"')]);
+    expect(ghLib.createRelease).not.toHaveBeenCalled();
+    expect(ghLib.releaseExists).not.toHaveBeenCalled();
+  });
+
+  test("beta→stable creates stable/vN THEN bare vN + verifies release", async () => {
+    mockRemote({ "beta/v0.113.0": SHA });
+    const r = await handler(params({ from: "beta", to: "stable" }));
+    expect(r.success).toBe(true);
+    expect(r.tag).toBe("stable/v0.113.0");
+    expect(r.bareTag).toBe("v0.113.0");
+    const creates = tagCreateCalls().map((c) => c[1][2]);
+    expect(creates).toEqual(["stable/v0.113.0", "v0.113.0"]);
+    expect(r.release).toBe(true);
+  });
+
+  test("stable: bare push failure → success:false with missing list", async () => {
+    mockRemote({ "beta/v0.113.0": SHA });
+    gitLib.gitStrict.mockImplementation((cmd) => {
+      if (cmd === "push origin v0.113.0") throw new Error("network");
+      return "";
+    });
+    const r = await handler(params({ from: "beta", to: "stable" }));
+    expect(r.success).toBe(false);
+    expect(r.pushed).toContain("stable/v0.113.0");
+    expect(r.missing).toContain("v0.113.0");
+  });
+
+  test("re-run after partial failure completes only the missing bare tag", async () => {
+    mockRemote({ "beta/v0.113.0": SHA, "stable/v0.113.0": SHA });
+    const r = await handler(params({ from: "beta", to: "stable" }));
+    expect(r.success).toBe(true);
+    const creates = tagCreateCalls().map((c) => c[1][2]);
+    expect(creates).toEqual(["v0.113.0"]); // stable/ exists remotely → only bare created
+  });
+
+  test("stable: release absent after poll → createRelease fallback", async () => {
+    mockRemote({ "beta/v0.113.0": SHA });
+    ghLib.releaseExists.mockReturnValue(false);
+    const r = await handler(params({ from: "beta", to: "stable", releaseNotes: "## notes" }));
+    expect(ghLib.createRelease).toHaveBeenCalledWith(
+      expect.objectContaining({ tag: "v0.113.0", notes: "## notes" }),
+      expect.anything(),
+    );
+    expect(r.release).toBe(true);
+  });
+});

--- a/plugins/devops/mcp-server/ship/tools/release.js
+++ b/plugins/devops/mcp-server/ship/tools/release.js
@@ -6,16 +6,16 @@
 import { z } from "zod";
 import { execFileSync } from "node:child_process";
 import { git, gitStrict, currentBranch, headShort, dirtyState, isWorktree, isRebasedOnto, fileOverlap, syncLocalBranch, treeOf } from "../lib/git.js";
-import { createPR, mergePR, createRelease, findExistingPR, watchPRChecks } from "../lib/github.js";
+import { createPR, mergePR, findExistingPR, watchPRChecks } from "../lib/github.js";
 import { detectRepoMode } from "../lib/repo-mode.js";
 
 export const schema = z.object({
   base: z.string().default("main").describe("Base branch for PR (may be a feature branch for intermediate merges)"),
   title: z.string().max(70).describe("PR title (conventional commit format)"),
   body: z.string().describe("PR body (must start with Closes #N if applicable)"),
-  tag: z.string().nullable().default(null).describe("Version tag to create (e.g. v0.18.0), null to skip — ignored for intermediate merges"),
-  releaseNotes: z.string().nullable().default(null).describe("GitHub release notes (CHANGELOG mirror) — ignored for intermediate merges"),
-  prerelease: z.boolean().default(false).describe("Mark as pre-release (for 0.x versions)"),
+  tag: z.string().nullable().default(null).describe("Bare version tag (e.g. v0.18.0) — the tool publishes it as alpha/<tag> (ring model), null to skip. Ignored for intermediate merges"),
+  releaseNotes: z.string().nullable().default(null).describe("CHANGELOG entry — NOT published at ship time (releases happen at promotion via ship_promote); recorded as releaseDeferred"),
+  prerelease: z.boolean().default(false).describe("Deprecated — releases are created at promotion time; kept for caller compatibility"),
   commitMessage: z.string().nullable().default(null).describe("If set, stage all and commit with this message before pushing"),
   mergeStrategy: z.enum(["squash", "merge", "rebase"]).default("squash").describe("PR merge strategy. Use 'merge' for overlapping files to preserve ancestry chain."),
   skipChecks: z.boolean().default(false).describe("Skip the pre-merge CI checks gate. Use only for hot-fixes when CI is broken. Env DEVOPS_SHIP_SKIP_CHECKS=1 also forces skip."),
@@ -24,7 +24,7 @@ export const schema = z.object({
 });
 
 export async function handler(params) {
-  const { base, title, body, tag, releaseNotes, prerelease, commitMessage, mergeStrategy, skipChecks, checksTimeoutSec } = params;
+  const { base, title, body, tag, releaseNotes, commitMessage, mergeStrategy, skipChecks, checksTimeoutSec } = params;
   const cwd = params.cwd;
   if (!cwd) throw new Error("cwd is required — MCP server runs in the plugin directory, not the target repo");
   const opts = { cwd };
@@ -237,35 +237,41 @@ export async function handler(params) {
     result.baseSync = baseSync.method;
     if (baseSync.warning) result.baseSyncWarning = baseSync.warning;
 
-    // Tag + Release (only for final merges to main, skip for intermediate)
+    // Alpha channel tag (only for final merges to main, skip for intermediate).
+    // Every ship publishes to the EARLIEST channel autonomously — beta/stable
+    // tags and GitHub Releases are created by ship_promote at promotion time
+    // (ring model, spec §3.1). The tag is ANNOTATED so channel identity and
+    // ship time live in the tag object (R4).
     if (!intermediate && tag) {
+      const channelTag = `alpha/${tag}`;
       try {
-        const remoteTag = git(`ls-remote --tags origin ${tag}`, opts);
-        if (remoteTag && remoteTag.includes(tag)) {
-          result.tagWarning = `Tag ${tag} already exists on remote — skipping creation.`;
+        const remoteTag = git(`ls-remote --tags origin ${channelTag}`, opts);
+        if (remoteTag && remoteTag.includes(channelTag)) {
+          result.tagWarning = `Tag ${channelTag} already exists on remote — skipping creation.`;
           result.tagVerified = true;
         } else {
           // Create tag on the merge commit (origin/base), not on the current HEAD
-          gitStrict(`tag ${tag} origin/${base}`, opts);
-          gitStrict(`push origin ${tag}`, opts);
-          const tagCheck = git(`ls-remote --tags origin ${tag}`, opts);
-          result.tagVerified = tagCheck !== null && tagCheck.includes(tag);
+          execFileSync("git", [
+            "tag", "-a", channelTag, `origin/${base}`, "-m",
+            JSON.stringify({ channel: "alpha", version: tag.replace(/^v/, "") }),
+          ], { cwd, encoding: "utf8", timeout: 15_000, stdio: ["pipe", "pipe", "pipe"] });
+          gitStrict(`push origin ${channelTag}`, opts);
+          const tagCheck = git(`ls-remote --tags origin ${channelTag}`, opts);
+          result.tagVerified = tagCheck !== null && tagCheck.includes(channelTag);
         }
-        result.tag = tag;
+        result.tag = channelTag;
+        result.channel = "alpha";
       } catch (e) {
-        result.tag = tag;
+        result.tag = channelTag;
+        result.channel = "alpha";
         result.tagVerified = false;
         result.tagError = e.message?.slice(0, 200);
       }
 
+      // No GitHub Release at ship time — promotion owns Releases. The notes
+      // land in the stable Release when ship_promote fast-tracks/promotes.
       if (releaseNotes) {
-        try {
-          createRelease({ tag, title: tag, notes: releaseNotes, prerelease }, opts);
-          result.release = true;
-        } catch (e) {
-          result.release = false;
-          result.releaseError = e.message?.slice(0, 200);
-        }
+        result.releaseDeferred = true;
       }
     } else if (intermediate && tag) {
       result.tag = null;

--- a/plugins/devops/mcp-server/ship/tools/release.test.js
+++ b/plugins/devops/mcp-server/ship/tools/release.test.js
@@ -92,9 +92,9 @@ beforeEach(() => {
   // Distinct-but-equal trees keyed by ref → postMergeTreeMatch is true ONLY when
   // the code looks up the two correct refs (HEAD and origin/main), not by accident.
   gitLib.treeOf.mockImplementation((ref) => (ref === "HEAD" ? "T1" : "T1"));
-  // ls-remote --tags returns the tag → tag already exists, skip creation path.
+  // ls-remote --tags returns the alpha channel tag → tag already exists, skip creation path.
   gitLib.git.mockImplementation((cmd) =>
-    cmd.includes("ls-remote --tags") ? "abc\trefs/tags/v1.0.0" : "remoteSha",
+    cmd.includes("ls-remote --tags") ? "abc\trefs/tags/alpha/v1.0.0" : "remoteSha",
   );
   gitLib.gitStrict.mockReturnValue("");
   ghLib.findExistingPR.mockReturnValue(null);
@@ -264,5 +264,52 @@ describe("ship_release — #207 parallel-change data-loss guards", () => {
     const push = pushCall();
     expect(push[0]).toContain("--force-with-lease");
     expect(push[0]).not.toContain("--force-with-lease=");
+  });
+});
+
+describe("ship_release — alpha channel tagging (ring model)", () => {
+  test("creates annotated alpha/<tag> on origin/base, pushes, defers the GitHub Release", async () => {
+    // First ls-remote (existence check) → empty; post-push verify → tag present.
+    let lsCalls = 0;
+    gitLib.git.mockImplementation((cmd) => {
+      if (cmd.includes("ls-remote --tags")) {
+        lsCalls += 1;
+        return lsCalls === 1 ? "" : "abc\trefs/tags/alpha/v1.0.0";
+      }
+      return "remoteSha";
+    });
+
+    const res = await handler(params());
+
+    expect(res.success).toBe(true);
+    expect(res.tag).toBe("alpha/v1.0.0");
+    expect(res.channel).toBe("alpha");
+    expect(res.tagVerified).toBe(true);
+    // Annotated tag with channel payload, created on the merge commit.
+    const { execFileSync } = await import("node:child_process");
+    const tagCall = execFileSync.mock.calls.find((c) => c[0] === "git" && c[1][0] === "tag");
+    expect(tagCall).toBeDefined();
+    expect(tagCall[1]).toEqual([
+      "tag", "-a", "alpha/v1.0.0", "origin/main", "-m",
+      expect.stringContaining('"channel":"alpha"'),
+    ]);
+    // No Release at ship time — promotion owns Releases (spec §3.1).
+    expect(ghLib.createRelease).not.toHaveBeenCalled();
+    expect(res.releaseDeferred).toBe(true);
+  });
+
+  test("existing alpha tag on remote → skip creation, still verified", async () => {
+    const res = await handler(params());
+    expect(res.tagVerified).toBe(true);
+    expect(res.tagWarning).toMatch(/alpha\/v1\.0\.0 already exists/);
+    const { execFileSync } = await import("node:child_process");
+    expect(execFileSync.mock.calls.find((c) => c[0] === "git" && c[1]?.[0] === "tag")).toBeUndefined();
+  });
+
+  test("intermediate merge still skips tagging entirely", async () => {
+    const res = await handler(params({ base: "feat/parent" }));
+    expect(res.tag).toBeNull();
+    expect(res.tagSkipped).toMatch(/intermediate/);
+    expect(ghLib.createRelease).not.toHaveBeenCalled();
   });
 });

--- a/plugins/devops/skills/devops-plugin-update/SKILL.md
+++ b/plugins/devops/skills/devops-plugin-update/SKILL.md
@@ -34,11 +34,22 @@ PLUGIN_SUBDIR = plugins/devops
 HOOK_SCRIPT = ${PLUGIN_ROOT}/hooks/session-start/ss.plugin.update.js
 ```
 
-## Step 0 — Capture current state
+## Step 0 — Capture current state + channel
 
 1. Read current version from `MARKETPLACE_DIR/PLUGIN_SUBDIR/.claude-plugin/plugin.json`
 2. Read current git SHA: `git -C MARKETPLACE_DIR rev-parse --short HEAD`
-3. Report: `Currently installed: v{version} ({sha})`
+3. Read the channel pin from `~/.claude/plugins/.channels.json` (key = marketplace
+   name, missing/invalid → `stable`). One channel per MARKETPLACE — a single
+   clone cannot serve two plugins on different channels.
+4. **`--channel <alpha|beta|stable>` flag:** re-pin by writing the sidecar
+   (`{"dotclaude": "beta"}` merged into the existing JSON), then continue with
+   the update so the new pin takes effect immediately.
+5. Compute drift: latest version visible to the pin vs. latest alpha
+   (`git -C MARKETPLACE_DIR ls-remote --tags origin`, numeric compare on
+   `alpha/vX.Y.Z` / `beta/vX.Y.Z` / `stable/vX.Y.Z` / bare `vX.Y.Z`).
+6. Report: `Currently installed: v{version} ({sha}) — Channel: {channel},
+   latest visible: v{N}` and, when alpha is ahead:
+   `(alpha has v{M} available)`.
 
 ## Step 1 — Run update hook
 
@@ -49,9 +60,12 @@ node HOOK_SCRIPT
 ```
 
 The hook handles:
-- `git pull --ff-only` on all marketplace clones
-- Cache rebuild with `cp -a` (archive mode for dotfiles)
-- `installed_plugins.json` registry update
+- Channel-aware update on all marketplace clones (ring model): once a
+  `stable/*` tag exists, the clone is pinned to the highest version visible
+  to the channel pin via a detached tag checkout; before that, a bootstrap
+  fallback keeps the legacy `git pull --ff-only` behavior
+- Cache rebuild (recursive copy incl. dotfiles)
+- `installed_plugins.json` registry update (incl. informational `channel`)
 - Silent verification (version alignment, cache completeness)
 
 Capture and display the hook's stdout (update status lines).

--- a/plugins/devops/skills/devops-release/SKILL.md
+++ b/plugins/devops/skills/devops-release/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: devops-release
+version: 0.1.0
+description: >-
+  Deliberate channel promotion for the ring model: move an already-shipped
+  version alpha→beta→stable (or fast-track alpha→stable) by re-tagging the
+  SAME commit via the ship_promote MCP tool. Never rebuilds, never bumps
+  versions, never runs autonomously — promotion is always a user decision.
+  Triggers on: "release", "promote", "promotion", "channel release",
+  "auf stable heben", "promote to beta", "promote to stable". Do NOT trigger
+  for shipping new work (use /devops-ship) or plugin updates
+  (/devops-plugin-update).
+allowed-tools: Bash(git *), AskUserQuestion, Read
+---
+
+# Release — Channel Promotion
+
+Promote a shipped version to a higher channel. Ship publishes every version
+to **alpha** autonomously; this skill is the deliberate half of the ring
+model (spec: `docs/superpowers/specs/2026-07-11-tag-channel-system-design.md`).
+
+> **CRITICAL — `cwd` is required on every MCP tool call.**
+> The ship MCP server runs in the plugin directory, NOT the target repo.
+> Every `ship_promote` call MUST include `cwd` set to the current working
+> directory of this Claude session.
+
+## Step 0 — Load deferred MCP schema
+
+`ship_promote` may be deferred. Load it first:
+
+```
+ToolSearch({ query: "select:mcp__plugin_devops_dotclaude-ship__ship_promote", max_results: 5 })
+```
+
+If the tool is not registered → STOP and report (do NOT fall back to manual
+`git tag` — the promotion guards live in the tool).
+
+## Step 1 — Gather channel state
+
+```bash
+git ls-remote --tags origin
+```
+
+Parse tag names (`alpha/vX.Y.Z`, `beta/vX.Y.Z`, `stable/vX.Y.Z`, bare
+`vX.Y.Z` = stable alias) and compute the latest version per channel by
+**numeric** version comparison — never lexicographic, never
+`--sort=v:refname` across channel prefixes.
+
+Render ONE line:
+
+```
+Channels: alpha v0.117.0 · beta v0.114.0 · stable v0.112.0
+```
+
+If alpha has never shipped a channel tag → report "no channel tags yet —
+ship something first" and stop.
+
+## Step 2 — Ask which promotion
+
+Precompute only the **meaningful** promotions (source strictly ahead of
+target). Present via AskUserQuestion, recommended option first:
+
+- `alpha vX → beta` (Recommended when alpha > beta)
+- `beta vY → stable`
+- `alpha vX → stable (fast-track)` — legitimate skip; beta is optional
+- Abbrechen
+
+If NO promotion is meaningful (all channels equal) → report "all channels
+are at vX — nothing to promote" and stop. Never promote autonomously, even
+with `--autonomous` in the trigger.
+
+## Step 3 — Execute
+
+Single-step promotion:
+
+```
+ship_promote({ version: "0.117.0", from: "alpha", to: "beta", cwd: "<cwd>" })
+```
+
+**Fast-track** = TWO sequential calls so the ring invariant
+(stable ⊆ beta ⊆ alpha) always holds:
+
+1. `ship_promote({ version, from: "alpha", to: "beta", cwd })`
+2. `ship_promote({ version, from: "beta", to: "stable", releaseNotes: "<CHANGELOG entry for the version>", cwd })`
+
+For any promotion to `stable`, pass `releaseNotes` (read the version's
+CHANGELOG.md entry) — used as fallback notes if release.yml did not create
+the GitHub Release.
+
+**Partial failure recovery:** re-run the SAME call(s). Every step is
+skip-if-exists idempotent; an already-completed step returns
+`alreadyPromoted: true` and the missing tags are completed
+(`pushed`/`missing` in the result show exactly what happened).
+
+**Guard errors are final** — do not work around them:
+- `monotonicity: ...` → the target channel is already ahead; roll forward
+  (ship a newer version) instead.
+- `ancestry: ...` → the SHA is not on origin/main; something is wrong —
+  investigate, never force.
+- `... published tags are immutable` → never delete/move tags to "fix" this.
+
+## Step 4 — Report
+
+Render the completion card (`render_completion_card`, variant `ready`,
+summary "promoted vX.Y.Z to <channel>"). Include:
+- the new one-line channel state (re-run Step 1)
+- for stable: whether the GitHub Release exists (`release: true`)
+- any `userFinalTest` item for lagging consumers ("Consumer-Maschine:
+  nächster SessionStart pinnt auf stable/vX.Y.Z")
+
+## Rollback = roll forward
+
+There is deliberately NO demote operation (immutable tags + latest-wins
+resolution). A bad promotion is corrected by fixing on a branch, shipping a
+new version (alpha), and fast-track promoting the fix.

--- a/plugins/devops/skills/devops-ship/SKILL.md
+++ b/plugins/devops/skills/devops-ship/SKILL.md
@@ -255,9 +255,15 @@ See `deep-knowledge/call-examples.md` for the three reference payloads
 For intermediate merges: no tag, no release notes, no version commit —
 the tool automatically skips tag/release creation when `base` is not `main`.
 
-The tool handles: commit (optional), rebase verification, push (explicit force-with-lease after rebase), PR create (or reuse with mergeability check), **pre-merge CI checks gate (waits for green)**, **pre-merge rebase re-check (closes the checks-window race)**, merge (squash or merge commit), **post-merge tree guard**, tag (main only), GitHub release (main only).
+The tool handles: commit (optional), rebase verification, push (explicit force-with-lease after rebase), PR create (or reuse with mergeability check), **pre-merge CI checks gate (waits for green)**, **pre-merge rebase re-check (closes the checks-window race)**, merge (squash or merge commit), **post-merge tree guard**, **alpha channel tag** (main only), GitHub release deferred to promotion.
 
-Returns: `{ branch, commit, rebased, pushed, pr: {number, url}, checks: {status, passed, failed, pending}, merged, mergeStrategy, intermediate, tag, tagVerified, release, postMergeTreeMatch, postMergeWarning }`.
+Returns: `{ branch, commit, rebased, pushed, pr: {number, url}, checks: {status, passed, failed, pending}, merged, mergeStrategy, intermediate, tag, channel, tagVerified, releaseDeferred, postMergeTreeMatch, postMergeWarning }`.
+
+**Ring model (channels):** the tag is `alpha/vX.Y.Z` — every ship publishes to
+the EARLIEST channel autonomously. beta/stable tags and GitHub Releases are
+created later by `/devops-release` (deliberate promotion, same SHA, no rebuild).
+Pass the bare `tag: "vX.Y.Z"` as before; the tool prefixes the channel. See
+`docs/superpowers/specs/2026-07-11-tag-channel-system-design.md`.
 
 **Pre-merge CI gate** (default ON): after PR create, `ship_release` runs `gh pr checks --watch` (default 600s timeout). If checks fail or timeout → `success: false`, `checksBlocked: true`, PR stays open, branch not deleted. Render `ship-blocked` card with the failing check names + run URLs.
 
@@ -625,6 +631,28 @@ instead of `All DONE` / `Alles ERLEDIGT`.
 Call `render_completion_card` MCP tool (dotclaude-completion server) with data from previous steps.
 
 **CRITICAL — `cwd` is required for clickable links.** Without `cwd`, `getRepoUrl` falls back to the MCP server's own working directory (plugin dir, not your target repo) and the card renders PR/commit/branch as plain text. Always pass the same `cwd` you used for the ship tools.
+
+### Promotion-gap nudge (final ship to main only — MANDATORY)
+
+Deliberate promotion has no heartbeat without a forcing function — invisible
+channel lag is how stable rots. Before rendering the card, compute the drift:
+
+```bash
+git ls-remote --tags origin
+```
+
+- Latest alpha version = highest `alpha/vX.Y.Z` (numeric compare, never lexicographic).
+- Latest stable version = highest of `stable/vX.Y.Z` ∪ bare `vX.Y.Z`.
+- No channel tags at all (pre-migration repo) → skip silently.
+
+When alpha > stable, append ONE `userFinalTest` item:
+- Gap < 3 versions AND last stable tag younger than 7 days (annotated
+  taggerdate via `git for-each-ref --format='%(taggerdate:iso)' 'refs/tags/stable/*'`):
+  `{ action: "alpha ist N Version(en) vor stable — /devops-release zum Promoten" }`
+- Gap ≥ 3 versions OR ≥ 7 days: escalate the wording:
+  `{ action: "⚠ stable ist N Versionen / D Tage hinter alpha — /devops-release ausführen" }`
+
+Visible lag is the ring model working; the nudge just keeps it visible.
 
 ```
 render_completion_card({

--- a/plugins/devops/skills/devops-ship/deep-knowledge/call-examples.md
+++ b/plugins/devops/skills/devops-ship/deep-knowledge/call-examples.md
@@ -19,6 +19,11 @@ ship_release({
 })
 ```
 
+Pass the BARE tag (`v0.18.0`) — the tool publishes it as the annotated
+channel tag `alpha/v0.18.0` (ring model) and defers the GitHub Release to
+promotion (`releaseDeferred: true` in the result; `/devops-release` owns
+beta/stable tags + Releases).
+
 ## Intermediate ship (sub-branch → feature branch)
 
 ```

--- a/plugins/devops/skills/devops-ship/deep-knowledge/pre-flight.md
+++ b/plugins/devops/skills/devops-ship/deep-knowledge/pre-flight.md
@@ -78,17 +78,18 @@ knows what needs updating. But they MUST be reported before proceeding.
 After Step 4 (Commit/Push/PR/Merge), before Step 5 (Cleanup), verify:
 
 ```bash
-# 6a. Git tag exists on remote
-git ls-remote --tags origin | grep "v$NEW_VERSION"
+# 6a. Alpha channel tag exists on remote (ring model — ship publishes to alpha)
+git ls-remote --tags origin | grep "alpha/v$NEW_VERSION"
 ```
-If no tag → CREATE it now. This is the most commonly missed step.
+If no tag → CREATE it now (annotated: `git tag -a alpha/v$NEW_VERSION origin/main -m '{"channel":"alpha"}'`).
+This is the most commonly missed step.
 
 ```
-# 6b. GitHub release exists (if CI creates one)
-Check via GitHub API whether a release for v$NEW_VERSION exists.
+# 6b. NO GitHub release is expected at ship time
+Releases are created at promotion (/devops-release): stable promotion pushes
+the bare v$NEW_VERSION tag which triggers release.yml. Do NOT create a
+release here, and do NOT treat a missing release as a ship failure.
 ```
-If no release but tag exists → OK (CI may create it async).
-If no release and no tag → ABORT cleanup, tag first.
 
 ```bash
 # 6c. Merged commit on main has correct version

--- a/plugins/devops/skills/devops-ship/deep-knowledge/release-flow.md
+++ b/plugins/devops/skills/devops-ship/deep-knowledge/release-flow.md
@@ -39,47 +39,40 @@ Merge the PR via the GitHub API:
 - Verify remote branch is gone: `git ls-remote --heads origin <branch>`
 - If branch persists (API hiccup), cleanup step 3 handles it as a fallback
 
-## Tag
+## Tag — alpha channel (ring model)
 
-After merge, create version tag on main:
+After merge, `ship_release` creates the ANNOTATED alpha tag on main:
 
 ```bash
-git checkout main
-git pull origin main
-git tag v<X.Y.Z>
-git push origin v<X.Y.Z>
+git tag -a alpha/v<X.Y.Z> origin/main -m '{"channel":"alpha","version":"<X.Y.Z>"}'
+git push origin alpha/v<X.Y.Z>
 ```
 
 - Tag on the **squash-merge commit on main** — not on the feature branch
-- Format: `vX.Y.Z`
+- Format: `alpha/vX.Y.Z` — every ship publishes to the earliest channel;
+  `beta/vX.Y.Z`, `stable/vX.Y.Z` and the bare `vX.Y.Z` alias are created by
+  `/devops-release` (promotion, same SHA)
+- Annotated, never lightweight — promotion time/actor must be derivable from
+  the tag object (all channel tags share one commit)
 - Skip if version bump was "none"
-- Verify tag exists: `git ls-remote --tags origin | grep "v<X.Y.Z>"`
+- Verify tag exists: `git ls-remote --tags origin | grep "alpha/v<X.Y.Z>"`
+- Published tags are immutable — never move or delete them
 
-## GitHub Release (MANDATORY for every tag)
+## GitHub Release — at PROMOTION, not at ship
 
-After tag push, create a GitHub Release. Format per `templates/github-release.md`.
+Ship creates NO GitHub Release (alpha ships on every merge — a Release per
+alpha is noise). Releases are owned by the promotion flow:
 
-```bash
-# Generate commit list since last tag for release notes
-PREV_TAG=$(git describe --tags --abbrev=0 HEAD~1 2>/dev/null || echo "")
-if [ -n "$PREV_TAG" ]; then
-  COMMITS=$(git log ${PREV_TAG}..HEAD --oneline)
-else
-  COMMITS=$(git log --oneline -20)
-fi
-```
+- **beta**: tags-only at launch (no Release; deferred until an external beta
+  audience exists — spec §11)
+- **stable**: the bare `v<X.Y.Z>` tag push triggers `.github/workflows/release.yml`
+  (notes from CHANGELOG); `ship_promote` polls for the Release and creates it
+  via `gh` as an idempotent fallback. Range computation must exclude channel
+  tags: `git describe --tags --match 'v[0-9]*' --abbrev=0 HEAD~1`.
 
-Create a GitHub Release via the API with the following content:
-
-- **Title**: `v<X.Y.Z>`
-- **Tag**: `v<X.Y.Z>` (must already exist)
-- **Body**: Mirror the CHANGELOG entry for this version (What's New sections: Added/Changed/Fixed + Contributors)
-- **Scope**: Only changes since previous release tag — not cumulative
-- **Content**: Mirror CHANGELOG entry for this version (same sections/bullets)
-- **Assets**: Attach build artifacts if CI produces them
-- **Pre-release**: Mark as pre-release for `0.x` versions
-- **Verification**: Confirm release exists via GitHub API — must show correct version + notes
-- If CI auto-creates releases from tag push, verify the release exists instead of creating one
+Format per `templates/github-release.md`: title/tag `v<X.Y.Z>`, body mirrors
+the CHANGELOG entry (Added/Changed/Fixed + Contributors), scope = changes
+since the previous STABLE release only, verification via GitHub API.
 
 ## CI tag filter
 

--- a/plugins/devops/skills/devops-ship/deep-knowledge/versioning.md
+++ b/plugins/devops/skills/devops-ship/deep-knowledge/versioning.md
@@ -91,24 +91,31 @@ head -5 CHANGELOG.md
 
 All must show the new version. If not → amend the commit.
 
-## Git tag (MANDATORY for all version bumps)
+## Git tag (MANDATORY for all version bumps) — alpha channel
 
-After PR merge to main:
+Every ship publishes to the EARLIEST channel (ring model). After PR merge to
+main, `ship_release` creates the ANNOTATED channel tag automatically:
 
 ```bash
-git tag v<X.Y.Z>
-git push origin v<X.Y.Z>
+git tag -a alpha/v<X.Y.Z> origin/main -m '{"channel":"alpha","version":"<X.Y.Z>"}'
+git push origin alpha/v<X.Y.Z>
 ```
 
 **Verify tag exists on remote:**
 ```bash
-git ls-remote --tags origin | grep "v<X.Y.Z>"
+git ls-remote --tags origin | grep "alpha/v<X.Y.Z>"
 ```
 
 If tag is missing → create it. This is the most commonly forgotten step.
 The `pre-flight.md` Post-Ship Verification catches this automatically.
 
 Skip tag only if bump type is "none" (internal-only change).
+
+**beta/stable tags and the bare `v<X.Y.Z>` alias are NEVER created at ship
+time** — they are produced by `/devops-release` (`ship_promote`) when a
+version is deliberately promoted. GitHub Releases equally live at promotion
+time (stable). Published tags are immutable — never move or delete them;
+rollback = roll forward via a new version.
 
 ## Build-ID
 

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.112.0",
+  "version": "0.113.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

Introduces the tag-based release channel system (ring model) designed in `docs/superpowers/specs/2026-07-11-tag-channel-system-design.md`:

- **Ship stays autonomous:** `ship_release` now creates the annotated channel tag `alpha/vX.Y.Z` on every final ship to main and defers GitHub Releases to promotion time.
- **New `ship_promote` MCP tool + `/devops-release` skill:** deliberate promotion alpha→beta→stable by re-tagging the SAME commit SHA (bit-identical, no rebuild, no version bump). Monotonicity/ancestry/immutability guards, idempotent partial-failure recovery, stable promotion creates the bare `vX.Y.Z` alias + GitHub Release (poll + fallback).
- **Channel-aware consumer updates:** `ss.plugin.update` pins the marketplace clone to the highest version visible to the per-marketplace channel pin (`~/.claude/plugins/.channels.json`, default stable) via detached tag checkout; bootstrap fallback keeps legacy pull behavior until the first `stable/*` tag exists (oscillation-free migration).
- **Promotion-gap nudge** on the ship completion card + channel drift line in `/devops-plugin-update`.
- **release.yml fixes:** fetch-depth 0 + fetch-tags (describe was silently broken), `--match 'v[0-9]*'` previous-tag filter.

Design hardened by redteam review (10 findings resolved) and PO review (scope trimmed); see spec §11/§12.

## Test plan

- 25 new vitest tests (channel resolvers ESM+CJS, promote guards/idempotency, alpha tagging) — 708 total green
- eslint clean
- Rollout: channel system activates with the first stable promotion via `/devops-release`; until then consumers behave exactly as today (bootstrap fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)