### PR TITLE
feat(concept): persistent ship channel + stable bridge connection

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.113.0"
+    "version": "0.114.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.113.0",
+      "version": "0.114.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.113.0",
+      "version": "0.114.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.114.0] — 2026-07-12
+
+### Fixed
+
+- **The concept bridge no longer loses its connection during implementation — keepalive and pickup are now separate tasks.** The green "Claude verbunden" indicator gates on `claude_ts`, which only a Claude-side `POST /heartbeat` advances (the server self-pulse touches `server_ts`, which deliberately does not count). The single background watcher both pulsed the heartbeat AND `exit 0`-ed to wake Claude the instant a submission landed — so during an `implement` (many minutes of a busy REPL, where the idle-only cron can't fire) nothing pulsed `/heartbeat` and the page flipped to "nicht verbunden" precisely while the user waited for progress. The watcher is now split into a **keepalive pulser** (pulses every ~20 s, never exits on pending, runs the whole session) and a **pickup waker** (watches `/pending`, exits to wake Claude, re-launched per round), so `claude_ts` stays warm across a long implement. A stale, misleading monitoring doc that claimed the server self-pulse keeps the indicator green was corrected. (`bridge-server.md`, `monitoring.md`, `devops-concept` SKILL Step 3.)
+- **The bridge server refuses to double-bind its port — the "connection flickers for no reason" symptom is gone.** On Windows the default `SO_REUSEADDR` let a second `concept-server.py` instance bind the SAME port and hijack a share of the connections; `curl` then hit the healthy instance on one request (200) and the wedged one on the next (HTTP 000), so the indicator flickered between connected and disconnected. The server now binds exclusively (`SO_EXCLUSIVEADDRUSE` on Windows, `allow_reuse_address=False`) and a duplicate launch fails loudly (`cannot bind port … exit 1`) instead of silently double-binding. (`concept-server.py` new `ConceptBridgeServer`, regression test.)
+
+### Added
+
+- **Concept final report leads with a persistent status channel + a 🚀 ship CTA — implementation completion is now visible and actionable.** Previously the final-report panel showed only a disposition fieldset and an optional "Issues erstellen" button: no progress recap, no way to ship, and any completion signal rode on the fragile live connection. The panel now opens with an always-visible status channel (Übermittelt → verarbeitet → implementiert → Bereit) topped by a prominent "🚀 Shippen" button and a non-committal "Iterationen ansehen" nudge. It is DOM-driven (present because the section carries `data-final-report`), so it survives reloads and a stale heartbeat — there is nothing to dismiss and re-open, the ship affordance simply stays put. A new `action: "ship"` branch runs the full ship pipeline from the panel (the explicit button is the authorisation, like "Mit Feedback implementieren"; hard ship-gate failures still stop and report, and a force-push to main still needs confirmation). Validation-gate patterns 36–38 (`status-channel`, `ship-btn`, `submitShip`) keep the scaffold present. (`devops-concept` templates/SKILL/validation-gate, `concept-server` exclusive bind; regression test, 709 total.)
+
 ## [0.113.0] — 2026-07-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.113.0**
+**Version: 0.114.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.113.0",
+  "version": "0.114.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/scripts/concept-server.py
+++ b/plugins/devops/scripts/concept-server.py
@@ -51,6 +51,13 @@ The watchdog runs every 30 s. Both branches call `os._exit(0)` so the
 listening socket is released immediately — no graceful drain — because
 the only client at that point is a cron that should also be dying.
 
+The listening socket requests **exclusive** port ownership (see
+`ConceptBridgeServer`): a duplicate launch on the same port fails loudly at
+bind time instead of silently double-binding. On Windows the default
+`SO_REUSEADDR` would otherwise let a second instance hijack a share of the
+connections, which surfaces as a connection indicator that flickers between
+connected and disconnected for no apparent reason.
+
 This bypasses Chrome MCP JS injection limitations entirely. The page
 communicates with Claude through HTTP endpoints instead of requiring
 JavaScript eval injection into the browser tab.
@@ -76,6 +83,7 @@ import argparse
 import http.server
 import json
 import os
+import socket
 import sys
 import time
 import threading
@@ -467,6 +475,43 @@ def _watchdog(html_path, heartbeat_timeout_ms, interval_s=30, html_grace_s=10):
             os._exit(0)
 
 
+class ConceptBridgeServer(http.server.ThreadingHTTPServer):
+    """Threaded HTTP server that refuses to share its port.
+
+    On Windows, the socketserver default `allow_reuse_address = True` maps to
+    `SO_REUSEADDR`, which lets a SECOND process bind the SAME port and
+    silently hijack a share of the incoming connections. `curl` then hits the
+    healthy instance on one request (200) and the wedged one on the next
+    (HTTP 000 / timeout) — the "connection indicator flickers for no apparent
+    reason" bug. We defend against it two ways:
+
+    - `allow_reuse_address = False` on Windows so WE never advertise the
+      hijackable `SO_REUSEADDR` flag.
+    - `SO_EXCLUSIVEADDRUSE` on the listening socket so no OTHER process can
+      bind the port while we hold it. A duplicate launch now fails loudly at
+      bind time instead of silently double-binding.
+
+    On POSIX, `allow_reuse_address` stays `True` — there `SO_REUSEADDR` only
+    permits rebinding a socket stuck in `TIME_WAIT` after a quick restart,
+    which is the behaviour we want and does NOT enable hijacking.
+    """
+
+    allow_reuse_address = (os.name != 'nt')
+    daemon_threads = True
+
+    def server_bind(self):
+        if os.name == 'nt':
+            try:
+                self.socket.setsockopt(
+                    socket.SOL_SOCKET, socket.SO_EXCLUSIVEADDRUSE, 1
+                )
+            except (AttributeError, OSError):
+                # Option unavailable on this build — fall through; the
+                # documented pre-launch port sweep is the backstop.
+                pass
+        super().server_bind()
+
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(add_help=False)
     parser.add_argument('port', nargs='?', default='8700')
@@ -504,7 +549,21 @@ if __name__ == '__main__':
         daemon=True,
     ).start()
 
-    with http.server.ThreadingHTTPServer(('', port), ConceptBridgeHandler) as httpd:
+    try:
+        httpd = ConceptBridgeServer(('', port), ConceptBridgeHandler)
+    except OSError as exc:
+        # Exclusive bind (Windows) or TIME_WAIT (POSIX) — either way the port
+        # is already taken. Fail loudly so the launcher's single-listener
+        # assertion / 200-gate catches it, instead of silently double-binding
+        # and producing the flickering-connection symptom.
+        sys.stderr.write(
+            f"[concept-server] cannot bind port {port}: {exc}\n"
+            f"[concept-server] another instance already owns it — sweep the "
+            f"port first (see bridge-server.md § port sweep), then relaunch.\n"
+        )
+        sys.exit(1)
+
+    with httpd:
         print(f"Concept bridge server on http://localhost:{port}/")
         print(f"Serving: {os.getcwd()}")
         if html_path:

--- a/plugins/devops/scripts/concept-server.test.js
+++ b/plugins/devops/scripts/concept-server.test.js
@@ -51,6 +51,46 @@ function stopServer(proc) {
   });
 }
 
+describe.skipIf(!PY)("concept-server refuses to double-bind its port (A3)", () => {
+  // Regression for the "connection flickers for no reason" bug: on Windows the
+  // default SO_REUSEADDR let a SECOND process bind the SAME port and hijack a
+  // share of the connections. The server now binds exclusively, so a duplicate
+  // launch must FAIL loudly (non-zero exit) instead of silently double-binding.
+  test("a second instance on the same port exits non-zero instead of sharing it", async () => {
+    const BIND_PORT = PORT + 1;
+    const proc1 = spawn(PY, [SERVER, String(BIND_PORT)], { stdio: ["ignore", "pipe", "pipe"] });
+    try {
+      // Wait until instance 1 actually owns the port.
+      const deadline = Date.now() + 10000;
+      let up = false;
+      while (Date.now() < deadline) {
+        try {
+          const r = await fetch(`http://127.0.0.1:${BIND_PORT}/reload`);
+          if (r.ok) { up = true; break; }
+        } catch { /* not up yet */ }
+        await new Promise(r => setTimeout(r, 150));
+      }
+      expect(up).toBe(true);
+
+      // Instance 2 must fail to bind rather than silently double-bind.
+      const proc2 = spawn(PY, [SERVER, String(BIND_PORT)], { stdio: ["ignore", "pipe", "pipe"] });
+      let stderr = "";
+      proc2.stderr.on("data", d => { stderr += d.toString(); });
+      const exitCode = await new Promise((resolve, reject) => {
+        const t = setTimeout(() => {
+          try { proc2.kill("SIGKILL"); } catch { /* gone */ }
+          reject(new Error("second instance did not exit — it may have silently double-bound"));
+        }, 8000);
+        proc2.once("exit", code => { clearTimeout(t); resolve(code); });
+      });
+      expect(exitCode).not.toBe(0);
+      expect(stderr).toMatch(/cannot bind port/i);
+    } finally {
+      await stopServer(proc1);
+    }
+  }, 30000);
+});
+
 describe.skipIf(!PY)("concept-server reload counter across restarts (#225)", () => {
   test("counter after restart is higher than any counter from the previous run", async () => {
     // Run 1: boot, bump the counter once (Claude wrote an iteration).

--- a/plugins/devops/skills/devops-concept/SKILL.md
+++ b/plugins/devops/skills/devops-concept/SKILL.md
@@ -378,10 +378,11 @@ and `deep-knowledge/templates.md` § Iteration Tabs for the reference HTML.
 
 ### Post-Generation Validation (mandatory gate)
 
-After writing the HTML file, grep it for the 35 mandatory interactive
+After writing the HTML file, grep it for the 38 mandatory interactive
 patterns (heartbeat, panel states, iteration tabs, section TOC, reload
 polling, generic form-collection catch-all scoped to the active
-iteration, post-submit content dimmer, etc.).
+iteration, post-submit content dimmer, persistent status channel + ship
+CTA, etc.).
 **If ANY pattern is missing → DO NOT open the page.** Fix the HTML first,
 then re-validate. See `deep-knowledge/validation-gate.md` for the full
 pattern list and common failure modes.
@@ -690,13 +691,48 @@ interruption is a hard `gh` failure that needs the user's eyes.
 4. Proceed to Step 6 — Completion Card. The disposition recorded here
    drives the cleanup branch in Step 6a.
 
+**`action: "ship"` ("🚀 Shippen" button — only on final report):**
+
+**Zero-prompt invariant.** The user committed by clicking Shippen — an
+explicit authorisation for a real, outward-facing release, exactly like the
+"Mit Feedback implementieren" button authorises real code changes. Do NOT ask
+a follow-up question; the payload plus the final-report context are
+sufficient. The ONLY justified interruption is a hard ship-pipeline failure
+that needs the user's eyes (merge conflict, failing build/preflight gate) —
+surface that verbatim and stop.
+
+1. Read the `disposition` sub-object from the payload (same shape as
+   dispose-concept) and store it for Step 6a. Do NOT apply cleanup yet.
+2. Run the full ship pipeline via the `devops-ship` skill (ship_preflight →
+   ship_build → ship_version_bump → ship_release → ship_cleanup). The button
+   click authorises the ship; it does NOT waive the gates `devops-ship`
+   already enforces. If a gate blocks, report the blocker to the user and
+   STOP — never fake a completion or force past a failing gate. (A force-push
+   to main/master still requires explicit user confirmation per the user's
+   own rules — the Shippen click does not stand in for that.)
+3. On a successful release, rewrite the live final-report section in place:
+   - Reveal the `[data-ship-state="done"]` hint and set the channel to the
+     shipped state, including the version (e.g. "Geshippt · v0.113.0").
+   - Add a one-line "Shipped" note (version + tag) to the Zusammenfassung.
+   Then POST `/reload`, and only AFTER that POST `/reset` with the captured
+   `_version` (reload-before-reset, same order as every other branch).
+4. Run Step 6a cleanup only (bridge shutdown + disposition from step 1). Do
+   **NOT** render a second concept completion card — `devops-ship` already
+   rendered its own ship card, which is the authoritative closing artefact
+   (rendering another here would be a duplicate summary). If the ship was
+   blocked at a gate in step 2, skip cleanup, leave the concept session open
+   so the user can retry, and report the blocker instead.
+
 **Critical invariant:** a submit with `action: "iterate"` MUST NEVER cause
 code or file changes outside of the concept HTML file itself. The user
 relies on that guarantee to explore ideas safely. `action: "create-issues"`
 only writes GitHub issues + the final-report HTML — no code/file changes
 in the project tree. `action: "dispose-concept"` only triggers Step 6
 cleanup — no code/file changes either, just disposition of the concept's
-own HTML / decisions JSON artefacts.
+own HTML / decisions JSON artefacts. `action: "ship"` is the one action that
+DOES reach outward — it runs the real release pipeline — and that is exactly
+why it is gated behind its own explicit final-report button, never behind
+iterate/implement.
 ### 5c. Update the Page
 After processing, **append a new tab** to the same HTML file and signal
 the browser to reload. This is the ONLY update path — there is no
@@ -794,15 +830,17 @@ preservation) stays identical.
 
 **Verbatim copy directive (mandatory):**
 The final-report JS block — `updateCreateIssuesPanel`, `submitCreateIssues`,
-`collectDisposition`, `submitDisposeConcept`, plus the `change` listener on
+`collectDisposition`, `submitShip`, `submitDisposeConcept`, plus the
+`ship-btn` / `view-iterations-btn` wiring, the `change` listener on
 `section[data-open-questions] input[type="checkbox"]` and the
 `DOMContentLoaded` wiring — MUST be copied verbatim from
-`deep-knowledge/templates.md` § Final-report append (the block starting at
-the comment `// --- Final-report "Issues erstellen" action ---`). Do NOT
-inline a simplified `updateCreateIssuesPanel` or omit the event-listener
-wiring; either omission is the regression that issue #165 reports.
+`deep-knowledge/templates.md` (the block starting at the comment
+`// --- Final-report "Issues erstellen" action ---` through the
+`// --- Final-report "Shippen" action ---` block). Do NOT
+inline a simplified `updateCreateIssuesPanel`, drop `submitShip`, or omit the
+event-listener wiring; any omission leaves a visible-but-inert button.
 After writing, the post-generation validation gate
-(`deep-knowledge/validation-gate.md` Phase 1) MUST find patterns 28–35
+(`deep-knowledge/validation-gate.md` Phase 1) MUST find patterns 28–38
 in the generated file.
 
 **Open questions / TODOs section — when to include:**
@@ -829,6 +867,9 @@ Return to Step 4 (monitor for next submission). The loop continues until:
 
 If the active section is the final report, the submissions Claude expects
 are:
+- `action: "ship"` — fired by the persistent status channel's primary
+  "🚀 Shippen" button. Runs the real release pipeline (Step 5b · ship).
+  Carries the current disposition for Step 6a cleanup.
 - `action: "create-issues"` — fired by the "Issues erstellen" button when
   open questions / TODOs are present and at least one is selected.
 - `action: "dispose-concept"` — fired by the always-visible "Concept

--- a/plugins/devops/skills/devops-concept/deep-knowledge/bridge-server.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/bridge-server.md
@@ -54,13 +54,20 @@ AND provides HTTP endpoints for heartbeat and decision exchange.
 
    **Sweep the port BEFORE launching — exactly one instance must own it.**
    A prior instance that did not fully die (its listening socket lingers in
-   TIME_WAIT/CLOSE_WAIT) plus a fresh launch leaves **two** servers bound to
-   the same port (Windows permits this via `SO_REUSEADDR`). `curl` then hits
-   whichever accepts the connection — sometimes the healthy one (200),
-   sometimes the wedged one (HTTP 000 / timeout). The symptom is a connection
-   indicator that flickers between connected and "Claude nicht verbunden" for
-   no apparent reason, plus a watcher (step 3) that trips on the wedged
-   replies. Kill every listener on the port first, then start exactly one:
+   TIME_WAIT/CLOSE_WAIT) plus a fresh launch used to leave **two** servers
+   bound to the same port (Windows permitted this via `SO_REUSEADDR`). `curl`
+   then hit whichever accepted the connection — sometimes the healthy one
+   (200), sometimes the wedged one (HTTP 000 / timeout) — surfacing as a
+   connection indicator that flickers between connected and "Claude nicht
+   verbunden" for no apparent reason.
+
+   **The server now binds the port EXCLUSIVELY** (`SO_EXCLUSIVEADDRUSE` on
+   Windows, `allow_reuse_address=False`; see `concept-server.py` §
+   `ConceptBridgeServer`), so a silent double-bind can no longer happen — a
+   duplicate launch instead **fails loudly** (`cannot bind port … exit 1`).
+   That turns the old silent flicker into a clear error, but you still MUST
+   sweep first: a lingering prior instance would make the fresh launch fail.
+   Kill every listener on the port first, then start exactly one:
    ```bash
    # PowerShell tool
    Get-NetTCPConnection -LocalPort {port} -State Listen -EA SilentlyContinue |
@@ -138,7 +145,7 @@ AND provides HTTP endpoints for heartbeat and decision exchange.
          Bash: curl -s http://localhost:{port}/decisions
          • Parse the JSON. Note `_version`. Strip `_version` and `_processed_at`
            before treating the rest as decision data. Read `action` — it is
-           one of FOUR values, each with its own SKILL.md Step 5b branch:
+           one of FIVE values, each with its own SKILL.md Step 5b branch:
              - "iterate"        → next iteration on the concept page only
              - "implement"      → apply real code changes + final-report
              - "create-issues"  → apply the user-value gate (SKILL.md Step 5b,
@@ -146,21 +153,27 @@ AND provides HTTP endpoints for heartbeat and decision exchange.
                                   autonomously run `gh issue create` for each
                                   gated item; NO AskUserQuestion, the user
                                   already committed by clicking the button
+             - "ship"           → run the full ship pipeline (/devops-ship),
+                                  mark the final report shipped, advance to
+                                  Step 6; NO AskUserQuestion, the button click
+                                  authorised the release. Stop + report on a
+                                  hard gate failure — never force past a gate
              - "dispose-concept"→ record disposition, advance to Step 6
            Process per Step 5 (Live Feedback Loop) — act on the user's choices
            (approve/tweak/reject, included options, comment-driven tweaks).
            Step 5c writes the new iteration to the HTML file and POSTs
            `/reload` BEFORE the reset below. Reset is the LAST action.
 
-         • **Zero-prompt invariant for create-issues + dispose-concept.**
-           These two branches MUST complete end-to-end without asking the
-           user anything. The payload (items[] for create-issues,
-           disposition{} for dispose-concept) is self-sufficient by design;
-           any missing optional field falls back to a sane default. If you
-           catch yourself reaching for AskUserQuestion in either branch,
-           stop — the answer is in the payload, the concept HTML, or the
-           project's new-issue extension. The user signed off by clicking
-           the button.
+         • **Zero-prompt invariant for create-issues + ship + dispose-concept.**
+           These branches MUST complete end-to-end without asking the user
+           anything. The payload (items[] for create-issues, disposition{} for
+           ship + dispose-concept) is self-sufficient by design; any missing
+           optional field falls back to a sane default. If you catch yourself
+           reaching for AskUserQuestion in any of them, stop — the answer is in
+           the payload, the concept HTML, or the project's new-issue extension.
+           The user signed off by clicking the button. (Exception: `ship` MUST
+           still stop and surface a hard ship-pipeline gate failure, and a
+           force-push to main/master still needs explicit confirmation.)
 
          • After the file rewrite AND the `/reload` POST have completed,
            reset conditionally — pass the noted version:
@@ -197,46 +210,80 @@ AND provides HTTP endpoints for heartbeat and decision exchange.
    the contract explicit: every tick does both. Minimum cron resolution is 1 min,
    so the max submit-to-process lag is ~60 s — acceptable for interactive flows.
 
-   **The cron alone does NOT keep the indicator green — add a background
-   watcher.** The page flips to "Claude nicht verbunden" as soon as Claude's
-   last `/heartbeat` POST is older than `HEARTBEAT_STALE_MS` (90 s). The
-   once-a-minute cron is the documented keepalive, but session-only crons
+   **The cron alone does NOT keep the indicator green — add TWO decoupled
+   background tasks.** The page flips to "Claude nicht verbunden" as soon as
+   Claude's last `/heartbeat` POST is older than `HEARTBEAT_STALE_MS` (90 s).
+   The once-a-minute cron is the documented keepalive, but session-only crons
    fire ONLY while the REPL is idle and have multi-minute gaps in practice
    (observed: a 638 s gap with the cron registered and the session idle) — so
-   during normal reading/thinking the indicator goes red, and because the SAME
-   cron is the only pickup path, submissions are also picked up late.
+   during normal reading/thinking the indicator goes red.
 
-   Alongside the cron, launch a **detached background watcher** (Bash tool,
-   `run_in_background: true`) that both keeps the heartbeat warm AND wakes
-   Claude the instant a submission lands — its `exit 0` re-invokes the model
-   immediately, instead of waiting up to 60 s for the next cron tick:
+   **Keepalive and pickup MUST be separate tasks.** The naive single watcher
+   (pulse + `exit 0` on pending) has a load-bearing flaw: `exit 0` is how it
+   wakes Claude, so the instant a submission lands the watcher is *gone* — and
+   for an `implement` submission Claude then processes for many minutes with
+   NOTHING pulsing `/heartbeat` (the idle-only cron can't fire during a busy
+   `implement` turn). The indicator goes red *precisely during implementation*
+   — exactly when the user is watching for progress. Splitting the two roles
+   removes that coupling.
+
+   Launch both as **detached background tasks** (Bash tool,
+   `run_in_background: true`, no trailing `&`, no `nohup`):
+
+   **(1) Keepalive pulser — pulses only, NEVER exits on pending.** Launched
+   once at concept open; runs for the whole session so `claude_ts` stays warm
+   even across a long `implement`. Exits only when the concept is truly gone:
    ```bash
    fails=0
    while true; do
-     [ -f .claude/concept-active.json ] || { echo "WATCHER_EXIT reason=STATE_GONE"; exit 0; }
-     grep -q '"port": {port}' .claude/concept-active.json 2>/dev/null || { echo "WATCHER_EXIT reason=PORT_CHANGED"; exit 0; }
+     [ -f .claude/concept-active.json ] || { echo "PULSER_EXIT reason=STATE_GONE"; exit 0; }
+     grep -q '"port": {port}' .claude/concept-active.json 2>/dev/null || { echo "PULSER_EXIT reason=PORT_CHANGED"; exit 0; }
      if curl -s -X POST --max-time 8 http://localhost:{port}/heartbeat >/dev/null 2>&1; then
        fails=0
-       p=$(curl -s --max-time 8 http://localhost:{port}/pending | python -c "import sys,json;print('yes' if json.load(sys.stdin).get('pending') else 'no')" 2>/dev/null)
-       [ "$p" = "yes" ] && { echo "WATCHER_EXIT reason=PENDING_SUBMISSION"; exit 0; }
      else
        fails=$((fails+1))
-       [ "$fails" -ge 4 ] && { echo "WATCHER_EXIT reason=SERVER_DEAD"; exit 0; }
+       [ "$fails" -ge 4 ] && { echo "PULSER_EXIT reason=SERVER_DEAD"; exit 0; }
      fi
      sleep 20
    done
    ```
-   Pulse every ~20 s (well under the 90 s threshold). **Tolerate transient
-   blips:** declare `SERVER_DEAD` only after ≥4 consecutive failed POSTs — a
-   single failed `curl` (server busy, a competing request, a duplicate-instance
-   wedge per step 2) must NOT tear the watcher down, or the page goes stale
-   again on every hiccup. The loop self-terminates when the state file is gone,
-   its port changed, or the server is truly unreachable, so it cannot become a
-   ghost (the `--html` watchdog still backs it up). On `PENDING_SUBMISSION`
-   Claude processes the payload, then **re-launches the watcher** for the next
-   round. Keep the cron too: it is the backup pickup path during the brief
-   window when the watcher has exited for processing and not yet been
-   re-launched.
+
+   **(2) Pickup waker — wakes Claude the instant a submission lands.** Its
+   `exit 0` re-invokes the model immediately instead of waiting up to 60 s for
+   the next cron tick. Re-launched after each processing round. It does NOT
+   pulse the heartbeat (that is the pulser's job) — it only watches `/pending`:
+   ```bash
+   fails=0
+   while true; do
+     [ -f .claude/concept-active.json ] || { echo "WAKER_EXIT reason=STATE_GONE"; exit 0; }
+     grep -q '"port": {port}' .claude/concept-active.json 2>/dev/null || { echo "WAKER_EXIT reason=PORT_CHANGED"; exit 0; }
+     if p=$(curl -s --max-time 8 http://localhost:{port}/pending | python -c "import sys,json;print('yes' if json.load(sys.stdin).get('pending') else 'no')" 2>/dev/null); then
+       fails=0
+       [ "$p" = "yes" ] && { echo "WAKER_EXIT reason=PENDING_SUBMISSION"; exit 0; }
+     else
+       fails=$((fails+1))
+       [ "$fails" -ge 4 ] && { echo "WAKER_EXIT reason=SERVER_DEAD"; exit 0; }
+     fi
+     sleep 20
+   done
+   ```
+
+   Both pulse/poll every ~20 s (well under the 90 s threshold). **Tolerate
+   transient blips:** declare `SERVER_DEAD` only after ≥4 consecutive failures
+   — a single failed `curl` (server busy, a competing request, a
+   duplicate-instance wedge per step 2) must NOT tear a task down, or the page
+   goes stale again on every hiccup. Both self-terminate when the state file
+   is gone, its port changed, or the server is truly unreachable, so neither
+   can become a ghost (the `--html` watchdog still backs them up).
+
+   **Lifecycle:** launch BOTH at concept open. On `PENDING_SUBMISSION` the
+   waker exits and wakes Claude; Claude processes the payload, then
+   **re-launches only the waker** for the next round — the pulser is still
+   running and must not be duplicated (a second pulser on the same port is
+   harmless but wasteful; if unsure, the pulser's `STATE_GONE`/`PORT_CHANGED`
+   guards make a stale one exit on its own). Keep the cron too: it is the
+   backup pickup path during the brief window between the waker exiting and
+   being re-launched.
 
 4. **Persist active-concept state.** Write `.claude/concept-active.json` in
    the project root with the metadata the SessionStart resume hook

--- a/plugins/devops/skills/devops-concept/deep-knowledge/monitoring.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/monitoring.md
@@ -124,10 +124,20 @@ curl -s -X POST http://localhost:$PORT/heartbeat
 ```
 Sent by the cron job every ~60s, and additionally on each manual poll cycle.
 
-The bridge server also self-pulses `_heartbeat_ts` every 30s from a daemon
-thread — so the indicator stays green even while Claude's REPL is busy and
-session-scoped crons can't fire. The Claude-side POSTs above are redundant
-with that self-pulse (kept as a fallback in case the thread stalls).
+The bridge server self-pulses `_server_ts` (NOT the heartbeat) every 30s
+from a daemon thread. That proves the *server process* is alive — it does
+**not** keep the indicator green, because the connection indicator gates
+exclusively on `claude_ts`, which ONLY a Claude-side `POST /heartbeat`
+advances. This split is deliberate: a server-only pulse used to render as
+"Claude verbunden" and hid the case where Claude's polling cron had died.
+
+Consequently the green indicator requires something Claude-side to POST
+`/heartbeat` at least every `HEARTBEAT_STALE_MS` (90s). The cron alone is
+NOT enough (idle-only, multi-minute gaps), so the **keepalive pulser**
+background task (see `bridge-server.md` § step 3, task 1) is the primary
+keepalive — it pulses every ~20s for the whole session and, crucially, does
+NOT exit when a submission is pending, so `claude_ts` stays warm even during
+a long `implement`.
 
 **Check submission** (poll for user decisions):
 ```bash

--- a/plugins/devops/skills/devops-concept/deep-knowledge/templates.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/templates.md
@@ -58,6 +58,7 @@ must see their own language. The locale hint is authoritative.
 | `panel.step_implemented`       | Implementation complete        | Implementierung abgeschlossen |
 | `panel.step_implemented_active`| Implementation in progress     | Implementierung läuft |
 | `panel.step_waiting`           | Waiting…                       | Warten… |
+| `panel.step_ready`             | Ready to ship                  | Bereit zum Shippen |
 | `panel.disconnected_title`     | Claude is not connected        | Claude ist nicht verbunden |
 | `panel.disconnected_hint`      | You can still submit — your click is queued and delivered as soon as Claude is back. | Du kannst trotzdem absenden — der Klick wird gespeichert und gesendet, sobald Claude wieder da ist. |
 | `panel.connecting_title`       | Claude is connecting           | Claude verbindet sich |
@@ -101,6 +102,12 @@ must see their own language. The locale hint is authoritative.
 | `final.dispose_btn_hint`       | Closes the concept session and applies the file disposition above. | Schliesst die Concept-Session und wendet die Datei-Disposition oben an. |
 | `final.dispose_running`        | Cleaning up …                  | Räume auf … |
 | `final.dispose_done`           | Concept ended.                 | Concept beendet. |
+| `final.ship_heading`           | Ready to ship                  | Bereit zum Shippen |
+| `final.ship_btn`               | Ship it                        | Shippen |
+| `final.ship_hint`              | Runs the full ship pipeline (build, version bump, release, merge). | Startet die komplette Ship-Pipeline (Build, Version-Bump, Release, Merge). |
+| `final.ship_running`           | Shipping …                     | Wird geshippt … |
+| `final.ship_done`              | Shipped                        | Geshippt |
+| `final.view_iterations`        | Review iterations              | Iterationen ansehen |
 | `proto.feedback_title`         | Feedback                       | Feedback |
 | `proto.feedback_toggle`        | Open feedback                  | Feedback öffnen |
 | `proto.feedback_general`       | General notes on this prototype | Allgemeine Anmerkungen zum Prototyp |
@@ -271,6 +278,46 @@ the `[ui-locale: ...]` hint produced.
            [data-open-questions] content) and the always-visible
            disposition fieldset that drives Step 6 cleanup. -->
       <div id="panel-final-report" style="display: none;">
+        <!-- Persistent status channel. Renders the concept's whole pipeline
+             at a glance and culminates in the ship CTA. It is DOM-driven —
+             present because the active section carries data-final-report — so
+             it survives page reloads AND stays fully visible even when the
+             Claude heartbeat is stale (the ship affordance never depends on a
+             live connection, which is the whole point of the persistent
+             channel over a transient completion overlay). -->
+        <div class="status-channel" id="status-channel">
+          <div class="status-channel__heading">{{final.ship_heading}}</div>
+          <ol class="status-steps" aria-live="polite">
+            <li data-step="submitted" data-state="done">
+              <span class="step-icon" aria-hidden="true">✓</span>
+              <span class="step-label">{{panel.step_submitted}}</span>
+            </li>
+            <li data-step="received" data-state="done">
+              <span class="step-icon" aria-hidden="true">✓</span>
+              <span class="step-label">{{panel.step_received}}</span>
+            </li>
+            <li data-step="implemented" data-state="done">
+              <span class="step-icon" aria-hidden="true">✓</span>
+              <span class="step-label">{{panel.step_implemented}}</span>
+            </li>
+            <li data-step="ready" data-state="active">
+              <span class="step-icon" aria-hidden="true">●</span>
+              <span class="step-label">{{panel.step_ready}}</span>
+            </li>
+          </ol>
+          <button id="ship-btn" class="primary submit-btn ship-btn">
+            <span aria-hidden="true">🚀</span> {{final.ship_btn}}
+          </button>
+          <p class="hint">{{final.ship_hint}}</p>
+          <p class="hint hint-running" data-ship-state="running" hidden>
+            <span aria-hidden="true">⏳</span> {{final.ship_running}}
+          </p>
+          <p class="hint hint-done" data-ship-state="done" hidden>
+            <span aria-hidden="true">✓</span> {{final.ship_done}}
+          </p>
+          <button type="button" id="view-iterations-btn" class="link-btn">{{final.view_iterations}}</button>
+        </div>
+
         <div class="final-report-indicator">
           <span class="check-icon">✓</span>
           <strong>{{final.status}}</strong>
@@ -2085,6 +2132,56 @@ body.content-dimmed .content-dimmer:not([hidden]) {
   font-size: 0.85rem;
   line-height: 1.5;
 }
+
+/* Persistent status channel — the always-visible pipeline recap that ends in
+   the ship CTA. Boxed so it reads as a distinct "status" surface. Pure DOM /
+   connection-independent by design: the ship affordance must never disappear
+   just because the heartbeat went stale. */
+.status-channel {
+  border: 1px solid var(--border-color, #30363d);
+  border-radius: 8px;
+  padding: 0.85rem 0.95rem 1rem;
+  margin-bottom: 1rem;
+  background: color-mix(in srgb, var(--success-color, #3fb950) 6%, transparent);
+}
+.status-channel__heading {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-secondary, #8b949e);
+  margin-bottom: 0.6rem;
+}
+.status-channel .status-steps { margin-bottom: 0.85rem; }
+.ship-btn {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  font-weight: 600;
+}
+#ship-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.status-channel .hint[data-ship-state="running"] { color: var(--accent-color, #58a6ff); }
+.status-channel .hint[data-ship-state="done"] { color: var(--success-color, #3fb950); }
+.link-btn {
+  display: inline-block;
+  margin-top: 0.6rem;
+  padding: 0;
+  border: none;
+  background: none;
+  color: var(--accent-color, #58a6ff);
+  font-size: 0.8rem;
+  cursor: pointer;
+  text-decoration: underline;
+}
+.link-btn:hover { opacity: 0.8; }
+/* Transient highlight when "Review iterations" nudges the tab bar into view. */
+.iteration-tabs.tabs-nudge { animation: tabs-nudge 1.2s ease; }
+@keyframes tabs-nudge {
+  0%, 100% { box-shadow: none; }
+  30% { box-shadow: 0 0 0 2px var(--accent-color, #58a6ff); }
+}
+
 #panel-create-issues #create-issues-btn:disabled {
   opacity: 0.5;
   cursor: not-allowed;
@@ -2866,6 +2963,62 @@ async function submitDisposeConcept() {
 document.getElementById('dispose-concept-btn')
   ?.addEventListener('click', submitDisposeConcept);
 
+// --- Final-report "Shippen" action ---
+// Primary CTA of the persistent status channel. Available whenever the
+// final-report section is live (implementation done). Clicking it is an
+// EXPLICIT user commit — like "Mit Feedback implementieren" it authorises a
+// real, outward-facing action — so Claude runs the full ship pipeline on
+// pickup (SKILL.md Step 5b · ship branch). Ships the current disposition too
+// so Step 6 cleanup still runs after the release lands.
+async function submitShip() {
+  const active = document.querySelector('section[data-iteration][data-active]');
+  if (!active || !active.hasAttribute('data-final-report')) return;
+
+  const btn = document.getElementById('ship-btn');
+  const wrap = document.getElementById('status-channel');
+  if (!btn || !wrap) return;
+
+  btn.disabled = true;
+  wrap.querySelectorAll('.hint[data-ship-state]').forEach(el => {
+    el.hidden = el.dataset.shipState !== 'running';
+  });
+
+  const payload = {
+    submitted: true,
+    action: 'ship',
+    disposition: collectDisposition()
+  };
+  const container = document.getElementById('concept-decisions');
+  if (container) container.textContent = JSON.stringify(payload);
+  document.body.classList.add('concept-submitted', 'content-dimmed');
+  showContentDimmer();
+
+  try {
+    await fetch('/decisions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+  } catch (e) {
+    localStorage.setItem(STORAGE_KEY + '-pending', JSON.stringify(payload));
+  }
+}
+
+document.getElementById('ship-btn')?.addEventListener('click', submitShip);
+
+// "Iterationen ansehen" — non-committal, client-only. Scrolls the iteration
+// tab bar into view and flashes it so the user can revisit earlier iterations
+// / the agenda without leaving the final report. The ship CTA stays put — the
+// whole point of the persistent channel is that there is nothing to re-open.
+document.getElementById('view-iterations-btn')?.addEventListener('click', () => {
+  const tabs = document.querySelector('.iteration-tabs');
+  if (!tabs) return;
+  tabs.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+  tabs.classList.remove('tabs-nudge');
+  void tabs.offsetWidth;  // force reflow so the animation restarts
+  tabs.classList.add('tabs-nudge');
+});
+
 // Recompute gating whenever the user toggles a checkbox inside the
 // open-questions section. The generic change listener (for saveState)
 // fires the same event, so we just hook into the same channel.
@@ -2895,7 +3048,11 @@ async function retryPendingSubmission() {
 Claude-side: on receiving the payload, branch on `action`:
 - `iterate` → Step 5b iterate branch: summarize + append next iteration only
 - `implement` → Step 5b implement branch: actually write code/files, then
-  still append a new iteration as a frozen "implementiert" record
+  append the final-report section (frozen "implementiert" record)
+- `create-issues` → Step 5b create-issues branch: user-value gate + `gh issue create`
+- `ship` → Step 5b ship branch: run the full ship pipeline (`/devops-ship`),
+  then mark the final report shipped and run Step 6 cleanup
+- `dispose-concept` → Step 5b dispose branch: record disposition, run Step 6
 
 ## Panel State Reset
 
@@ -3430,8 +3587,20 @@ The final-report section closes a concept session. It is appended via the
 implement-action branch of Step 5b (see `SKILL.md` § Final-report append).
 The right-side panel automatically switches to `panel-final-report` mode
 when `showIteration()` detects `data-final-report` on the active section
-— no iterate / implement buttons, only an optional "Issues erstellen"
-button gated on the presence of open questions / TODOs.
+— no iterate / implement buttons. Instead it leads with the **persistent
+status channel** (`#status-channel`): the full pipeline recap (Übermittelt →
+verarbeitet → implementiert → Bereit) topped by the primary **🚀 Shippen**
+CTA and a non-committal "Iterationen ansehen" link. Below that sit the
+optional "Issues erstellen" button (gated on open questions / TODOs) and the
+always-visible disposition fieldset.
+
+The status channel is deliberately **DOM-driven, not connection-driven**: it
+is present because the section carries `data-final-report`, so it survives
+reloads and stays fully visible even when the Claude heartbeat is stale. This
+is the design reason it replaces a transient completion overlay — the ship
+affordance must never vanish just because the connection flickered. Reviewing
+earlier iterations (via the ever-present tab bar or the "Iterationen ansehen"
+nudge) never hides the ship CTA, so there is nothing to "re-open".
 
 ### Final-report section HTML
 

--- a/plugins/devops/skills/devops-concept/deep-knowledge/validation-gate.md
+++ b/plugins/devops/skills/devops-concept/deep-knowledge/validation-gate.md
@@ -33,7 +33,7 @@ no legitimate matches — do not "keep it as a convenience". The decision panel
 
 ## Phase 1 — Shared patterns (ALL templates)
 
-Every concept page must contain these 35 patterns, regardless of template:
+Every concept page must contain these 38 patterns, regardless of template:
 
 | # | Pattern to grep | Purpose |
 |---|----------------|---------|
@@ -72,7 +72,10 @@ Every concept page must contain these 35 patterns, regardless of template:
 | 32 | `panel-dispose-concept` | Disposition fieldset on the final-report panel. Always visible while `panel-final-report` is active; carries the discard / keep / gitignore radio group + optional `moveTo` input. See templates.md § Disposition Control. |
 | 33 | `submitDisposeConcept` | JS handler wired to `#dispose-concept-btn`. POSTs `action: "dispose-concept"` with the current disposition payload so Step 6a can run the cleanup branch. |
 | 34 | `submitCreateIssues` | JS handler wired to `#create-issues-btn`. POSTs `action: "create-issues"` with the selected open-question items plus the current disposition payload. Dropping this leaves the button visible but inert — no console error, no network request on click. |
-| 35 | `collectDisposition` | Reads the disposition fieldset (`dispose-mode` radio + optional `dispose-move-to` input) into the `{ mode, moveTo }` shape required by both `submitCreateIssues` and `submitDisposeConcept` payloads. Without this, both buttons throw at submit time. |
+| 35 | `collectDisposition` | Reads the disposition fieldset (`dispose-mode` radio + optional `dispose-move-to` input) into the `{ mode, moveTo }` shape required by `submitCreateIssues`, `submitShip`, and `submitDisposeConcept` payloads. Without this, those buttons throw at submit time. |
+| 36 | `status-channel` | Persistent status channel on the final-report panel — the always-visible pipeline recap (Übermittelt → verarbeitet → implementiert → Bereit) that leads to the ship CTA. DOM-driven so it survives reload + stale heartbeat. See templates.md § Final Report Panel. |
+| 37 | `ship-btn` | The persistent channel's primary "🚀 Shippen" CTA. Fires `action: "ship"` (real release pipeline). |
+| 38 | `submitShip` | JS handler wired to `#ship-btn`. POSTs `action: "ship"` with the current disposition. Dropping it leaves the ship button visible but inert (no console error, no network request on click). |
 
 **Failure for 21 / 22:** if either pattern is missing, the page is rejected
 at the post-generation gate. See § Generic Form Collection below for the

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.113.0",
+  "version": "0.114.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary
Two bridge-connection bugfixes plus the persistent status channel with a ship CTA for `/devops-concept`.

## Connection (fixes)
- **Exclusive port bind** (`SO_EXCLUSIVEADDRUSE` on Windows): a duplicate `concept-server.py` no longer silently double-binds and hijacks connections — the "connection flickers for no reason" symptom. Duplicate launch now fails loudly.
- **Keepalive split from pickup**: a dedicated pulser keeps `claude_ts` warm through a long `implement`, so the page no longer flips to "nicht verbunden" during implementation. Corrected a stale monitoring doc that claimed the server self-pulse keeps the indicator green.

## Persistent status channel + ship (feature)
- Final-report panel leads with an always-visible status channel (Übermittelt → verarbeitet → implementiert → Bereit) topped by a **🚀 Shippen** CTA and an "Iterationen ansehen" nudge. DOM-driven → survives reload + stale heartbeat; nothing to dismiss/re-open.
- New `action: "ship"` runs the full ship pipeline from the panel (explicit button = authorisation; hard gate failures still stop).
- `validation-gate` patterns 36–38 (`status-channel`, `ship-btn`, `submitShip`).

709 tests green; regression test asserts a second server on the same port exits non-zero.