### PR TITLE
fix(graphify): cap background update concurrency to one per repo

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.118.0"
+    "version": "0.118.1"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.118.0",
+      "version": "0.118.1",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.118.0",
+      "version": "0.118.1",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.118.1] — 2026-07-19
+
+### Fixed
+
+- **Background `graphify update` builds no longer stack until they exhaust RAM — `bgWithSentinel` now holds a per-project PID lock.** On an affected machine the working set filled to 99% (31.6 / 31.9 GB, ~0.3 GB free) and the system was thrashing on a 55 GB commit charge; the cause was **12 concurrent `graphify update .` runs** (~29.5 GB commit combined, several 3–6 GB each) spawned by the devops-graph refresh and never reaped. Root cause: the SessionStart (10-min `runOnce`) and PreToolUse (2-min `markRefresh`) throttles only **debounce** — they gate how *often* a build may be kicked, not whether one is already running. On a large repo a single AST build runs longer than its throttle window while a trigger recurs at least as often (the `*/10` git-sync cron opens a fresh session — hence a fresh throttle window — every 10 min), so a new build launched roughly every 10 min on top of the still-running previous ones and they piled up unbounded over ~3.5 h. The comment in `ss.graphify.js` even claimed the throttle "cannot stack concurrent runs" — false whenever a run outlives the cooldown. The fix adds a real mutex at the single spawn chokepoint (`bgWithSentinel`, through which all three spawn sites funnel — the SessionStart refresh and both PreToolUse self-heal paths): before spawning it checks a per-project lock file recording the detached runner's PID + spawn time and **skips** when that PID is still alive; the runner clears the lock when its build exits. PID-liveness plus a 45-min stale timeout mean a crashed runner never wedges refresh forever, and every read fails open so the guard can never block a legitimate build. Runaway processes on the affected machine were killed as immediate triage (commit charge 55 → 26 GB). (`graphify-state` 0.5.0 → 0.6.0: new `updateInFlight`/`updateLockPath`/`writeUpdateLock`/`clearUpdateLock`, `spawnBgRunner` now returns the runner PID and carries a lock argv, `runBgEntrypointChild` releases the lock on exit; `ss.graphify` throttle comment corrected; +9 tests, 757 total. Codex review gate was unavailable this ship — external usage limit — covered instead by the +9 unit/e2e tests and full-suite verification.)
+
 ## [0.118.0] — 2026-07-18
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.118.0**
+**Version: 0.118.1**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.118.0",
+  "version": "0.118.1",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/hooks/lib/graphify-state.js
+++ b/plugins/devops/hooks/lib/graphify-state.js
@@ -1,7 +1,7 @@
 'use strict';
 /**
  * @lib graphify-state
- * @version 0.5.0
+ * @version 0.6.0
  * @plugin devops
  * @description Consent + session-state helpers for the graphify enforcement
  *   layer (devops-graph). Default-on / opt-out model: graphify enforcement is
@@ -16,6 +16,16 @@
  *   records background `graphify update`/`hook uninstall` outcomes to a
  *   per-project sentinel file so a silent failure (stdio:'ignore') can be
  *   surfaced at the next SessionStart instead of vanishing.
+ *
+ *   `bgWithSentinel` additionally holds a per-project PID lock
+ *   (`updateInFlight`/`updateLockPath`) so at most ONE `graphify update` runs
+ *   per project at a time. The SessionStart (10-min) and PreToolUse (2-min)
+ *   spawn throttles only DEBOUNCE bursts; on a large repo a single build can
+ *   outlast its throttle window while a trigger recurs (e.g. the git-sync cron
+ *   opens a fresh session every 10 min), so time-based throttling alone let
+ *   builds stack without bound — measured in the field at 12 concurrent runs /
+ *   ~29 GB commit, exhausting RAM. The lock bounds concurrency across ALL spawn
+ *   triggers (they all funnel through `bgWithSentinel`).
  */
 
 const fs = require('node:fs');
@@ -213,6 +223,73 @@ const NO_SENTINEL = '-';
 // background runner (see the require.main block at the bottom of this file).
 const BG_RUN_FLAG = '--bg-run';
 
+// ── graphify-update concurrency lock ─────────────────────────────────────────
+// A single `graphify update .` on a large repo can outlast the SessionStart
+// (10-min) and PreToolUse (2-min) spawn throttles, which only DEBOUNCE bursts.
+// When a trigger recurs at least as often as the build takes (e.g. the */10
+// git-sync cron opens a fresh session — hence a fresh throttle window — every
+// 10 min), purely time-based throttling let builds stack without bound (measured
+// in the field: 12 concurrent runs, ~29 GB commit, RAM exhausted). This PID lock
+// bounds concurrency to ONE build per project across every trigger.
+const UPDATE_LOCK_STALE_MS = 45 * 60 * 1000;
+
+/** Per-project lock file recording the live background-update runner's PID. */
+function updateLockPath(cwd) {
+  const key = crypto.createHash('md5').update(`updatelock:${cwd}`).digest('hex').slice(0, 12);
+  return path.join(os.tmpdir(), `dotclaude-graphupdate-${key}.lock`);
+}
+
+/**
+ * True iff `pid` names a live process. `process.kill(pid, 0)` sends no signal —
+ * it only probes existence: it throws ESRCH when the process is gone and EPERM
+ * when it exists but is owned by another user (still "alive" for our purposes).
+ * A non-integer / non-positive pid is never alive. Never throws.
+ */
+function pidAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e) {
+    return !!(e && e.code === 'EPERM');
+  }
+}
+
+/**
+ * True iff a `graphify update` background runner is still active for `cwd`. The
+ * lock records the detached runner's PID and spawn time; the runner outlives its
+ * graphify child (it awaits the child's exit — see runBgEntrypointChild), so a
+ * live runner PID means a live build. A lock whose PID is dead, or older than
+ * UPDATE_LOCK_STALE_MS (a runner that crashed without clearing it, or a rare
+ * PID reuse), is treated as NOT in flight so a refresh can never wedge forever.
+ * Never throws — any read/parse error fails OPEN (returns false → allow a spawn).
+ */
+function updateInFlight(cwd) {
+  try {
+    const { pid, ts } = JSON.parse(fs.readFileSync(updateLockPath(cwd), 'utf8'));
+    if (typeof ts === 'number' && Date.now() - ts > UPDATE_LOCK_STALE_MS) return false;
+    return pidAlive(pid);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Record the live update runner's PID so a concurrent trigger skips
+ * (see updateInFlight). Written by bgWithSentinel right after the spawn issues.
+ * Never throws — a tmp write failure degrades to "no guard", never a crash.
+ */
+function writeUpdateLock(cwd, pid) {
+  try {
+    fs.writeFileSync(updateLockPath(cwd), JSON.stringify({ pid, ts: Date.now() }));
+  } catch { /* tmp unwritable — degrade to no guard, never throw */ }
+}
+
+/** Remove the update lock (the runner clears it once its build exits). No-op when absent. Never throws. */
+function clearUpdateLock(cwd) {
+  try { fs.unlinkSync(updateLockPath(cwd)); } catch { /* absent already */ }
+}
+
 /**
  * Launch a fire-and-forget background process that must (a) never block session
  * start, (b) outlive the short-lived hook that spawns it, and (c) NOT pop a
@@ -263,18 +340,23 @@ const BG_RUN_FLAG = '--bg-run';
  * @param {string[]} args argument vector
  * @param {string} cwd    working directory for the build
  * @param {string|null} sentinel absolute sentinel path, or null for none
- * @returns {boolean} true iff the runner spawn was issued (not whether it succeeds)
+ * @param {string|null} lock absolute update-lock path (cleared by the runner on
+ *   exit), or null for none — only the `graphify update` path passes one.
+ * @returns {number|null} the runner's PID if the spawn was issued, else null
+ *   (spawn error — node/toolchain absent). PID, not boolean, so the caller can
+ *   record it in the concurrency lock.
  */
-function spawnBgRunner(cmd, args, cwd, sentinel) {
+function spawnBgRunner(cmd, args, cwd, sentinel, lock) {
   try {
-    spawn(
+    const child = spawn(
       process.execPath,
-      [__filename, BG_RUN_FLAG, sentinel || NO_SENTINEL, cwd, cmd, ...args],
+      [__filename, BG_RUN_FLAG, sentinel || NO_SENTINEL, lock || NO_SENTINEL, cwd, cmd, ...args],
       { cwd, detached: true, stdio: 'ignore', windowsHide: true },
-    ).unref();
-    return true;
+    );
+    child.unref();
+    return child.pid || null;
   } catch {
-    return false; // node/toolchain absent — never let this degrade session start
+    return null; // node/toolchain absent — never let this degrade session start
   }
 }
 
@@ -282,11 +364,12 @@ function spawnBgRunner(cmd, args, cwd, sentinel) {
  * Fire-and-forget background command, windowless on Windows and surviving the
  * hook that launches it, with NO completion sentinel. Used for graphify
  * side-tasks whose outcome we do not surface (`uv tool install`, `graphify hook
- * uninstall`). See spawnBgRunner for the windowless mechanism.
+ * uninstall`). See spawnBgRunner for the windowless mechanism. No concurrency
+ * lock — these side-tasks are one-shot/idempotent, not the stackable build.
  * @returns {boolean} true iff the spawn was issued
  */
 function bgWindowless(cmd, args, cwd) {
-  return spawnBgRunner(cmd, args, cwd, null);
+  return spawnBgRunner(cmd, args, cwd, null, null) != null;
 }
 
 /**
@@ -296,12 +379,25 @@ function bgWindowless(cmd, args, cwd) {
  * command exits, so a LATER SessionStart can detect and surface the failure
  * (see readSentinel + ss.graphify.js). git-invisible (os.tmpdir(), not the
  * project) and windowless on Windows (see spawnBgRunner). Fail-open.
- * @returns {boolean} true iff the spawn was issued (not whether it succeeds)
+ *
+ * Concurrency guard: this is the single chokepoint for EVERY `graphify update`
+ * spawn (the SessionStart refresh + both PreToolUse self-heal paths), so the PID
+ * lock taken here bounds concurrency to one build per project for all triggers.
+ * When a build is already in flight the call is a no-op (returns false) — the
+ * time-based throttles at the call sites only debounce bursts and cannot see a
+ * run that outlived its window (the RAM-exhaustion bug). The runner clears the
+ * lock when its build exits (see the --bg-run entrypoint → runBgEntrypointChild).
+ * @returns {boolean} true iff a spawn was issued; false when skipped (already
+ *   in flight) or the spawn errored.
  */
 function bgWithSentinel(cmd, args, cwd) {
+  if (updateInFlight(cwd)) return false; // a build is already running — never stack
   const sentinel = sentinelPath(cwd);
+  const lock = updateLockPath(cwd);
   try { fs.unlinkSync(sentinel); } catch { /* no previous sentinel */ }
-  return spawnBgRunner(cmd, args, cwd, sentinel);
+  const pid = spawnBgRunner(cmd, args, cwd, sentinel, lock);
+  if (pid != null) writeUpdateLock(cwd, pid);
+  return pid != null;
 }
 
 /**
@@ -348,6 +444,10 @@ module.exports = {
   queryDone,
   isGraphifyQueryCommand,
   sentinelPath,
+  updateLockPath,
+  updateInFlight,
+  writeUpdateLock,
+  clearUpdateLock,
   bgWindowless,
   bgWithSentinel,
   readSentinel,
@@ -372,9 +472,21 @@ module.exports = {
  * @param {string} runCwd
  * @param {(text: string) => void} writeSentinel
  * @param {(code: number) => void} [exitFn] injectable for tests; defaults to process.exit
+ * @param {() => void} [clearLock] release the concurrency lock once the build
+ *   settles (ok OR fail); defaults to a no-op. NOT called on the shell-retry
+ *   path — the retried child is still running, so the lock must persist.
  */
-function runBgEntrypointChild(runCmd, runArgs, runCwd, writeSentinel, exitFn) {
+function runBgEntrypointChild(runCmd, runArgs, runCwd, writeSentinel, exitFn, clearLock) {
   const doExit = exitFn || ((code) => process.exit(code));
+  const releaseLock = clearLock || (() => {});
+  // Terminal path: record the outcome, release the lock, exit the runner. Order
+  // matters — the sentinel is written before the lock clears so a watcher that
+  // sees the lock gone can already read the result.
+  const finish = (sentinelText) => {
+    writeSentinel(sentinelText);
+    releaseLock();
+    doExit(0);
+  };
   const spawnChild = (useShell) => spawn(runCmd, runArgs, {
     cwd: runCwd,
     stdio: 'ignore',
@@ -389,19 +501,18 @@ function runBgEntrypointChild(runCmd, runArgs, runCwd, writeSentinel, exitFn) {
       if (allowShellRetry && process.platform === 'win32' && err && err.code === 'ENOENT') {
         // Likely a .cmd/.bat shim that shell-less spawn() cannot exec — retry
         // once through cmd.exe, matching pre-fix behavior for that edge case.
+        // Lock stays held: the retried child is the same logical build.
         try {
           attach(spawnChild(true), false);
           return;
         } catch { /* fall through to fail below */ }
       }
-      writeSentinel('fail');
-      doExit(0);
+      finish('fail');
     });
     child.on('exit', (code) => {
       if (settled) return;
       settled = true;
-      writeSentinel(code === 0 ? 'ok' : (code == null ? 'fail' : `fail:${code}`));
-      doExit(0);
+      finish(code === 0 ? 'ok' : (code == null ? 'fail' : `fail:${code}`));
     });
   };
   let child;
@@ -414,8 +525,7 @@ function runBgEntrypointChild(runCmd, runArgs, runCwd, writeSentinel, exitFn) {
       attach(spawnChild(true), false);
       return;
     } catch {
-      writeSentinel('fail');
-      doExit(0);
+      finish('fail');
       return;
     }
   }
@@ -424,19 +534,25 @@ function runBgEntrypointChild(runCmd, runArgs, runCwd, writeSentinel, exitFn) {
 
 // ── Background runner entrypoint ─────────────────────────────────────────────
 // When this file is executed directly as `node graphify-state.js --bg-run
-// <sentinel|'-'> <cwd> <cmd> [args...]` it acts as the detached, windowless
-// wrapper spawned by spawnBgRunner: it runs the real command as a NON-detached,
-// windowsHide child (created with CREATE_NO_WINDOW → hidden console, no window),
-// waits for it, and writes the ok/fail sentinel. Guarded by require.main so a
-// normal `require()` of this module never triggers it.
+// <sentinel|'-'> <lock|'-'> <cwd> <cmd> [args...]` it acts as the detached,
+// windowless wrapper spawned by spawnBgRunner: it runs the real command as a
+// NON-detached, windowsHide child (created with CREATE_NO_WINDOW → hidden
+// console, no window), waits for it, writes the ok/fail sentinel, and clears the
+// concurrency lock. Guarded by require.main so a normal `require()` of this
+// module never triggers it.
 if (require.main === module && process.argv[2] === BG_RUN_FLAG) {
   const sentinelArg = process.argv[3];
-  const runCwd = process.argv[4];
-  const runCmd = process.argv[5];
-  const runArgs = process.argv.slice(6);
+  const lockArg = process.argv[4];
+  const runCwd = process.argv[5];
+  const runCmd = process.argv[6];
+  const runArgs = process.argv.slice(7);
   const writeSentinel = (text) => {
     if (sentinelArg === NO_SENTINEL) return;
     try { fs.writeFileSync(sentinelArg, text); } catch { /* tmp unwritable — nothing to surface to */ }
   };
-  runBgEntrypointChild(runCmd, runArgs, runCwd, writeSentinel);
+  const clearLock = () => {
+    if (lockArg === NO_SENTINEL) return;
+    try { fs.unlinkSync(lockArg); } catch { /* absent already — nothing to clear */ }
+  };
+  runBgEntrypointChild(runCmd, runArgs, runCwd, writeSentinel, undefined, clearLock);
 }

--- a/plugins/devops/hooks/lib/graphify-state.test.js
+++ b/plugins/devops/hooks/lib/graphify-state.test.js
@@ -23,6 +23,10 @@ import {
   globalConsentPath,
   readGlobalState,
   runBgEntrypointChild,
+  updateInFlight,
+  updateLockPath,
+  writeUpdateLock,
+  clearUpdateLock,
 } from "./graphify-state.js";
 
 function tmp() {
@@ -382,5 +386,108 @@ describe("runBgEntrypointChild — shell-less default + shim fallback", () => {
     const shim = path.join(dir, "shimfail.cmd");
     fs.writeFileSync(shim, "@exit /b 7\r\n");
     expect(await runChild(shim, [], dir)).toBe("fail:7");
+  }, 10000);
+});
+
+// ── graphify-update concurrency mutex ────────────────────────────────────────
+// Regression guard for the RAM-exhaustion bug: the SessionStart (10-min) and
+// PreToolUse (2-min) spawn throttles only DEBOUNCE — when a single
+// `graphify update .` runs longer than the throttle window (large repo) and a
+// trigger (e.g. the */10 git-sync cron creating a fresh session) fires at least
+// as often, runs stacked without bound (measured: 12 concurrent, ~29 GB commit).
+// bgWithSentinel now takes a PID lock so at most ONE build runs per project.
+describe("updateInFlight / updateLockPath — graphify-update concurrency mutex", () => {
+  let dir;
+  beforeEach(() => { dir = tmp(); });
+  afterEach(() => {
+    clearUpdateLock(dir);
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+  });
+
+  test("no lock file → not in flight", () => {
+    expect(updateInFlight(dir)).toBe(false);
+  });
+
+  test("lock with a LIVE pid → in flight (blocks a second spawn)", () => {
+    writeUpdateLock(dir, process.pid); // this test process is alive by definition
+    expect(updateInFlight(dir)).toBe(true);
+  });
+
+  test("lock with a DEAD pid → not in flight (never wedges on a crashed runner)", () => {
+    // 2147483647 names no live process → process.kill(pid, 0) throws ESRCH.
+    fs.writeFileSync(updateLockPath(dir), JSON.stringify({ pid: 2147483647, ts: Date.now() }));
+    expect(updateInFlight(dir)).toBe(false);
+  });
+
+  test("lock older than the stale window → not in flight even if the pid is live", () => {
+    fs.writeFileSync(updateLockPath(dir), JSON.stringify({ pid: process.pid, ts: Date.now() - 46 * 60 * 1000 }));
+    expect(updateInFlight(dir)).toBe(false);
+  });
+
+  test("corrupt lock → not in flight (fail-open: allow a fresh spawn)", () => {
+    fs.writeFileSync(updateLockPath(dir), "{ not json");
+    expect(updateInFlight(dir)).toBe(false);
+  });
+
+  test("updateLockPath stable per cwd, distinct across cwds, distinct from sentinelPath", () => {
+    expect(updateLockPath(dir)).toBe(updateLockPath(dir));
+    expect(updateLockPath(dir)).not.toBe(updateLockPath(tmp()));
+    expect(updateLockPath(dir)).not.toBe(sentinelPath(dir));
+  });
+
+  test("clearUpdateLock removes the lock and is a no-op when absent", () => {
+    writeUpdateLock(dir, process.pid);
+    expect(updateInFlight(dir)).toBe(true);
+    clearUpdateLock(dir);
+    expect(updateInFlight(dir)).toBe(false);
+    expect(() => clearUpdateLock(dir)).not.toThrow();
+  });
+});
+
+describe("bgWithSentinel — concurrency guard (never stack graphify update)", () => {
+  const waitForSentinel = async (cwd, timeoutMs = 5000) => {
+    const start = Date.now();
+    for (;;) {
+      const s = readSentinel(cwd);
+      if (s !== null) return s;
+      if (Date.now() - start > timeoutMs) return null;
+      await new Promise((r) => setTimeout(r, 100));
+    }
+  };
+  const waitForGone = async (p, timeoutMs = 5000) => {
+    const start = Date.now();
+    while (fs.existsSync(p)) {
+      if (Date.now() - start > timeoutMs) return false;
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    return true;
+  };
+
+  test("skips (returns false, writes NO sentinel) when a build is already in flight", () => {
+    const dir = tmp();
+    writeUpdateLock(dir, process.pid); // simulate a live in-flight runner
+    // Pre-seed a sentinel: a real spawn unlinks it first, so if it survives the
+    // call, bgWithSentinel skipped without spawning.
+    fs.writeFileSync(sentinelPath(dir), "ok");
+    expect(bgWithSentinel("node", ["-e", "process.exit(0)"], dir)).toBe(false);
+    expect(fs.existsSync(sentinelPath(dir))).toBe(true); // untouched → no spawn
+    clearUpdateLock(dir);
+    clearSentinel(dir);
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+  });
+
+  test("spawns and writes a lock when none is in flight; runner clears the lock on exit", async () => {
+    const dir = tmp();
+    const okCmd = process.platform === "win32" ? "ver" : "true";
+    expect(updateInFlight(dir)).toBe(false);
+    expect(bgWithSentinel(okCmd, [], dir)).toBe(true);
+    // Lock is written synchronously right after the spawn issues (the detached
+    // runner has not booted node yet, so it cannot have cleared it).
+    expect(fs.existsSync(updateLockPath(dir))).toBe(true);
+    // Build finishes → sentinel appears AND the runner cleared its lock.
+    expect(await waitForSentinel(dir)).toEqual({ status: "ok" });
+    expect(await waitForGone(updateLockPath(dir))).toBe(true);
+    clearSentinel(dir);
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
   }, 10000);
 });

--- a/plugins/devops/hooks/session-start/ss.graphify.js
+++ b/plugins/devops/hooks/session-start/ss.graphify.js
@@ -169,8 +169,14 @@ if (runOnce('ss-graphify-hookuninstall', cwdKey) && isGitRepo()) {
 const needsRebuild = !graphNudge.hasGraph(cwd)
   || graphNudge.graphIsStale(cwd)
   || (runOnce('ss-graphify-validate', cwdKey, { cooldownMs: 24 * 60 * 60 * 1000 }) && !graphLooksValid());
-// Throttle the rebuild so repeated SessionStart re-entries (multiple agents /
-// worktrees on the same cwd) cannot stack concurrent `graphify update` runs.
+// Debounce bursts of SessionStart re-entries (multiple agents / worktrees on the
+// same cwd) so they do not each kick a rebuild within 10 min. This is only a
+// DEBOUNCE, not a mutex: on a large repo a single `graphify update` can run
+// longer than the cooldown while a trigger recurs at least as often (e.g. the
+// */10 git-sync cron opens a fresh session every 10 min), which previously let
+// runs stack without bound. The hard concurrency guard lives in
+// gstate.bgWithSentinel (a per-project PID lock) — it is what actually caps
+// concurrency at one build per project across all spawn triggers.
 if (needsRebuild && runOnce('ss-graphify-update', cwdKey, { cooldownMs: 10 * 60 * 1000 })) {
   gstate.bgWithSentinel('graphify', ['update', '.'], cwd); // background, key-less, AST-only, free
 }

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.118.0",
+  "version": "0.118.1",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary
Background `graphify update .` builds spawned by the devops-graph refresh stacked without bound and exhausted RAM — an affected machine hit 99% memory (~0.3 GB free) with **12 concurrent runs** consuming ~29.5 GB of commit charge, thrashing on a 55 GB total commit.

## Root cause
The SessionStart (10-min `runOnce`) and PreToolUse (2-min `markRefresh`) spawn throttles only **debounce** how *often* a build is kicked — they never check whether one is still running. On a large repo a single AST build outlives its throttle window while the `*/10` git-sync cron opens a fresh session (hence a fresh throttle window) every 10 min, so a new build launched on top of the still-running ones and they piled up over ~3.5 h. The comment in `ss.graphify.js` even claimed the throttle "cannot stack concurrent runs" — false whenever a run outlives the cooldown.

## Fix
A per-project **PID lock** at the single spawn chokepoint (`bgWithSentinel`, through which all three spawn sites funnel — the SessionStart refresh and both PreToolUse self-heal paths): before spawning, skip when a live runner already holds the lock; record the detached runner's PID + spawn time on spawn; the runner clears the lock when its build exits. PID-liveness plus a 45-min stale timeout ensure a crashed runner never wedges refresh forever, and every read fails open so the guard can never block a legitimate build.

## Tests
+9 unit/e2e tests (`updateInFlight` live/dead/stale/corrupt-lock, `bgWithSentinel` skip-when-in-flight, runner-clears-lock end-to-end). Full suite **757 green**, lint clean.

## Notes
- Runaway processes on the affected machine were killed as immediate triage (commit charge 55 → 26 GB).
- Codex review gate unavailable this ship (external usage limit) — covered instead by the added tests + full-suite verification.