### PR TITLE
feat(docs): proportional documentation-maintenance system

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.115.1"
+    "version": "0.116.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.115.1",
+      "version": "0.116.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.115.1",
+      "version": "0.116.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.116.0] — 2026-07-13
+
+### Added
+
+- **Documentation is now maintained as part of implementation and shipping — not just the auto-generated roster counts.** Until now the plugin only kept *machine facts* fresh (hook/skill/agent counts, the lifecycle roster, table rows via `gen-*.js`); the *content* layer — prose, flows, folder structure — drifted the moment behavior or architecture changed, no implementation agent was told to touch docs (`code-defaults.md` even says "don't comment untouched code"), and no ship step reconciled docs against what actually shipped. A new **proportional** content-docs layer closes that gap on top of the roster layer: a single-source `deep-knowledge/documentation-maintenance.md` (the docs' target-state definition, living-vs-point-in-time classification, a change→doc-action trigger matrix, and bounded folder-restructure rules that never delete dated specs); a `## Rules` directive in all six implementation agents (core/frontend/feature/ai/designer/windows) to update affected `docs/`/README/architecture in the same change — explicitly scoped to project docs, **not** code comments, so `code-defaults.md` is untouched; and a new `/devops-ship` **Step 2.6 (Docs-Sync)** that reconciles living docs against the frozen shipped diff before the version bump. Proportional throughout (trivial changes need none) and non-blocking (a ship never aborts over docs — unavoidable debt is recorded in the CHANGELOG instead). Design spec: `docs/superpowers/specs/2026-07-13-documentation-maintenance-design.md`. (`deep-knowledge/documentation-maintenance.md` new, 6 agent Rules bullets, `devops-ship` SKILL Step 2.6, `CONVENTIONS.md` living-docs section.)
+
 ## [0.115.1] — 2026-07-13
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.115.1**
+**Version: 0.116.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/docs/superpowers/specs/2026-07-13-documentation-maintenance-design.md
+++ b/docs/superpowers/specs/2026-07-13-documentation-maintenance-design.md
@@ -1,0 +1,98 @@
+# Documentation Maintenance — Design
+
+**Date:** 2026-07-13
+**Status:** Implemented (local, unshipped)
+**Scope:** devops plugin — implementation agents, `/devops-ship`, deep-knowledge
+
+## Problem
+
+Most consumer projects have a `docs/` folder, but it is routinely ignored:
+
+- During **implementation**, agents change behavior, flows, and architecture
+  without ever touching the docs that describe them.
+- During **ship**, nothing reconciles docs against what was actually shipped — new
+  features go undocumented, changed flows go stale, and the folder structure never
+  adapts when the architecture moves.
+
+Goal: after every ship the docs are in their *target state* — no doc misleads, and
+materially new capabilities are discoverable — even when features are added or
+architecture changes.
+
+## Current state (before this change)
+
+The plugin already had a **mechanical roster-freshness system**, and only that:
+
+- `gen-readme-sections.js` / `gen-dk-index.js` / `gen-project-map.js` regenerate
+  counts, the hook-lifecycle roster, skill/agent table rows, the deep-knowledge
+  index, and the project map.
+- `ship_build` runs the generators; `ship_preflight` warns (advisory, never blocks)
+  on stale markers or missing table rows; `ss.git.check` nudges once per 8h.
+
+Gaps: this covers **machine facts only**. There was no upkeep for prose, flows, or
+folder structure; no implementation-agent directive to touch docs (in fact
+`code-defaults.md` says "don't add comments to code you didn't change"); and no
+ship step that reconciles content-level docs against the shipped diff.
+
+## Design
+
+A **proportional** content-docs layer on top of the existing mechanical layer.
+Proportional is the key constraint: "target state" means *not-misleading +
+discoverable*, not "regenerate everything on every ship" (which would bloat docs
+and slow every ship).
+
+Three touchpoints, one shared source of truth:
+
+1. **`deep-knowledge/documentation-maintenance.md`** — the single source of truth:
+   scope (project docs, not code comments, not roster markers), the definition of
+   target state, the living-vs-point-in-time classification, the proportional
+   trigger matrix, and the folder-restructure rules.
+
+2. **Implementation-agent directive** — one `## Rules` bullet in each of the six
+   implementation agents (`core`, `frontend`, `feature`, `ai`, `designer`,
+   `windows`), referencing the deep-knowledge file. Agents update affected project
+   docs as part of the *same* change. Explicitly scoped to project docs, not code
+   comments, so it does not contradict `code-defaults.md`.
+
+3. **`/devops-ship` Step 2.6 (Docs-Sync)** — a reconciliation gate inserted between
+   Build (Step 2) and Version Bump (Step 3). It diffs the shipped change against
+   living docs, applies proportional updates, and commits them into the
+   version-bump commit. Non-blocking by design: a ship never aborts over docs.
+
+`CONVENTIONS.md` § Auto-Maintained Documentation gained a "Living documentation"
+subsection delineating the two layers (mechanical roster vs. content) so future
+contributors don't confuse them.
+
+## Key decisions & rationale
+
+- **Ship step placement — between Build and Version Bump.** By then the diff is
+  frozen (rebase + build + Codex gate done) and Step 3 is already the editorial
+  step (CHANGELOG). Doc edits land in the same version commit — no stray extra
+  commit after the PR is building.
+- **Shared deep-knowledge file + one-line agent bullets** (not inline prose in six
+  places), mirroring the existing `pre-mortem.md` / `local-llm-delegation.md`
+  pattern. DRY; tune wording centrally. `gen-dk-index.js` picks up the new file
+  automatically.
+- **Restructuring is bounded and additive-first**, and dated specs/concepts are
+  never deleted — they are the historical record. This protects the repo's
+  established "dated specs are immutable" convention.
+- **Non-blocking.** Docs debt is recorded in the CHANGELOG, never a ship blocker —
+  keeps the proportional promise and avoids turning docs into a release gate.
+
+## Alternatives considered
+
+- **Preflight heuristic** ("diff adds a new skill/dir but no docs changed → warn").
+  Rejected: detecting "new feature" from a diff heuristically is noisy; the
+  judgment belongs to the Claude-driven Step 2.6, not a script. Preflight stays
+  roster-only.
+- **Standalone `/devops-docs` skill** (on-demand audit + sync). Deferred as a
+  follow-up: the three touchpoints above cover the stated need (docs maintained
+  during implementation and ship). A new skill is a larger surface (frontmatter,
+  README row, tests) and would expand scope beyond the request.
+
+## Files changed
+
+- `plugins/devops/deep-knowledge/documentation-maintenance.md` (new)
+- `plugins/devops/agents/{core,frontend,feature,ai,designer,windows}.md` (Rules bullet)
+- `plugins/devops/skills/devops-ship/SKILL.md` (Step 2.6)
+- `plugins/devops/CONVENTIONS.md` (Living documentation subsection)
+- regenerated: `deep-knowledge/INDEX.md`, `.claude/project-map.md`, README/architecture markers

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.115.1",
+  "version": "0.116.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/CONVENTIONS.md
+++ b/plugins/devops/CONVENTIONS.md
@@ -260,6 +260,16 @@ Three layers, three failure windows covered: generate (can't drift) →
 preflight verify (catches the un-generated tables) → session nudge (catches
 "forgot to refresh entirely").
 
+### Living documentation (prose, flows, structure)
+
+The markers above cover **machine facts only**. The **content** layer — prose,
+flows, folder structure, curated descriptions — is kept current by people and
+agents, not generators: implementation agents update affected docs as part of
+their change, and `/devops-ship` Step 2.6 (Docs-Sync) reconciles living docs
+against the shipped diff before the version bump. Proportional (trivial changes
+need none), non-blocking, and it never rewrites dated specs/concepts. Rules and
+the trigger matrix: `deep-knowledge/documentation-maintenance.md`.
+
 ## General Rules
 
 - All code is JavaScript (Node.js), no Bash scripts

--- a/plugins/devops/agents/ai.md
+++ b/plugins/devops/agents/ai.md
@@ -42,6 +42,7 @@ Your worktree starts on HEAD (main). You MUST rebase immediately:
 ## Rules
 
 - Read `{PLUGIN_ROOT}/deep-knowledge/pre-mortem.md` before non-trivial implementation.
+- Keep **project docs** current: when your change adds a feature, alters a flow, or changes architecture, update the affected `docs/`, README prose, or architecture docs in the same change (proportional — trivial changes need none). See `{PLUGIN_ROOT}/deep-knowledge/documentation-maintenance.md`. Project docs only, not code comments (code-defaults.md still applies).
 - For mechanical integration boilerplate (client DTOs, schema → type conversion, repeated wrappers, >20 lines): read `{PLUGIN_ROOT}/deep-knowledge/local-llm-delegation.md` and delegate to `local_generate` when the gate is green.
 - Always handle API rate limits and timeouts
 - Implement fallbacks for model unavailability

--- a/plugins/devops/agents/core.md
+++ b/plugins/devops/agents/core.md
@@ -42,6 +42,7 @@ Your worktree starts on HEAD (main). You MUST rebase immediately:
 ## Rules
 
 - Read `{PLUGIN_ROOT}/deep-knowledge/pre-mortem.md` before non-trivial implementation.
+- Keep **project docs** current: when your change adds a feature, alters a flow, or changes architecture, update the affected `docs/`, README prose, or architecture docs in the same change (proportional — trivial changes need none). See `{PLUGIN_ROOT}/deep-knowledge/documentation-maintenance.md`. Project docs only, not code comments (code-defaults.md still applies).
 - For mechanical code generation (DTOs, CRUD, schema, test boilerplate, >20 lines): read `{PLUGIN_ROOT}/deep-knowledge/local-llm-delegation.md` and delegate to `local_generate` when the gate is green.
 - Define interfaces/contracts before implementation
 - Commit contracts separately from implementation (clear git bisect point)

--- a/plugins/devops/agents/designer.md
+++ b/plugins/devops/agents/designer.md
@@ -108,6 +108,7 @@ DESIGN_RESULT:
 
 ## Rules
 
+- Keep **project docs** current: when your work adds a flow, changes a user journey, or alters the design system/tokens in ways users or developers rely on, update the affected `docs/`, README prose, or design-system docs in the same change (proportional — trivial changes need none). See `{PLUGIN_ROOT}/deep-knowledge/documentation-maintenance.md`. Project docs only, not code comments (code-defaults.md still applies).
 - **Existing design systems and style guides are binding.** If the project has a design system, component library, Figma library, style guide, or established design tokens, they MUST be treated as the authoritative source of truth. All new work MUST conform to them — colors, typography, spacing, components, patterns. Deviate ONLY when the user explicitly approves a departure. At the start of every task, run `search_design_system` and check the project for existing token files, style guides, or component libraries.
 - Always start with user flow before visual design (understand the journey first)
 - Never skip edge cases — empty, error, and loading states are not optional

--- a/plugins/devops/agents/feature.md
+++ b/plugins/devops/agents/feature.md
@@ -124,6 +124,7 @@ Agent({ subagent_type: "research", model: "sonnet", prompt: "..." })
 ## Rules
 
 - Read `{PLUGIN_ROOT}/deep-knowledge/pre-mortem.md` before non-trivial implementation.
+- Keep **project docs** current: when the feature adds capability, alters a flow, or changes architecture, update the affected `docs/`, README prose, or architecture docs in the same change (proportional — trivial changes need none). See `{PLUGIN_ROOT}/deep-knowledge/documentation-maintenance.md`. Project docs only, not code comments (code-defaults.md still applies).
 - When implementing mechanical code directly (not via sub-agent): read `{PLUGIN_ROOT}/deep-knowledge/local-llm-delegation.md` and delegate to `local_generate` when the gate is green.
 - Always work in a worktree (isolation: worktree)
 - Commit logical units, not mega-commits

--- a/plugins/devops/agents/frontend.md
+++ b/plugins/devops/agents/frontend.md
@@ -41,6 +41,7 @@ Your worktree starts on HEAD (main). You MUST rebase immediately:
 ## Rules
 
 - Read `{PLUGIN_ROOT}/deep-knowledge/pre-mortem.md` before non-trivial implementation.
+- Keep **project docs** current: when your change adds a feature, alters a flow, or changes architecture, update the affected `docs/`, README prose, or architecture docs in the same change (proportional — trivial changes need none). See `{PLUGIN_ROOT}/deep-knowledge/documentation-maintenance.md`. Project docs only, not code comments (code-defaults.md still applies).
 - For mechanical UI boilerplate (prop-typed components, form scaffolds, barrel exports, repeated variants, >20 lines): read `{PLUGIN_ROOT}/deep-knowledge/local-llm-delegation.md` and delegate to `local_generate` when the gate is green.
 - Always verify visual output in a real browser (follow
   `{PLUGIN_ROOT}/deep-knowledge/test-strategy.md` § Web Tech → Always Browser-Test).

--- a/plugins/devops/agents/windows.md
+++ b/plugins/devops/agents/windows.md
@@ -42,6 +42,7 @@ Your worktree starts on HEAD (main). You MUST rebase immediately:
 
 ## Rules
 
+- Keep **project docs** current: when your change adds a feature, alters a flow, or changes architecture, update the affected `docs/`, README prose, or architecture docs in the same change (proportional — trivial changes need none). See `{PLUGIN_ROOT}/deep-knowledge/documentation-maintenance.md`. Project docs only, not code comments (code-defaults.md still applies).
 - Always handle Windows-specific paths (backslashes, %APPDATA%, etc.)
 - Test with both admin and non-admin privileges in mind
 - Installer changes need manual testing (can't be automated in CI)

--- a/plugins/devops/deep-knowledge/INDEX.md
+++ b/plugins/devops/deep-knowledge/INDEX.md
@@ -19,6 +19,7 @@ Quick-reference for all deep-knowledge topics. Read this FIRST to find the right
 | [content-conventions.md](content-conventions.md) | Content Conventions — Sizing & Self-Reference | How to size and structure project-persistent content (CLAUDE.md, skills, |
 | [decision-format.md](decision-format.md) | Decision Format | When presenting multiple options (via AskUserQuestion or inline), use this |
 | [desktop-testing.md](desktop-testing.md) | Automated Desktop Testing (Computer Use) | > **Single-Source-of-Truth for test autonomy decisions:** see [test-autonomy.... |
+| [documentation-maintenance.md](documentation-maintenance.md) | Documentation Maintenance | Keep project docs in their target state as behavior, flows, and architecture ... |
 | [edge-profiles.md](edge-profiles.md) | Edge Profiles | Configuration and usage rules for the two Microsoft Edge profiles used by thi... |
 | [fact-verification.md](fact-verification.md) | Fact Verification | Cross-cutting rule for all web research, claims, and statistics. |
 | [git-hygiene.md](git-hygiene.md) | Git Hygiene | Cross-cutting git rules referenced by `/devops-commit`, `/devops-ship`, and h... |

--- a/plugins/devops/deep-knowledge/documentation-maintenance.md
+++ b/plugins/devops/deep-knowledge/documentation-maintenance.md
@@ -1,0 +1,85 @@
+# Documentation Maintenance
+
+Keep project docs in their target state as behavior, flows, and architecture change.
+
+Cross-cutting rule for every implementation agent and for `/devops-ship`. It covers
+the **content** layer of documentation — prose, flows, folder structure, curated
+descriptions — which no generator maintains. The mechanical roster layer (counts,
+hook lifecycle, skill/agent table rows) is handled separately by
+`gen-readme-sections.js` and friends; see `CONVENTIONS.md` §
+Auto-Maintained Documentation. The two are complementary: generators keep *facts*
+in sync, this keeps *meaning* in sync.
+
+## Scope
+
+Applies to **project documentation only**: `docs/`, README prose, architecture and
+design docs, in-repo usage guides, and flow/workflow docs.
+
+- **Not code comments.** `code-defaults.md` ("don't add docstrings/comments to code
+  you didn't change") still governs source files — that rule is untouched.
+- **Not the auto-generated roster markers.** Never hand-edit text between
+  `<!--devops:…-->` markers; the generators own those.
+
+## Definition of "target state"
+
+Proportional, not exhaustive. After a change lands, the docs are in target state
+when both hold:
+
+1. **Nothing misleads.** No living doc still describes behavior, a flow, or a
+   structure that the change removed or altered.
+2. **New capability is discoverable.** A materially new user-visible feature or
+   flow can be found from the place a reader would look (README feature list, the
+   relevant `docs/` guide, or a linked design spec).
+
+"Target state" is *not-misleading + discoverable*, not "document every line." Most
+small changes need nothing.
+
+## Living vs. point-in-time docs
+
+| Class | Examples | On change |
+|-------|----------|-----------|
+| **Living** — update in place | README prose, architecture overviews, usage/how-to guides, flow docs, folder-structure docs, API/contract references | Edit to match reality |
+| **Point-in-time** — append-only | dated design specs (`docs/**/specs/*`), dated concept pages (`docs/concepts/*`), CHANGELOG entries, ADRs | **Never retro-edit.** Supersede with a new dated doc + a one-line "superseded by" pointer |
+
+The distinction is the safety rail: a superseded decision stays on record as
+history; only living docs get rewritten.
+
+## Trigger matrix (proportional)
+
+| Change kind | Doc action |
+|-------------|------------|
+| Typo, internal refactor, dependency/version bump | none |
+| Bugfix restoring documented behavior | none (unless a doc described the buggy behavior) |
+| New user-visible feature | make it discoverable (README feature list / `docs/` guide); add a dated design spec if the design is non-trivial |
+| Changed flow / workflow / UX path | update the affected flow doc or guide in place |
+| Architecture change (new subsystem, moved boundary, changed contract) | update the architecture doc + every affected reference |
+| New subsystem / module / top-level folder | extend or add the `docs/` section; restructure `docs/` if the current layout no longer fits |
+| Removed / renamed feature | remove or redirect the stale living doc; leave dated records intact |
+
+## Folder-structure changes
+
+Restructuring `docs/` is in scope — but bounded:
+
+- **Trigger only on real drift.** Restructure when the architecture changed enough
+  that the current layout misleads or scatters related docs. Not for tidiness.
+- **Additive-first.** Prefer adding a section or subfolder over moving many files.
+- **Mirror the code.** A reader should find a doc where they'd expect the
+  corresponding code to live.
+- **Fix links on move.** When you move a file, update every in-repo link to it.
+- **HARD RULE — never delete history.** Dated specs, dated concepts, and CHANGELOG
+  entries are the historical record. Never delete or rewrite them; supersede with a
+  new dated doc and a "superseded by" pointer.
+
+## When this runs
+
+- **Implementation agents** — as part of the *same* change that alters behavior,
+  a flow, or architecture; never a deferred pass. Proportional per the matrix
+  above (most changes need nothing).
+- **`/devops-ship` Step 2.6 (Docs-Sync)** — a reconciliation gate against the
+  frozen shipped diff, before the version bump. It is the safety net that catches
+  living-doc drift the implementer missed, and its edits land in the version-bump
+  commit. Non-blocking: a ship never aborts over docs; unavoidable doc debt is
+  recorded in the CHANGELOG entry instead.
+
+For sizing and the "reference over duplicate" rule, follow `content-conventions.md`
+— reference existing docs by name rather than paraphrasing them here.

--- a/plugins/devops/docs/architecture.html
+++ b/plugins/devops/docs/architecture.html
@@ -213,7 +213,7 @@
 │   ├── plugin.json            <span style="color:var(--text2)"># Plugin manifest (name, version, mcpServers, hooks)</span>
 │   └── marketplace.json       <span style="color:var(--text2)"># Marketplace registration</span>
 ├── agents/                    <span style="color:var(--accent2)"># <!--devops:count:agents-->12<!--/devops:count:agents--> agent definitions (*.md with YAML frontmatter)</span>
-├── deep-knowledge/            <span style="color:var(--warn)"># <!--devops:count:dk-->31<!--/devops:count:dk--> cross-cutting reference docs</span>
+├── deep-knowledge/            <span style="color:var(--warn)"># <!--devops:count:dk-->32<!--/devops:count:dk--> cross-cutting reference docs</span>
 ├── hooks/
 │   ├── hooks.json             <span style="color:var(--purple)"># Hook registry (event &rarr; command mapping)</span>
 │   ├── lib/                   <span style="color:var(--text2)"># plugin-guard, run-once, session-id</span>

--- a/plugins/devops/skills/devops-ship/SKILL.md
+++ b/plugins/devops/skills/devops-ship/SKILL.md
@@ -222,6 +222,29 @@ If `success: false` → call `render_completion_card` with variant `ship-blocked
    - **other non-zero** → surface first line of stderr, continue to Step 3
 3. If codex-plugin-cc not installed → skip silently
 
+## Step 2.6 — Docs-Sync
+
+Reconcile living documentation against the **frozen shipped diff** before the
+version bump — so doc edits land in the same version-bump commit. This is the
+ship-time counterpart to the docs upkeep implementation agents already do.
+
+1. Determine what this ship actually changes — new feature, changed flow, new
+   subsystem, architecture/contract change, or removal. Use the diff since the
+   merge-base, not intentions.
+2. Apply the **proportional** doc action per
+   `${CLAUDE_PLUGIN_ROOT}/deep-knowledge/documentation-maintenance.md` § Trigger Matrix:
+   - trivial (typo / refactor / dep or version bump / pure bugfix) → no
+     living-doc change; note "no living-docs impact" and continue.
+   - new or changed behavior, flow, or architecture → update the affected living
+     docs (`docs/`, README prose, architecture/flow docs) in place; restructure
+     `docs/` only when the layout no longer fits (additive-first, never delete
+     dated specs/concepts).
+3. Commit any doc edits on the current branch so they ship with this version.
+
+**Non-blocking:** never abort a ship over docs. Unavoidable doc debt proceeds —
+record the gap in the CHANGELOG entry (Step 3). The mechanical roster markers
+(counts, rosters) are handled separately by `ship_build` in Step 2.
+
 ## Step 3 — Version Bump
 
 **If `intermediate: true` (from Step 1)**: skip this step entirely. Version bumps only happen on final ship to main.

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.115.1",
+  "version": "0.116.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

Adds a proportional documentation-maintenance layer so `docs/` stays in its target state after every ship — without regenerating everything. Sits on top of the existing mechanical roster-freshness system (counts/lifecycle/table-rows), covering the content layer it never touched: prose, flows, folder structure.

- **`deep-knowledge/documentation-maintenance.md`** (new) — single source of truth: target-state definition, living-vs-point-in-time classification, a change→doc-action trigger matrix, and bounded folder-restructure rules (additive-first, never delete dated specs).
- **Implementation agents** — a `## Rules` directive in all six (core/frontend/feature/ai/designer/windows) to update affected `docs/`/README/architecture in the same change. Scoped to **project docs, not code comments** — no conflict with `code-defaults.md`.
- **`/devops-ship` Step 2.6 (Docs-Sync)** — reconciles living docs against the frozen shipped diff before the version bump; non-blocking.
- **`CONVENTIONS.md`** — delineates mechanical roster vs. living-docs layers.
- Dogfood: dated design spec `docs/superpowers/specs/2026-07-13-documentation-maintenance-design.md`.

Proportional throughout (trivial changes need none) and non-blocking (a ship never aborts over docs).

## Tests
- vitest: 717 passed / 44 files
- eslint: 0 errors
- `gen-readme-sections --check`: markers up-to-date