### PR TITLE
fix(graphify): windowless bg spawns under Windows Terminal (0.116.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.116.1"
+    "version": "0.116.2"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.116.1",
+      "version": "0.116.2",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.116.1",
+      "version": "0.116.2",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.116.2] — 2026-07-17
+
+### Fixed
+
+- **Background graphify builds are now truly windowless on stock Windows 11 — the 0.116.1 runner fix was still popping visible Windows Terminal tabs.** Users kept getting a `graphify "update" "."` tab on every SessionStart refresh despite the detached-runner fix, because that fix only holds under classic `conhost.exe`: on machines where **Windows Terminal is the registered Default Terminal Application** (the Windows 11 default — no registry override needed), console-session creation is delegated to WT, which surfaces a visible, focus-stealing tab even for children created with `CREATE_NO_WINDOW`. Measured trigger (visible-window-title polling on a live Win11 26200 machine): the *extra cmd.exe layer* from `shell: true` — the runner wrapped every argv-based command in a second `cmd.exe /d /s /c`, and that indirection is what WT's delegation picks up. The runner's child spawn now defaults to **shell-less direct spawn** (windowsHide, non-detached, under the detached runner) on every platform and retries exactly once through `cmd.exe` only when the target is a `.cmd`/`.bat` shim (sync `EINVAL` per the CVE-2024-27980 hardening, or async `ENOENT`) — pre-fix behavior preserved for that edge case, sentinel `ok`/`fail:<code>` semantics unchanged. End-to-end verified on the real path: a full `graphify update .` ran with **zero** new visible windows, sentinel `ok`, graph.json freshly rebuilt. Delivery note: the machine that reported this was still on 0.116.0 because 0.116.1 never left the alpha channel — promote to stable so consumers actually receive windowless builds. (`graphify-state` 0.4.0 → 0.5.0, child-spawn logic extracted as `runBgEntrypointChild`; +5 tests, 723 total.)
+
 ## [0.116.1] — 2026-07-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.116.1**
+**Version: 0.116.2**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.116.1",
+  "version": "0.116.2",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/hooks/lib/graphify-state.js
+++ b/plugins/devops/hooks/lib/graphify-state.js
@@ -1,7 +1,7 @@
 'use strict';
 /**
  * @lib graphify-state
- * @version 0.4.0
+ * @version 0.5.0
  * @plugin devops
  * @description Consent + session-state helpers for the graphify enforcement
  *   layer (devops-graph). Default-on / opt-out model: graphify enforcement is
@@ -230,12 +230,34 @@ const BG_RUN_FLAG = '--bg-run';
  * windowless Node runner (`node graphify-state.js --bg-run …`). node.exe is a
  * console app, so detaching it gives it no console and `windowsHide`
  * (CREATE_NO_WINDOW) means no window — and being detached, it outlives the hook.
- * The runner then launches the real command as a NON-detached child WITH
- * `windowsHide`, so that child is created with CREATE_NO_WINDOW directly (a flag
- * that DOES reach a first-generation child) → a hidden console, no window. The
- * runner waits for it and writes the ok/fail sentinel itself, so there is no
- * fragile cmd `%errorlevel%`/redirection quoting anymore and win32 now reports a
- * real exit code too. Fail-open: any spawn error is swallowed.
+ *
+ * That much was 0.116.0's fix and it is correct under plain `conhost.exe` (the
+ * classic per-process console host): a first-generation child created with
+ * CREATE_NO_WINDOW gets a real but invisible console, full stop. It measurably
+ * FAILS, however, on a machine where **Windows Terminal is the registered
+ * "Default Terminal Application"** (the Win11 default, no registry override
+ * needed) — empirically verified on this machine (Windows 11 build 26200).
+ * Under WT delegation, any console-session creation gets handed off to Windows
+ * Terminal itself rather than a plain hidden conhost, and WT opens a new,
+ * VISIBLE, focus-stealing tab — even though the child was created with
+ * CREATE_NO_WINDOW. The specific trigger measured here is the *extra shell
+ * layer*: `spawn(cmd, args, { shell:true })` on win32 runs the target through
+ * `cmd.exe /d /s /c "<cmd> <args>"`, i.e. a SECOND cmd.exe wrapping the already
+ * argv-based command; that double indirection is what WT's delegation picks up
+ * and surfaces as a tab. Spawning the target directly — no shell layer at all —
+ * does not trigger it: measured with a real `graphify update .` run and with a
+ * forced-failure `cmd.exe` child (title-probe + poll of visible window titles
+ * showed no new window in either case, while the shell:true path reliably
+ * produced one). All call sites here pass a plain argv vector (no `&&`/`|`
+ * shell syntax), so shell:false is safe by construction; the one shell:true
+ * fallback below exists solely for the (currently theoretical) case of a
+ * `.cmd`/`.bat` shim binary, which Node's non-shell spawn cannot exec on
+ * Windows — see the retry in `runBgEntrypointChild` below.
+ *
+ * The runner launches the real command as a NON-detached, windowsHide child,
+ * waits for it, and writes the ok/fail sentinel itself, so there is no fragile
+ * cmd `%errorlevel%`/redirection quoting and win32 now reports a real exit code
+ * too. Fail-open: any spawn error is swallowed.
  *
  * @param {string} cmd    bare command (e.g. "graphify")
  * @param {string[]} args argument vector
@@ -330,7 +352,75 @@ module.exports = {
   bgWithSentinel,
   readSentinel,
   clearSentinel,
+  runBgEntrypointChild,
 };
+
+/**
+ * Spawn the real background command as a NON-detached, windowsHide child of the
+ * (already detached, windowless) `--bg-run` runner, write the ok/fail sentinel
+ * once it exits, and `process.exit(0)` the runner. Tries a shell-less spawn
+ * first (the fix for the Windows-Terminal-delegation window flash — see
+ * spawnBgRunner's doc comment); if that spawn itself throws or emits `error`
+ * with `ENOENT` (typically a `.cmd`/`.bat` shim spawn() cannot exec directly),
+ * it retries exactly once through `shell:true` on win32 so a shim install still
+ * runs — same behavior as before this fix, just no longer the default path.
+ * Exported for unit testing the fallback/command-construction logic; the actual
+ * window-visibility behavior is not unit-testable (see qa_hints in the
+ * accompanying commit/PR).
+ * @param {string} runCmd
+ * @param {string[]} runArgs
+ * @param {string} runCwd
+ * @param {(text: string) => void} writeSentinel
+ * @param {(code: number) => void} [exitFn] injectable for tests; defaults to process.exit
+ */
+function runBgEntrypointChild(runCmd, runArgs, runCwd, writeSentinel, exitFn) {
+  const doExit = exitFn || ((code) => process.exit(code));
+  const spawnChild = (useShell) => spawn(runCmd, runArgs, {
+    cwd: runCwd,
+    stdio: 'ignore',
+    windowsHide: true,
+    shell: useShell,
+  });
+  const attach = (child, allowShellRetry) => {
+    let settled = false;
+    child.on('error', (err) => {
+      if (settled) return;
+      settled = true;
+      if (allowShellRetry && process.platform === 'win32' && err && err.code === 'ENOENT') {
+        // Likely a .cmd/.bat shim that shell-less spawn() cannot exec — retry
+        // once through cmd.exe, matching pre-fix behavior for that edge case.
+        try {
+          attach(spawnChild(true), false);
+          return;
+        } catch { /* fall through to fail below */ }
+      }
+      writeSentinel('fail');
+      doExit(0);
+    });
+    child.on('exit', (code) => {
+      if (settled) return;
+      settled = true;
+      writeSentinel(code === 0 ? 'ok' : (code == null ? 'fail' : `fail:${code}`));
+      doExit(0);
+    });
+  };
+  let child;
+  try {
+    child = spawnChild(false);
+  } catch {
+    // Synchronous throw (rare — spawn() normally reports async via 'error').
+    // Retry through the shell once before giving up, same as the async path.
+    try {
+      attach(spawnChild(true), false);
+      return;
+    } catch {
+      writeSentinel('fail');
+      doExit(0);
+      return;
+    }
+  }
+  attach(child, true);
+}
 
 // ── Background runner entrypoint ─────────────────────────────────────────────
 // When this file is executed directly as `node graphify-state.js --bg-run
@@ -348,24 +438,5 @@ if (require.main === module && process.argv[2] === BG_RUN_FLAG) {
     if (sentinelArg === NO_SENTINEL) return;
     try { fs.writeFileSync(sentinelArg, text); } catch { /* tmp unwritable — nothing to surface to */ }
   };
-  let child;
-  try {
-    child = spawn(runCmd, runArgs, {
-      cwd: runCwd,
-      stdio: 'ignore',
-      windowsHide: true,
-      // shell on win32 so a `.cmd`/`.bat` shim (e.g. some `uv`/`graphify`
-      // installs) resolves; the shell is NOT detached here and carries
-      // windowsHide, so its (and the grandchild's) console stays hidden.
-      shell: process.platform === 'win32',
-    });
-  } catch {
-    writeSentinel('fail');
-    process.exit(0);
-  }
-  child.on('error', () => { writeSentinel('fail'); process.exit(0); });
-  child.on('exit', (code) => {
-    writeSentinel(code === 0 ? 'ok' : (code == null ? 'fail' : `fail:${code}`));
-    process.exit(0);
-  });
+  runBgEntrypointChild(runCmd, runArgs, runCwd, writeSentinel);
 }

--- a/plugins/devops/hooks/lib/graphify-state.test.js
+++ b/plugins/devops/hooks/lib/graphify-state.test.js
@@ -22,6 +22,7 @@ import {
   isDeclinedAnywhere,
   globalConsentPath,
   readGlobalState,
+  runBgEntrypointChild,
 } from "./graphify-state.js";
 
 function tmp() {
@@ -336,5 +337,50 @@ describe("background-build sentinel — bgWithSentinel end-to-end", () => {
     expect(s.status).toBe("fail"); // the regression this guards against
     clearSentinel(dir);
     try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+  }, 10000);
+});
+
+// Direct-call tests for the runner's child-spawn logic — the shell-less default
+// (the Windows-Terminal-delegation window fix) plus the one-shot shell retry
+// for `.cmd`/`.bat` shims. Window visibility itself is not unit-testable; these
+// pin the command-construction/fallback semantics the fix must not break.
+describe("runBgEntrypointChild — shell-less default + shim fallback", () => {
+  const testWin = process.platform === "win32" ? test : test.skip;
+  const runChild = (cmd, args, cwd) =>
+    new Promise((resolve) => {
+      let sentinel;
+      runBgEntrypointChild(cmd, args, cwd, (text) => { sentinel = text; }, () => resolve(sentinel));
+    });
+
+  let dir;
+  beforeEach(() => { dir = tmp(); });
+  afterEach(() => {
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+  });
+
+  test("exit 0 through the shell-less path → 'ok'", async () => {
+    expect(await runChild("node", ["-e", "process.exit(0)"], dir)).toBe("ok");
+  }, 10000);
+
+  test("non-zero exit → 'fail:<code>' (exit code preserved)", async () => {
+    expect(await runChild("node", ["-e", "process.exit(3)"], dir)).toBe("fail:3");
+  }, 10000);
+
+  test("nonexistent command → settles as 'fail' (never hangs, never throws)", async () => {
+    expect(await runChild("definitely-not-a-real-cmd-x9z", [], dir)).toMatch(/^fail/);
+  }, 10000);
+
+  testWin(".cmd shim → falls back to the shell exactly once and still reports 'ok'", async () => {
+    // spawn() without shell cannot exec a .cmd (sync EINVAL since the
+    // CVE-2024-27980 hardening) — the runner must retry through cmd.exe.
+    const shim = path.join(dir, "shim.cmd");
+    fs.writeFileSync(shim, "@exit /b 0\r\n");
+    expect(await runChild(shim, [], dir)).toBe("ok");
+  }, 10000);
+
+  testWin(".cmd shim with non-zero exit → shell retry preserves the code", async () => {
+    const shim = path.join(dir, "shimfail.cmd");
+    fs.writeFileSync(shim, "@exit /b 7\r\n");
+    expect(await runChild(shim, [], dir)).toBe("fail:7");
   }, 10000);
 });

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.116.1",
+  "version": "0.116.2",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

Background graphify spawns still popped a visible `graphify "update" "."` console tab on stock Windows 11 despite the 0.116.1 detached-runner fix. Root cause (empirically proven on a live Win11 26200 machine via visible-window-title polling): the 0.116.1 fix only holds under classic conhost — when **Windows Terminal is the registered Default Terminal Application** (the Win11 default), console-session creation is delegated to WT, which renders a visible, focus-stealing tab even for `CREATE_NO_WINDOW` children. The measured trigger is the extra `cmd.exe /d /s /c` layer from `shell: true` in the runner's child spawn.

## Fix

- Runner child spawn (`--bg-run` entrypoint) now defaults to a **shell-less direct spawn** (windowsHide, non-detached, under the detached runner) on every platform.
- One-shot `cmd.exe` retry only for `.cmd`/`.bat` shims (sync `EINVAL` per CVE-2024-27980 hardening, or async `ENOENT`) — pre-fix behavior preserved for that edge case.
- Sentinel `ok`/`fail:<code>` semantics unchanged; logic extracted as `runBgEntrypointChild` with direct unit tests (+5, 723 total).

## Verification

- End-to-end on the real path: full `graphify update .` with **0** new visible windows, sentinel `ok`, `graph.json` freshly rebuilt.
- Codex review: CLEAN. Lint + full vitest suite green.

## Delivery note

The reporting machine was still on 0.116.0 because 0.116.1 never left the alpha channel — promote to stable (`/devops-release`) so consumers actually receive windowless builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)