### PR TITLE
fix(graphify): windowless background builds on Windows

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.116.0"
+    "version": "0.116.1"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.116.0",
+      "version": "0.116.1",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.116.0",
+      "version": "0.116.1",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.116.1] — 2026-07-15
+
+### Fixed
+
+- **Background graphify builds no longer flash a console window on Windows — the "windowless" promise from 0.115.0 is now actually kept.** Despite `windowsHide: true` on every spawn, users still got a cmd/graphify window popping up on each SessionStart refresh and every PreToolUse self-heal (multiple accumulating per session). Root cause, verified with a user32 `EnumWindows` detector: the window belongs to the **graphify** process itself, not cmd — a `detached` shell has no console of its own (`DETACHED_PROCESS`), so the `graphify` grandchild it launches inherits none and Windows hands it a fresh, VISIBLE console; `windowsHide` only reaches the direct child (the shell), never the grandchild. Dropping `detached` instead kills the build the instant the hook `process.exit()`s (proven: no sentinel written). The fix routes background spawns through a detached, windowless **Node runner** (`spawnBgRunner`): the runner outlives the hook (detached node.exe gets no console, `windowsHide` ⇒ `CREATE_NO_WINDOW`, no window) and launches the real command as a NON-detached `windowsHide` child that inherits a hidden console — so nothing is ever visible — then waits for it and writes the ok/fail sentinel itself. This also drops the fragile cmd `%errorlevel%`/redirection quoting, so win32 now records real exit codes in the sentinel too. New `bgWindowless` helper (sentinel-less, for `uv install` / `graphify hook uninstall`); `bgWithSentinel` rewritten to delegate. Verified on the real production path: NO_WINDOW + sentinel `ok` after the parent exits. (`graphify-state` 0.3.0 → 0.4.0, `ss.graphify` 0.3.0 → 0.3.1; +1 test, 718 total.)
+
 ## [0.116.0] — 2026-07-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.116.0**
+**Version: 0.116.1**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.116.0",
+  "version": "0.116.1",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/hooks/lib/graphify-state.js
+++ b/plugins/devops/hooks/lib/graphify-state.js
@@ -1,7 +1,7 @@
 'use strict';
 /**
  * @lib graphify-state
- * @version 0.3.0
+ * @version 0.4.0
  * @plugin devops
  * @description Consent + session-state helpers for the graphify enforcement
  *   layer (devops-graph). Default-on / opt-out model: graphify enforcement is
@@ -207,49 +207,87 @@ function sentinelPath(cwd) {
   return path.join(os.tmpdir(), `dotclaude-graphbuild-${key}.sentinel`);
 }
 
+// Sentinel argv sentinel value meaning "run windowless, but write no sentinel".
+const NO_SENTINEL = '-';
+// argv flag that turns a plain `node graphify-state.js` invocation into the
+// background runner (see the require.main block at the bottom of this file).
+const BG_RUN_FLAG = '--bg-run';
+
 /**
- * Detached background spawn with a completion sentinel (Gap #5). Plain bg()
- * spawns (detached + stdio:'ignore') make a failing `graphify extract`
- * completely invisible — this wraps the command in a platform shell that
- * writes `ok` or `fail:<code>` to a per-project sentinel file once the
+ * Launch a fire-and-forget background process that must (a) never block session
+ * start, (b) outlive the short-lived hook that spawns it, and (c) NOT pop a
+ * console window on Windows. Achieving all three at once is the whole trick.
+ *
+ * The naive `spawn(cmd, { detached:true, shell:true, windowsHide:true })` fails
+ * (c): a DETACHED shell has no console of its own (DETACHED_PROCESS), so the
+ * grandchild it launches (`graphify` / `uv`, a console app) inherits none and
+ * Windows hands it a fresh, VISIBLE console — `windowsHide` on the shell cannot
+ * reach the grandchild. That is the cmd/graphify window users saw flash on
+ * every SessionStart refresh and every PreToolUse self-heal. Dropping `detached`
+ * kills (b) instead: without it the build is reaped when the hook `process.exit`s.
+ *
+ * The fix is one level of indirection. We spawn THIS file as a DETACHED,
+ * windowless Node runner (`node graphify-state.js --bg-run …`). node.exe is a
+ * console app, so detaching it gives it no console and `windowsHide`
+ * (CREATE_NO_WINDOW) means no window — and being detached, it outlives the hook.
+ * The runner then launches the real command as a NON-detached child WITH
+ * `windowsHide`, so that child is created with CREATE_NO_WINDOW directly (a flag
+ * that DOES reach a first-generation child) → a hidden console, no window. The
+ * runner waits for it and writes the ok/fail sentinel itself, so there is no
+ * fragile cmd `%errorlevel%`/redirection quoting anymore and win32 now reports a
+ * real exit code too. Fail-open: any spawn error is swallowed.
+ *
+ * @param {string} cmd    bare command (e.g. "graphify")
+ * @param {string[]} args argument vector
+ * @param {string} cwd    working directory for the build
+ * @param {string|null} sentinel absolute sentinel path, or null for none
+ * @returns {boolean} true iff the runner spawn was issued (not whether it succeeds)
+ */
+function spawnBgRunner(cmd, args, cwd, sentinel) {
+  try {
+    spawn(
+      process.execPath,
+      [__filename, BG_RUN_FLAG, sentinel || NO_SENTINEL, cwd, cmd, ...args],
+      { cwd, detached: true, stdio: 'ignore', windowsHide: true },
+    ).unref();
+    return true;
+  } catch {
+    return false; // node/toolchain absent — never let this degrade session start
+  }
+}
+
+/**
+ * Fire-and-forget background command, windowless on Windows and surviving the
+ * hook that launches it, with NO completion sentinel. Used for graphify
+ * side-tasks whose outcome we do not surface (`uv tool install`, `graphify hook
+ * uninstall`). See spawnBgRunner for the windowless mechanism.
+ * @returns {boolean} true iff the spawn was issued
+ */
+function bgWindowless(cmd, args, cwd) {
+  return spawnBgRunner(cmd, args, cwd, null);
+}
+
+/**
+ * Background spawn WITH a completion sentinel (Gap #5). A plain detached spawn
+ * with stdio:'ignore' makes a failing `graphify update` completely invisible —
+ * the runner writes `ok` / `fail:<code>` to a per-project sentinel file once the
  * command exits, so a LATER SessionStart can detect and surface the failure
  * (see readSentinel + ss.graphify.js). git-invisible (os.tmpdir(), not the
- * project). Fail-open: any spawn error is swallowed, matching the shape of
- * the plain bg() helpers in ss.graphify.js / pre.tokens.guard.js.
+ * project) and windowless on Windows (see spawnBgRunner). Fail-open.
  * @returns {boolean} true iff the spawn was issued (not whether it succeeds)
  */
 function bgWithSentinel(cmd, args, cwd) {
   const sentinel = sentinelPath(cwd);
   try { fs.unlinkSync(sentinel); } catch { /* no previous sentinel */ }
-  const quoted = args.map((a) => `"${String(a).replace(/"/g, '""')}"`).join(' ');
-  // Two Windows traps shape this implementation:
-  //   1. No exit code on win32: %errorlevel% expands at cmd PARSE time (before
-  //      the command runs → always 0), and once expanded the token ends in a
-  //      digit directly before `>` (`echo fail:0>"…"`), which cmd parses as a
-  //      file-handle redirection — the sentinel then contains neither `ok` nor
-  //      `fail`. A bare `fail` (ends in a letter) has neither problem.
-  //   2. Quoting: a manual spawn('cmd.exe', ['/c', inner]) makes node escape
-  //      the inner quotes as \" — cmd.exe does not understand backslash
-  //      escapes, the redirect path breaks, and NO sentinel is ever written.
-  //      `shell: true` lets node compose the platform shell line verbatim.
-  const inner = process.platform === 'win32'
-    ? `${cmd} ${quoted} && (echo ok>"${sentinel}") || (echo fail>"${sentinel}")`
-    : `${cmd} ${quoted} && echo ok > "${sentinel}" || echo "fail:$?" > "${sentinel}"`;
-  try {
-    spawn(inner, [], {
-      cwd, detached: true, stdio: 'ignore', windowsHide: true, shell: true,
-    }).unref();
-    return true;
-  } catch {
-    return false; // toolchain / shell absent
-  }
+  return spawnBgRunner(cmd, args, cwd, sentinel);
 }
 
 /**
  * Read the last background-build sentinel for `cwd`. Returns null when no
- * sentinel exists yet (never ran, or still running). `code` is null when the
- * platform shell could not report one (win32 — see bgWithSentinel).
- * Never throws.
+ * sentinel exists yet (never ran, or still running). `code` is null only when
+ * the child was terminated by a signal (no numeric exit code); a normal
+ * non-zero exit reports its code on every platform now (the runner reads it from
+ * Node's `exit` event — see spawnBgRunner). Never throws.
  * @returns {null|{status:'ok'}|{status:'fail', code:number|null}|{status:'unknown'}}
  */
 function readSentinel(cwd) {
@@ -288,7 +326,46 @@ module.exports = {
   queryDone,
   isGraphifyQueryCommand,
   sentinelPath,
+  bgWindowless,
   bgWithSentinel,
   readSentinel,
   clearSentinel,
 };
+
+// ── Background runner entrypoint ─────────────────────────────────────────────
+// When this file is executed directly as `node graphify-state.js --bg-run
+// <sentinel|'-'> <cwd> <cmd> [args...]` it acts as the detached, windowless
+// wrapper spawned by spawnBgRunner: it runs the real command as a NON-detached,
+// windowsHide child (created with CREATE_NO_WINDOW → hidden console, no window),
+// waits for it, and writes the ok/fail sentinel. Guarded by require.main so a
+// normal `require()` of this module never triggers it.
+if (require.main === module && process.argv[2] === BG_RUN_FLAG) {
+  const sentinelArg = process.argv[3];
+  const runCwd = process.argv[4];
+  const runCmd = process.argv[5];
+  const runArgs = process.argv.slice(6);
+  const writeSentinel = (text) => {
+    if (sentinelArg === NO_SENTINEL) return;
+    try { fs.writeFileSync(sentinelArg, text); } catch { /* tmp unwritable — nothing to surface to */ }
+  };
+  let child;
+  try {
+    child = spawn(runCmd, runArgs, {
+      cwd: runCwd,
+      stdio: 'ignore',
+      windowsHide: true,
+      // shell on win32 so a `.cmd`/`.bat` shim (e.g. some `uv`/`graphify`
+      // installs) resolves; the shell is NOT detached here and carries
+      // windowsHide, so its (and the grandchild's) console stays hidden.
+      shell: process.platform === 'win32',
+    });
+  } catch {
+    writeSentinel('fail');
+    process.exit(0);
+  }
+  child.on('error', () => { writeSentinel('fail'); process.exit(0); });
+  child.on('exit', (code) => {
+    writeSentinel(code === 0 ? 'ok' : (code == null ? 'fail' : `fail:${code}`));
+    process.exit(0);
+  });
+}

--- a/plugins/devops/hooks/lib/graphify-state.test.js
+++ b/plugins/devops/hooks/lib/graphify-state.test.js
@@ -14,6 +14,7 @@ import {
   consentPath,
   isGraphifyQueryCommand,
   sentinelPath,
+  bgWindowless,
   bgWithSentinel,
   readSentinel,
   clearSentinel,
@@ -238,6 +239,34 @@ describe("isGraphifyQueryCommand — only real query runs relent the gate", () =
   });
 });
 
+describe("bgWindowless — sentinel-less background runner", () => {
+  const waitFor = async (p, timeoutMs = 8000) => {
+    const start = Date.now();
+    while (!fs.existsSync(p)) {
+      if (Date.now() - start > timeoutMs) return false;
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    return true;
+  };
+
+  test("runs the command through the detached runner but writes NO sentinel", async () => {
+    const dir = tmp();
+    const marker = path.join(dir, "marker.txt");
+    // A tiny writer script the runner will execute — proves the runner actually
+    // ran the command, without stressing shell quoting (mkdtemp paths have no spaces).
+    const writer = path.join(dir, "writer.cjs");
+    fs.writeFileSync(writer, `require("fs").writeFileSync(process.argv[2], "ran");`);
+    // Bare `node` (not process.execPath) — the real callers pass bare command
+    // names too, and the win32 runner-shell mangles an absolute exe path that
+    // contains spaces (e.g. "C:\\Program Files\\nodejs\\node.exe").
+    expect(bgWindowless("node", [writer, marker], dir)).toBe(true);
+    expect(await waitFor(marker)).toBe(true);        // command executed + survived
+    expect(fs.existsSync(sentinelPath(dir))).toBe(false); // NO sentinel written
+    clearSentinel(dir);
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+  }, 12000);
+});
+
 describe("background-build sentinel — read/clear", () => {
   let dir;
   beforeEach(() => { dir = tmp(); });
@@ -273,9 +302,10 @@ describe("background-build sentinel — read/clear", () => {
   });
 });
 
-// End-to-end through the REAL platform shell — exactly the path that silently
-// broke on cmd.exe (%errorlevel% parse-time expansion + trailing-digit handle
-// redirection made the fail-sentinel unparseable). Detached spawn → poll.
+// End-to-end through the REAL detached Node runner (spawnBgRunner) — the runner
+// executes the command as a windowless, non-detached child and writes the
+// sentinel from Node's `exit` event, so both ok and non-zero exits are reported
+// on every platform. Detached spawn → poll.
 describe("background-build sentinel — bgWithSentinel end-to-end", () => {
   const waitForSentinel = async (cwd, timeoutMs = 5000) => {
     const start = Date.now();

--- a/plugins/devops/hooks/session-start/ss.graphify.js
+++ b/plugins/devops/hooks/session-start/ss.graphify.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * @hook ss.graphify
- * @version 0.3.0
+ * @version 0.3.1
  * @event SessionStart
  * @plugin devops
  * @description graphify enforcement — install-check + auto-build wiring for the
@@ -45,7 +45,7 @@ require('../lib/plugin-guard');
 
 const fs = require('fs');
 const crypto = require('crypto');
-const { spawn, execSync } = require('child_process');
+const { execSync } = require('child_process');
 const { runOnce } = require('../lib/run-once');
 const gstate = require('../lib/graphify-state');
 const graphNudge = require('../lib/graph-nudge');
@@ -105,18 +105,13 @@ function isGitRepo() {
 }
 
 function bg(cmd, args) {
-  // Detached + unref so a 5-10s graphify build never blocks session start.
-  // `shell` on Windows so a `graphify.cmd`/`.bat` shim (what `uv tool install`
-  // produces) actually runs — a bare spawn cannot exec a .cmd and would
-  // silently no-op, leaving the graph un-refreshed. `windowsHide` suppresses
-  // the console window that `shell:true` would otherwise pop on Windows for
-  // every invocation (matches bgWithSentinel in hooks/lib/graphify-state.js).
-  // Guarded: a missing toolchain throws → no-op.
-  try {
-    spawn(cmd, args, {
-      cwd, detached: true, stdio: 'ignore', shell: process.platform === 'win32', windowsHide: true,
-    }).unref();
-  } catch { /* toolchain absent */ }
+  // Fire-and-forget background task (uv install / graphify hook uninstall) with
+  // NO sentinel. Delegates to gstate.bgWindowless, which runs it through a
+  // detached, windowless Node runner: survives this hook's exit AND never pops a
+  // console window on Windows (a naive detached shell spawn does — the grandchild
+  // graphify/uv process inherits no console and Windows gives it a visible one).
+  // Fail-open inside the helper: a missing toolchain never degrades session start.
+  gstate.bgWindowless(cmd, args, cwd);
 }
 
 if (gstate.isDeclinedAnywhere(cwd)) {

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.116.0",
+  "version": "0.116.1",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

Background `graphify update` / `uv install` spawns flashed a **cmd/graphify console window** on Windows — on every SessionStart refresh and every PreToolUse self-heal, accumulating multiple per session. Despite `windowsHide: true` already being set on every spawn (the "windowless" work from 0.115.0), the windows kept appearing.

## Root cause (verified with a user32 `EnumWindows` detector)

The visible window belongs to the **graphify** process itself, not cmd. A `detached` shell has no console of its own (`DETACHED_PROCESS`), so the `graphify` grandchild it launches inherits none and Windows hands it a fresh, VISIBLE console. `windowsHide` only reaches the direct child (the shell) — never the grandchild. Simply dropping `detached` instead kills the build the instant the hook `process.exit()`s (proven: no sentinel written).

## Fix

Route background spawns through a **detached, windowless Node runner** (`spawnBgRunner`):
- The runner (`node graphify-state.js --bg-run …`) is detached, so it outlives the hook; node.exe detached gets no console and `windowsHide` (`CREATE_NO_WINDOW`) means no window.
- It launches the real command as a **NON-detached** `windowsHide` child, which is created with `CREATE_NO_WINDOW` directly (a flag that DOES reach a first-generation child) → hidden console, no window.
- It waits for the child and writes the ok/fail sentinel itself — dropping the fragile cmd `%errorlevel%`/redirection quoting, so win32 now records real exit codes too.

New `bgWindowless` helper (sentinel-less, for `uv install` / `graphify hook uninstall`); `bgWithSentinel` rewritten to delegate.

## Verification

- Real production path (`gstate.bgWithSentinel('graphify', ['update','.'])`): **NO_WINDOW** + sentinel `ok` after the parent exits.
- Survival + windowless + sentinel each proven independently on Windows.
- **718/718** tests green, lint clean.

Files: `graphify-state` 0.3.0 → 0.4.0, `ss.graphify` 0.3.0 → 0.3.1.