### PR TITLE
feat(graphify): default-on opt-out, key-less update, windowless

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.114.0"
+    "version": "0.115.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.114.0",
+      "version": "0.115.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.114.0",
+      "version": "0.115.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.115.0] — 2026-07-12
+
+### Changed
+
+- **graphify's knowledge graph is now default-on and opt-out in every devops project — it just works, needs no consent prompt, and stops popping console windows.** graphify was previously opt-in behind a per-project consent offer that in practice was almost never accepted (telemetry: hundreds of mentions, ~0 real `graphify query` runs), so the token-saving graph sat unused; meanwhile its git-hook-driven rebuild spawned a Python process on every commit and — amplified by the 10-minute git-sync cron — kept flashing a cmd window on Windows. Enforcement is now enabled unless a project **or** the machine-wide `~/.claude/graphify.json` carries `{"consent":false}` (`isEnabled`, default-on; a corrupt opt-out record now fails **closed** rather than silently re-enabling). If the `graphify` CLI is missing it installs best-effort in the background (`uv tool install graphifyy`, fail-open, one-time non-blocking disclosure — no interaction). The graph is built and kept fresh **key-lessly** via `graphify update .` (AST-only, no LLM key — the old `graphify extract . --update` demanded a key on doc-heavy repos and failed every session). devops no longer installs graphify's own git hooks: it removes them once (`graphify hook uninstall`, a one-time legacy cleanup, no more daily fight) and owns freshness itself windowlessly via SessionStart + the PreToolUse self-heal, with `windowsHide` on every spawn — killing the recurring console-window popups at the source. The global off-switch is now honored at SessionStart too, so a machine-wide opt-out truly suppresses install, hook-removal, and builds. Both consent offers (SessionStart + value-moment) are gone. (`ss.graphify` → 0.3.0, `graphify-state` → 0.3.0, `pre.tokens.guard` → 0.8.0, `graph-nudge` → 0.3.0; devops-graph skill rewritten; +8 new tests, 717 total.)
+
 ## [0.114.0] — 2026-07-12
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.114.0**
+**Version: 0.115.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.114.0",
+  "version": "0.115.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/hooks/lib/graph-nudge.js
+++ b/plugins/devops/hooks/lib/graph-nudge.js
@@ -1,7 +1,7 @@
 'use strict';
 /**
  * @lib graph-nudge
- * @version 0.2.0
+ * @version 0.3.0
  * @plugin devops
  * @description Pure helpers for the ambient graphify nudge injected by
  *   pre.tokens.guard on the first broad search of a session. Detects whether a
@@ -47,25 +47,6 @@ function buildGraphNudge() {
     'Y handled), prefer `graphify query "<question>"` over grepping raw files — it',
     'reads the graph, not the code, so it is cheaper. Refresh with /devops-graph if',
     'the code changed meaningfully.',
-  ].join('\n');
-}
-
-/**
- * One-line offer surfaced at the moment a broad search is blocked in a project
- * that has no graphify decision yet — the point where the token cost is concrete
- * and the value proposition lands hardest (much higher conversion than the
- * passive SessionStart offer). Steers Claude to offer enabling graphify via
- * AskUserQuestion. Kept short so it rides an existing block message.
- */
-function buildGraphifyOffer() {
-  return [
-    '💡 [graphify] Broad searches like this are exactly what a code knowledge graph makes cheap.',
-    'This project has no graphify decision yet — offer the user (AskUserQuestion) to enable it.',
-    'On YES: `uv tool install graphifyy && graphify install && graphify hook install && graphify extract .`,',
-    'then write .claude/graphify.json {"consent":true,"autoBuild":true}. After extract completes, verify',
-    'graphify-out/graph.json exists and report its node count to the user; if it is missing, report the',
-    'failure instead of claiming success. On NO: write {"consent":false}.',
-    'Never install without confirmation.',
   ].join('\n');
 }
 
@@ -188,7 +169,6 @@ module.exports = {
   graphJsonPath,
   hasGraph,
   buildGraphNudge,
-  buildGraphifyOffer,
   suggestQuery,
   scanSources,
   stalenessInfo,

--- a/plugins/devops/hooks/lib/graph-nudge.test.js
+++ b/plugins/devops/hooks/lib/graph-nudge.test.js
@@ -2,7 +2,7 @@ import { describe, test, expect, beforeAll, afterAll } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { hasGraph, buildGraphNudge, buildGraphifyOffer, graphJsonPath, graphIsStale, stalenessInfo, suggestQuery } from "./graph-nudge.js";
+import { hasGraph, buildGraphNudge, graphJsonPath, graphIsStale, stalenessInfo, suggestQuery } from "./graph-nudge.js";
 
 describe("hasGraph — graph.json detection", () => {
   let dir;
@@ -49,15 +49,6 @@ describe("buildGraphNudge — ambient hint text", () => {
     expect(t).toContain("graphify query");
     expect(t).toContain("graphify-out/graph.json");
     expect(t).toContain("/devops-graph");
-  });
-});
-
-describe("buildGraphifyOffer — value-moment offer text", () => {
-  test("names graphify, AskUserQuestion, and the consent file", () => {
-    const t = buildGraphifyOffer();
-    expect(t).toContain("graphify");
-    expect(t).toContain("AskUserQuestion");
-    expect(t).toContain("graphify.json");
   });
 });
 

--- a/plugins/devops/hooks/lib/graphify-metrics.test.js
+++ b/plugins/devops/hooks/lib/graphify-metrics.test.js
@@ -44,7 +44,10 @@ describe("graphify-metrics — event telemetry", () => {
 
   test("creates parent directories on demand", () => {
     expect(fs.existsSync(path.dirname(file))).toBe(false);
-    record("offer_shown", { source: "session_start" }, { path: file });
+    // Generic lib-level event name — the hooks themselves no longer emit
+    // `offer_shown` (the value-moment offer was removed), but record() is a
+    // generic sink that accepts any event name.
+    record("self_heal_kicked", { source: "session_start" }, { path: file });
     expect(fs.existsSync(file)).toBe(true);
   });
 

--- a/plugins/devops/hooks/lib/graphify-state.js
+++ b/plugins/devops/hooks/lib/graphify-state.js
@@ -76,23 +76,57 @@ function readGlobalState() {
 }
 
 /**
+ * Read a consent record file distinguishing TRULY ABSENT (no such file) from
+ * PRESENT-but-unparseable/invalid (file exists but JSON.parse fails, or the
+ * parsed value is not an object). This distinction matters for `isEnabled`:
+ * a corrupted opt-out record must not silently re-enable the feature (R5) —
+ * corruption is the one failure mode that must fail CLOSED (declined), while
+ * a genuinely absent record is the normal default-on case and must fail OPEN
+ * (enabled). Never throws.
+ * @returns {{present: boolean, obj: object|null}}
+ */
+function readRecordDistinguishingAbsence(filePath) {
+  let raw;
+  try {
+    raw = fs.readFileSync(filePath, 'utf8');
+  } catch {
+    return { present: false, obj: null }; // truly absent (or unreadable — treat as absent)
+  }
+  try {
+    const obj = JSON.parse(raw);
+    return { present: true, obj: obj && typeof obj === 'object' ? obj : null };
+  } catch {
+    return { present: true, obj: null }; // present but unparseable
+  }
+}
+
+/**
  * True iff graphify enforcement is enabled for `cwd` — the DEFAULT-ON gate.
  * Enabled UNLESS an explicit opt-out (`consent:false`) exists in either the
  * per-project record (.claude/graphify.json) or the global, machine-wide
  * record (~/.claude/graphify.json) — either one being `consent:false` disables
  * it. "No record at all" (project AND global) counts as ENABLED — graphify is
  * key-less, opt-out, and auto-installing by default (see ss.graphify.js).
- * Never throws.
+ * A record that IS PRESENT but unparseable/corrupt (e.g. caught mid atomic
+ * rewrite, or disk corruption) is treated as DECLINED, not enabled — the safe,
+ * sticky direction for the one signal that must never silently flip back on
+ * (R5). Never throws.
  */
 function isEnabled(cwd) {
   try {
-    const project = readState(cwd);
-    if (project && project.consent === false) return false;
-    const global = readGlobalState();
-    if (global && global.consent === false) return false;
+    const project = readRecordDistinguishingAbsence(consentPath(cwd));
+    if (project.present) {
+      if (project.obj === null) return false; // present but corrupt → treat as opted-out
+      if (project.obj.consent === false) return false;
+    }
+    const global = readRecordDistinguishingAbsence(globalConsentPath());
+    if (global.present) {
+      if (global.obj === null) return false; // present but corrupt → treat as opted-out
+      if (global.obj.consent === false) return false;
+    }
     return true;
   } catch {
-    return true; // fail-open — never let a read error disable the feature
+    return true; // fail-open — never let an unexpected read error disable the feature
   }
 }
 

--- a/plugins/devops/hooks/lib/graphify-state.js
+++ b/plugins/devops/hooks/lib/graphify-state.js
@@ -1,16 +1,19 @@
 'use strict';
 /**
  * @lib graphify-state
- * @version 0.2.0
+ * @version 0.3.0
  * @plugin devops
  * @description Consent + session-state helpers for the graphify enforcement
- *   layer (devops-graph). The consent record lives at `.claude/graphify.json`
- *   in the consumer project and is written ONLY after the user explicitly opts
- *   in (consent:true) or out (consent:false) — hooks never write it silently.
- *   Also tracks a per-session "graphify query already ran" flag so the
- *   PreToolUse hard-gate can relent once Claude has consulted the graph, and
- *   provides `bgWithSentinel`/`readSentinel` — a shared detached-spawn wrapper
- *   that records background `graphify extract`/`hook install` outcomes to a
+ *   layer (devops-graph). Default-on / opt-out model: graphify enforcement is
+ *   ENABLED unless an explicit `consent:false` record exists, checked at
+ *   `.claude/graphify.json` in the consumer project (`readState`/`isDeclined`)
+ *   OR the global, machine-wide `~/.claude/graphify.json` (`readGlobalState`)
+ *   — either one being `consent:false` disables it (`isEnabled`). Hooks never
+ *   WRITE either record — the user opts out manually. Also tracks a
+ *   per-session "graphify query already ran" flag so the PreToolUse hard-gate
+ *   can relent once Claude has consulted the graph, and provides
+ *   `bgWithSentinel`/`readSentinel` — a shared detached-spawn wrapper that
+ *   records background `graphify update`/`hook uninstall` outcomes to a
  *   per-project sentinel file so a silent failure (stdio:'ignore') can be
  *   surfaced at the next SessionStart instead of vanishing.
  */
@@ -56,6 +59,50 @@ function isDeclined(cwd) {
  */
 function isUndecided(cwd) {
   return readState(cwd) === null;
+}
+
+function globalConsentPath() {
+  return path.join(os.homedir(), '.claude', 'graphify.json');
+}
+
+/** Parsed GLOBAL (machine-wide) consent record, or null if absent/unreadable. Never throws. */
+function readGlobalState() {
+  try {
+    const obj = JSON.parse(fs.readFileSync(globalConsentPath(), 'utf8'));
+    return obj && typeof obj === 'object' ? obj : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * True iff graphify enforcement is enabled for `cwd` — the DEFAULT-ON gate.
+ * Enabled UNLESS an explicit opt-out (`consent:false`) exists in either the
+ * per-project record (.claude/graphify.json) or the global, machine-wide
+ * record (~/.claude/graphify.json) — either one being `consent:false` disables
+ * it. "No record at all" (project AND global) counts as ENABLED — graphify is
+ * key-less, opt-out, and auto-installing by default (see ss.graphify.js).
+ * Never throws.
+ */
+function isEnabled(cwd) {
+  try {
+    const project = readState(cwd);
+    if (project && project.consent === false) return false;
+    const global = readGlobalState();
+    if (global && global.consent === false) return false;
+    return true;
+  } catch {
+    return true; // fail-open — never let a read error disable the feature
+  }
+}
+
+/**
+ * True iff the user has explicitly opted OUT for this project OR machine-wide
+ * (either record has `consent:false`). Distinct from `isDeclined(cwd)`, which
+ * only checks the per-project record.
+ */
+function isDeclinedAnywhere(cwd) {
+  return !isEnabled(cwd);
 }
 
 function refreshFlagPath(cwd) {
@@ -196,6 +243,10 @@ module.exports = {
   hasConsent,
   isDeclined,
   isUndecided,
+  globalConsentPath,
+  readGlobalState,
+  isEnabled,
+  isDeclinedAnywhere,
   refreshFlagPath,
   markRefresh,
   queryFlagPath,

--- a/plugins/devops/hooks/lib/graphify-state.test.js
+++ b/plugins/devops/hooks/lib/graphify-state.test.js
@@ -17,6 +17,10 @@ import {
   bgWithSentinel,
   readSentinel,
   clearSentinel,
+  isEnabled,
+  isDeclinedAnywhere,
+  globalConsentPath,
+  readGlobalState,
 } from "./graphify-state.js";
 
 function tmp() {
@@ -79,6 +83,83 @@ describe("isUndecided — offer eligibility", () => {
   test("consent:false → decided (not undecided)", () => {
     fs.writeFileSync(consentPath(dir), JSON.stringify({ consent: false }));
     expect(isUndecided(dir)).toBe(false);
+  });
+});
+
+describe("isEnabled / isDeclinedAnywhere — default-on opt-out gate", () => {
+  let dir; // project dir
+  let homeDir; // faked global home (~/.claude/graphify.json)
+  let origHome;
+  let origUserProfile;
+
+  beforeEach(() => {
+    dir = tmp();
+    fs.mkdirSync(path.join(dir, ".claude"), { recursive: true });
+    homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "gstate-home-"));
+    fs.mkdirSync(path.join(homeDir, ".claude"), { recursive: true });
+    origHome = process.env.HOME;
+    origUserProfile = process.env.USERPROFILE;
+    // os.homedir() honors HOME (POSIX) / USERPROFILE (win32) — override both so
+    // globalConsentPath() resolves under our disposable temp dir on either OS.
+    process.env.HOME = homeDir;
+    process.env.USERPROFILE = homeDir;
+  });
+
+  afterEach(() => {
+    if (origHome === undefined) delete process.env.HOME; else process.env.HOME = origHome;
+    if (origUserProfile === undefined) delete process.env.USERPROFILE; else process.env.USERPROFILE = origUserProfile;
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+    try { fs.rmSync(homeDir, { recursive: true, force: true }); } catch {}
+  });
+
+  test("globalConsentPath resolves under the (faked) home dir", () => {
+    expect(globalConsentPath()).toBe(path.join(homeDir, ".claude", "graphify.json"));
+  });
+
+  test("no project record, no global record → enabled by default (opt-out model)", () => {
+    expect(readGlobalState()).toBeNull();
+    expect(isEnabled(dir)).toBe(true);
+    expect(isDeclinedAnywhere(dir)).toBe(false);
+  });
+
+  test("record present but no consent key → still enabled (no explicit opt-out)", () => {
+    fs.writeFileSync(consentPath(dir), JSON.stringify({ autoBuild: true }));
+    expect(isEnabled(dir)).toBe(true);
+  });
+
+  test("project consent:false → disabled", () => {
+    fs.writeFileSync(consentPath(dir), JSON.stringify({ consent: false }));
+    expect(isEnabled(dir)).toBe(false);
+    expect(isDeclinedAnywhere(dir)).toBe(true);
+  });
+
+  test("global consent:false (no project record) → disabled machine-wide", () => {
+    fs.writeFileSync(globalConsentPath(), JSON.stringify({ consent: false }));
+    expect(readGlobalState()).toEqual({ consent: false });
+    expect(isEnabled(dir)).toBe(false);
+    expect(isDeclinedAnywhere(dir)).toBe(true);
+  });
+
+  test("project consent:true + global consent:false → still disabled (either opt-out wins)", () => {
+    fs.writeFileSync(consentPath(dir), JSON.stringify({ consent: true }));
+    fs.writeFileSync(globalConsentPath(), JSON.stringify({ consent: false }));
+    expect(isEnabled(dir)).toBe(false);
+  });
+
+  test("project consent:true, no global opt-out → enabled", () => {
+    fs.writeFileSync(consentPath(dir), JSON.stringify({ consent: true }));
+    expect(isEnabled(dir)).toBe(true);
+  });
+
+  test("fail-open: malformed project JSON → still enabled", () => {
+    fs.writeFileSync(consentPath(dir), "{ not json");
+    expect(isEnabled(dir)).toBe(true);
+  });
+
+  test("fail-open: malformed global JSON → readGlobalState null, isEnabled still true", () => {
+    fs.writeFileSync(globalConsentPath(), "{ not json");
+    expect(readGlobalState()).toBeNull();
+    expect(isEnabled(dir)).toBe(true);
   });
 });
 

--- a/plugins/devops/hooks/lib/graphify-state.test.js
+++ b/plugins/devops/hooks/lib/graphify-state.test.js
@@ -151,15 +151,27 @@ describe("isEnabled / isDeclinedAnywhere — default-on opt-out gate", () => {
     expect(isEnabled(dir)).toBe(true);
   });
 
-  test("fail-open: malformed project JSON → still enabled", () => {
+  test("R5: present-but-unparseable PROJECT record → treated as declined (fails CLOSED, not open)", () => {
     fs.writeFileSync(consentPath(dir), "{ not json");
-    expect(isEnabled(dir)).toBe(true);
+    // readState/readGlobalState stay null on corruption (low-level, unchanged) —
+    // it is isEnabled's job to distinguish absent from corrupt-but-present.
+    expect(readState(dir)).toBeNull();
+    expect(isEnabled(dir)).toBe(false);
+    expect(isDeclinedAnywhere(dir)).toBe(true);
   });
 
-  test("fail-open: malformed global JSON → readGlobalState null, isEnabled still true", () => {
+  test("R5: present-but-unparseable GLOBAL record → treated as declined (fails CLOSED, not open)", () => {
     fs.writeFileSync(globalConsentPath(), "{ not json");
     expect(readGlobalState()).toBeNull();
+    expect(isEnabled(dir)).toBe(false);
+    expect(isDeclinedAnywhere(dir)).toBe(true);
+  });
+
+  test("R5: truly-absent project AND global records → still enabled (default-on unaffected)", () => {
+    expect(fs.existsSync(consentPath(dir))).toBe(false);
+    expect(fs.existsSync(globalConsentPath())).toBe(false);
     expect(isEnabled(dir)).toBe(true);
+    expect(isDeclinedAnywhere(dir)).toBe(false);
   });
 });
 

--- a/plugins/devops/hooks/pre-tool-use/pre.tokens.guard.graphgate.test.js
+++ b/plugins/devops/hooks/pre-tool-use/pre.tokens.guard.graphgate.test.js
@@ -76,10 +76,11 @@ describe("pre.tokens.guard — graphify hard-gate (integration)", () => {
     cleanup(dir);
   });
 
-  test("no consent → graph gate never fires", () => {
+  test("no consent record (default-on, opt-out model) → graph gate STILL fires", () => {
     const dir = project({ consent: null, graph: "fresh" });
     const r = runGrep(dir, "s-noconsent", "gamma");
-    expect(r.stderr).not.toContain("GRAPHIFY GATE");
+    expect(r.status).toBe(2);
+    expect(r.stderr).toContain("GRAPHIFY GATE");
     cleanup(dir);
   });
 
@@ -119,40 +120,6 @@ describe("pre.tokens.guard — graphify hard-gate (integration)", () => {
     const r = runGrep(dir, "s-heal", "omega");
     expect(r.stderr).not.toContain("GRAPHIFY GATE"); // never block beyond tolerance
     expect(fs.existsSync(refreshFlagPath(dir))).toBe(true); // background refresh kicked
-    cleanup(dir);
-  });
-});
-
-describe("pre.tokens.guard — value-moment graphify offer (undecided projects)", () => {
-  function gitProject() {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "graphoffer-"));
-    fs.mkdirSync(path.join(dir, ".claude"), { recursive: true });
-    fs.writeFileSync(
-      path.join(dir, ".claude", "settings.json"),
-      JSON.stringify({ enabledPlugins: { "devops@dotclaude": true } })
-    );
-    fs.writeFileSync(path.join(dir, "a.js"), "const x = 1;");
-    spawnSync("git", ["init", "-q"], { cwd: dir });
-    return dir;
-  }
-
-  test("undecided + no graph + git → broad search block carries the offer, throttled", () => {
-    const dir = gitProject();
-    const first = runGrep(dir, "s-offer", "needle");
-    expect(first.status).toBe(2); // still blocked by the token guard
-    expect(first.stderr).toContain("[graphify]");
-    expect(first.stderr).toContain("AskUserQuestion");
-    // Weekly throttle: a second broad search this week does NOT re-offer.
-    const second = runGrep(dir, "s-offer", "haystack");
-    expect(second.stderr).not.toContain("[graphify]");
-    cleanup(dir);
-  });
-
-  test("declined project → no offer", () => {
-    const dir = gitProject();
-    fs.writeFileSync(path.join(dir, ".claude", "graphify.json"), JSON.stringify({ consent: false }));
-    const r = runGrep(dir, "s-declined-offer", "needle");
-    expect(r.stderr).not.toContain("[graphify]");
     cleanup(dir);
   });
 });

--- a/plugins/devops/hooks/pre-tool-use/pre.tokens.guard.graphgate.test.js
+++ b/plugins/devops/hooks/pre-tool-use/pre.tokens.guard.graphgate.test.js
@@ -12,6 +12,15 @@ const HOOK = path.join(__dirname, "pre.tokens.guard.js");
 const OLD = new Date(Date.now() - 60_000);
 const NOW = new Date();
 
+// Isolate the GLOBAL (~/.claude/graphify.json) consent record from whatever
+// happens to exist on the machine running this test — without this, isEnabled()
+// reads the real $HOME/graphify.json and a globally-opted-out dev machine makes
+// every "gate fires" assertion below flake. Same HOME/USERPROFILE-override
+// idiom as graphify-state.test.js. No graphify.json is written here, so the
+// global record resolves to "absent" (enabled) for all tests below by default.
+const HOME_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "graphgate-home-"));
+fs.mkdirSync(path.join(HOME_DIR, ".claude"), { recursive: true });
+
 // Build a temp project. graph:"fresh"|"stale"|"none", consent:true|false|null.
 function project({ consent, graph }) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "graphgate-"));
@@ -45,11 +54,12 @@ function project({ consent, graph }) {
   return dir;
 }
 
-function runGrep(dir, sid, pattern) {
+function runGrep(dir, sid, pattern, homeDir = HOME_DIR) {
   const res = spawnSync(process.execPath, [HOOK], {
     cwd: dir,
     input: JSON.stringify({ tool_name: "Grep", tool_input: { pattern }, session_id: sid }),
     encoding: "utf8",
+    env: { ...process.env, HOME: homeDir, USERPROFILE: homeDir },
   });
   return { status: res.status, stderr: res.stderr || "" };
 }
@@ -107,6 +117,20 @@ describe("pre.tokens.guard — graphify hard-gate (integration)", () => {
     const r = runGrep(dir, "s-queried", "zeta");
     expect(r.stderr).not.toContain("GRAPHIFY GATE");
     cleanup(dir);
+  });
+
+  test("globally declined (~/.claude/graphify.json consent:false) → gate never fires, even with no project record", () => {
+    const dir = project({ consent: null, graph: "fresh" });
+    const declinedHome = fs.mkdtempSync(path.join(os.tmpdir(), "graphgate-home-declined-"));
+    fs.mkdirSync(path.join(declinedHome, ".claude"), { recursive: true });
+    fs.writeFileSync(
+      path.join(declinedHome, ".claude", "graphify.json"),
+      JSON.stringify({ consent: false })
+    );
+    const r = runGrep(dir, "s-global-declined", "eta", declinedHome);
+    expect(r.stderr).not.toContain("GRAPHIFY GATE");
+    cleanup(dir);
+    cleanup(declinedHome);
   });
 
   test("stale graph BEYOND tolerance → self-heal refresh requested, not gated", () => {

--- a/plugins/devops/hooks/pre-tool-use/pre.tokens.guard.js
+++ b/plugins/devops/hooks/pre-tool-use/pre.tokens.guard.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * @hook pre.tokens.guard
- * @version 0.7.0
+ * @version 0.8.0
  * @event PreToolUse
  * @plugin devops
  * @description Block Read/Bash/Glob/Grep operations that would consume a
@@ -26,7 +26,6 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 const crypto = require('crypto');
-const { execSync } = require('child_process');
 
 const cwd = process.cwd();
 const CONFIG_DIR = path.join(cwd, '.claude');
@@ -37,16 +36,6 @@ const CONFIG_PATH = path.join(CONFIG_DIR, 'token-config.json');
 // bg() helper — it wraps the same detached/stdio:'ignore' spawn shape but
 // also records ok/fail to a sentinel file so a silent failure (Gap #5) can
 // be surfaced at the next SessionStart instead of vanishing.
-
-function isGitRepo() {
-  try {
-    return execSync('git rev-parse --is-inside-work-tree', {
-      cwd, encoding: 'utf8', timeout: 4000, stdio: ['pipe', 'pipe', 'pipe'],
-    }).trim() === 'true';
-  } catch {
-    return false;
-  }
-}
 
 const PLAN_DEFAULTS = require('../lib/plan-defaults');
 
@@ -204,9 +193,11 @@ process.stdin.on('end', () => {
     process.exit(0);
   }
 
-  // ── graphify hard-gate (consented + graph within staleness tolerance) ────
-  // When the user has opted graphify in for this project AND a usable graph
-  // exists, force a broad raw-file search through the graph first. This is a
+  // ── graphify hard-gate (enabled + graph within staleness tolerance) ──────
+  // Graphify is default-ON (opt-out — see gstate.isEnabled): unless the user
+  // has explicitly disabled it (.claude/graphify.json or ~/.claude/graphify.json
+  // {"consent":false}), when a usable graph exists, force a broad raw-file
+  // search through the graph first. This is a
   // BOUNDED-tolerance gate, not a strict fresh/stale one: a graph that lags a
   // small number of files behind the working tree is still useful, so the
   // gate still enforces on it (with a disclosure line + a kicked background
@@ -231,7 +222,7 @@ process.stdin.on('end', () => {
       const gstate = require('../lib/graphify-state');
       const metrics = require('../lib/graphify-metrics');
       const sid = hook.session_id || hook.sessionId || 'nosid';
-      if (gstate.hasConsent(cwd) && graphNudge.hasGraph(cwd)) {
+      if (gstate.isEnabled(cwd) && graphNudge.hasGraph(cwd)) {
         const info = graphNudge.stalenessInfo(cwd);
         const withinTolerance = !info.truncated && info.newerCount <= GRAPHIFY_STALE_TOLERANCE;
         if (!withinTolerance) {
@@ -242,7 +233,7 @@ process.stdin.on('end', () => {
           // sentinel-tracked — see Gap #5) so the graph converges and the gate
           // can enforce on LATER searches this session. Never blocks.
           if (gstate.markRefresh(cwd, 2 * 60 * 1000)) {
-            gstate.bgWithSentinel('graphify', ['extract', '.', '--update'], cwd);
+            gstate.bgWithSentinel('graphify', ['update', '.'], cwd);
             // Infinity is JSON-null; -1 keeps "unbounded" distinguishable in the log.
             const newerCount = Number.isFinite(info.newerCount) ? info.newerCount : -1;
             metrics.record('self_heal_kicked', { newerCount, truncated: info.truncated }, { cwd, sid });
@@ -254,7 +245,7 @@ process.stdin.on('end', () => {
             // Within tolerance but still lagging by >0 files — enforce AND kick
             // a refresh in parallel so it converges toward newerCount 0.
             if (info.newerCount > 0 && gstate.markRefresh(cwd, 2 * 60 * 1000)) {
-              gstate.bgWithSentinel('graphify', ['extract', '.', '--update'], cwd);
+              gstate.bgWithSentinel('graphify', ['update', '.'], cwd);
               metrics.record('self_heal_kicked', { newerCount: info.newerCount, truncated: false }, { cwd, sid });
             }
             const suggestion = graphNudge.suggestQuery(toolInput.pattern);
@@ -377,25 +368,6 @@ process.stdin.on('end', () => {
     if (fs.existsSync(projectMap)) {
       console.error(`\nHint: Read .claude/project-map.md to find the right path first.`);
     }
-
-    // Value-moment graphify offer: a broad search just got blocked in a git
-    // project that has no graphify decision yet and no graph. This is where the
-    // token cost is concrete, so conversion is far higher than the passive
-    // SessionStart offer. Throttled once per week per project (shares nothing
-    // with the SessionStart offer key, so at most two low-cost offers/week).
-    try {
-      const gstate = require('../lib/graphify-state');
-      const graphNudge = require('../lib/graph-nudge');
-      if (gstate.isUndecided(cwd) && !graphNudge.hasGraph(cwd) && isGitRepo()) {
-        const { runOnce } = require('../lib/run-once');
-        const cwdKey = crypto.createHash('md5').update(cwd).digest('hex').slice(0, 12);
-        if (runOnce('graphify-block-offer', cwdKey, { cooldownMs: 7 * 24 * 60 * 60 * 1000 })) {
-          console.error('');
-          console.error(graphNudge.buildGraphifyOffer());
-          try { require('../lib/graphify-metrics').record('offer_shown', { source: 'value_moment' }, { cwd }); } catch {}
-        }
-      }
-    } catch { /* never let the offer break the block */ }
   }
 
   console.error(line);

--- a/plugins/devops/hooks/session-start/ss.graphify.js
+++ b/plugins/devops/hooks/session-start/ss.graphify.js
@@ -1,28 +1,40 @@
 #!/usr/bin/env node
 /**
  * @hook ss.graphify
- * @version 0.2.0
+ * @version 0.3.0
  * @event SessionStart
  * @plugin devops
  * @description graphify enforcement — install-check + auto-build wiring for the
- *   devops-graph feature. Behavior depends on the per-project consent record at
- *   .claude/graphify.json (written ONLY after the user opts in/out via the
- *   offer below — never silently):
- *     - consent:true  → ensure graphify is installed; (once/day) install its git
- *       hooks; if the graph is missing/stale/invalid (once/day JSON.parse
- *       validity check), kick off a background `graphify extract . --update`
- *       (AST-only, free) via a sentinel-tracked spawn. Keeps the graph fresh so
- *       the PreToolUse graphify-gate enforces against current data. If the
- *       PREVIOUS background build failed, surface it as one line before doing
- *       anything else (see reportBgFailureIfAny / hooks/lib/graphify-state's
- *       readSentinel — bg spawns are stdio:'ignore', so without this a failing
- *       build is otherwise invisible).
- *     - consent:false → stay silent (user declined).
- *     - no record     → (throttled, weekly) emit a one-time instruction for
- *       Claude to OFFER enabling graphify via AskUserQuestion, and record an
- *       `offer_shown` metrics event (see hooks/lib/graphify-metrics).
- *   Fail-open and non-blocking: every graphify invocation is detached/guarded so
- *   a missing Python toolchain never degrades session start.
+ *   devops-graph feature. DEFAULT-ON, opt-out, key-less, windowless: no
+ *   AskUserQuestion, no interaction, no per-project setup. Behavior depends on
+ *   gstate.isEnabled/isDeclined, which read (never write) the per-project
+ *   record at .claude/graphify.json and the global, machine-wide record at
+ *   ~/.claude/graphify.json:
+ *     - declined (either record has consent:false) → stay silent, exit 0.
+ *     - enabled (INCLUDING no record at all — the default) →
+ *         - surface any PREVIOUS background build failure as one line before
+ *           doing anything else (see reportBgFailureIfAny / hooks/lib/
+ *           graphify-state's readSentinel — bg spawns are stdio:'ignore', so
+ *           without this a failing build is otherwise invisible).
+ *         - if this is the first time graphify auto-enables for a project with
+ *           NO record (nothing to do with consent:true — that value is no
+ *           longer written by anyone), print a ONE-TIME (weekly-throttled)
+ *           transparency line so the user knows it's on and how to opt out.
+ *         - if graphify is not installed: kick a best-effort background
+ *           `uv tool install graphifyy` (windowless, fail-open) and exit —
+ *           the graph builds next session once the CLI lands.
+ *         - if graphify IS installed: once/24h remove graphify's own git
+ *           hooks (`graphify hook uninstall` — those pop a console window on
+ *           Windows on every commit; devops owns freshness instead via this
+ *           SessionStart refresh + the PreToolUse self-heal, both windowless).
+ *           Then, if the graph is missing/stale/invalid (once/day JSON.parse
+ *           validity check), kick off a background `graphify update .`
+ *           (AST-only, free, key-less) via a sentinel-tracked spawn. Keeps the
+ *           graph fresh so the PreToolUse graphify-gate enforces against
+ *           current data.
+ *   Fail-open and non-blocking: every graphify invocation is detached/guarded
+ *   (windowless on Windows too) so a missing Python toolchain never degrades
+ *   session start.
  */
 
 require('../lib/plugin-guard');
@@ -33,7 +45,6 @@ const { spawn, execSync } = require('child_process');
 const { runOnce } = require('../lib/run-once');
 const gstate = require('../lib/graphify-state');
 const graphNudge = require('../lib/graph-nudge');
-const metrics = require('../lib/graphify-metrics');
 
 const cwd = process.cwd();
 const cwdKey = crypto.createHash('md5').update(cwd).digest('hex').slice(0, 12);
@@ -48,7 +59,7 @@ function reportBgFailureIfAny() {
   if (sentinel && sentinel.status === 'fail') {
     const codeInfo = sentinel.code == null ? '' : ` (exit ${sentinel.code})`;
     process.stdout.write(
-      `⚠ graphify background build failed${codeInfo} — run \`graphify extract . --update\` manually or /devops-graph\n`
+      `⚠ graphify background build failed${codeInfo} — run \`graphify update .\` manually or /devops-graph\n`
     );
     gstate.clearSentinel(cwd); // one report per failure, not every session
   }
@@ -93,60 +104,64 @@ function bg(cmd, args) {
   // Detached + unref so a 5-10s graphify build never blocks session start.
   // `shell` on Windows so a `graphify.cmd`/`.bat` shim (what `uv tool install`
   // produces) actually runs — a bare spawn cannot exec a .cmd and would
-  // silently no-op, leaving the graph un-refreshed. Guarded: a missing
-  // toolchain throws → no-op.
+  // silently no-op, leaving the graph un-refreshed. `windowsHide` suppresses
+  // the console window that `shell:true` would otherwise pop on Windows for
+  // every invocation (matches bgWithSentinel in hooks/lib/graphify-state.js).
+  // Guarded: a missing toolchain throws → no-op.
   try {
     spawn(cmd, args, {
-      cwd, detached: true, stdio: 'ignore', shell: process.platform === 'win32',
+      cwd, detached: true, stdio: 'ignore', shell: process.platform === 'win32', windowsHide: true,
     }).unref();
   } catch { /* toolchain absent */ }
 }
 
-const state = gstate.readState(cwd);
+if (gstate.isDeclined(cwd)) {
+  process.exit(0); // explicit opt-out (project or global) — never nag
+}
 
-if (state && state.consent === true) {
-  reportBgFailureIfAny();
-  // Opted in. Keep the graph fresh so the gate enforces against current code.
-  if (!graphifyInstalled()) {
-    if (runOnce('ss-graphify-reinstall', cwdKey, { cooldownMs: 24 * 60 * 60 * 1000 })) {
-      process.stdout.write(
-        '[graphify] Enabled for this project but the `graphify` CLI is not on PATH. ' +
-        'Offer the user to reinstall (`uv tool install graphifyy && graphify install`), ' +
-        'or to disable graphify here (set .claude/graphify.json {"consent":false}).\n'
-      );
-    }
-    process.exit(0);
-  }
-  if (isGitRepo() && runOnce('ss-graphify-hookinstall', cwdKey, { cooldownMs: 24 * 60 * 60 * 1000 })) {
-    bg('graphify', ['hook', 'install']); // idempotent git post-commit/checkout AST rebuild
-  }
-  // Once/24h deeper validity check (JSON.parse) beyond hasGraph()'s cheap size
-  // floor — a present-but-empty/corrupt graph.json must trigger a rebuild too.
-  const needsRebuild = !graphNudge.hasGraph(cwd)
-    || graphNudge.graphIsStale(cwd)
-    || (runOnce('ss-graphify-validate', cwdKey, { cooldownMs: 24 * 60 * 60 * 1000 }) && !graphLooksValid());
-  // Throttle the rebuild so repeated SessionStart re-entries (multiple agents /
-  // worktrees on the same cwd) cannot stack concurrent `graphify extract`.
-  if (needsRebuild && runOnce('ss-graphify-extract', cwdKey, { cooldownMs: 10 * 60 * 1000 })) {
-    gstate.bgWithSentinel('graphify', ['extract', '.', '--update'], cwd); // background, AST-only, free
+// Enabled — including the common case of NO record at all (default-on).
+reportBgFailureIfAny();
+
+// First time graphify auto-enables for a project with no record at all: a
+// one-time (weekly-throttled), non-blocking transparency line. Not an offer —
+// no interaction, nothing to confirm, just disclosure + the opt-out path.
+if (gstate.isUndecided(cwd) && runOnce('ss-graphify-auto-enabled', cwdKey, { cooldownMs: 7 * 24 * 60 * 60 * 1000 })) {
+  process.stdout.write(
+    '[graphify] Auto-enabled for this project (knowledge-graph, token-saver). ' +
+    'Disable: .claude/graphify.json {"consent":false}.\n'
+  );
+}
+
+if (!graphifyInstalled()) {
+  // Best-effort, windowless background install — fail-open if `uv` is absent.
+  // Never blocks: the graph builds next session once the CLI lands on PATH.
+  if (runOnce('ss-graphify-install', cwdKey, { cooldownMs: 24 * 60 * 60 * 1000 })) {
+    bg('uv', ['tool', 'install', 'graphifyy']);
+    process.stdout.write(
+      '[graphify] Not installed yet — installing in the background (`uv tool install graphifyy`). ' +
+      'The knowledge graph will build automatically once installed. Disable: .claude/graphify.json {"consent":false}.\n'
+    );
   }
   process.exit(0);
 }
 
-if (state && state.consent === false) {
-  process.exit(0); // declined — never nag
+// Installed. Once/24h remove graphify's OWN git hooks — those fire a Python
+// rebuild on every commit/checkout and pop a console window on Windows.
+// devops owns freshness instead via this SessionStart refresh (below) and the
+// PreToolUse self-heal (pre.tokens.guard.js), both windowless. Idempotent and
+// guarded/fail-open: a missing toolchain here never degrades session start.
+if (isGitRepo() && runOnce('ss-graphify-hookuninstall', cwdKey, { cooldownMs: 24 * 60 * 60 * 1000 })) {
+  bg('graphify', ['hook', 'uninstall']);
 }
 
-// No decision yet → offer ONCE (re-offer at most weekly if ignored).
-// Only in real git projects — never nag in scratch/throwaway folders.
-if (isGitRepo() && runOnce('ss-graphify-offer', cwdKey, { cooldownMs: 7 * 24 * 60 * 60 * 1000 })) {
-  metrics.record('offer_shown', { source: 'session_start' }, { cwd });
-  process.stdout.write(
-    '[graphify] No knowledge-graph config for this project. Offer the user (AskUserQuestion) to enable graphify — ' +
-    'it builds a queryable code graph so broad searches use the graph instead of grepping (token saver), kept fresh via git hooks. ' +
-    'On YES: run `uv tool install graphifyy && graphify install && graphify hook install && graphify extract .`, then write .claude/graphify.json {"consent":true,"autoBuild":true}. ' +
-    'After extract completes, verify graphify-out/graph.json exists and report its node count to the user; if missing, report the failure instead of claiming success. ' +
-    'On NO: write .claude/graphify.json {"consent":false}. Always confirm before installing — never silently.\n'
-  );
+// Once/24h deeper validity check (JSON.parse) beyond hasGraph()'s cheap size
+// floor — a present-but-empty/corrupt graph.json must trigger a rebuild too.
+const needsRebuild = !graphNudge.hasGraph(cwd)
+  || graphNudge.graphIsStale(cwd)
+  || (runOnce('ss-graphify-validate', cwdKey, { cooldownMs: 24 * 60 * 60 * 1000 }) && !graphLooksValid());
+// Throttle the rebuild so repeated SessionStart re-entries (multiple agents /
+// worktrees on the same cwd) cannot stack concurrent `graphify update` runs.
+if (needsRebuild && runOnce('ss-graphify-update', cwdKey, { cooldownMs: 10 * 60 * 1000 })) {
+  gstate.bgWithSentinel('graphify', ['update', '.'], cwd); // background, key-less, AST-only, free
 }
 process.exit(0);

--- a/plugins/devops/hooks/session-start/ss.graphify.js
+++ b/plugins/devops/hooks/session-start/ss.graphify.js
@@ -23,10 +23,14 @@
  *         - if graphify is not installed: kick a best-effort background
  *           `uv tool install graphifyy` (windowless, fail-open) and exit —
  *           the graph builds next session once the CLI lands.
- *         - if graphify IS installed: once/24h remove graphify's own git
- *           hooks (`graphify hook uninstall` — those pop a console window on
+ *         - if graphify IS installed: ONE-TIME (per project, persistent —
+ *           never re-run) legacy cleanup of graphify's own git hooks
+ *           (`graphify hook uninstall` — those pop a console window on
  *           Windows on every commit; devops owns freshness instead via this
  *           SessionStart refresh + the PreToolUse self-heal, both windowless).
+ *           This is NOT a recurring fight: new projects never get graphify's
+ *           git hooks installed by devops in the first place, so the removal
+ *           only ever needs to happen once per project.
  *           Then, if the graph is missing/stale/invalid (once/day JSON.parse
  *           validity check), kick off a background `graphify update .`
  *           (AST-only, free, key-less) via a sentinel-tracked spawn. Keeps the
@@ -115,8 +119,8 @@ function bg(cmd, args) {
   } catch { /* toolchain absent */ }
 }
 
-if (gstate.isDeclined(cwd)) {
-  process.exit(0); // explicit opt-out (project or global) — never nag
+if (gstate.isDeclinedAnywhere(cwd)) {
+  process.exit(0); // explicit opt-out (project OR global) — never nag
 }
 
 // Enabled — including the common case of NO record at all (default-on).
@@ -135,6 +139,9 @@ if (gstate.isUndecided(cwd) && runOnce('ss-graphify-auto-enabled', cwdKey, { coo
 if (!graphifyInstalled()) {
   // Best-effort, windowless background install — fail-open if `uv` is absent.
   // Never blocks: the graph builds next session once the CLI lands on PATH.
+  // NOTE: `graphifyy` is intentionally unpinned (no version pin) — it is a
+  // first-party CLI under active development; disclosure of this tradeoff is
+  // handled separately (out of scope for this fix pass).
   if (runOnce('ss-graphify-install', cwdKey, { cooldownMs: 24 * 60 * 60 * 1000 })) {
     bg('uv', ['tool', 'install', 'graphifyy']);
     process.stdout.write(
@@ -145,12 +152,20 @@ if (!graphifyInstalled()) {
   process.exit(0);
 }
 
-// Installed. Once/24h remove graphify's OWN git hooks — those fire a Python
-// rebuild on every commit/checkout and pop a console window on Windows.
-// devops owns freshness instead via this SessionStart refresh (below) and the
-// PreToolUse self-heal (pre.tokens.guard.js), both windowless. Idempotent and
-// guarded/fail-open: a missing toolchain here never degrades session start.
-if (isGitRepo() && runOnce('ss-graphify-hookuninstall', cwdKey, { cooldownMs: 24 * 60 * 60 * 1000 })) {
+// Installed. ONE-TIME (per project, not per-day) legacy cleanup of graphify's
+// OWN git hooks — those fire a Python rebuild on every commit/checkout and pop
+// a console window on Windows. devops owns freshness instead via this
+// SessionStart refresh (below) and the PreToolUse self-heal
+// (pre.tokens.guard.js), both windowless. This is a ONE-TIME sweep, not a
+// perpetual fight: new projects are never given graphify's git hooks in the
+// first place (devops never installs them), so once removed here there is
+// nothing left to reintroduce them short of the user deliberately running
+// `graphify hook install` again — which we must not then immediately undo.
+// runOnce with no cooldownMs is checked FIRST (persistent per-project marker,
+// no re-entry ever) so the ~4s `isGitRepo()` git spawn only runs the one time
+// the uninstall is actually due — it must never gate every session (R7).
+// Guarded/fail-open: a missing toolchain here never degrades session start.
+if (runOnce('ss-graphify-hookuninstall', cwdKey) && isGitRepo()) {
   bg('graphify', ['hook', 'uninstall']);
 }
 

--- a/plugins/devops/skills/devops-graph/SKILL.md
+++ b/plugins/devops/skills/devops-graph/SKILL.md
@@ -1,46 +1,46 @@
 ---
 name: devops-graph
-version: 0.3.0
+version: 0.4.0
 description: >-
-  Codebase knowledge graph via the external graphify CLI, with opt-in
-  enforcement. Detects graphify, offers to install it (confirmation — never
-  silent), builds/refreshes the graph, and answers codebase questions with
-  `graphify query`. Once the user opts in per project, the graph is kept fresh
-  automatically (git hooks + SessionStart) and broad raw-file searches are
-  hard-gated toward the graph. Deliberately does NOT install graphify's own
-  PreToolUse hook (would collide with the devops token-guard); the enforcement
-  is devops-owned. Triggers: "knowledge graph", "graphify", "code graph",
+  Codebase knowledge graph via the external graphify CLI, default-on and
+  opt-out. Detects graphify, auto-installs it in the background if missing,
+  keeps the graph fresh with a key-less `graphify update .`, and answers
+  codebase questions with `graphify query`. Enabled automatically in every
+  project unless `.claude/graphify.json` (or the global `~/.claude/graphify.json`)
+  has `{"consent":false}`. Once enabled, the graph is kept fresh windowlessly
+  (SessionStart refresh + PreToolUse self-heal — graphify's own git hooks are
+  removed, not installed) and broad raw-file searches are hard-gated toward
+  the graph. Deliberately does NOT install graphify's own PreToolUse hook
+  (would collide with the devops token-guard); the enforcement is
+  devops-owned. Triggers: "knowledge graph", "graphify", "code graph",
   "/devops-graph". Do NOT trigger for simple single-file lookups.
 allowed-tools: Bash(node *), Bash(graphify *), Bash(uv *), Bash(pipx *), Read, Glob, Write
 ---
 
-# devops-graph — Codebase Knowledge Graph (opt-in enforced)
+# devops-graph — Codebase Knowledge Graph (default-on, opt-out)
 
 Thin orchestration over the real [`graphify`](https://github.com/safishamsi/graphify)
 CLI. graphify stays the single source of truth — this skill reimplements
-nothing. It **detects**, **offers to install**, **freshens the graph**, and
-**queries** it. After a per-project opt-in (recorded in `.claude/graphify.json`)
-the graph is kept fresh automatically and broad searches are hard-gated toward
-it — see [Enforcement](#enforcement-after-opt-in).
+nothing. It **detects**, **auto-installs** if missing, **freshens the graph**,
+and **queries** it. graphify enforcement is **enabled by default** in every
+project — no consent prompt, no offer to confirm. The graph is kept fresh
+automatically and broad searches are hard-gated toward it — see
+[Enforcement](#enforcement-default-on).
 
 ## Hard rules
 
-- **Never install silently.** If graphify is missing, *offer* and wait for an
-  explicit OK before running any install command. The consent record
-  (`.claude/graphify.json`) is written only after the user decides.
-- **After writing the consent record, log the decision.** Immediately after
-  writing `.claude/graphify.json` (either `{"consent":true,...}` or
-  `{"consent":false}`), append one telemetry line so offer→conversion is
-  measurable end to end:
-  ```bash
-  node -e "require('${CLAUDE_PLUGIN_ROOT}/hooks/lib/graphify-metrics').record('consent_written', {consent: <true|false>}, {cwd: process.cwd()})"
-  ```
-  This never blocks anything and is best-effort — if it errors, ignore it and
-  continue.
+- **No consent prompt, ever.** Enforcement is default-on. Never ask the user
+  to confirm enabling graphify and never write a consent record on their
+  behalf — `.claude/graphify.json` / `~/.claude/graphify.json` are read-only
+  from hooks; only the user edits them, manually, to opt out.
 - **Never run `graphify claude install`.** That command writes graphify's own
   PreToolUse hook + CLAUDE.md skill, which collides with the devops plugin's
   PreToolUse hooks (the project-map re-scoping hint and `pre.tokens.guard.js`).
   Our enforcement is devops-owned instead (single, ordered hook chain).
+- **Never install graphify's own git hooks.** They pop a console window on
+  Windows on every commit/checkout. `ss.graphify` actively removes them
+  (`graphify hook uninstall`) if present — devops owns graph freshness
+  instead, windowlessly, via SessionStart + PreToolUse self-heal.
 - **Do not touch `project-map`.** It is a different layer (cheap always-on
   orientation, not on-demand deep retrieval).
 
@@ -57,20 +57,23 @@ Parse the single JSON line:
 - `{"installed":true,...}` → go to Step 3.
 - `{"installed":false}` → go to Step 2.
 
-## Step 2 — Offer install (confirmation required)
+## Step 2 — Install if missing (background, no confirmation needed)
 
-Tell the user graphify is not installed and offer the command. **Do not run it
-until the user confirms.** Recommended:
+If graphify is missing, `ss.graphify` already kicked off a best-effort,
+windowless background install (`uv tool install graphifyy`) at SessionStart —
+this is auto-installed, not offered. If you land here mid-session and the CLI
+still isn't on PATH, you may run the same command directly:
 
 ```bash
-uv tool install graphifyy && graphify install
+uv tool install graphifyy
 ```
 
 Fallbacks if `uv` is absent: `pipx install graphifyy` or `pip install graphifyy`
-(pip needs manual PATH setup). On decline, stop here and report that the graph
-features are unavailable until graphify is installed.
+(pip needs manual PATH setup). This is fail-open — if no installer is
+available, report that graph features are unavailable this session and fall
+back to normal Grep/Glob.
 
-After a confirmed install, re-run Step 1 to verify before continuing.
+After install, re-run Step 1 to verify before continuing.
 
 ## Step 3 — Ensure the graph is fresh
 
@@ -78,13 +81,16 @@ Check for `graphify-out/graph.json` in the project root (use **Glob**). If it is
 missing or the user expects recent code changes to be reflected, refresh it:
 
 ```bash
-graphify extract . --update
+graphify update .
 ```
 
-`--update` is incremental and AST-only for code, so it costs no API tokens.
-A first-time full build on a large repo may take longer; say so before running.
-Only docs/PDF/image extraction would incur LLM cost — do not enable that unless
-the user asks.
+`graphify update` is incremental, AST-only, and key-less — it costs no API
+tokens and needs no LLM key. A first-time full build on a large repo may take
+longer; say so before running. Do **not** use `graphify extract . --update`
+for this automatic path — that command needs an LLM API key once docs/PDF/image
+extraction is involved and is not run automatically. `graphify extract` is
+still the right command only if the user explicitly wants full semantic
+extraction over docs/papers/images.
 
 ## Step 4 — Query
 
@@ -97,22 +103,33 @@ graphify query "<the user's question>"
 Relay the result. For follow-up questions in the same session, reuse the
 existing graph — only re-run Step 3 if the code changed meaningfully.
 
-## Enforcement (after opt-in)
+## Enforcement (default-on)
 
-The user can opt a project in (the `ss.graphify` SessionStart hook offers this
-once). Opt-in is recorded in `.claude/graphify.json`:
+graphify enforcement is **enabled by default** in every project. The only way
+to turn it off is an explicit opt-out record — hooks never write these, only
+the user does:
 
-- `{"consent":true,"autoBuild":true}` → **enabled**
-- `{"consent":false}` → **declined** (never nagged again)
-- absent → **undecided** (offer shown, throttled weekly)
+- `.claude/graphify.json` with `{"consent":false}` → disabled for this project.
+- `~/.claude/graphify.json` with `{"consent":false}` → disabled machine-wide,
+  for every project.
+- Absent (both project and global) → **enabled** — this is the default and
+  the common case.
 
-When **enabled**, two things become automatic — no need to invoke this skill:
+The first time graphify auto-enables for a project with no record at all,
+`ss.graphify` prints a one-time (weekly-throttled), non-blocking transparency
+line disclosing that it's on and how to opt out. This is a disclosure, not an
+offer — there is nothing to confirm.
 
-**1. Auto-build / freshness (D2).** `ss.graphify` ensures graphify is installed,
-installs graphify's git hooks once (`graphify hook install` — post-commit/
-post-checkout AST rebuild, free), and kicks off a background
-`graphify extract . --update` whenever the graph is missing or stale. So the
-graph follows the code via both git hooks *and* SessionStart.
+When **enabled**, two things are automatic — no need to invoke this skill:
+
+**1. Auto-install + auto-build / freshness.** `ss.graphify` ensures graphify
+is installed (best-effort background `uv tool install graphifyy` if missing),
+removes graphify's own git hooks once per project if present (`graphify hook
+uninstall` — those pop a console window on Windows on every commit), and kicks
+off a background `graphify update .` (windowless, sentinel-tracked) whenever
+the graph is missing, stale, or fails a periodic validity check. So the graph
+follows the code purely via windowless SessionStart refresh + PreToolUse
+self-heal — never via graphify's own git hooks.
 
 **2. Hard gate (D3).** `pre.tokens.guard` **blocks** a broad raw-file Grep/Glob
 (exit 2) and tells Claude to run `graphify query` instead. Two preconditions
@@ -140,7 +157,8 @@ tested).
 ## Out of scope (v1)
 
 - No graphify MCP server (`python -m graphify.serve`) — shell-out per query.
-- Auto-build is **code-only** (`--update`, AST). Doc/PDF/image semantic
-  extraction (which costs API tokens) is never enabled automatically.
+- Auto-build is **code-only** (`graphify update .`, AST). Doc/PDF/image semantic
+  extraction via `graphify extract` (which costs API tokens) is never enabled
+  automatically — only on explicit user request.
 - The gate only covers *broad* searches (Grep/Glob with no `path`); targeted,
   path-scoped reads are intentionally left free.

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.114.0",
+  "version": "0.115.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary
graphify's knowledge graph is now **default-on / opt-out** in every devops project — no consent prompt, key-less builds, and windowless (no more per-commit cmd-window popups).

## What changed
- **Opt-out default-on** (`isEnabled`): enabled unless a project OR the machine-wide `~/.claude/graphify.json` carries `{"consent":false}`. Both consent offers (SessionStart + value-moment) removed. A corrupt opt-out record fails **closed**.
- **Key-less rebuild**: `graphify update .` (AST-only, no LLM key) replaces `graphify extract . --update`, which demanded a key on doc-heavy repos and failed every session.
- **Windowless**: devops no longer installs graphify's git hooks — it removes them once (`graphify hook uninstall`) and owns freshness via SessionStart + the PreToolUse self-heal, `windowsHide` on every spawn.
- **Auto-install**: best-effort `uv tool install graphifyy` when the CLI is missing (fail-open, one-time non-blocking disclosure, no interaction).

## Verification
- 717/717 tests pass, `eslint` clean.
- Red-team pass fixed before merge: global off-switch now honored at SessionStart (was project-only), one-time (not daily) hook-uninstall, fail-closed on corrupt consent, non-blocking git check reordered, test HOME-isolation.

## Residual (disclosed)
- Auto-install package intentionally unpinned + first-party. Possible brief window flash from graphify's own Python subprocesses at SessionStart/self-heal (no longer per-commit). Graph may lag briefly mid-session in very long sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)