### PR TITLE
feat(autonomous): live-window resume/shutdown timing (0.118.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.117.0"
+    "version": "0.118.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.117.0",
+      "version": "0.118.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.117.0",
+      "version": "0.118.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.118.0] — 2026-07-18
+
+### Changed
+
+- **Autonomous resume and fail-safe shutdown timers now fire on the *real* remaining token window instead of almost always defaulting to a flat 5h.** Both the auto-resume cron (`devops-autonomous` Step 4e) and the fail-safe OS shutdown timer (Step 5.0) derive their delay from `session.resetInMinutes` in `~/.claude/usage-live.json` — but that file is only kept minute-fresh by the native statusLine writer, which never runs in the Desktop app. In those (common) unattended sessions the snapshot was stale, so age-correction bounced to the safe-but-blunt flat-5h fallback: a resume that could fire minutes after the window resets waited the full 5h, and the shutdown timer powered off a whole period late. Both CLIs now **freshen usage first** — when the cached snapshot is stale (older than 3 min) or absent they best-effort run the headless `refresh-usage` scraper (`--no-login`, so it never opens a window) before computing; a warm cache (terminal session) is detected via `isCacheFresh` and skips the scrape entirely. The scrape is 90s-bounded and fully swallowed: a slow, broken, or logged-out scraper never delays arming past its cap nor throws, and the 5h fallback stays the safety net when it yields nothing. `now` is read *after* the scrape so a freshly written snapshot is not misread as future-dated — which would have re-triggered the very fallback the refresh exists to avoid. The resume buffer past the reset boundary is raised **10 → 15 min** so the cron lands further clear of the reset before nudging capped worktrees; the shutdown timer keeps its `[90 min, 5 h]` clamp and adds no buffer (a powered-off PC resumes nothing). Codex review gate was unavailable this ship (external usage limit) — covered instead by +13 unit tests (isCacheFresh boundaries for both scripts, the 15-min buffer lock) and full-suite verification. (`autonomous-resume-schedule.js` buffer 10→15 + refresh, `autonomous-shutdown-timer.js` refresh, `devops-autonomous` SKILL 0.4.2 → 0.5.0 Step 4e/5.0, `shutdown-watchdog.md` rationale; 748 tests.)
+
 ## [0.117.0] — 2026-07-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.117.0**
+**Version: 0.118.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.117.0",
+  "version": "0.118.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/scripts/autonomous-resume-schedule.js
+++ b/plugins/devops/scripts/autonomous-resume-schedule.js
@@ -8,12 +8,17 @@
  * worktrees to continue with »weiter« (Step 0.2).
  *
  * Timing — "just after the current window resets, else a flat 5h":
- *   - Read `session.resetInMinutes` from ~/.claude/usage-live.json (last scrape),
- *     age-correct it against the snapshot `timestamp`.
- *   - Fire at `now + effectiveMin + BUFFER`. The BUFFER pushes the fire moment
- *     PAST the reset boundary (clock skew, scrape lag) — the cron must wake up
- *     when budget is back, not a hair before. effectiveMin is clamped to one full
- *     window (≤ 5h) defensively.
+ *   - The CLI first FRESHENS usage: when ~/.claude/usage-live.json is stale (older
+ *     than REFRESH_MAX_AGE_MIN, or absent), it best-effort runs the headless
+ *     refresh-usage scraper (`--no-login`, bounded) so the REAL remaining window is
+ *     used instead of silently defaulting to the flat-5h fallback. A warm cache
+ *     (native statusLine writer, terminal sessions) skips the scrape entirely.
+ *   - Read `session.resetInMinutes` from the (now-fresh) snapshot and age-correct
+ *     it against the snapshot `timestamp`.
+ *   - Fire at `now + effectiveMin + BUFFER`. The BUFFER (15 min) pushes the fire
+ *     moment PAST the reset boundary (clock skew, scrape lag) — the cron must wake
+ *     up when budget is truly back, not a hair before. effectiveMin is clamped to
+ *     one full window (≤ 5h) defensively.
  *   - Fall back to a flat 5h whenever usage data is missing, stale (>5h old),
  *     future-dated, or already reset. 5h is always safe: the active window started
  *     at or before "now", so its reset is at or before now+5h ("im Zweifel 5h").
@@ -27,9 +32,11 @@
  *                       `cron` is a ready-to-use 5-field expression in LOCAL time
  *                       for a one-shot CronCreate — no LLM date math needed.
  *
- * Cross-platform: pure file-read + date math, no native calls.
+ * The pure resolver (computeResumeDelayMinutes) does only file-read + date math and
+ * is fully cross-platform; the CLI additionally best-effort refreshes usage first.
  */
 
+const { spawnSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
@@ -37,8 +44,9 @@ const os = require('os');
 const USAGE_JSON_PATH = path.join(os.homedir(), '.claude', 'usage-live.json');
 
 const WINDOW_MAX_MIN = 5 * 60; // 300 — one full token period (cap & flat fallback)
-const RESET_BUFFER_MIN = 10;   // pad past the reset boundary so budget is truly back
+const RESET_BUFFER_MIN = 15;   // pad past the reset boundary so budget is truly back
 const MAX_STALE_MIN = 300;     // usage older than a full window → unreliable → fallback
+const REFRESH_MAX_AGE_MIN = 3; // cache younger than this is fresh enough → skip the scrape
 
 /**
  * Pure delay resolver — no I/O, exported for tests.
@@ -92,12 +100,49 @@ function readUsageJson() {
   }
 }
 
+/**
+ * Is the cached usage snapshot recent enough to trust without a re-scrape?
+ * Pure — exported for tests.
+ * @param {object|null} usageData  Parsed usage-live.json (or null/garbage).
+ * @param {number} nowMs           Current epoch ms.
+ * @returns {boolean}
+ */
+function isCacheFresh(usageData, nowMs) {
+  const ts = usageData && usageData.timestamp;
+  if (!ts) return false;
+  const ageMin = (nowMs - new Date(ts).getTime()) / 60000;
+  return Number.isFinite(ageMin) && ageMin >= 0 && ageMin <= REFRESH_MAX_AGE_MIN;
+}
+
+/**
+ * Best-effort freshen usage-live.json via the headless scraper so the resume cron
+ * fires on the REAL remaining window instead of the flat-5h fallback. Bounded and
+ * fully swallowed: a slow/broken/logged-out scrape must never delay or break
+ * scheduling — we simply fall through to whatever the cache (or 5h fallback) holds.
+ */
+function refreshUsageBestEffort() {
+  try {
+    const scraper = path.join(__dirname, 'refresh-usage-headless.js');
+    spawnSync(process.execPath, [scraper, '--no-login', '--quiet'], {
+      cwd: os.tmpdir(), // always-local CWD — a UNC session dir can't break the spawn
+      timeout: 90_000,
+      stdio: 'ignore',
+    });
+  } catch {
+    // ignore — scheduling proceeds on the existing snapshot
+  }
+}
+
 function pad2(n) {
   return String(n).padStart(2, '0');
 }
 
 // --- CLI entry (skipped when require()'d by tests) ---
 if (require.main === module) {
+  // Freshen first so a stale desktop-session cache doesn't silently force flat 5h.
+  if (!isCacheFresh(readUsageJson(), Date.now())) refreshUsageBestEffort();
+  // Capture `now` AFTER the (possibly ~60s) scrape: a fresh snapshot's timestamp
+  // must be ≤ now, else age-correction reads it as future-dated → flat-5h fallback.
   const now = Date.now();
   const plan = computeResumeDelayMinutes(readUsageJson(), now);
   const fireAtMs = now + plan.delayMinutes * 60000;
@@ -118,8 +163,10 @@ if (require.main === module) {
 
 module.exports = {
   computeResumeDelayMinutes,
+  isCacheFresh,
   toCronExpression,
   WINDOW_MAX_MIN,
   RESET_BUFFER_MIN,
   MAX_STALE_MIN,
+  REFRESH_MAX_AGE_MIN,
 };

--- a/plugins/devops/scripts/autonomous-resume-schedule.test.js
+++ b/plugins/devops/scripts/autonomous-resume-schedule.test.js
@@ -1,9 +1,11 @@
 import { describe, test, expect } from "vitest";
 import {
   computeResumeDelayMinutes,
+  isCacheFresh,
   toCronExpression,
   WINDOW_MAX_MIN,
   RESET_BUFFER_MIN,
+  REFRESH_MAX_AGE_MIN,
 } from "./autonomous-resume-schedule.js";
 
 // Fixed "now" so age-correction is deterministic.
@@ -23,7 +25,7 @@ describe("computeResumeDelayMinutes — reset-window mapping", () => {
 
   test("imminent reset (3 min remaining) → fires soon, NO floor", () => {
     const r = computeResumeDelayMinutes(atNow(3), NOW);
-    expect(r.delayMinutes).toBe(3 + RESET_BUFFER_MIN); // 13 — not floored to 90+
+    expect(r.delayMinutes).toBe(3 + RESET_BUFFER_MIN); // 18 — not floored to 90+
     expect(r.source).toBe("reset-window");
   });
 
@@ -86,6 +88,44 @@ describe("computeResumeDelayMinutes — fallback to flat 5h (no buffer)", () => 
   test("fallback delay carries NO buffer (flat 5h == 300)", () => {
     const r = computeResumeDelayMinutes(null, NOW);
     expect(r.delayMinutes).toBe(300);
+  });
+});
+
+describe("RESET_BUFFER_MIN — resume lands past the reset boundary", () => {
+  test("buffer is 15 min (real remaining window + 15 for resume)", () => {
+    expect(RESET_BUFFER_MIN).toBe(15);
+  });
+
+  test("delay = real remaining + 15, not a flat 5h", () => {
+    const r = computeResumeDelayMinutes(atNow(120), NOW);
+    expect(r.delayMinutes).toBe(135); // 120 remaining + 15 buffer
+    expect(r.source).toBe("reset-window");
+  });
+});
+
+describe("isCacheFresh — gate for the pre-schedule usage refresh", () => {
+  test("fresh snapshot (0 min old) → no scrape needed", () => {
+    expect(isCacheFresh(atNow(180, 0), NOW)).toBe(true);
+  });
+
+  test("exactly at the age boundary → still fresh", () => {
+    expect(isCacheFresh(atNow(180, REFRESH_MAX_AGE_MIN), NOW)).toBe(true);
+  });
+
+  test("just past the age boundary → stale, must refresh", () => {
+    expect(isCacheFresh(atNow(180, REFRESH_MAX_AGE_MIN + 1), NOW)).toBe(false);
+  });
+
+  test.each([
+    ["null usage", null],
+    ["empty object", {}],
+    ["missing timestamp", { session: { resetInMinutes: 120 } }],
+  ])("%s → not fresh (must refresh)", (_label, usage) => {
+    expect(isCacheFresh(usage, NOW)).toBe(false);
+  });
+
+  test("future-dated snapshot (clock skew) → not fresh", () => {
+    expect(isCacheFresh(atNow(180, -5), NOW)).toBe(false);
   });
 });
 

--- a/plugins/devops/scripts/autonomous-shutdown-timer.js
+++ b/plugins/devops/scripts/autonomous-shutdown-timer.js
@@ -11,8 +11,13 @@
  * this `shutdown.exe` call could not be placed.
  *
  * Timer length — "remaining 5h-period + floor" (user choice):
- *   - Read `session.resetInMinutes` from ~/.claude/usage-live.json (last scrape),
- *     age-correct it against the snapshot `timestamp`.
+ *   - FRESHEN first (arm, no override): when ~/.claude/usage-live.json is stale
+ *     (older than REFRESH_MAX_AGE_MIN, or absent), best-effort run the headless
+ *     refresh-usage scraper (`--no-login`, bounded) so the timer tracks the REAL
+ *     remaining window instead of silently defaulting to the flat-5h fallback. A
+ *     warm cache (native statusLine writer) skips the scrape entirely.
+ *   - Read `session.resetInMinutes` from the (now-fresh) snapshot and age-correct
+ *     it against the snapshot `timestamp`.
  *   - Clamp to [90 min, 5 h]. The 90-min FLOOR stops a near-empty token window
  *     from cutting off still-running work; the 5 h CAP is one full token period.
  *   - Fall back to 5 h if usage data is missing, stale (>5 h old), or the period
@@ -26,8 +31,9 @@
  *
  * Subcommands (stdout: JSON):
  *   arm [resetMinutesOverride]   Place `shutdown /s /t <seconds>`. Optional numeric
- *                                override skips the usage-file read (testing / when
- *                                the caller already knows resetInMinutes).
+ *                                override skips BOTH the usage refresh and the
+ *                                usage-file read (testing / when the caller already
+ *                                knows resetInMinutes).
  *                                → { ok, armed, seconds, minutes, source }
  *   cancel                       Run `shutdown /a`. A "nothing scheduled" result is
  *                                treated as success (idempotent).
@@ -46,6 +52,7 @@ const USAGE_JSON_PATH = path.join(os.homedir(), '.claude', 'usage-live.json');
 const FIVE_HOURS_SEC = 5 * 60 * 60; // 18000 — fallback & hard cap (one token period)
 const FLOOR_SEC = 90 * 60;          // 5400  — min, guards against cutting off live work
 const MAX_STALE_MIN = 300;          // usage older than a full window → unreliable → fallback
+const REFRESH_MAX_AGE_MIN = 3;      // cache younger than this is fresh enough → skip the scrape
 
 function fail(msg) {
   process.stdout.write(JSON.stringify({ ok: false, error: msg }) + '\n');
@@ -107,6 +114,40 @@ function readUsageJson() {
   }
 }
 
+/**
+ * Is the cached usage snapshot recent enough to trust without a re-scrape?
+ * Pure — exported for tests.
+ * @param {object|null} usageData  Parsed usage-live.json (or null/garbage).
+ * @param {number} nowMs           Current epoch ms.
+ * @returns {boolean}
+ */
+function isCacheFresh(usageData, nowMs) {
+  const ts = usageData && usageData.timestamp;
+  if (!ts) return false;
+  const ageMin = (nowMs - new Date(ts).getTime()) / 60000;
+  return Number.isFinite(ageMin) && ageMin >= 0 && ageMin <= REFRESH_MAX_AGE_MIN;
+}
+
+/**
+ * Best-effort freshen usage-live.json via the headless scraper so the fail-safe
+ * timer tracks the REAL remaining window instead of the flat-5h fallback. Bounded
+ * and fully swallowed: a slow/broken/logged-out scrape must never delay arming past
+ * its 90s cap or throw — we fall through to whatever the cache (or 5h) holds. The
+ * 5h fallback keeps this net safe even if the refresh yields nothing.
+ */
+function refreshUsageBestEffort() {
+  try {
+    const scraper = path.join(__dirname, 'refresh-usage-headless.js');
+    spawnSync(process.execPath, [scraper, '--no-login', '--quiet'], {
+      cwd: safeCwd(), // always-local CWD — a UNC session dir can't break the spawn
+      timeout: 90_000,
+      stdio: 'ignore',
+    });
+  } catch {
+    // ignore — arming proceeds on the existing snapshot
+  }
+}
+
 function shutdownExe() {
   const root = process.env.SystemRoot || process.env.windir || 'C:\\Windows';
   return path.join(root, 'System32', 'shutdown.exe');
@@ -130,6 +171,11 @@ function runArm(argv) {
       0, // age 0 → use override verbatim (clamped)
     );
   } else {
+    // Freshen first so a stale desktop-session cache doesn't force the flat-5h
+    // fallback; scrape only when the cache is actually stale (bounded, best-effort).
+    // Read `now` AFTER the scrape so a fresh timestamp isn't seen as future-dated
+    // (which would bounce it to the 5h fallback).
+    if (!isCacheFresh(readUsageJson(), Date.now())) refreshUsageBestEffort();
     plan = computeShutdownDelaySeconds(readUsageJson(), Date.now());
   }
 
@@ -177,7 +223,9 @@ if (require.main === module) {
 
 module.exports = {
   computeShutdownDelaySeconds,
+  isCacheFresh,
   FIVE_HOURS_SEC,
   FLOOR_SEC,
   MAX_STALE_MIN,
+  REFRESH_MAX_AGE_MIN,
 };

--- a/plugins/devops/scripts/autonomous-shutdown-timer.test.js
+++ b/plugins/devops/scripts/autonomous-shutdown-timer.test.js
@@ -1,8 +1,10 @@
 import { describe, test, expect } from "vitest";
 import {
   computeShutdownDelaySeconds,
+  isCacheFresh,
   FIVE_HOURS_SEC,
   FLOOR_SEC,
+  REFRESH_MAX_AGE_MIN,
 } from "./autonomous-shutdown-timer.js";
 
 // Fixed "now" so age-correction is deterministic.
@@ -96,5 +98,31 @@ describe("computeShutdownDelaySeconds — fallback to 5h", () => {
     const r = computeShutdownDelaySeconds(atNow(180, -30), NOW);
     expect(r.seconds).toBe(FIVE_HOURS_SEC);
     expect(r.source).toBe("fallback-5h");
+  });
+});
+
+describe("isCacheFresh — gate for the pre-arm usage refresh", () => {
+  test("fresh snapshot (0 min old) → no scrape needed", () => {
+    expect(isCacheFresh(atNow(180, 0), NOW)).toBe(true);
+  });
+
+  test("exactly at the age boundary → still fresh", () => {
+    expect(isCacheFresh(atNow(180, REFRESH_MAX_AGE_MIN), NOW)).toBe(true);
+  });
+
+  test("just past the age boundary → stale, must refresh", () => {
+    expect(isCacheFresh(atNow(180, REFRESH_MAX_AGE_MIN + 1), NOW)).toBe(false);
+  });
+
+  test.each([
+    ["null usage", null],
+    ["empty object", {}],
+    ["missing timestamp", { session: { resetInMinutes: 120 } }],
+  ])("%s → not fresh (must refresh)", (_label, usage) => {
+    expect(isCacheFresh(usage, NOW)).toBe(false);
+  });
+
+  test("future-dated snapshot (clock skew) → not fresh", () => {
+    expect(isCacheFresh(atNow(180, -5), NOW)).toBe(false);
   });
 });

--- a/plugins/devops/skills/devops-autonomous/SKILL.md
+++ b/plugins/devops/skills/devops-autonomous/SKILL.md
@@ -379,13 +379,17 @@ on its own — this cron is the global "budget is back, keep going" nudge. It on
 applies in `notify` mode (shutdown=no): a shutdown PC has nothing to resume, which is
 why Step 2 Q4 is never asked when shutdown=yes.
 
-**Fire timing — compute it, don't guess.** Run the helper; it derives the fire moment
-from the live token-window reset (with a buffer past the reset boundary) and falls
-back to a flat 5h when usage data is missing or stale:
+**Fire timing — compute it, don't guess.** Run the helper; it first **freshens usage**
+(best-effort headless `--no-login` scrape, only when the cached snapshot is stale) so
+the fire moment tracks the **real** remaining token window instead of silently
+defaulting to a flat 5h. It then fires at `remaining window + 15-min buffer` past the
+reset boundary, and falls back to a flat 5h only when usage data stays missing/stale:
 
 ```bash
 node "$CLAUDE_PLUGIN_ROOT/scripts/autonomous-resume-schedule.js"
 ```
+
+The helper self-refreshes — do **not** run `/devops-refresh-usage` separately first.
 
 Parse the JSON: `{ delayMinutes, cron, fireAtLocal, source }`. `cron` is a ready-to-use
 5-field one-shot expression in local time — use it verbatim, no manual date math. Then:
@@ -450,9 +454,11 @@ and never reaches Step 8 — the exact "tokens ran out, PC stayed on all night" 
 node "$CLAUDE_PLUGIN_ROOT/scripts/autonomous-shutdown-timer.js" arm
 ```
 
-The script reads `~/.claude/usage-live.json`, sets the timer to the remaining
-5h-period (`session.resetInMinutes`, age-corrected) **clamped to [90 min, 5 h]**,
-and falls back to **5 h** if usage data is missing/stale. It calls
+The script first **freshens usage** (best-effort headless `--no-login` scrape, only
+when the cached snapshot is stale) so the timer tracks the **real** remaining window
+instead of defaulting to a flat 5h. It then sets the timer to the remaining 5h-period
+(`session.resetInMinutes`, age-corrected) **clamped to [90 min, 5 h]**, and falls back
+to **5 h** if usage data stays missing/stale. It calls
 `shutdown.exe /s /t <seconds>` directly with an absolute path and a guaranteed-local
 CWD (UNC-safe). Parse the JSON: on `ok:true` log the armed window
 (`{minutes} min, source={source}`) to `AUTONOMOUS-LOG.md`; on `ok:false` or

--- a/plugins/devops/skills/devops-autonomous/SKILL.md
+++ b/plugins/devops/skills/devops-autonomous/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: devops-autonomous
-version: 0.4.2
+version: 0.5.0
 description: >-
   Fully autonomous agent orchestration for when the user is away from the PC.
   Runs agents without supervision (implementation, desktop interaction, live

--- a/plugins/devops/skills/devops-autonomous/deep-knowledge/shutdown-watchdog.md
+++ b/plugins/devops/skills/devops-autonomous/deep-knowledge/shutdown-watchdog.md
@@ -103,20 +103,29 @@ Parse the JSON:
 
 ### Timer length — "remaining 5h-period + floor"
 
-The script reads `~/.claude/usage-live.json` (last usage scrape) and resolves the
-delay purely (`computeShutdownDelaySeconds`, unit-tested):
+Before reading usage, `arm` (no override) **freshens** `~/.claude/usage-live.json`
+when the cached snapshot is stale (older than `REFRESH_MAX_AGE_MIN`, or absent): it
+best-effort runs the headless `refresh-usage` scraper (`--no-login`, 90 s-bounded,
+all failures swallowed). This is what makes the timer track the **real** remaining
+window instead of silently defaulting to the flat-5h fallback in desktop sessions,
+where the native statusLine writer never keeps the file warm. A warm cache (terminal
+session) is younger than `REFRESH_MAX_AGE_MIN`, so the scrape is skipped entirely.
+
+The script then resolves the delay purely (`computeShutdownDelaySeconds`, unit-tested):
 
 1. Take `session.resetInMinutes`, **age-correct** it by the snapshot `timestamp`
-   (`effective = resetInMinutes − minutesSinceSnapshot`).
+   (`effective = resetInMinutes − minutesSinceSnapshot`). `now` is read *after* the
+   scrape, so a fresh snapshot is never misread as future-dated.
 2. **Clamp to [90 min, 5 h].** The 90-min FLOOR stops a near-empty token window from
    cutting off still-running work; the 5 h CAP is one full token period.
 3. **Fall back to 5 h** when usage data is missing, unparsable, stale (>5 h old),
    future-dated (clock skew), or the period already elapsed — *"5h passt im
    Zweifelsfall immer"*.
 
-Why a live scrape is **not** triggered here: it would cost ~60 s and spin up the Edge
-scraper at run start. The cached snapshot is precise enough for a coarse fail-safe,
-and the 5 h fallback is safe when it is absent.
+Why the refresh is **bounded and skippable**: a scrape costs up to ~60 s and spins up
+the Edge scraper. Capping it at 90 s and gating it on cache staleness keeps arming
+prompt in the common (warm-cache) case, and the 5 h fallback stays safe whenever the
+refresh yields nothing — so accuracy is gained without weakening the fail-safe.
 
 ### Robustness
 

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.117.0",
+  "version": "0.118.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

Autonomous resume cron (Step 4e) and fail-safe shutdown timer (Step 5.0) now fire on the **real** remaining token window instead of almost always defaulting to a flat 5h.

- Both CLIs freshen `usage-live.json` before computing — best-effort, 90s-bounded, `--no-login` (never opens a window) — gated on cache staleness via `isCacheFresh` (a warm terminal cache skips the scrape entirely).
- `now` is captured *after* the scrape so a freshly written snapshot isn't misread as future-dated (which would bounce it back to the 5h fallback).
- Resume buffer raised **10 → 15 min**; the shutdown timer keeps its `[90 min, 5 h]` clamp and adds no buffer (a powered-off PC resumes nothing).
- Falls back to the flat-5h safety net whenever the refresh yields nothing.

**Why:** `usage-live.json` is only kept warm by the native statusLine writer, which never runs in the Desktop app — so unattended sessions almost always hit the stale-cache → flat-5h fallback.

## Verification

- +13 unit tests (isCacheFresh boundaries for both scripts, 15-min buffer lock); full suite **748/748**; lint clean.
- Resume CLI verified end-to-end: `{"delayMinutes":296,...,"source":"reset-window"}` — real remaining + 15, not fallback-5h.
- Codex review gate unavailable this ship (external usage limit).

## Docs

`devops-autonomous` SKILL Step 4e/5.0 + `shutdown-watchdog.md` rationale updated proportionally (per the #252 docs-maintenance convention).