### PR TITLE
fix(graphify): machine-wide build cap + channel-aware ship card

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.119.0"
+    "version": "0.119.1"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.119.0",
+      "version": "0.119.1",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.119.0",
+      "version": "0.119.1",
       "author": {
         "name": "Jerry0022"
       },

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -15,24 +15,30 @@ for the full rationale (double-restart problem, observed cache/registry drift).
 
 This extension is **additive** — every plugin-default step still runs unchanged.
 
-## Step 6.5 — Announce the self-update IN the completion card
+## Step 6.5 — Announce the local channel outcome IN the completion card
 
-Runs only when the **self-update will actually run** (see Step 8 guards). Do this
-**before** calling `render_completion_card` in Step 6, using pure file reads (no MCP):
+Do this **before** calling `render_completion_card` in Step 6, using pure file reads
+(no MCP). **Channel-aware (ring model):** a plain `/devops-ship` publishes vNew to the
+**alpha** channel only. The local install follows its channel pin at
+`~/.claude/plugins/.channels.json` (`{ "dotclaude": "<channel>" }`; absent → `stable`).
+Whether the local install moves to vNew depends on that pin — it does NOT
+automatically sync to every ship.
 
-1. Read marketplace version: `~/.claude/plugins/marketplaces/dotclaude/plugins/devops/.claude-plugin/plugin.json` → `version`.
+1. Read the channel pin: `~/.claude/plugins/.channels.json` → `dotclaude` (absent/unknown → `stable`).
 2. Read installed version: `~/.claude/plugins/installed_plugins.json` → `plugins["devops@dotclaude"][0].version`.
-3. If they differ (or will differ because this ship bumped the version), add one
-   `userFinalTest` item to the Step 6 card payload, in the user's language:
+3. Add exactly one `userFinalTest` item, in the user's language:
+   - **Pin is `alpha`** — the install tracks alpha, so the Step 8 finalizer moves it to vNew:
+     > `{ action: "devops lokal (alpha) auf v<vNew> synchronisiert — Claude einmal neu starten, dann ist die neue Version aktiv.", afterDeployment: true }`
+   - **Pin is `beta`/`stable`** (the default) — an alpha-only ship does NOT reach this
+     install. Do **not** claim any local sync; point to promotion:
+     > `{ action: "v<vNew> ist auf alpha veröffentlicht; dein <pin>-Install bleibt auf v<installed>. /devops-release promoten (alpha→<pin>), danach zieht der Install v<vNew> beim nächsten Start.", afterDeployment: true }`
 
-   > `{ action: "devops lokal auf v<vNew> synchronisiert — Claude einmal neu starten, dann ist die neue Version aktiv.", afterDeployment: true }`
-
-This keeps the completion card the **last visible output** (per plugin Step 6) while
-still telling the user the one thing they must do: restart once. Do **not** print any
-restart notice as separate prose after the card — the card carries it.
-
-If the versions already match and this ship did not bump the plugin version, skip the
-card item (the Step 8 sync will be a silent no-op / in-place cache repair).
+**Never assert "lokal auf vNew synchronisiert" on a beta/stable pin.** The finalizer
+(Step 8) correctly holds the install on its pinned channel tag, so an alpha-only ship
+leaves it unchanged — a false "synced" claim sends the user hunting a non-existent
+sync failure (observed 2026-07-19). This keeps the completion card the **last visible
+output** (per plugin Step 6); do **not** print the notice as separate prose after the
+card — the card carries it.
 
 ## Step 8 — Self-update finalizer (silent, runs LAST)
 
@@ -41,6 +47,15 @@ card item (the Step 8 sync will be a silent no-op / in-place cache repair).
 > and writes `~/.claude/plugins/.mcp-stale.json`; once that sentinel exists,
 > `pre.mcp.health` blocks every further MCP call (including the completion card).
 > Running it before the card would brick the card render.
+
+> **Channel-aware — NOT a guaranteed move to vNew.** The finalizer runs
+> `ss.plugin.update`, which is channel-pinned (ring model): it reconciles the local
+> install to the **highest version visible to the pin** (`.channels.json`, default
+> `stable`) via a detached channel-tag checkout — NOT to `main`/vNew. After a plain
+> (alpha-only) ship on a stable/beta pin the version does NOT move and the finalizer
+> only cache-repairs — that is EXPECTED, not a drift bug. Do NOT force the marketplace
+> clone onto `main`/an alpha tag to "fix" it (the pin resets it every SessionStart by
+> design). The install receives vNew only after `/devops-release` promotes it to the pin.
 
 ### Guards — skip the finalizer entirely when ANY of:
 

--- a/.claude/skills/ship/reference.md
+++ b/.claude/skills/ship/reference.md
@@ -5,6 +5,15 @@ so after the merge the locally-installed devops in *this* Claude Code instance m
 be brought in sync with what was just shipped — otherwise the running instance keeps
 the old version and the next session lands in a stale state ("devops nicht verfügbar").
 
+> **Channel caveat (ring model).** "In sync with what was just shipped" only holds
+> when the local install's channel pin (`~/.claude/plugins/.channels.json`, default
+> `stable`) actually receives the shipped version. A plain `/devops-ship` publishes to
+> **alpha** only, so on the default stable pin the local install correctly STAYS on the
+> previous stable version until `/devops-release` promotes it — the Step 8 finalizer is
+> then a cache-repair no-op, not a failure. Do not "fix" the detached-HEAD marketplace
+> clone by forcing it onto `main`; the pin resets it by design. See the memory
+> `project_ring_model_local_stays_stable` for the full symptom/diagnosis note.
+
 ## Why a post-ship self-update is needed here (and nowhere else)
 
 A normal consumer project shipping its app has nothing to do with the devops plugin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.119.1] — 2026-07-19
+
+### Fixed
+
+- **`graphify update` background builds can no longer saturate RAM/disk across worktrees — a machine-wide concurrency cap now backs the per-project lock.** 0.118.1 added a per-project PID lock so one project cannot stack builds, but it does nothing ACROSS projects: each active worktree/cwd triggers its own `graphify update`, so a multi-worktree machine still ran several GB-heavy builds at once (observed live: physical RAM pegged at 100% + disk queue length >100, builds spawning per cwd even while the per-project lock held). `bgWithSentinel` — the single chokepoint all three spawn triggers funnel through (SessionStart refresh + both PreToolUse self-heals) — now also enforces `globalUpdatesInFlight() < updateGlobalCap()` before spawning: it scans every `dotclaude-graphupdate-*.lock` in the lock dir, counts those with a live PID and a non-stale stamp, and skips once the total live builds across ALL cwds reaches the cap (default 2, override `DOTCLAUDE_GRAPH_MAX_BUILDS`). The lock dir is overridable via `DOTCLAUDE_GRAPHLOCK_DIR` for test isolation. Both bounds fail-open (any read error → treated as "not in flight") so the guard can never wedge refresh shut. (`graphify-state` 0.6.0 → 0.7.0: new `lockBaseDir`/`updateGlobalCap`/`globalUpdatesInFlight` + cap check in `bgWithSentinel`; +4 tests, 768 total. Codex review gate unavailable this ship — external usage limit.)
+- **Ship extension no longer falsely claims "devops lokal auf vNew synchronisiert" after an alpha-only ship.** The `/devops-ship` project extension's Step 6.5 card item asserted the local install had synced to the just-shipped version — but a plain ship publishes to the **alpha** channel only, and the default local pin is **stable**, so a stable/beta-pinned install correctly does NOT receive the ship (ring model). The false claim sent a user hunting a non-existent "sync failure" (this session, 2026-07-19). Step 6.5 is now channel-aware: it reads `~/.claude/plugins/.channels.json` and, on a beta/stable pin, points to `/devops-release` instead of claiming a sync. Step 8 and `reference.md` get matching ring-model notes so the finalizer's expected no-op on a stable pin is not mistaken for drift. (`.claude/skills/ship/SKILL.md` Step 6.5/8, `reference.md` channel caveat.)
+
 ## [0.119.0] — 2026-07-19
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.119.0**
+**Version: 0.119.1**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.119.0",
+  "version": "0.119.1",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/hooks/lib/graphify-state.js
+++ b/plugins/devops/hooks/lib/graphify-state.js
@@ -1,7 +1,7 @@
 'use strict';
 /**
  * @lib graphify-state
- * @version 0.6.0
+ * @version 0.7.0
  * @plugin devops
  * @description Consent + session-state helpers for the graphify enforcement
  *   layer (devops-graph). Default-on / opt-out model: graphify enforcement is
@@ -17,15 +17,17 @@
  *   per-project sentinel file so a silent failure (stdio:'ignore') can be
  *   surfaced at the next SessionStart instead of vanishing.
  *
- *   `bgWithSentinel` additionally holds a per-project PID lock
- *   (`updateInFlight`/`updateLockPath`) so at most ONE `graphify update` runs
- *   per project at a time. The SessionStart (10-min) and PreToolUse (2-min)
- *   spawn throttles only DEBOUNCE bursts; on a large repo a single build can
- *   outlast its throttle window while a trigger recurs (e.g. the git-sync cron
- *   opens a fresh session every 10 min), so time-based throttling alone let
- *   builds stack without bound — measured in the field at 12 concurrent runs /
- *   ~29 GB commit, exhausting RAM. The lock bounds concurrency across ALL spawn
- *   triggers (they all funnel through `bgWithSentinel`).
+ *   `bgWithSentinel` additionally enforces TWO concurrency bounds on
+ *   `graphify update` (all spawn triggers funnel through it): a per-project PID
+ *   lock (`updateInFlight`/`updateLockPath`) so at most ONE build runs per
+ *   project, AND a machine-wide cap (`globalUpdatesInFlight`/`updateGlobalCap`,
+ *   default 2) so the TOTAL live builds across all cwds is bounded. The
+ *   SessionStart (10-min) and PreToolUse (2-min) throttles only DEBOUNCE bursts;
+ *   on a large repo a single build outlasts its throttle window while a trigger
+ *   recurs (e.g. a 10-min git-sync cron), so time-based throttling alone let
+ *   builds stack without bound — measured at 12 concurrent runs / ~29 GB commit,
+ *   exhausting RAM. The per-project lock alone still let N worktrees each run a
+ *   heavy build (RAM + disk saturation), which the global cap prevents.
  */
 
 const fs = require('node:fs');
@@ -223,20 +225,40 @@ const NO_SENTINEL = '-';
 // background runner (see the require.main block at the bottom of this file).
 const BG_RUN_FLAG = '--bg-run';
 
-// ── graphify-update concurrency lock ─────────────────────────────────────────
-// A single `graphify update .` on a large repo can outlast the SessionStart
-// (10-min) and PreToolUse (2-min) spawn throttles, which only DEBOUNCE bursts.
-// When a trigger recurs at least as often as the build takes (e.g. the */10
-// git-sync cron opens a fresh session — hence a fresh throttle window — every
-// 10 min), purely time-based throttling let builds stack without bound (measured
-// in the field: 12 concurrent runs, ~29 GB commit, RAM exhausted). This PID lock
-// bounds concurrency to ONE build per project across every trigger.
+// ── graphify-update concurrency control ──────────────────────────────────────
+// Two layers bound how much `graphify update` runs at once:
+//   1. PER-PROJECT lock (updateInFlight): a single `graphify update .` on a large
+//      repo can outlast the SessionStart (10-min) and PreToolUse (2-min) spawn
+//      throttles, which only DEBOUNCE bursts. When a trigger recurs at least as
+//      often as the build takes (e.g. a 10-min git-sync cron opening a fresh
+//      session), time-based throttling alone let builds stack without bound
+//      (measured: 12 concurrent runs, ~29 GB commit, RAM exhausted). The PID lock
+//      caps concurrency at ONE build PER PROJECT across every trigger.
+//   2. MACHINE-WIDE cap (globalUpdatesInFlight + updateGlobalCap): the per-project
+//      lock does nothing ACROSS projects — N active worktrees/cwds each get their
+//      own build, so a multi-worktree machine still ran several heavy builds at
+//      once (observed saturating RAM + disk even with the per-project lock). The
+//      global cap bounds the TOTAL live builds across all cwds (default 2, via
+//      DOTCLAUDE_GRAPH_MAX_BUILDS).
+// Both layers read the same lock files; the lock dir is os.tmpdir() in production
+// and overridable via DOTCLAUDE_GRAPHLOCK_DIR for test isolation.
 const UPDATE_LOCK_STALE_MS = 45 * 60 * 1000;
+
+/** Directory holding the per-project update-lock files. Overridable for tests. */
+function lockBaseDir() {
+  return process.env.DOTCLAUDE_GRAPHLOCK_DIR || os.tmpdir();
+}
+
+/** Machine-wide cap on concurrent `graphify update` runners (default 2, min 1). */
+function updateGlobalCap() {
+  const n = parseInt(process.env.DOTCLAUDE_GRAPH_MAX_BUILDS, 10);
+  return Number.isInteger(n) && n > 0 ? n : 2;
+}
 
 /** Per-project lock file recording the live background-update runner's PID. */
 function updateLockPath(cwd) {
   const key = crypto.createHash('md5').update(`updatelock:${cwd}`).digest('hex').slice(0, 12);
-  return path.join(os.tmpdir(), `dotclaude-graphupdate-${key}.lock`);
+  return path.join(lockBaseDir(), `dotclaude-graphupdate-${key}.lock`);
 }
 
 /**
@@ -288,6 +310,30 @@ function writeUpdateLock(cwd, pid) {
 /** Remove the update lock (the runner clears it once its build exits). No-op when absent. Never throws. */
 function clearUpdateLock(cwd) {
   try { fs.unlinkSync(updateLockPath(cwd)); } catch { /* absent already */ }
+}
+
+/**
+ * Count `graphify update` runners live across ALL projects — the machine-wide
+ * concurrency signal the per-project lock cannot provide. Scans every
+ * `dotclaude-graphupdate-*.lock` in the lock dir and counts those whose recorded
+ * PID is still alive and whose stamp is within UPDATE_LOCK_STALE_MS (stale/dead
+ * locks are ignored, exactly like updateInFlight). Never throws — returns what it
+ * counted (0 on a scan error) so a read failure can never wedge refresh shut.
+ */
+function globalUpdatesInFlight() {
+  const dir = lockBaseDir();
+  let n = 0;
+  try {
+    for (const f of fs.readdirSync(dir)) {
+      if (!/^dotclaude-graphupdate-.*\.lock$/.test(f)) continue;
+      try {
+        const { pid, ts } = JSON.parse(fs.readFileSync(path.join(dir, f), 'utf8'));
+        if (typeof ts === 'number' && Date.now() - ts > UPDATE_LOCK_STALE_MS) continue;
+        if (pidAlive(pid)) n++;
+      } catch { /* unreadable/corrupt lock — skip */ }
+    }
+  } catch { /* lock dir unreadable — treat as none in flight */ }
+  return n;
 }
 
 /**
@@ -380,18 +426,22 @@ function bgWindowless(cmd, args, cwd) {
  * (see readSentinel + ss.graphify.js). git-invisible (os.tmpdir(), not the
  * project) and windowless on Windows (see spawnBgRunner). Fail-open.
  *
- * Concurrency guard: this is the single chokepoint for EVERY `graphify update`
- * spawn (the SessionStart refresh + both PreToolUse self-heal paths), so the PID
- * lock taken here bounds concurrency to one build per project for all triggers.
- * When a build is already in flight the call is a no-op (returns false) — the
- * time-based throttles at the call sites only debounce bursts and cannot see a
- * run that outlived its window (the RAM-exhaustion bug). The runner clears the
- * lock when its build exits (see the --bg-run entrypoint → runBgEntrypointChild).
- * @returns {boolean} true iff a spawn was issued; false when skipped (already
- *   in flight) or the spawn errored.
+ * Concurrency control: this is the single chokepoint for EVERY `graphify update`
+ * spawn (the SessionStart refresh + both PreToolUse self-heal paths), so both
+ * bounds apply to all triggers: (1) the PER-PROJECT PID lock skips when this cwd
+ * already has a live build — the time-based throttles at the call sites only
+ * debounce bursts and cannot see a run that outlived its window (the original
+ * RAM-exhaustion bug); (2) the MACHINE-WIDE cap skips when the total live builds
+ * across all cwds already equals updateGlobalCap() — the per-project lock alone
+ * let N worktrees each run a heavy build and saturate RAM + disk. The runner
+ * clears the lock when its build exits (see the --bg-run entrypoint →
+ * runBgEntrypointChild).
+ * @returns {boolean} true iff a spawn was issued; false when skipped (this cwd
+ *   already building, or global cap reached) or the spawn errored.
  */
 function bgWithSentinel(cmd, args, cwd) {
-  if (updateInFlight(cwd)) return false; // a build is already running — never stack
+  if (updateInFlight(cwd)) return false; // this project already has a live build
+  if (globalUpdatesInFlight() >= updateGlobalCap()) return false; // machine-wide cap reached
   const sentinel = sentinelPath(cwd);
   const lock = updateLockPath(cwd);
   try { fs.unlinkSync(sentinel); } catch { /* no previous sentinel */ }
@@ -444,8 +494,11 @@ module.exports = {
   queryDone,
   isGraphifyQueryCommand,
   sentinelPath,
+  lockBaseDir,
+  updateGlobalCap,
   updateLockPath,
   updateInFlight,
+  globalUpdatesInFlight,
   writeUpdateLock,
   clearUpdateLock,
   bgWindowless,

--- a/plugins/devops/hooks/lib/graphify-state.test.js
+++ b/plugins/devops/hooks/lib/graphify-state.test.js
@@ -27,6 +27,8 @@ import {
   updateLockPath,
   writeUpdateLock,
   clearUpdateLock,
+  globalUpdatesInFlight,
+  updateGlobalCap,
 } from "./graphify-state.js";
 
 function tmp() {
@@ -463,6 +465,20 @@ describe("bgWithSentinel — concurrency guard (never stack graphify update)", (
     return true;
   };
 
+  // Isolate the lock dir so bgWithSentinel's global-cap check counts only THIS
+  // test's locks — not real graphify builds on the machine running the suite,
+  // which could otherwise trip the cap and flip an expected spawn into a skip.
+  let origLockDir;
+  beforeEach(() => {
+    origLockDir = process.env.DOTCLAUDE_GRAPHLOCK_DIR;
+    process.env.DOTCLAUDE_GRAPHLOCK_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "gstate-lockiso-"));
+  });
+  afterEach(() => {
+    try { fs.rmSync(process.env.DOTCLAUDE_GRAPHLOCK_DIR, { recursive: true, force: true }); } catch {}
+    if (origLockDir === undefined) delete process.env.DOTCLAUDE_GRAPHLOCK_DIR;
+    else process.env.DOTCLAUDE_GRAPHLOCK_DIR = origLockDir;
+  });
+
   test("skips (returns false, writes NO sentinel) when a build is already in flight", () => {
     const dir = tmp();
     writeUpdateLock(dir, process.pid); // simulate a live in-flight runner
@@ -489,5 +505,78 @@ describe("bgWithSentinel — concurrency guard (never stack graphify update)", (
     expect(await waitForGone(updateLockPath(dir))).toBe(true);
     clearSentinel(dir);
     try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+  }, 10000);
+});
+
+// ── machine-wide concurrency cap ─────────────────────────────────────────────
+// The per-project lock does nothing ACROSS projects — N worktrees each get their
+// own build, so a multi-worktree machine ran several heavy builds at once (RAM +
+// disk saturation). bgWithSentinel now also caps the TOTAL live builds across all
+// cwds at updateGlobalCap() (default 2). Lock dir is isolated per test so the
+// count reflects only what the test wrote.
+describe("globalUpdatesInFlight / machine-wide cap", () => {
+  let origLockDir, origCap, isoDir;
+  beforeEach(() => {
+    origLockDir = process.env.DOTCLAUDE_GRAPHLOCK_DIR;
+    origCap = process.env.DOTCLAUDE_GRAPH_MAX_BUILDS;
+    isoDir = fs.mkdtempSync(path.join(os.tmpdir(), "gstate-cap-"));
+    process.env.DOTCLAUDE_GRAPHLOCK_DIR = isoDir;
+  });
+  afterEach(() => {
+    try { fs.rmSync(isoDir, { recursive: true, force: true }); } catch {}
+    if (origLockDir === undefined) delete process.env.DOTCLAUDE_GRAPHLOCK_DIR;
+    else process.env.DOTCLAUDE_GRAPHLOCK_DIR = origLockDir;
+    if (origCap === undefined) delete process.env.DOTCLAUDE_GRAPH_MAX_BUILDS;
+    else process.env.DOTCLAUDE_GRAPH_MAX_BUILDS = origCap;
+  });
+
+  test("default cap is 2; positive env override respected; invalid → default", () => {
+    delete process.env.DOTCLAUDE_GRAPH_MAX_BUILDS;
+    expect(updateGlobalCap()).toBe(2);
+    process.env.DOTCLAUDE_GRAPH_MAX_BUILDS = "5";
+    expect(updateGlobalCap()).toBe(5);
+    process.env.DOTCLAUDE_GRAPH_MAX_BUILDS = "0";
+    expect(updateGlobalCap()).toBe(2);
+    process.env.DOTCLAUDE_GRAPH_MAX_BUILDS = "abc";
+    expect(updateGlobalCap()).toBe(2);
+  });
+
+  test("counts only live, non-stale locks across cwds", () => {
+    expect(globalUpdatesInFlight()).toBe(0);
+    writeUpdateLock("/proj/a", process.pid);
+    writeUpdateLock("/proj/b", process.pid);
+    expect(globalUpdatesInFlight()).toBe(2);
+    // dead pid + stale stamp are ignored, exactly like updateInFlight
+    fs.writeFileSync(updateLockPath("/proj/c"), JSON.stringify({ pid: 2147483647, ts: Date.now() }));
+    fs.writeFileSync(updateLockPath("/proj/d"), JSON.stringify({ pid: process.pid, ts: Date.now() - 46 * 60 * 1000 }));
+    expect(globalUpdatesInFlight()).toBe(2);
+  });
+
+  test("bgWithSentinel skips (no spawn) when the global cap is reached, even for a fresh cwd", () => {
+    process.env.DOTCLAUDE_GRAPH_MAX_BUILDS = "2";
+    writeUpdateLock("/proj/a", process.pid);
+    writeUpdateLock("/proj/b", process.pid); // 2 live across other cwds → cap reached
+    const fresh = fs.mkdtempSync(path.join(os.tmpdir(), "gstate-fresh-"));
+    expect(updateInFlight(fresh)).toBe(false);        // this cwd itself is free…
+    fs.writeFileSync(sentinelPath(fresh), "ok");       // pre-seed to prove no spawn
+    expect(bgWithSentinel("node", ["-e", "process.exit(0)"], fresh)).toBe(false); // …but cap blocks
+    expect(fs.existsSync(sentinelPath(fresh))).toBe(true); // untouched → no spawn
+    clearSentinel(fresh);
+    try { fs.rmSync(fresh, { recursive: true, force: true }); } catch {}
+  });
+
+  test("bgWithSentinel spawns when still below the cap", async () => {
+    process.env.DOTCLAUDE_GRAPH_MAX_BUILDS = "2";
+    writeUpdateLock("/proj/a", process.pid); // 1 live < cap 2
+    const okCmd = process.platform === "win32" ? "ver" : "true";
+    const fresh = fs.mkdtempSync(path.join(os.tmpdir(), "gstate-fresh-"));
+    expect(bgWithSentinel(okCmd, [], fresh)).toBe(true);
+    // let it settle so the detached runner clears its own lock before teardown
+    const start = Date.now();
+    while (readSentinel(fresh) === null && Date.now() - start < 5000) {
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    clearSentinel(fresh);
+    try { fs.rmSync(fresh, { recursive: true, force: true }); } catch {}
   }, 10000);
 });

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.119.0",
+  "version": "0.119.1",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary
`graphify update` builds saturated RAM + disk across worktrees — the per-project PID lock from 0.118.1 does not bound builds ACROSS cwds, so N worktrees each ran a GB-heavy build (observed live: 100% RAM, disk queue >100). Also, the ship extension falsely claimed a local sync after an alpha-only ship.

## Fix
- **Machine-wide concurrency cap** in `bgWithSentinel` (`globalUpdatesInFlight() < updateGlobalCap()`, default 2, override `DOTCLAUDE_GRAPH_MAX_BUILDS`), layered on the per-project PID lock — bounds total live `graphify update` runners across ALL cwds. Lock dir overridable via `DOTCLAUDE_GRAPHLOCK_DIR` for tests. Fail-open throughout.
- **Ship extension Step 6.5 is now channel-aware**: no false "devops lokal auf vNew synchronisiert" on a beta/stable pin (ring model — a plain ship is alpha-only); points to `/devops-release` instead. Step 8 + `reference.md` get matching ring-model notes.

## Tests
+4 (`globalUpdatesInFlight` live/dead/stale counting, cap default/override, `bgWithSentinel` skip-at-cap + spawn-below-cap). Full suite **768 green**, lint clean.

## Notes
- Codex review gate unavailable this ship (external usage limit) — covered by the added tests + full-suite verification.