### PR TITLE
feat(mcp): auto-reap orphaned MCP-server processes (0.120.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.119.2"
+    "version": "0.120.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.119.2",
+      "version": "0.120.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.119.2",
+      "version": "0.120.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.120.0] — 2026-07-20
+
+### Added
+
+- **Leaked MCP-server processes are now reclaimed automatically — a census-guarded reaper ends the RAM creep from closed Claude Desktop sessions.** Claude Desktop spawns per-session MCP servers (discord `bun`, github/playwright via `npx`, plugin stdio `node`); when a session closes they are not reliably terminated and linger as orphans (dead parent PID), accumulating GB of RAM over a day (observed live: ~16 GB across 11 sessions, most from already-closed ones). New `hooks/lib/mcp-reaper.js` reclaims exactly those: a process is reaped only when it matches an MCP-launcher signature (`.claude/plugins/cache/` path, or an npx marker **with** the `mcp` token so bare `npx vite`/`npx tsx` never match) AND its parent is dead AND it lies outside the **live-Claude census** — the union of every live `claude`/`claude-code` process subtree, which protects a running session's own servers (they are cousins of the reaper, not its descendants, so a self-pid-only guard is not enough). Fail-safe throughout: Windows-only (POSIX reparents orphans to a live PID 1, so the signal never fires), an unbuildable census reaps nothing, and a TOCTOU re-validation against a fresh snapshot runs before every SIGTERM/SIGKILL so a reused pid is never hit; the module is dry-run by default (`--apply` required). Wired in via `ss.mcp.reap` (SessionStart, detached/windowless/silent) and `stop.mcp.reap` (Stop, 20-min per-worktree cooldown) so it runs in the background without a restart; `scripts/mcp-reap.js` is the manual entry point (`--json` preview, `--apply` reclaim now). Hardened against an adversarial red-team pass (R1–R8: cousin false-positives, npx over-match, POSIX no-op, TOCTOU, own-process self-match) and proven live — a synthetic orphan was reaped while all 29 real session servers survived. (New `hooks/lib/mcp-reaper.js` + `scripts/mcp-reap.js` + `ss.mcp.reap`/`stop.mcp.reap` hooks + `scheduled-tasks/mcp-reap`; 46 unit tests, 838 total. Codex review gate unavailable this ship — external usage limit — covered by the red-team pass + live synthetic-orphan verification.)
+
 ## [0.119.2] — 2026-07-19
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.119.2**
+**Version: 0.120.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ For the full extension guide with examples per skill, see `deep-knowledge/skill-
 
 ## Features
 
-- **<!--devops:count:hooks-->35<!--/devops:count:hooks--> Hooks** — automated guards and triggers across the full session lifecycle
+- **<!--devops:count:hooks-->37<!--/devops:count:hooks--> Hooks** — automated guards and triggers across the full session lifecycle
 - **<!--devops:count:skills-->23<!--/devops:count:skills--> Skills** — devops-ship, devops-commit, devops-flow, devops-new-issue, devops-project-setup, devops-readme, devops-refresh-usage, devops-extend-skill, devops-repo-health, devops-claude-md-lint, devops-concept, devops-agents, devops-plugin-update, devops-autonomous, devops-burn, devops-burn-backlog, devops-learn, devops-harden, devops-polish, devops-test-plan
 - **<!--devops:count:agents-->12<!--/devops:count:agents--> Agents** — AI, Core, Designer, Feature, Frontend, Gamer, PO, QA, Redteam, Research, Windows
 - **Completion Flow** — mandatory card after every task (8 variants), visual verification, ship recommendation
@@ -178,7 +178,7 @@ For the full extension guide with examples per skill, see `deep-knowledge/skill-
 
 ### Hooks (automatic, no user action needed)
 
-<!--devops:count:hooks-->35<!--/devops:count:hooks--> hooks fire automatically across the session lifecycle — no user action needed.
+<!--devops:count:hooks-->37<!--/devops:count:hooks--> hooks fire automatically across the session lifecycle — no user action needed.
 
 <details>
 <summary><strong>By session lifecycle</strong> — when does it fire?</summary>
@@ -197,6 +197,7 @@ SessionStart  ──>  UserPromptSubmit  ──>  PreToolUse  ──>  PostToolU
 - `ss.mcp.deps` — Auto-install MCP server dependencies into CLAUDE_PLUGIN_DATA, and self-heal partial i…
 - `ss.mcp.envcheck` — Detect enabled plugins whose .mcp.json references env vars that are not set.
 - `ss.mcp.verify` — Verify every MCP server declared in this plugin's .mcp.json has its entry file presen…
+- `ss.mcp.reap` — Reclaim orphaned Claude Desktop MCP server processes leaked by previously-closed sess…
 - `ss.tokens.scan` — Scan project for expensive files and update config for the pre.tokens.guard hook.
 - `ss.git.check` — Check for stale changes AND workspace setup issues at session start.
 - `ss.git.sync` — Registers a recurring git sync cron job (every 10 minutes).
@@ -237,6 +238,7 @@ SessionStart  ──>  UserPromptSubmit  ──>  PreToolUse  ──>  PostToolU
 - `stop.flow.browsertest` — Light-verification enforcement gate (the "V" of the V&V gate).
 - `stop.flow.guard` — Per-turn completion card + validation enforcement (the validation half of the V&V gate).
 - `stop.flow.selfcalibration` — Run self-calibration when Claude finishes a response turn.
+- `stop.mcp.reap` — Periodic background reclaim of orphaned Claude Desktop MCP server processes — the "ru…
 <!--/devops:block:hook-lifecycle-->
 
 </details>
@@ -652,7 +654,7 @@ Wk  ━━──╏─────────   15% +1%   · 4d 22h left
 devops/
 ├── .claude-plugin/plugin.json     ← Plugin manifest
 ├── CONVENTIONS.md                 ← Naming, versioning, extension rules
-├── hooks/                         ← <!--devops:count:hooks-->35<!--/devops:count:hooks--> hooks (JS) registered in hooks.json
+├── hooks/                         ← <!--devops:count:hooks-->37<!--/devops:count:hooks--> hooks (JS) registered in hooks.json
 ├── skills/                        ← <!--devops:count:skills-->23<!--/devops:count:skills--> skill definitions (SKILL.md)
 ├── agents/                        ← <!--devops:count:agents-->12<!--/devops:count:agents--> agent definitions
 ├── deep-knowledge/                ← Cross-cutting reference docs

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.119.2",
+  "version": "0.120.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/docs/architecture.html
+++ b/plugins/devops/docs/architecture.html
@@ -169,7 +169,7 @@
 <section id="overview">
 <h1>Architecture Documentation <small>devops v0.87.0</small></h1>
 <p class="lead">
-  A comprehensive DevOps automation plugin for Claude Code &mdash; <!--devops:count:hooks-->35<!--/devops:count:hooks--> hooks, <!--devops:count:skills-->23<!--/devops:count:skills--> skills, <!--devops:count:agents-->12<!--/devops:count:agents--> agents,
+  A comprehensive DevOps automation plugin for Claude Code &mdash; <!--devops:count:hooks-->37<!--/devops:count:hooks--> hooks, <!--devops:count:skills-->23<!--/devops:count:skills--> skills, <!--devops:count:agents-->12<!--/devops:count:agents--> agents,
   2 MCP servers, a deterministic completion card engine, and a 3-layer extension system.
 </p>
 <div role="note" style="margin:.4rem 0 1.4rem;padding:.6rem .9rem;background:var(--bg2);border-left:3px solid var(--warn);border-radius:4px;color:var(--text2);font-size:.85rem;">
@@ -180,13 +180,13 @@
 
 <div class="card-grid">
   <div class="card">
-    <h4><!--devops:count:hooks-->35<!--/devops:count:hooks--> Hooks</h4>
+    <h4><!--devops:count:hooks-->37<!--/devops:count:hooks--> Hooks</h4>
     <p style="color:var(--text2);font-size:.85rem">Lifecycle guards across SessionStart, UserPromptSubmit, PreToolUse, PostToolUse, Stop</p>
-    <span class="badge b-hook">SessionStart &times;<!--devops:count:hooks:ss-->14<!--/devops:count:hooks:ss--></span>
+    <span class="badge b-hook">SessionStart &times;<!--devops:count:hooks:ss-->15<!--/devops:count:hooks:ss--></span>
     <span class="badge b-hook">Prompt &times;<!--devops:count:hooks:prompt-->8<!--/devops:count:hooks:prompt--></span>
     <span class="badge b-hook">Pre &times;<!--devops:count:hooks:pre-->6<!--/devops:count:hooks:pre--></span>
     <span class="badge b-hook">Post &times;<!--devops:count:hooks:post-->4<!--/devops:count:hooks:post--></span>
-    <span class="badge b-hook">Stop &times;<!--devops:count:hooks:stop-->3<!--/devops:count:hooks:stop--></span>
+    <span class="badge b-hook">Stop &times;<!--devops:count:hooks:stop-->4<!--/devops:count:hooks:stop--></span>
   </div>
   <div class="card">
     <h4><!--devops:count:skills-->23<!--/devops:count:skills--> Skills</h4>
@@ -217,11 +217,11 @@
 ├── hooks/
 │   ├── hooks.json             <span style="color:var(--purple)"># Hook registry (event &rarr; command mapping)</span>
 │   ├── lib/                   <span style="color:var(--text2)"># plugin-guard, run-once, session-id</span>
-│   ├── session-start/         <span style="color:var(--purple)"># <!--devops:count:hooks:ss-->14<!--/devops:count:hooks:ss--> hooks (ss.*)</span>
+│   ├── session-start/         <span style="color:var(--purple)"># <!--devops:count:hooks:ss-->15<!--/devops:count:hooks:ss--> hooks (ss.*)</span>
 │   ├── user-prompt-submit/    <span style="color:var(--purple)"># <!--devops:count:hooks:prompt-->8<!--/devops:count:hooks:prompt--> hooks (prompt.*)</span>
 │   ├── pre-tool-use/          <span style="color:var(--purple)"># <!--devops:count:hooks:pre-->6<!--/devops:count:hooks:pre--> hooks (pre.*)</span>
 │   ├── post-tool-use/         <span style="color:var(--purple)"># <!--devops:count:hooks:post-->4<!--/devops:count:hooks:post--> hooks (post.*)</span>
-│   └── stop/                  <span style="color:var(--purple)"># <!--devops:count:hooks:stop-->3<!--/devops:count:hooks:stop--> hooks (stop.*)</span>
+│   └── stop/                  <span style="color:var(--purple)"># <!--devops:count:hooks:stop-->4<!--/devops:count:hooks:stop--> hooks (stop.*)</span>
 ├── mcp-server/
 │   ├── index.js               <span style="color:var(--orange)"># dotclaude-completion MCP</span>
 │   └── ship/

--- a/plugins/devops/hooks/hooks.json
+++ b/plugins/devops/hooks/hooks.json
@@ -11,6 +11,7 @@
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-start/ss.mcp.deps.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-start/ss.mcp.envcheck.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-start/ss.mcp.verify.js" },
+          { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-start/ss.mcp.reap.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-start/ss.tokens.scan.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-start/ss.git.check.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-start/ss.git.sync.js" },
@@ -75,7 +76,8 @@
         "hooks": [
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/stop/stop.flow.browsertest.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/stop/stop.flow.guard.js" },
-          { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/stop/stop.flow.selfcalibration.js" }
+          { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/stop/stop.flow.selfcalibration.js" },
+          { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/stop/stop.mcp.reap.js" }
         ]
       }
     ],

--- a/plugins/devops/hooks/lib/mcp-reaper.js
+++ b/plugins/devops/hooks/lib/mcp-reaper.js
@@ -1,6 +1,6 @@
 /**
  * @module mcp-reaper
- * @version 0.1.0
+ * @version 0.2.0
  * @description Reclaims orphaned Claude Desktop MCP server child processes.
  *
  *   Claude Desktop spawns per-session MCP servers (bun for the discord
@@ -9,23 +9,56 @@
  *   these child processes are not reliably terminated — they become
  *   orphaned (their parent PID dies) and linger, accumulating RAM.
  *
- *   PROVEN safe-kill heuristic (validated live — freed 8 GB in one pass).
- *   A process is a reap candidate iff BOTH hold:
+ *   WINDOWS ONLY. The dead-parent orphan signal only means anything on
+ *   Windows: a Windows child process's ParentProcessId is a historical
+ *   "creator PID" that is never rewritten once the parent exits, and
+ *   Windows does not reparent orphans to any other process. On POSIX,
+ *   orphaned children are reparented to a live PID 1 (init/systemd), so a
+ *   dead-parent check would never fire and would be actively misleading if
+ *   implemented naively. findReapable() therefore returns `[]` on any
+ *   non-win32 platform — a documented no-op, not "not yet implemented".
+ *
+ *   A process is a reap candidate iff ALL of the following hold:
  *     1. MCP-server signature (isClaudeMcpServer) — command line matches a
- *        known MCP launcher pattern (plugin-cache path, or npx cache path).
+ *        known MCP launcher pattern: a `.claude/plugins/cache/` path, or an
+ *        npx-cache marker (`_npx`/`npx-cli`) COMBINED with the token `mcp`
+ *        (so a bare `npx vite`/`npx tsx` never matches).
  *     2. Orphaned — its parent PID is NOT alive (isProcessAlive(ppid) is
- *        false). This is the critical safety invariant: an *active*
- *        session's MCP server always has a live parent chain, so a
- *        dead-parent process can never belong to the active session.
+ *        false).
+ *     3. Outside the live-Claude census (liveClaudeExclusion) — NOT itself,
+ *        and NOT a structural descendant (in the current process-table
+ *        snapshot), of any currently-live process named `claude`/
+ *        `claude.exe`, or whose command contains `claude-code`. This is the
+ *        PRIMARY safety net: in real deployment the reaper runs as a
+ *        hook/scheduled-task CHILD of `claude.exe`, so a live session's own
+ *        MCP servers are typically COUSINS of the reaper (children of the
+ *        same shared claude.exe), not its ancestors/descendants — a
+ *        self-pid-only exclusion can never protect a cousin. Over-inclusion
+ *        here (e.g. Desktop renderer processes) is intentional and safe.
+ *        FAIL-SAFE GATE: if the census cannot be built (no live Claude-like
+ *        process found anywhere in the snapshot) findReapable() returns
+ *        `[]` unconditionally — an empty census means "protection unknown",
+ *        never "nothing to protect".
+ *     4. Outside the caller's own process subtree (computeSelfSubtree) — an
+ *        ADDITIONAL, narrower belt on top of the census: protects the
+ *        reaper's own direct ancestor/descendant chain even in the rare
+ *        case where that chain isn't itself recognized as "claude-like" by
+ *        the census's naming heuristics.
+ *     5. Not the reaper's own running process (ownProcessSignature) —
+ *        independent of `selfPid`: the reaper's own script, once installed,
+ *        lives under `.claude/plugins/cache/**` and would otherwise
+ *        self-match the MCP-cache signature.
  *
- *   On top of that, findReapable() additionally excludes the CALLER's own
- *   process subtree (ancestors + descendants of `selfPid`) regardless of
- *   what isAlive() reports for them — belt-and-suspenders so a live session
- *   can never reap itself even under a pathological/stubbed liveness check.
+ *   TOCTOU: reap() re-validates every candidate against a FRESH process
+ *   snapshot immediately before each SIGTERM and again before any SIGKILL
+ *   escalation (revalidateCandidate). A pid that got reused for something
+ *   else between the scan and the kill is skipped, never touched.
  *
- *   Fails safe: any enumeration failure returns `[]` (nothing to reap, never
- *   throws), and the default mode everywhere is dry-run — nothing is ever
- *   killed unless the caller explicitly opts in.
+ *   Fails safe end-to-end: any enumeration failure returns `[]` (nothing to
+ *   reap, never throws), an unbuildable census refuses to produce
+ *   candidates, a TOCTOU mismatch skips instead of killing, and the default
+ *   mode everywhere is dry-run — nothing is ever killed unless the caller
+ *   explicitly opts in.
  */
 
 'use strict';
@@ -35,14 +68,23 @@ const { isProcessAlive } = require('./mcp-status');
 
 const IS_WIN = process.platform === 'win32';
 
-// A process command line matching either of these is an MCP-server launcher.
-// Path fragment is matched case-insensitively with slashes normalized, so it
-// catches both `.claude/plugins/cache/...` (posix) and
-// `...\.claude\plugins\cache\...` (windows) command lines alike. This also
-// covers the "bun server child" case (bun running server.ts) as long as its
-// command line references the same cache path, which it does in practice.
+// A process command line matching either of these is an MCP-server launcher
+// signature. Path fragment is matched case-insensitively with slashes
+// normalized, so it catches both `.claude/plugins/cache/...` (posix) and
+// `...\.claude\plugins\cache\...` (windows) command lines alike.
 const CACHE_PATH_FRAGMENT = '.claude/plugins/cache/';
+// An npx-cache marker ALONE is not enough (any `npx <tool>` would match) —
+// it must be combined with the `mcp` token so bare dev-tool npx invocations
+// (`npx vite`, `npx tsx`, ...) are never flagged.
 const NPX_FRAGMENTS = ['_npx', 'npx-cli'];
+const MCP_TOKEN = 'mcp';
+
+// A currently-live process is considered a "live Claude root" for census
+// purposes when its name is exactly one of these...
+const CLAUDE_NAMES = new Set(['claude', 'claude.exe']);
+// ...or its command line contains this substring (catches the CLI running
+// under a generic `node`/`node.exe` process name).
+const CLAUDE_COMMAND_FRAGMENT = 'claude-code';
 
 // Fallback estimate used only when the OS query could not report a process's
 // actual working-set size (rssBytes). Rough, deliberately conservative.
@@ -55,6 +97,10 @@ function normalizeSlashes(str) {
   return String(str || '').replace(/\\/g, '/');
 }
 
+function normalizedCommand(proc) {
+  return normalizeSlashes(proc && proc.command).toLowerCase();
+}
+
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -64,12 +110,73 @@ function sleep(ms) {
 // ---------------------------------------------------------------------------
 
 /**
+ * Parse the raw stdout of the PowerShell `ConvertTo-Json` pipeline into a
+ * normalized process list. Pure function (no process I/O) so the
+ * "single result → object, not array" ConvertTo-Json quirk is directly
+ * unit-testable without shelling out.
+ * @param {string} jsonText
+ * @returns {Array<{pid:number, ppid:number, name:string, command:string, rssBytes:number}>}
+ */
+function parseWin32ProcessJson(jsonText) {
+  const trimmed = String(jsonText || '').trim();
+  if (!trimmed) return [];
+  let parsed;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return [];
+  }
+  // ConvertTo-Json emits a bare object (not a 1-element array) when exactly
+  // one result comes through the pipeline — normalize both shapes.
+  const arr = Array.isArray(parsed) ? parsed : [parsed];
+  return arr
+    .map((p) => ({
+      pid: Number(p.ProcessId),
+      ppid: Number(p.ParentProcessId),
+      name: p.Name || '',
+      command: p.CommandLine || '',
+      rssBytes: Number(p.WorkingSetSize) || 0,
+    }))
+    .filter((p) => Number.isFinite(p.pid));
+}
+
+/**
+ * Parse `wmic process ... /format:csv` output. `wmic` does not quote fields,
+ * so a CommandLine containing commas is ambiguous — resolved by taking the
+ * last 4 columns positionally (Name, ParentProcessId, ProcessId,
+ * WorkingSetSize are always plain tokens/numbers) and treating everything
+ * between the leading Node column and those 4 as the CommandLine, however
+ * many embedded commas it contains. Pure function, unit-testable.
+ * @param {string} csvText
+ * @returns {Array<{pid:number, ppid:number, name:string, command:string, rssBytes:number}>}
+ */
+function parseWmicCsv(csvText) {
+  const procs = [];
+  for (const rawLine of String(csvText || '').split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || /^Node,/i.test(line)) continue; // skip blank lines + header
+    const parts = line.split(',');
+    if (parts.length < 5) continue;
+    const workingSetSize = Number(parts[parts.length - 1]);
+    const processId = Number(parts[parts.length - 2]);
+    const parentProcessId = Number(parts[parts.length - 3]);
+    const name = parts[parts.length - 4];
+    const command = parts.slice(1, parts.length - 4).join(',');
+    if (!Number.isFinite(processId)) continue;
+    procs.push({
+      pid: processId,
+      ppid: Number.isFinite(parentProcessId) ? parentProcessId : 0,
+      name: name || '',
+      command: command || name || '',
+      rssBytes: Number.isFinite(workingSetSize) ? workingSetSize : 0,
+    });
+  }
+  return procs;
+}
+
+/**
  * Best-effort fallback process listing via `wmic` (older Windows / when the
- * PowerShell CIM path fails for any reason). `wmic process ... /format:csv`
- * does not quote fields, so a CommandLine containing commas is ambiguous —
- * this parser resolves that by taking the last 4 columns positionally
- * (Name, ParentProcessId, ProcessId, WorkingSetSize are always plain
- * numbers/tokens) and treating everything in between as the CommandLine.
+ * PowerShell CIM path fails for any reason). Never throws.
  * @returns {Array<{pid:number, ppid:number, name:string, command:string, rssBytes:number}>}
  */
 function listProcessesWindowsWmic() {
@@ -79,27 +186,7 @@ function listProcessesWindowsWmic() {
       ['process', 'get', 'ProcessId,ParentProcessId,Name,CommandLine,WorkingSetSize', '/format:csv'],
       { encoding: 'utf8', timeout: 15000, maxBuffer: 20 * 1024 * 1024 }
     );
-    const procs = [];
-    for (const rawLine of out.split(/\r?\n/)) {
-      const line = rawLine.trim();
-      if (!line || /^Node,/i.test(line)) continue; // skip blank lines + header
-      const parts = line.split(',');
-      if (parts.length < 5) continue;
-      const workingSetSize = Number(parts[parts.length - 1]);
-      const processId = Number(parts[parts.length - 2]);
-      const parentProcessId = Number(parts[parts.length - 3]);
-      const name = parts[parts.length - 4];
-      const command = parts.slice(1, parts.length - 4).join(',');
-      if (!Number.isFinite(processId)) continue;
-      procs.push({
-        pid: processId,
-        ppid: Number.isFinite(parentProcessId) ? parentProcessId : 0,
-        name: name || '',
-        command: command || name || '',
-        rssBytes: Number.isFinite(workingSetSize) ? workingSetSize : 0,
-      });
-    }
-    return procs;
+    return parseWmicCsv(out);
   } catch {
     return [];
   }
@@ -121,19 +208,7 @@ function listProcessesWindows() {
       ['-NoProfile', '-NonInteractive', '-Command', psCommand],
       { encoding: 'utf8', timeout: 15000, maxBuffer: 20 * 1024 * 1024 }
     );
-    const trimmed = out.trim();
-    if (!trimmed) return [];
-    const parsed = JSON.parse(trimmed);
-    const arr = Array.isArray(parsed) ? parsed : [parsed];
-    return arr
-      .map((p) => ({
-        pid: Number(p.ProcessId),
-        ppid: Number(p.ParentProcessId),
-        name: p.Name || '',
-        command: p.CommandLine || '',
-        rssBytes: Number(p.WorkingSetSize) || 0,
-      }))
-      .filter((p) => Number.isFinite(p.pid));
+    return parseWin32ProcessJson(out);
   } catch {
     return listProcessesWindowsWmic();
   }
@@ -141,7 +216,9 @@ function listProcessesWindows() {
 
 /**
  * Enumerate processes on macOS/Linux via `ps -eo pid=,ppid=,rss=,comm=,args=`.
- * Never throws.
+ * Never throws. NOTE: findReapable() ignores this platform's dead-parent
+ * signal entirely (see module header) — this is kept for listProcesses()
+ * completeness / potential future signature-only tooling, not for reaping.
  * @returns {Array<{pid:number, ppid:number, name:string, command:string, rssBytes:number}>}
  */
 function listProcessesPosix() {
@@ -193,19 +270,96 @@ function listProcesses() {
 /**
  * Does this process's command line match a known Claude MCP-server launcher
  * signature? Signature match ONLY — this says nothing about liveness/orphan
- * status. Never reaps based on this alone; see findReapable().
+ * status or census membership. Never reaps based on this alone; see
+ * findReapable().
  * @param {{command?: string}} proc
  * @returns {boolean}
  */
 function isClaudeMcpServer(proc) {
-  const cmd = normalizeSlashes(proc && proc.command).toLowerCase();
+  const cmd = normalizedCommand(proc);
   if (!cmd) return false;
   if (cmd.includes(CACHE_PATH_FRAGMENT)) return true;
-  return NPX_FRAGMENTS.some((frag) => cmd.includes(frag));
+  const hasNpxMarker = NPX_FRAGMENTS.some((frag) => cmd.includes(frag));
+  return hasNpxMarker && cmd.includes(MCP_TOKEN);
 }
 
 // ---------------------------------------------------------------------------
-// Self-subtree computation — never reap the calling session's own tree
+// Own-process guard (R7) — independent of selfPid
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalized signature of the currently-running script (process.argv[1]),
+ * used to guarantee the reaper never flags its own process, independent of
+ * whether `selfPid` was threaded through correctly. Matters because once
+ * installed, the reaper's own script lives under `.claude/plugins/cache/**`
+ * and would otherwise self-match isClaudeMcpServer().
+ * @returns {string} normalized, lowercased path fragment (possibly empty)
+ */
+function ownProcessSignature() {
+  const argvPath = process.argv && process.argv[1];
+  return normalizeSlashes(argvPath).toLowerCase();
+}
+
+// ---------------------------------------------------------------------------
+// Live-Claude census (R2/R3) — the primary safety net
+// ---------------------------------------------------------------------------
+
+function isLiveClaudeRoot(proc, isAlive) {
+  if (!proc) return false;
+  const name = String(proc.name || '').toLowerCase();
+  const cmd = normalizedCommand(proc);
+  const looksLikeClaude = CLAUDE_NAMES.has(name) || cmd.includes(CLAUDE_COMMAND_FRAGMENT);
+  if (!looksLikeClaude) return false;
+  return isAlive(proc.pid);
+}
+
+/**
+ * Build the set of pids that belong to any LIVE Claude session: every live
+ * process named `claude`/`claude.exe` or whose command contains
+ * `claude-code`, PLUS the full descendant subtree of each (walking the ppid
+ * graph within the current snapshot). This is the primary protection
+ * against reaping a live session's own MCP servers — in real deployment
+ * they are children of the shared `claude.exe` (Desktop) or the `claude`
+ * CLI process, NOT of the reaper itself, so a self-pid-only exclusion is
+ * not enough (see computeSelfSubtree for the additional, narrower belt).
+ *
+ * Over-inclusion is intentional and safe: Claude Desktop's renderer
+ * processes and any other descendant also end up protected.
+ *
+ * @param {Array<{pid:number, ppid:number, name:string, command:string}>} procs
+ * @param {(pid:number)=>boolean} isAlive
+ * @returns {Set<number>} empty when no live Claude root was found. Callers
+ *   MUST treat an empty result as "protection unknown, refuse to act",
+ *   never as "nothing to protect" — see findReapable's fail-safe gate.
+ */
+function liveClaudeExclusion(procs, isAlive) {
+  if (!Array.isArray(procs) || !procs.length) return new Set();
+
+  const childrenOf = new Map();
+  for (const p of procs) {
+    const list = childrenOf.get(p.ppid) || [];
+    list.push(p.pid);
+    childrenOf.set(p.ppid, list);
+  }
+
+  const roots = procs.filter((p) => isLiveClaudeRoot(p, isAlive));
+  const census = new Set();
+  for (const root of roots) {
+    if (census.has(root.pid)) continue;
+    census.add(root.pid);
+    const queue = [...(childrenOf.get(root.pid) || [])];
+    while (queue.length) {
+      const pid = queue.shift();
+      if (census.has(pid)) continue;
+      census.add(pid);
+      for (const child of childrenOf.get(pid) || []) queue.push(child);
+    }
+  }
+  return census;
+}
+
+// ---------------------------------------------------------------------------
+// Self-subtree computation — additional belt on top of the census
 // ---------------------------------------------------------------------------
 
 /**
@@ -213,6 +367,11 @@ function isClaudeMcpServer(proc) {
  * they are the caller's own subtree: `selfPid` itself, every ancestor of
  * `selfPid` reachable within `procs`, and every descendant of `selfPid`
  * reachable within `procs`. Bounded against ppid-graph cycles.
+ *
+ * This is an ADDITIONAL, narrower safety net on top of liveClaudeExclusion —
+ * it protects the reaper's own direct lineage even in the (unlikely) case
+ * that lineage isn't itself recognized as "claude-like" by the census's
+ * naming heuristics.
  * @param {Array<{pid:number, ppid:number}>} procs
  * @param {number} selfPid
  * @returns {Set<number>}
@@ -255,30 +414,52 @@ function computeSelfSubtree(procs, selfPid) {
 // ---------------------------------------------------------------------------
 
 /**
- * Find reap candidates within a given process list: MCP-signature match AND
- * dead parent, excluding the caller's own subtree entirely (see
- * computeSelfSubtree). Fail-safe by construction — anything not proven both
- * MCP-signature-matched and orphaned is left alone.
+ * Find reap candidates within a given process list. WINDOWS ONLY — returns
+ * `[]` unconditionally on any other platform (see module header, R6).
+ *
+ * Applies, in order: the live-Claude census (with its own fail-safe gate),
+ * the caller's self-subtree, the own-process guard, the MCP signature, and
+ * the dead-parent check. Fail-safe by construction — anything not proven
+ * signature-matched, orphaned, AND outside every protected set is left
+ * alone.
  * @param {Array<{pid:number, ppid:number, name:string, command:string, rssBytes?:number}>} procs
- * @param {{selfPid?: number, isAlive?: (pid:number)=>boolean}} [opts]
+ * @param {{selfPid?: number, isAlive?: (pid:number)=>boolean, platform?: string, ownSignature?: string}} [opts]
  * @returns {Array<{pid:number, ppid:number, name:string, reason:string, rssBytes:number}>}
  */
 function findReapable(procs, opts = {}) {
   if (!Array.isArray(procs) || !procs.length) return [];
+
+  const platform = opts.platform || process.platform;
+  if (platform !== 'win32') return []; // R6: orphan detection is Windows-only
+
   const selfPid = Number.isInteger(opts.selfPid) ? opts.selfPid : process.pid;
   const isAlive = typeof opts.isAlive === 'function' ? opts.isAlive : isProcessAlive;
+  const ownSig = normalizeSlashes(
+    typeof opts.ownSignature === 'string' ? opts.ownSignature : ownProcessSignature()
+  ).toLowerCase();
 
-  const excluded = computeSelfSubtree(procs, selfPid);
+  const census = liveClaudeExclusion(procs, isAlive);
+  if (census.size === 0) {
+    // Fail-safe (R2): we could not prove ANY live Claude session exists to
+    // protect. Refuse to produce candidates at all rather than risk having
+    // excluded nothing. An empty census means "unknown", never "safe".
+    return [];
+  }
+
+  const selfSubtree = computeSelfSubtree(procs, selfPid);
+
   const out = [];
   for (const proc of procs) {
-    if (excluded.has(proc.pid)) continue;
+    if (census.has(proc.pid) || selfSubtree.has(proc.pid)) continue;
+    const cmd = normalizedCommand(proc);
+    if (ownSig && cmd.includes(ownSig)) continue; // R7: never flag our own running script
     if (!isClaudeMcpServer(proc)) continue;
     if (isAlive(proc.ppid)) continue; // parent alive → not orphaned → skip
     out.push({
       pid: proc.pid,
       ppid: proc.ppid,
       name: proc.name || '',
-      reason: 'orphaned-mcp-server (dead parent + mcp-signature match)',
+      reason: 'orphaned-mcp-server (dead parent + mcp-signature match, outside live-Claude census)',
       rssBytes: Number(proc.rssBytes) || 0,
     });
   }
@@ -286,51 +467,116 @@ function findReapable(procs, opts = {}) {
 }
 
 // ---------------------------------------------------------------------------
+// TOCTOU re-validation (R4)
+// ---------------------------------------------------------------------------
+
+/**
+ * Re-validate a single candidate pid against a FRESH process snapshot,
+ * immediately before it is signaled. Re-runs every condition that made it a
+ * candidate in the first place (signature, dead parent, census, self-
+ * subtree, own-process) against current data — never trusts the snapshot
+ * the original candidate list was built from. Called before both the
+ * SIGTERM and the SIGKILL escalation so a pid reused for something else
+ * between the scan and the kill is never touched.
+ * @param {number} pid
+ * @param {{listProcs: Function, isAlive: Function, selfPid: number, platform?: string, ownSignature?: string}} opts
+ * @returns {{ok: boolean, reason?: string}}
+ */
+function revalidateCandidate(pid, opts) {
+  const { listProcs, isAlive, selfPid, platform = process.platform, ownSignature } = opts;
+  if (platform !== 'win32') return { ok: false, reason: 'non-windows' };
+
+  const freshProcs = listProcs();
+  if (!Array.isArray(freshProcs) || !freshProcs.length) {
+    return { ok: false, reason: 'no-fresh-snapshot' };
+  }
+
+  const proc = freshProcs.find((p) => p.pid === pid);
+  if (!proc) return { ok: false, reason: 'pid-not-found' };
+
+  const ownSig = normalizeSlashes(
+    typeof ownSignature === 'string' ? ownSignature : ownProcessSignature()
+  ).toLowerCase();
+  const cmd = normalizedCommand(proc);
+  if (ownSig && cmd.includes(ownSig)) return { ok: false, reason: 'self-process' };
+
+  if (!isClaudeMcpServer(proc)) return { ok: false, reason: 'signature-mismatch' };
+  if (isAlive(proc.ppid)) return { ok: false, reason: 'parent-now-alive' };
+
+  const census = liveClaudeExclusion(freshProcs, isAlive);
+  if (census.size === 0) return { ok: false, reason: 'census-unbuildable' };
+  if (census.has(pid)) return { ok: false, reason: 'now-in-live-claude-census' };
+
+  const selfSubtree = computeSelfSubtree(freshProcs, selfPid);
+  if (selfSubtree.has(pid)) return { ok: false, reason: 'now-in-self-subtree' };
+
+  return { ok: true };
+}
+
+// ---------------------------------------------------------------------------
 // Reap execution
 // ---------------------------------------------------------------------------
 
 /**
- * Kill one candidate: SIGTERM, then (only if it survives a short grace
- * period) SIGKILL. On Windows both signals hard-terminate — that's
- * acceptable. Every kill attempt is guarded in try/catch; a failure is
- * reported via `errors`, never thrown.
+ * Kill one candidate: TOCTOU re-check, then SIGTERM; if it survives a short
+ * grace period, TOCTOU re-check again, then SIGKILL. On Windows both
+ * signals hard-terminate — that's acceptable. Every kill attempt is guarded
+ * in try/catch; a failure is reported via the returned `error`, never
+ * thrown. A failed re-check reports via `skipped` and never signals.
  * @param {{pid:number}} candidate
- * @param {(pid:number)=>boolean} isAlive
- * @param {number} graceMs
- * @returns {Promise<{killed:boolean, error:{pid:number, stage:string, error:string}|null}>}
+ * @param {{isAlive:Function, graceMs:number, listProcs:Function, selfPid:number, platform?:string, ownSignature?:string}} opts
+ * @returns {Promise<{killed:boolean, error:{pid:number, stage:string, error:string}|null, skipped:{pid:number, stage:string, reason:string}|null}>}
  */
-async function killCandidate(candidate, isAlive, graceMs) {
+async function killCandidate(candidate, opts) {
+  const { isAlive, graceMs, listProcs, selfPid, platform, ownSignature } = opts;
+  const revalOpts = { listProcs, isAlive, selfPid, platform, ownSignature };
+
+  const preTerm = revalidateCandidate(candidate.pid, revalOpts);
+  if (!preTerm.ok) {
+    return { killed: false, error: null, skipped: { pid: candidate.pid, stage: 'pre-SIGTERM', reason: preTerm.reason } };
+  }
+
   try {
     process.kill(candidate.pid, 'SIGTERM');
   } catch (err) {
-    return { killed: false, error: { pid: candidate.pid, stage: 'SIGTERM', error: err.message } };
+    return { killed: false, error: { pid: candidate.pid, stage: 'SIGTERM', error: err.message }, skipped: null };
   }
 
   if (graceMs > 0) await sleep(graceMs);
 
-  if (isAlive(candidate.pid)) {
-    try {
-      process.kill(candidate.pid, 'SIGKILL');
-    } catch (err) {
-      return { killed: false, error: { pid: candidate.pid, stage: 'SIGKILL', error: err.message } };
-    }
+  if (!isAlive(candidate.pid)) {
+    return { killed: true, error: null, skipped: null };
   }
 
-  return { killed: true, error: null };
+  const preKill = revalidateCandidate(candidate.pid, revalOpts);
+  if (!preKill.ok) {
+    return { killed: false, error: null, skipped: { pid: candidate.pid, stage: 'pre-SIGKILL', reason: preKill.reason } };
+  }
+
+  try {
+    process.kill(candidate.pid, 'SIGKILL');
+  } catch (err) {
+    return { killed: false, error: { pid: candidate.pid, stage: 'SIGKILL', error: err.message }, skipped: null };
+  }
+
+  return { killed: true, error: null, skipped: null };
 }
 
 /**
  * Scan for orphaned MCP-server processes and, unless `dryRun`, terminate
- * them. Default is dry-run — kill only when explicitly asked.
+ * them. Default is dry-run — kill only when explicitly asked. Windows only
+ * (see findReapable / module header) — a no-op elsewhere.
  * @param {{
  *   dryRun?: boolean,
  *   selfPid?: number,
  *   graceMs?: number,
  *   isAlive?: (pid:number)=>boolean,
  *   listProcs?: () => Array<object>,
+ *   platform?: string,
+ *   ownSignature?: string,
  *   logger?: {log: Function},
  * }} [opts]
- * @returns {Promise<{scanned:number, candidates:Array, killed:number[], errors:Array, freedEstimateMb:number}>}
+ * @returns {Promise<{scanned:number, candidates:Array, killed:number[], errors:Array, skipped:Array, freedEstimateMb:number}>}
  */
 async function reap(opts = {}) {
   const {
@@ -339,19 +585,23 @@ async function reap(opts = {}) {
     graceMs = DEFAULT_GRACE_MS,
     isAlive = isProcessAlive,
     listProcs = listProcesses,
+    platform = process.platform,
+    ownSignature,
     logger,
   } = opts;
 
   const procs = listProcs();
-  const candidates = findReapable(procs, { selfPid, isAlive });
+  const candidates = findReapable(procs, { selfPid, isAlive, platform, ownSignature });
   const killed = [];
   const errors = [];
+  const skipped = [];
 
   if (!dryRun) {
     for (const candidate of candidates) {
-      const result = await killCandidate(candidate, isAlive, graceMs);
+      const result = await killCandidate(candidate, { isAlive, graceMs, listProcs, selfPid, platform, ownSignature });
       if (result.killed) killed.push(candidate.pid);
       if (result.error) errors.push(result.error);
+      if (result.skipped) skipped.push(result.skipped);
     }
   }
 
@@ -365,16 +615,20 @@ async function reap(opts = {}) {
   if (logger && typeof logger.log === 'function') {
     logger.log(
       `mcp-reaper: scanned=${procs.length} candidates=${candidates.length} ` +
-      `killed=${killed.length} dryRun=${dryRun}`
+      `killed=${killed.length} skipped=${skipped.length} dryRun=${dryRun}`
     );
   }
 
-  return { scanned: procs.length, candidates, killed, errors, freedEstimateMb };
+  return { scanned: procs.length, candidates, killed, errors, skipped, freedEstimateMb };
 }
 
 module.exports = {
   listProcesses,
+  parseWin32ProcessJson,
+  parseWmicCsv,
   isClaudeMcpServer,
+  ownProcessSignature,
+  liveClaudeExclusion,
   computeSelfSubtree,
   findReapable,
   reap,

--- a/plugins/devops/hooks/lib/mcp-reaper.js
+++ b/plugins/devops/hooks/lib/mcp-reaper.js
@@ -1,0 +1,381 @@
+/**
+ * @module mcp-reaper
+ * @version 0.1.0
+ * @description Reclaims orphaned Claude Desktop MCP server child processes.
+ *
+ *   Claude Desktop spawns per-session MCP servers (bun for the discord
+ *   plugin, node via npx for github/playwright, node stdio servers for
+ *   `.claude/plugins/cache/**` plugins). When a Claude Code session ends,
+ *   these child processes are not reliably terminated — they become
+ *   orphaned (their parent PID dies) and linger, accumulating RAM.
+ *
+ *   PROVEN safe-kill heuristic (validated live — freed 8 GB in one pass).
+ *   A process is a reap candidate iff BOTH hold:
+ *     1. MCP-server signature (isClaudeMcpServer) — command line matches a
+ *        known MCP launcher pattern (plugin-cache path, or npx cache path).
+ *     2. Orphaned — its parent PID is NOT alive (isProcessAlive(ppid) is
+ *        false). This is the critical safety invariant: an *active*
+ *        session's MCP server always has a live parent chain, so a
+ *        dead-parent process can never belong to the active session.
+ *
+ *   On top of that, findReapable() additionally excludes the CALLER's own
+ *   process subtree (ancestors + descendants of `selfPid`) regardless of
+ *   what isAlive() reports for them — belt-and-suspenders so a live session
+ *   can never reap itself even under a pathological/stubbed liveness check.
+ *
+ *   Fails safe: any enumeration failure returns `[]` (nothing to reap, never
+ *   throws), and the default mode everywhere is dry-run — nothing is ever
+ *   killed unless the caller explicitly opts in.
+ */
+
+'use strict';
+
+const { execFileSync } = require('child_process');
+const { isProcessAlive } = require('./mcp-status');
+
+const IS_WIN = process.platform === 'win32';
+
+// A process command line matching either of these is an MCP-server launcher.
+// Path fragment is matched case-insensitively with slashes normalized, so it
+// catches both `.claude/plugins/cache/...` (posix) and
+// `...\.claude\plugins\cache\...` (windows) command lines alike. This also
+// covers the "bun server child" case (bun running server.ts) as long as its
+// command line references the same cache path, which it does in practice.
+const CACHE_PATH_FRAGMENT = '.claude/plugins/cache/';
+const NPX_FRAGMENTS = ['_npx', 'npx-cli'];
+
+// Fallback estimate used only when the OS query could not report a process's
+// actual working-set size (rssBytes). Rough, deliberately conservative.
+const FALLBACK_MB_PER_SERVER = 150;
+
+// Grace period between SIGTERM and a SIGKILL escalation, in ms.
+const DEFAULT_GRACE_MS = 300;
+
+function normalizeSlashes(str) {
+  return String(str || '').replace(/\\/g, '/');
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// ---------------------------------------------------------------------------
+// Process enumeration — cross-platform, fails safe (returns [] on any error)
+// ---------------------------------------------------------------------------
+
+/**
+ * Best-effort fallback process listing via `wmic` (older Windows / when the
+ * PowerShell CIM path fails for any reason). `wmic process ... /format:csv`
+ * does not quote fields, so a CommandLine containing commas is ambiguous —
+ * this parser resolves that by taking the last 4 columns positionally
+ * (Name, ParentProcessId, ProcessId, WorkingSetSize are always plain
+ * numbers/tokens) and treating everything in between as the CommandLine.
+ * @returns {Array<{pid:number, ppid:number, name:string, command:string, rssBytes:number}>}
+ */
+function listProcessesWindowsWmic() {
+  try {
+    const out = execFileSync(
+      'wmic',
+      ['process', 'get', 'ProcessId,ParentProcessId,Name,CommandLine,WorkingSetSize', '/format:csv'],
+      { encoding: 'utf8', timeout: 15000, maxBuffer: 20 * 1024 * 1024 }
+    );
+    const procs = [];
+    for (const rawLine of out.split(/\r?\n/)) {
+      const line = rawLine.trim();
+      if (!line || /^Node,/i.test(line)) continue; // skip blank lines + header
+      const parts = line.split(',');
+      if (parts.length < 5) continue;
+      const workingSetSize = Number(parts[parts.length - 1]);
+      const processId = Number(parts[parts.length - 2]);
+      const parentProcessId = Number(parts[parts.length - 3]);
+      const name = parts[parts.length - 4];
+      const command = parts.slice(1, parts.length - 4).join(',');
+      if (!Number.isFinite(processId)) continue;
+      procs.push({
+        pid: processId,
+        ppid: Number.isFinite(parentProcessId) ? parentProcessId : 0,
+        name: name || '',
+        command: command || name || '',
+        rssBytes: Number.isFinite(workingSetSize) ? workingSetSize : 0,
+      });
+    }
+    return procs;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Enumerate processes on Windows via PowerShell `Get-CimInstance Win32_Process`.
+ * Falls back to `wmic` on failure. Never throws.
+ * @returns {Array<{pid:number, ppid:number, name:string, command:string, rssBytes:number}>}
+ */
+function listProcessesWindows() {
+  try {
+    const psCommand =
+      'Get-CimInstance Win32_Process | ' +
+      'Select-Object ProcessId,ParentProcessId,Name,CommandLine,WorkingSetSize | ' +
+      'ConvertTo-Json -Compress';
+    const out = execFileSync(
+      'powershell.exe',
+      ['-NoProfile', '-NonInteractive', '-Command', psCommand],
+      { encoding: 'utf8', timeout: 15000, maxBuffer: 20 * 1024 * 1024 }
+    );
+    const trimmed = out.trim();
+    if (!trimmed) return [];
+    const parsed = JSON.parse(trimmed);
+    const arr = Array.isArray(parsed) ? parsed : [parsed];
+    return arr
+      .map((p) => ({
+        pid: Number(p.ProcessId),
+        ppid: Number(p.ParentProcessId),
+        name: p.Name || '',
+        command: p.CommandLine || '',
+        rssBytes: Number(p.WorkingSetSize) || 0,
+      }))
+      .filter((p) => Number.isFinite(p.pid));
+  } catch {
+    return listProcessesWindowsWmic();
+  }
+}
+
+/**
+ * Enumerate processes on macOS/Linux via `ps -eo pid=,ppid=,rss=,comm=,args=`.
+ * Never throws.
+ * @returns {Array<{pid:number, ppid:number, name:string, command:string, rssBytes:number}>}
+ */
+function listProcessesPosix() {
+  try {
+    const out = execFileSync(
+      'ps',
+      ['-eo', 'pid=,ppid=,rss=,comm=,args='],
+      { encoding: 'utf8', timeout: 15000, maxBuffer: 20 * 1024 * 1024 }
+    );
+    const procs = [];
+    for (const rawLine of out.split('\n')) {
+      const line = rawLine.trim();
+      if (!line) continue;
+      const m = line.match(/^(\d+)\s+(\d+)\s+(\d+)\s+(\S+)\s*(.*)$/);
+      if (!m) continue;
+      const [, pidStr, ppidStr, rssKbStr, comm, args] = m;
+      procs.push({
+        pid: Number(pidStr),
+        ppid: Number(ppidStr),
+        name: comm,
+        command: args || comm,
+        rssBytes: Number(rssKbStr) * 1024,
+      });
+    }
+    return procs;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Enumerate all OS processes, cross-platform. Fails safe: returns `[]` on
+ * any failure (missing tools, permission errors, timeouts) rather than
+ * throwing — a scan failure must never cascade into an unsafe decision.
+ * @returns {Array<{pid:number, ppid:number, name:string, command:string, rssBytes:number}>}
+ */
+function listProcesses() {
+  try {
+    return IS_WIN ? listProcessesWindows() : listProcessesPosix();
+  } catch {
+    return [];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Signature matching
+// ---------------------------------------------------------------------------
+
+/**
+ * Does this process's command line match a known Claude MCP-server launcher
+ * signature? Signature match ONLY — this says nothing about liveness/orphan
+ * status. Never reaps based on this alone; see findReapable().
+ * @param {{command?: string}} proc
+ * @returns {boolean}
+ */
+function isClaudeMcpServer(proc) {
+  const cmd = normalizeSlashes(proc && proc.command).toLowerCase();
+  if (!cmd) return false;
+  if (cmd.includes(CACHE_PATH_FRAGMENT)) return true;
+  return NPX_FRAGMENTS.some((frag) => cmd.includes(frag));
+}
+
+// ---------------------------------------------------------------------------
+// Self-subtree computation — never reap the calling session's own tree
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute the set of pids that must never be considered for reaping because
+ * they are the caller's own subtree: `selfPid` itself, every ancestor of
+ * `selfPid` reachable within `procs`, and every descendant of `selfPid`
+ * reachable within `procs`. Bounded against ppid-graph cycles.
+ * @param {Array<{pid:number, ppid:number}>} procs
+ * @param {number} selfPid
+ * @returns {Set<number>}
+ */
+function computeSelfSubtree(procs, selfPid) {
+  const byPid = new Map(procs.map((p) => [p.pid, p]));
+  const childrenOf = new Map();
+  for (const p of procs) {
+    const list = childrenOf.get(p.ppid) || [];
+    list.push(p.pid);
+    childrenOf.set(p.ppid, list);
+  }
+
+  const excluded = new Set([selfPid]);
+
+  // Walk up the parent chain (ancestors). Bounded by procs.length so a cycle
+  // in the ppid graph can't spin forever.
+  let pid = selfPid;
+  for (let i = 0; i < procs.length + 1; i++) {
+    const proc = byPid.get(pid);
+    if (!proc || excluded.has(proc.ppid)) break;
+    excluded.add(proc.ppid);
+    pid = proc.ppid;
+  }
+
+  // Walk down all descendants (BFS), guarded by `excluded` against cycles.
+  const queue = [...(childrenOf.get(selfPid) || [])];
+  while (queue.length) {
+    const child = queue.shift();
+    if (excluded.has(child)) continue;
+    excluded.add(child);
+    for (const grandchild of childrenOf.get(child) || []) queue.push(grandchild);
+  }
+
+  return excluded;
+}
+
+// ---------------------------------------------------------------------------
+// Candidate selection
+// ---------------------------------------------------------------------------
+
+/**
+ * Find reap candidates within a given process list: MCP-signature match AND
+ * dead parent, excluding the caller's own subtree entirely (see
+ * computeSelfSubtree). Fail-safe by construction — anything not proven both
+ * MCP-signature-matched and orphaned is left alone.
+ * @param {Array<{pid:number, ppid:number, name:string, command:string, rssBytes?:number}>} procs
+ * @param {{selfPid?: number, isAlive?: (pid:number)=>boolean}} [opts]
+ * @returns {Array<{pid:number, ppid:number, name:string, reason:string, rssBytes:number}>}
+ */
+function findReapable(procs, opts = {}) {
+  if (!Array.isArray(procs) || !procs.length) return [];
+  const selfPid = Number.isInteger(opts.selfPid) ? opts.selfPid : process.pid;
+  const isAlive = typeof opts.isAlive === 'function' ? opts.isAlive : isProcessAlive;
+
+  const excluded = computeSelfSubtree(procs, selfPid);
+  const out = [];
+  for (const proc of procs) {
+    if (excluded.has(proc.pid)) continue;
+    if (!isClaudeMcpServer(proc)) continue;
+    if (isAlive(proc.ppid)) continue; // parent alive → not orphaned → skip
+    out.push({
+      pid: proc.pid,
+      ppid: proc.ppid,
+      name: proc.name || '',
+      reason: 'orphaned-mcp-server (dead parent + mcp-signature match)',
+      rssBytes: Number(proc.rssBytes) || 0,
+    });
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Reap execution
+// ---------------------------------------------------------------------------
+
+/**
+ * Kill one candidate: SIGTERM, then (only if it survives a short grace
+ * period) SIGKILL. On Windows both signals hard-terminate — that's
+ * acceptable. Every kill attempt is guarded in try/catch; a failure is
+ * reported via `errors`, never thrown.
+ * @param {{pid:number}} candidate
+ * @param {(pid:number)=>boolean} isAlive
+ * @param {number} graceMs
+ * @returns {Promise<{killed:boolean, error:{pid:number, stage:string, error:string}|null}>}
+ */
+async function killCandidate(candidate, isAlive, graceMs) {
+  try {
+    process.kill(candidate.pid, 'SIGTERM');
+  } catch (err) {
+    return { killed: false, error: { pid: candidate.pid, stage: 'SIGTERM', error: err.message } };
+  }
+
+  if (graceMs > 0) await sleep(graceMs);
+
+  if (isAlive(candidate.pid)) {
+    try {
+      process.kill(candidate.pid, 'SIGKILL');
+    } catch (err) {
+      return { killed: false, error: { pid: candidate.pid, stage: 'SIGKILL', error: err.message } };
+    }
+  }
+
+  return { killed: true, error: null };
+}
+
+/**
+ * Scan for orphaned MCP-server processes and, unless `dryRun`, terminate
+ * them. Default is dry-run — kill only when explicitly asked.
+ * @param {{
+ *   dryRun?: boolean,
+ *   selfPid?: number,
+ *   graceMs?: number,
+ *   isAlive?: (pid:number)=>boolean,
+ *   listProcs?: () => Array<object>,
+ *   logger?: {log: Function},
+ * }} [opts]
+ * @returns {Promise<{scanned:number, candidates:Array, killed:number[], errors:Array, freedEstimateMb:number}>}
+ */
+async function reap(opts = {}) {
+  const {
+    dryRun = true,
+    selfPid = process.pid,
+    graceMs = DEFAULT_GRACE_MS,
+    isAlive = isProcessAlive,
+    listProcs = listProcesses,
+    logger,
+  } = opts;
+
+  const procs = listProcs();
+  const candidates = findReapable(procs, { selfPid, isAlive });
+  const killed = [];
+  const errors = [];
+
+  if (!dryRun) {
+    for (const candidate of candidates) {
+      const result = await killCandidate(candidate, isAlive, graceMs);
+      if (result.killed) killed.push(candidate.pid);
+      if (result.error) errors.push(result.error);
+    }
+  }
+
+  const freedEstimateMb = Math.round(
+    candidates.reduce((sum, c) => {
+      const mb = c.rssBytes > 0 ? c.rssBytes / (1024 * 1024) : FALLBACK_MB_PER_SERVER;
+      return sum + mb;
+    }, 0)
+  );
+
+  if (logger && typeof logger.log === 'function') {
+    logger.log(
+      `mcp-reaper: scanned=${procs.length} candidates=${candidates.length} ` +
+      `killed=${killed.length} dryRun=${dryRun}`
+    );
+  }
+
+  return { scanned: procs.length, candidates, killed, errors, freedEstimateMb };
+}
+
+module.exports = {
+  listProcesses,
+  isClaudeMcpServer,
+  computeSelfSubtree,
+  findReapable,
+  reap,
+};

--- a/plugins/devops/hooks/lib/mcp-reaper.js
+++ b/plugins/devops/hooks/lib/mcp-reaper.js
@@ -1,6 +1,6 @@
 /**
  * @module mcp-reaper
- * @version 0.2.0
+ * @version 0.2.1
  * @description Reclaims orphaned Claude Desktop MCP server child processes.
  *
  *   Claude Desktop spawns per-session MCP servers (bun for the discord
@@ -184,7 +184,7 @@ function listProcessesWindowsWmic() {
     const out = execFileSync(
       'wmic',
       ['process', 'get', 'ProcessId,ParentProcessId,Name,CommandLine,WorkingSetSize', '/format:csv'],
-      { encoding: 'utf8', timeout: 15000, maxBuffer: 20 * 1024 * 1024 }
+      { encoding: 'utf8', timeout: 15000, maxBuffer: 20 * 1024 * 1024, windowsHide: true }
     );
     return parseWmicCsv(out);
   } catch {
@@ -206,7 +206,7 @@ function listProcessesWindows() {
     const out = execFileSync(
       'powershell.exe',
       ['-NoProfile', '-NonInteractive', '-Command', psCommand],
-      { encoding: 'utf8', timeout: 15000, maxBuffer: 20 * 1024 * 1024 }
+      { encoding: 'utf8', timeout: 15000, maxBuffer: 20 * 1024 * 1024, windowsHide: true }
     );
     return parseWin32ProcessJson(out);
   } catch {

--- a/plugins/devops/hooks/lib/mcp-reaper.test.js
+++ b/plugins/devops/hooks/lib/mcp-reaper.test.js
@@ -1,131 +1,287 @@
 import { describe, test, expect, vi, afterEach } from "vitest";
-import { isClaudeMcpServer, findReapable, reap } from "./mcp-reaper.js";
+import {
+  isClaudeMcpServer,
+  liveClaudeExclusion,
+  computeSelfSubtree,
+  findReapable,
+  reap,
+  parseWin32ProcessJson,
+  parseWmicCsv,
+} from "./mcp-reaper.js";
 
 const CACHE_CMD_DISCORD =
   'C:\\Users\\jerry\\.claude\\plugins\\cache\\discord\\bin\\bun.exe run server.ts';
 const CACHE_CMD_GENERIC =
   'node "C:\\Users\\jerry\\.claude\\plugins\\cache\\github\\mcp-server\\index.js"';
 
+// Real evidence command lines from the red-team's live process table.
+const REAL_DISCORD_BUN =
+  'bun run --cwd C:/Users/jerry/.claude/plugins/cache/claude-plugins-official/discord/0.0.1 --shell=bun --silent start';
+const REAL_DEVOPS_STDIO =
+  'node C:/Users/jerry/.claude/plugins/cache/dotclaude/devops/0.119.1/mcp-server/index.js';
+const REAL_PLAYWRIGHT_NPX_CLI =
+  'node C:/Program Files/nodejs/node_modules/npm/bin/npx-cli.js "@playwright/mcp@latest" --browser msedge';
+const REAL_PLAYWRIGHT_NPX_DIRECT =
+  'node C:/Users/jerry/AppData/Local/npm-cache/_npx/a1b2c3/node_modules/.bin/../@playwright/mcp/cli.js --browser msedge';
+const REAL_CONTEXT7_NPX_CLI =
+  'node C:/Program Files/nodejs/node_modules/npm/bin/npx-cli.js -y "@upstash/context7-mcp@latest"';
+const REAL_CONTEXT7_NPX_DIRECT =
+  'node C:/Users/jerry/AppData/Local/npm-cache/_npx/d4e5f6/node_modules/@upstash/context7-mcp/dist/index.js';
+
+// A live "claude root" process — makes liveClaudeExclusion's census non-empty
+// so findReapable's fail-safe gate doesn't swallow every other test.
+const LIVE_CLAUDE_ROOT = { pid: 1, ppid: 0, name: "claude.exe", command: "C:\\Users\\jerry\\AppData\\Local\\Programs\\Claude\\Claude.exe" };
+
 // ---------------------------------------------------------------------------
-// isClaudeMcpServer — signature matching only
+// isClaudeMcpServer — tightened signature (R5): cache path, OR
+// (npx marker AND "mcp" token)
 // ---------------------------------------------------------------------------
 
 describe("isClaudeMcpServer", () => {
-  test("matches a bun launcher for a plugin-cache MCP server (discord)", () => {
-    expect(isClaudeMcpServer({ pid: 100, ppid: 1, name: "bun.exe", command: CACHE_CMD_DISCORD }))
-      .toBe(true);
+  test("matches the real discord bun launcher (plugin-cache path)", () => {
+    expect(isClaudeMcpServer({ command: REAL_DISCORD_BUN })).toBe(true);
   });
 
-  test("matches a node plugin-cache stdio MCP server", () => {
-    expect(isClaudeMcpServer({ pid: 101, ppid: 1, name: "node.exe", command: CACHE_CMD_GENERIC }))
-      .toBe(true);
+  test("matches the real devops stdio MCP server (plugin-cache path)", () => {
+    expect(isClaudeMcpServer({ command: REAL_DEVOPS_STDIO })).toBe(true);
   });
 
-  test("matches a node npx MCP server (_npx cache path)", () => {
-    const proc = {
-      pid: 102, ppid: 1, name: "node.exe",
-      command: "node C:\\Users\\jerry\\AppData\\Local\\npm-cache\\_npx\\abc123\\node_modules\\.bin\\playwright-mcp",
-    };
-    expect(isClaudeMcpServer(proc)).toBe(true);
+  test("matches the real playwright MCP server via npx-cli.js (npx marker + mcp token)", () => {
+    expect(isClaudeMcpServer({ command: REAL_PLAYWRIGHT_NPX_CLI })).toBe(true);
   });
 
-  test("matches node running npx-cli.js", () => {
-    const proc = {
-      pid: 103, ppid: 1, name: "node.exe",
-      command: "node C:\\Program Files\\nodejs\\node_modules\\npm\\bin\\npx-cli.js @modelcontextprotocol/server-github",
-    };
-    expect(isClaudeMcpServer(proc)).toBe(true);
+  test("matches the real playwright MCP server via direct _npx cache path (npx marker + mcp token)", () => {
+    expect(isClaudeMcpServer({ command: REAL_PLAYWRIGHT_NPX_DIRECT })).toBe(true);
+  });
+
+  test("matches the real context7 MCP server via npx-cli.js (npx marker + mcp token)", () => {
+    expect(isClaudeMcpServer({ command: REAL_CONTEXT7_NPX_CLI })).toBe(true);
+  });
+
+  test("matches the real context7 MCP server via direct _npx cache path (npx marker + mcp token)", () => {
+    expect(isClaudeMcpServer({ command: REAL_CONTEXT7_NPX_DIRECT })).toBe(true);
+  });
+
+  test("R5: does NOT match a bare `npx vite` (npx marker present in real form, no mcp token)", () => {
+    const proc = { command: "node C:\\Program Files\\nodejs\\node_modules\\npm\\bin\\npx-cli.js vite" };
+    expect(isClaudeMcpServer(proc)).toBe(false);
+  });
+
+  test("R5: does NOT match a bare `npx tsx` via the _npx cache path (npx marker present, no mcp token)", () => {
+    const proc = { command: "node C:\\Users\\jerry\\AppData\\Local\\npm-cache\\_npx\\ffaa11\\node_modules\\.bin\\tsx watch main.ts" };
+    expect(isClaudeMcpServer(proc)).toBe(false);
+  });
+
+  test("R5: does NOT match literal `npx create-react-app`", () => {
+    expect(isClaudeMcpServer({ command: "npx create-react-app my-app" })).toBe(false);
+  });
+
+  test("R5: does NOT match `npm exec eslint`", () => {
+    expect(isClaudeMcpServer({ command: "npm exec eslint ." })).toBe(false);
   });
 
   test("does NOT match an unrelated bun dev server (user project, not plugin cache)", () => {
-    const proc = {
-      pid: 200, ppid: 1, name: "bun.exe",
-      command: "bun run dev --cwd C:\\Users\\jerry\\projects\\my-app",
-    };
+    const proc = { command: "bun run dev --cwd C:\\Users\\jerry\\projects\\my-app" };
     expect(isClaudeMcpServer(proc)).toBe(false);
   });
 
   test("does NOT match a random node process outside plugins cache", () => {
-    expect(isClaudeMcpServer({ pid: 201, ppid: 1, name: "node.exe", command: "node index.js" }))
-      .toBe(false);
+    expect(isClaudeMcpServer({ command: "node index.js" })).toBe(false);
   });
 
   test("does NOT match Claude Desktop itself or its renderer processes", () => {
-    const proc = {
-      pid: 202, ppid: 1, name: "Claude.exe",
-      command: '"C:\\Users\\jerry\\AppData\\Local\\Programs\\Claude\\Claude.exe" --type=renderer',
-    };
+    const proc = { command: '"C:\\Users\\jerry\\AppData\\Local\\Programs\\Claude\\Claude.exe" --type=renderer' };
     expect(isClaudeMcpServer(proc)).toBe(false);
   });
 
   test("handles missing/empty command safely", () => {
-    expect(isClaudeMcpServer({ pid: 1, ppid: 0, name: "x", command: "" })).toBe(false);
-    expect(isClaudeMcpServer({ pid: 1, ppid: 0, name: "x" })).toBe(false);
+    expect(isClaudeMcpServer({ command: "" })).toBe(false);
+    expect(isClaudeMcpServer({})).toBe(false);
     expect(isClaudeMcpServer(null)).toBe(false);
   });
 });
 
 // ---------------------------------------------------------------------------
-// findReapable — signature + dead-parent rule + self-subtree exclusion
+// liveClaudeExclusion — the live-Claude census (R2/R3)
+// ---------------------------------------------------------------------------
+
+describe("liveClaudeExclusion", () => {
+  test("finds a live claude.exe root and its full descendant subtree", () => {
+    const procs = [
+      LIVE_CLAUDE_ROOT,
+      { pid: 2, ppid: 1, name: "bun.exe", command: REAL_DISCORD_BUN },
+      { pid: 3, ppid: 2, name: "node.exe", command: "some grandchild" },
+    ];
+    const isAlive = () => true;
+    const census = liveClaudeExclusion(procs, isAlive);
+    expect(census).toEqual(new Set([1, 2, 3]));
+  });
+
+  test("matches a root by command containing 'claude-code' even when the name isn't claude.exe", () => {
+    const procs = [
+      { pid: 7, ppid: 1, name: "node.exe", command: "node /usr/local/bin/claude-code" },
+      { pid: 8, ppid: 7, name: "node.exe", command: REAL_DEVOPS_STDIO },
+    ];
+    const isAlive = () => true;
+    const census = liveClaudeExclusion(procs, isAlive);
+    expect(census).toEqual(new Set([7, 8]));
+  });
+
+  test("a claude-named process that is NOT alive is not a root (and protects nothing)", () => {
+    const procs = [
+      LIVE_CLAUDE_ROOT,
+      { pid: 2, ppid: 1, name: "node.exe", command: REAL_DEVOPS_STDIO },
+    ];
+    const isAlive = () => false; // even the claude root reports dead
+    expect(liveClaudeExclusion(procs, isAlive)).toEqual(new Set());
+  });
+
+  test("no claude-like process anywhere -> empty census", () => {
+    const procs = [{ pid: 9, ppid: 1, name: "node.exe", command: REAL_DEVOPS_STDIO }];
+    expect(liveClaudeExclusion(procs, () => true)).toEqual(new Set());
+  });
+
+  test("empty process list -> empty census", () => {
+    expect(liveClaudeExclusion([], () => true)).toEqual(new Set());
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findReapable
 // ---------------------------------------------------------------------------
 
 describe("findReapable", () => {
-  test("flags an MCP-signature process whose parent is dead", () => {
-    const procs = [{ pid: 10, ppid: 999999, name: "node.exe", command: CACHE_CMD_GENERIC }];
-    const isAlive = (pid) => pid !== 999999;
+  test("flags a signature+dead-parent process that is OUTSIDE the live-claude census (positive case)", () => {
+    const procs = [
+      LIVE_CLAUDE_ROOT,
+      { pid: 10, ppid: 999999, name: "node.exe", command: CACHE_CMD_GENERIC }, // unrelated orphan
+    ];
+    const isAlive = (pid) => pid === 1; // only claude alive; 999999 dead
     const result = findReapable(procs, { selfPid: 5, isAlive });
     expect(result).toHaveLength(1);
     expect(result[0]).toMatchObject({ pid: 10, ppid: 999999 });
   });
 
   test("does NOT flag an MCP-signature process whose parent is alive", () => {
-    const procs = [{ pid: 11, ppid: 5, name: "node.exe", command: CACHE_CMD_GENERIC }];
-    const isAlive = () => true; // everything alive
+    const procs = [
+      LIVE_CLAUDE_ROOT,
+      { pid: 11, ppid: 999999, name: "node.exe", command: CACHE_CMD_GENERIC },
+    ];
+    const isAlive = () => true; // everything alive, including ppid 999999
     expect(findReapable(procs, { selfPid: 5, isAlive })).toHaveLength(0);
   });
 
   test("does NOT flag a non-MCP-signature process, even if orphaned", () => {
-    const procs = [{ pid: 12, ppid: 999999, name: "notepad.exe", command: "notepad.exe C:\\file.txt" }];
-    const isAlive = (pid) => pid !== 999999;
-    expect(findReapable(procs, { selfPid: 5, isAlive })).toHaveLength(0);
-  });
-
-  test("self-subtree exclusion: never flags the live session's own MCP server, " +
-    "even under a pathological isAlive stub that says everything is dead", () => {
-    // selfPid=5 is the live claude-code session; pid 20 is its own MCP-server
-    // child. isAlive is stubbed to always report "dead" to prove the subtree
-    // exclusion — not liveness alone — protects the live session's own tree.
     const procs = [
-      { pid: 5, ppid: 1, name: "node.exe", command: "claude-code" },
-      { pid: 20, ppid: 5, name: "node.exe", command: CACHE_CMD_GENERIC },
+      LIVE_CLAUDE_ROOT,
+      { pid: 12, ppid: 999999, name: "notepad.exe", command: "notepad.exe C:\\file.txt" },
     ];
-    const isAlive = () => false;
+    const isAlive = (pid) => pid === 1;
     expect(findReapable(procs, { selfPid: 5, isAlive })).toHaveLength(0);
   });
 
-  test("self-subtree exclusion also protects ancestors of selfPid", () => {
+  test("R2 FAIL-SAFE: no live claude process anywhere in the snapshot -> refuses to " +
+    "produce ANY candidates, even for a textbook signature+dead-parent match", () => {
+    const procs = [{ pid: 10, ppid: 999999, name: "node.exe", command: CACHE_CMD_GENERIC }];
+    const isAlive = (pid) => pid !== 999999; // parent genuinely dead
+    // No claude-like process anywhere -> census.size === 0 -> "unknown", refuse.
+    expect(findReapable(procs, { selfPid: 5, isAlive })).toEqual([]);
+  });
+
+  test("R2/R3 cousin topology: an MCP server descending from a dead intermediate wrapper is " +
+    "protected via the live-claude census, independent of the reaper's own position in the tree", () => {
     const procs = [
-      { pid: 1, ppid: 0, name: "node.exe", command: CACHE_CMD_GENERIC }, // ancestor, matches signature
-      { pid: 5, ppid: 1, name: "node.exe", command: "claude-code" }, // self
+      LIVE_CLAUDE_ROOT,
+      { pid: 900, ppid: 1, name: "node.exe", command: "node hook-runner.js" }, // the reaper — a COUSIN of the MCP server below, not its ancestor
+      { pid: 2, ppid: 1, name: "node.exe", command: "node npx-cli.js" }, // wrapper, still present in this snapshot
+      { pid: 901, ppid: 2, name: "node.exe", command: CACHE_CMD_GENERIC }, // MCP server, descends from the wrapper, not from the reaper
     ];
-    const isAlive = () => false;
-    expect(findReapable(procs, { selfPid: 5, isAlive })).toHaveLength(0);
+    // Only the claude root reports alive; the wrapper (901's immediate
+    // parent) reports dead. The naive dead-parent-only rule — and the OLD
+    // self-subtree-only exclusion rooted at selfPid=900 — would both flag
+    // 901, since it is neither an ancestor nor a descendant of the reaper.
+    const isAlive = (pid) => pid === 1;
+    const result = findReapable(procs, { selfPid: 900, isAlive });
+    expect(result).toEqual([]);
+
+    // Prove computeSelfSubtree ALONE (the old mechanism) would NOT have
+    // caught this — documenting why the census layer was necessary.
+    const oldStyleSubtree = computeSelfSubtree(procs, 900);
+    expect(oldStyleSubtree.has(901)).toBe(false);
   });
 
-  test("excludes selfPid itself even if it matches the MCP signature and looks orphaned", () => {
-    const procs = [{ pid: 5, ppid: 999999, name: "node.exe", command: CACHE_CMD_GENERIC }];
-    const isAlive = (pid) => pid !== 999999;
-    expect(findReapable(procs, { selfPid: 5, isAlive })).toHaveLength(0);
-  });
-
-  test("a sibling session's orphaned MCP server (unrelated subtree) IS flagged", () => {
+  test("R2/R3 live-ancestor-not-reaped: census protection overrides a dead-immediate-parent " +
+    "read even multiple hops down a still-present chain", () => {
     const procs = [
-      { pid: 5, ppid: 1, name: "node.exe", command: "claude-code" }, // self, alive chain
-      { pid: 30, ppid: 999999, name: "node.exe", command: CACHE_CMD_GENERIC }, // unrelated orphan
+      LIVE_CLAUDE_ROOT,
+      { pid: 2, ppid: 1, name: "node.exe", command: "node npx-cli.js wrapper" }, // intermediate, still present in the snapshot
+      { pid: 3, ppid: 2, name: "node.exe", command: CACHE_CMD_GENERIC }, // signature match, descends from the wrapper
     ];
-    const isAlive = (pid) => pid !== 999999;
-    const result = findReapable(procs, { selfPid: 5, isAlive });
-    expect(result.map((r) => r.pid)).toEqual([30]);
+    // isAlive reports pid 2 (the immediate parent of the target) as DEAD —
+    // the naive dead-parent signal alone would flag pid 3 as orphaned — but
+    // pid 3 is still structurally beneath the live claude root (pid 1) in
+    // this snapshot, so the census must protect it regardless.
+    const isAlive = (pid) => pid === 1;
+    const result = findReapable(procs, { selfPid: 999, isAlive });
+    expect(result).toEqual([]);
+  });
+
+  test("computeSelfSubtree still protects the reaper's own ancestor even when the census " +
+    "doesn't recognize that ancestor as claude-like", () => {
+    const procs = [
+      LIVE_CLAUDE_ROOT, // makes census non-empty
+      // The reaper's own parent process — happens to ALSO match the MCP
+      // signature (contrived, but proves the point) and its own recorded
+      // ppid is dead, so on signature+orphan alone it would be a
+      // "candidate" — but it is the reaper's direct ancestor.
+      { pid: 50, ppid: 999999, name: "node.exe", command: CACHE_CMD_GENERIC },
+      { pid: 900, ppid: 50, name: "node.exe", command: "node mcp-reaper.js" }, // the reaper itself
+    ];
+    const isAlive = (pid) => pid === 1;
+    const result = findReapable(procs, { selfPid: 900, isAlive });
+    expect(result).toEqual([]); // pid 50 protected via computeSelfSubtree, not via census
+  });
+
+  test("computeSelfSubtree still protects the reaper's own descendant even when the census " +
+    "doesn't recognize the reaper as claude-like", () => {
+    const procs = [
+      LIVE_CLAUDE_ROOT, // makes census non-empty, unrelated to the reaper below
+      { pid: 900, ppid: 999999, name: "node.exe", command: "node mcp-reaper.js" }, // reaper, NOT a descendant of claude in this snapshot
+      { pid: 901, ppid: 900, name: "node.exe", command: CACHE_CMD_GENERIC }, // reaper's own child, matches signature
+    ];
+    const isAlive = (pid) => pid === 1;
+    const result = findReapable(procs, { selfPid: 900, isAlive });
+    expect(result).toEqual([]); // pid 901 protected via computeSelfSubtree, not via census
+  });
+
+  test("R7: never flags a process whose command matches the reaper's own running script " +
+    "path, independent of selfPid", () => {
+    const procs = [
+      LIVE_CLAUDE_ROOT,
+      {
+        pid: 950, ppid: 999999, name: "node.exe",
+        command: "node C:\\Users\\jerry\\.claude\\plugins\\cache\\dotclaude\\devops\\0.119.1\\scripts\\mcp-reap.js",
+      },
+    ];
+    const isAlive = (pid) => pid === 1;
+    // selfPid deliberately WRONG/unrelated to prove the own-process guard
+    // works independent of selfPid resolution.
+    const result = findReapable(procs, {
+      selfPid: 5,
+      isAlive,
+      ownSignature: "c:/users/jerry/.claude/plugins/cache/dotclaude/devops/0.119.1/scripts/mcp-reap.js",
+    });
+    expect(result).toEqual([]);
+  });
+
+  test("R6: POSIX is a documented no-op — dead-parent reparenting to a live PID 1 never fires", () => {
+    const procs = [
+      { pid: 1, ppid: 0, name: "systemd", command: "/sbin/init" }, // PID 1, always alive on POSIX
+      { pid: 70, ppid: 1, name: "node", command: CACHE_CMD_GENERIC }, // orphan reparented to PID 1
+    ];
+    const isAlive = () => true; // this is what POSIX reparenting looks like
+    const result = findReapable(procs, { selfPid: 5, isAlive, platform: "linux" });
+    expect(result).toEqual([]);
   });
 
   test("empty process list -> empty result", () => {
@@ -134,7 +290,72 @@ describe("findReapable", () => {
 });
 
 // ---------------------------------------------------------------------------
-// reap — dry-run must never kill; apply mode kills via injected deps only
+// parseWin32ProcessJson — pure parser, incl. single-result object guard
+// ---------------------------------------------------------------------------
+
+describe("parseWin32ProcessJson", () => {
+  test("parses a JSON array of results", () => {
+    const json = JSON.stringify([
+      { ProcessId: 10, ParentProcessId: 1, Name: "node.exe", CommandLine: CACHE_CMD_GENERIC, WorkingSetSize: 1048576 },
+      { ProcessId: 11, ParentProcessId: 1, Name: "bun.exe", CommandLine: CACHE_CMD_DISCORD, WorkingSetSize: 2097152 },
+    ]);
+    const result = parseWin32ProcessJson(json);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({ pid: 10, ppid: 1, name: "node.exe", rssBytes: 1048576 });
+  });
+
+  test("guards against ConvertTo-Json emitting a bare object (not an array) for a single result", () => {
+    const json = JSON.stringify({ ProcessId: 42, ParentProcessId: 1, Name: "node.exe", CommandLine: CACHE_CMD_GENERIC, WorkingSetSize: 512 });
+    const result = parseWin32ProcessJson(json);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ pid: 42, ppid: 1 });
+  });
+
+  test("empty/malformed input -> []", () => {
+    expect(parseWin32ProcessJson("")).toEqual([]);
+    expect(parseWin32ProcessJson("not json")).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseWmicCsv — pure parser, embedded-comma robustness (R8)
+// ---------------------------------------------------------------------------
+
+describe("parseWmicCsv", () => {
+  test("reconstructs a CommandLine containing embedded commas without corruption, and it " +
+    "correctly resolves to an MCP signature match when it genuinely is one", () => {
+    const csv = [
+      "Node,CommandLine,Name,ParentProcessId,ProcessId,WorkingSetSize",
+      "MYHOST,node.exe --config C:\\Users\\jerry\\.claude\\plugins\\cache\\discord\\config,json,node.exe,1234,5678,104857600",
+    ].join("\r\n");
+    const result = parseWmicCsv(csv);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ pid: 5678, ppid: 1234, name: "node.exe" });
+    expect(result[0].command).toContain(".claude\\plugins\\cache\\discord\\config,json");
+    expect(isClaudeMcpServer(result[0])).toBe(true);
+  });
+
+  test("a benign CommandLine with embedded commas does NOT spuriously match the MCP signature", () => {
+    const csv = [
+      "Node,CommandLine,Name,ParentProcessId,ProcessId,WorkingSetSize",
+      'MYHOST,C:\\Program Files\\SomeApp\\app.exe --file "C:\\data,file.txt",app.exe,1,9999,20480',
+    ].join("\r\n");
+    const result = parseWmicCsv(csv);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ pid: 9999, ppid: 1, name: "app.exe" });
+    expect(result[0].command).toBe('C:\\Program Files\\SomeApp\\app.exe --file "C:\\data,file.txt"');
+    expect(isClaudeMcpServer(result[0])).toBe(false);
+  });
+
+  test("empty/malformed input -> []", () => {
+    expect(parseWmicCsv("")).toEqual([]);
+    expect(parseWmicCsv("Node,CommandLine,Name,ParentProcessId,ProcessId,WorkingSetSize")).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// reap — dry-run must never kill; apply mode kills via injected deps only;
+// TOCTOU re-validation (R4)
 // ---------------------------------------------------------------------------
 
 describe("reap", () => {
@@ -144,8 +365,11 @@ describe("reap", () => {
 
   test("dry-run (default) never calls process.kill, even with reapable candidates", async () => {
     const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
-    const procs = [{ pid: 40, ppid: 999999, name: "node.exe", command: CACHE_CMD_GENERIC, rssBytes: 100 * 1024 * 1024 }];
-    const isAlive = (pid) => pid !== 999999;
+    const procs = [
+      LIVE_CLAUDE_ROOT,
+      { pid: 40, ppid: 999999, name: "node.exe", command: CACHE_CMD_GENERIC, rssBytes: 100 * 1024 * 1024 },
+    ];
+    const isAlive = (pid) => pid === 1;
 
     const result = await reap({ selfPid: 5, listProcs: () => procs, isAlive }); // dryRun defaults true
 
@@ -163,25 +387,35 @@ describe("reap", () => {
 
   test("apply mode (dryRun:false) kills candidates via SIGTERM only when it dies promptly", async () => {
     const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
-    const procs = [{ pid: 41, ppid: 999999, name: "node.exe", command: CACHE_CMD_GENERIC }];
+    const procs = [
+      LIVE_CLAUDE_ROOT,
+      { pid: 41, ppid: 999999, name: "node.exe", command: CACHE_CMD_GENERIC },
+    ];
     // parent(999999) dead -> orphaned; pid 41 itself also reports dead after SIGTERM -> no SIGKILL needed
-    const isAlive = (pid) => pid !== 999999 && pid !== 41;
+    const isAlive = (pid) => pid === 1 || (pid !== 999999 && pid !== 41);
+    const listProcs = () => procs; // stable snapshot -> TOCTOU re-checks pass
 
-    const result = await reap({ selfPid: 5, listProcs: () => procs, isAlive, dryRun: false, graceMs: 0 });
+    const result = await reap({ selfPid: 5, listProcs, isAlive, dryRun: false, graceMs: 0 });
 
     expect(killSpy).toHaveBeenCalledTimes(1);
     expect(killSpy).toHaveBeenCalledWith(41, "SIGTERM");
     expect(result.killed).toEqual([41]);
     expect(result.errors).toEqual([]);
+    expect(result.skipped).toEqual([]);
   });
 
   test("apply mode escalates to SIGKILL if the process survives the grace period", async () => {
     const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
-    const procs = [{ pid: 42, ppid: 999999, name: "node.exe", command: CACHE_CMD_GENERIC }];
-    // parent dead (orphaned), but pid 42 itself still reports alive post-SIGTERM
-    const isAlive = (pid) => pid !== 999999;
+    const procs = [
+      LIVE_CLAUDE_ROOT,
+      { pid: 42, ppid: 999999, name: "node.exe", command: CACHE_CMD_GENERIC },
+    ];
+    // parent(999999) dead (orphaned), but pid 42 itself still reports alive
+    // post-SIGTERM, forcing the SIGKILL escalation.
+    const isAlive = (pid) => pid === 1 || pid === 42;
+    const listProcs = () => procs;
 
-    const result = await reap({ selfPid: 5, listProcs: () => procs, isAlive, dryRun: false, graceMs: 0 });
+    const result = await reap({ selfPid: 5, listProcs, isAlive, dryRun: false, graceMs: 0 });
 
     expect(killSpy).toHaveBeenCalledWith(42, "SIGTERM");
     expect(killSpy).toHaveBeenCalledWith(42, "SIGKILL");
@@ -190,37 +424,107 @@ describe("reap", () => {
 
   test("guards kill errors in try/catch and reports them without throwing", async () => {
     vi.spyOn(process, "kill").mockImplementation(() => { throw new Error("no such process"); });
-    const procs = [{ pid: 43, ppid: 999999, name: "node.exe", command: CACHE_CMD_GENERIC }];
-    const isAlive = (pid) => pid !== 999999;
+    const procs = [
+      LIVE_CLAUDE_ROOT,
+      { pid: 43, ppid: 999999, name: "node.exe", command: CACHE_CMD_GENERIC },
+    ];
+    const isAlive = (pid) => pid === 1;
+    const listProcs = () => procs;
 
-    const result = await reap({ selfPid: 5, listProcs: () => procs, isAlive, dryRun: false, graceMs: 0 });
+    const result = await reap({ selfPid: 5, listProcs, isAlive, dryRun: false, graceMs: 0 });
 
     expect(result.killed).toEqual([]);
     expect(result.errors).toHaveLength(1);
     expect(result.errors[0]).toMatchObject({ pid: 43, stage: "SIGTERM" });
   });
 
-  test("never touches the live session's own MCP server even in apply mode", async () => {
+  test("never touches a live session's own MCP server even in apply mode (cousin topology)", async () => {
     const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
     const procs = [
-      { pid: 5, ppid: 1, name: "node.exe", command: "claude-code" },
-      { pid: 20, ppid: 5, name: "node.exe", command: CACHE_CMD_GENERIC },
+      LIVE_CLAUDE_ROOT,
+      { pid: 900, ppid: 1, name: "node.exe", command: "node hook-runner.js" }, // reaper, cousin of the server below
+      { pid: 2, ppid: 1, name: "node.exe", command: "node npx-cli.js" }, // wrapper, still present in this snapshot
+      { pid: 901, ppid: 2, name: "node.exe", command: CACHE_CMD_GENERIC }, // live session's own MCP server, descends from the wrapper via the census
     ];
-    const isAlive = () => false; // pathological: everything looks dead
+    const isAlive = (pid) => pid === 1;
+    const listProcs = () => procs;
 
-    const result = await reap({ selfPid: 5, listProcs: () => procs, isAlive, dryRun: false, graceMs: 0 });
+    const result = await reap({ selfPid: 900, listProcs, isAlive, dryRun: false, graceMs: 0 });
 
     expect(result.candidates).toHaveLength(0);
     expect(result.killed).toEqual([]);
     expect(killSpy).not.toHaveBeenCalled();
   });
 
+  test("R4 TOCTOU: skips (does not kill) a candidate whose pid was reused before the SIGTERM " +
+    "re-check — the initial scan still lists it as a candidate, but the kill never fires", async () => {
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    const orphanProc = { pid: 60, ppid: 999999, name: "node.exe", command: CACHE_CMD_GENERIC };
+    const reusedProc = { pid: 60, ppid: 1, name: "notepad.exe", command: "notepad.exe unrelated.txt" };
+    let call = 0;
+    const listProcs = () => {
+      call += 1;
+      // call 1: initial scan (used to build `candidates`).
+      // call 2+: TOCTOU re-check — pid 60 has been reused by an unrelated process.
+      return call === 1 ? [LIVE_CLAUDE_ROOT, orphanProc] : [LIVE_CLAUDE_ROOT, reusedProc];
+    };
+    const isAlive = (pid) => pid === 1;
+
+    const result = await reap({ selfPid: 5, listProcs, isAlive, dryRun: false, graceMs: 0 });
+
+    expect(result.candidates).toHaveLength(1); // initial scan still flagged it
+    expect(result.killed).toEqual([]);
+    expect(killSpy).not.toHaveBeenCalled(); // TOCTOU pre-SIGTERM re-check caught the mismatch
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0]).toMatchObject({ pid: 60, stage: "pre-SIGTERM" });
+  });
+
+  test("R4 TOCTOU: skips the SIGKILL escalation if re-validation fails after the grace period " +
+    "(e.g. the process's parent came back alive in a race)", async () => {
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    const orphanProc = { pid: 61, ppid: 999999, name: "node.exe", command: CACHE_CMD_GENERIC };
+    let call = 0;
+    const listProcs = () => {
+      call += 1;
+      // call 1: initial scan. call 2: pre-SIGTERM re-check (still orphaned).
+      // call 3: pre-SIGKILL re-check — parent is now reported alive (race).
+      if (call <= 2) return [LIVE_CLAUDE_ROOT, orphanProc];
+      return [LIVE_CLAUDE_ROOT, { ...orphanProc, ppid: 1 }];
+    };
+    // pid 61 itself still reports ALIVE post-SIGTERM (forces the SIGKILL
+    // escalation path); ppid 999999 (the dead parent) never reports alive.
+    const isAlive = (pid) => pid === 1 || pid === 61;
+
+    const result = await reap({ selfPid: 5, listProcs, isAlive, dryRun: false, graceMs: 0 });
+
+    expect(killSpy).toHaveBeenCalledTimes(1); // only the SIGTERM, no SIGKILL
+    expect(killSpy).toHaveBeenCalledWith(61, "SIGTERM");
+    expect(result.killed).toEqual([]);
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0]).toMatchObject({ pid: 61, stage: "pre-SIGKILL" });
+  });
+
+  test("R6: reap() on a non-Windows platform never kills anything (findReapable no-op)", async () => {
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    const procs = [
+      { pid: 1, ppid: 0, name: "systemd", command: "/sbin/init" },
+      { pid: 70, ppid: 1, name: "node", command: CACHE_CMD_GENERIC },
+    ];
+    const result = await reap({
+      selfPid: 5, listProcs: () => procs, isAlive: () => true, dryRun: false, graceMs: 0, platform: "linux",
+    });
+    expect(result.candidates).toEqual([]);
+    expect(result.killed).toEqual([]);
+    expect(killSpy).not.toHaveBeenCalled();
+  });
+
   test("freedEstimateMb sums measured rssBytes when available", async () => {
     const procs = [
+      LIVE_CLAUDE_ROOT,
       { pid: 50, ppid: 999999, name: "node.exe", command: CACHE_CMD_GENERIC, rssBytes: 200 * 1024 * 1024 },
       { pid: 51, ppid: 999999, name: "bun.exe", command: CACHE_CMD_DISCORD, rssBytes: 300 * 1024 * 1024 },
     ];
-    const isAlive = (pid) => pid !== 999999;
+    const isAlive = (pid) => pid === 1;
     const result = await reap({ selfPid: 5, listProcs: () => procs, isAlive });
     expect(result.freedEstimateMb).toBe(500);
   });

--- a/plugins/devops/hooks/lib/mcp-reaper.test.js
+++ b/plugins/devops/hooks/lib/mcp-reaper.test.js
@@ -1,0 +1,227 @@
+import { describe, test, expect, vi, afterEach } from "vitest";
+import { isClaudeMcpServer, findReapable, reap } from "./mcp-reaper.js";
+
+const CACHE_CMD_DISCORD =
+  'C:\\Users\\jerry\\.claude\\plugins\\cache\\discord\\bin\\bun.exe run server.ts';
+const CACHE_CMD_GENERIC =
+  'node "C:\\Users\\jerry\\.claude\\plugins\\cache\\github\\mcp-server\\index.js"';
+
+// ---------------------------------------------------------------------------
+// isClaudeMcpServer — signature matching only
+// ---------------------------------------------------------------------------
+
+describe("isClaudeMcpServer", () => {
+  test("matches a bun launcher for a plugin-cache MCP server (discord)", () => {
+    expect(isClaudeMcpServer({ pid: 100, ppid: 1, name: "bun.exe", command: CACHE_CMD_DISCORD }))
+      .toBe(true);
+  });
+
+  test("matches a node plugin-cache stdio MCP server", () => {
+    expect(isClaudeMcpServer({ pid: 101, ppid: 1, name: "node.exe", command: CACHE_CMD_GENERIC }))
+      .toBe(true);
+  });
+
+  test("matches a node npx MCP server (_npx cache path)", () => {
+    const proc = {
+      pid: 102, ppid: 1, name: "node.exe",
+      command: "node C:\\Users\\jerry\\AppData\\Local\\npm-cache\\_npx\\abc123\\node_modules\\.bin\\playwright-mcp",
+    };
+    expect(isClaudeMcpServer(proc)).toBe(true);
+  });
+
+  test("matches node running npx-cli.js", () => {
+    const proc = {
+      pid: 103, ppid: 1, name: "node.exe",
+      command: "node C:\\Program Files\\nodejs\\node_modules\\npm\\bin\\npx-cli.js @modelcontextprotocol/server-github",
+    };
+    expect(isClaudeMcpServer(proc)).toBe(true);
+  });
+
+  test("does NOT match an unrelated bun dev server (user project, not plugin cache)", () => {
+    const proc = {
+      pid: 200, ppid: 1, name: "bun.exe",
+      command: "bun run dev --cwd C:\\Users\\jerry\\projects\\my-app",
+    };
+    expect(isClaudeMcpServer(proc)).toBe(false);
+  });
+
+  test("does NOT match a random node process outside plugins cache", () => {
+    expect(isClaudeMcpServer({ pid: 201, ppid: 1, name: "node.exe", command: "node index.js" }))
+      .toBe(false);
+  });
+
+  test("does NOT match Claude Desktop itself or its renderer processes", () => {
+    const proc = {
+      pid: 202, ppid: 1, name: "Claude.exe",
+      command: '"C:\\Users\\jerry\\AppData\\Local\\Programs\\Claude\\Claude.exe" --type=renderer',
+    };
+    expect(isClaudeMcpServer(proc)).toBe(false);
+  });
+
+  test("handles missing/empty command safely", () => {
+    expect(isClaudeMcpServer({ pid: 1, ppid: 0, name: "x", command: "" })).toBe(false);
+    expect(isClaudeMcpServer({ pid: 1, ppid: 0, name: "x" })).toBe(false);
+    expect(isClaudeMcpServer(null)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findReapable — signature + dead-parent rule + self-subtree exclusion
+// ---------------------------------------------------------------------------
+
+describe("findReapable", () => {
+  test("flags an MCP-signature process whose parent is dead", () => {
+    const procs = [{ pid: 10, ppid: 999999, name: "node.exe", command: CACHE_CMD_GENERIC }];
+    const isAlive = (pid) => pid !== 999999;
+    const result = findReapable(procs, { selfPid: 5, isAlive });
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ pid: 10, ppid: 999999 });
+  });
+
+  test("does NOT flag an MCP-signature process whose parent is alive", () => {
+    const procs = [{ pid: 11, ppid: 5, name: "node.exe", command: CACHE_CMD_GENERIC }];
+    const isAlive = () => true; // everything alive
+    expect(findReapable(procs, { selfPid: 5, isAlive })).toHaveLength(0);
+  });
+
+  test("does NOT flag a non-MCP-signature process, even if orphaned", () => {
+    const procs = [{ pid: 12, ppid: 999999, name: "notepad.exe", command: "notepad.exe C:\\file.txt" }];
+    const isAlive = (pid) => pid !== 999999;
+    expect(findReapable(procs, { selfPid: 5, isAlive })).toHaveLength(0);
+  });
+
+  test("self-subtree exclusion: never flags the live session's own MCP server, " +
+    "even under a pathological isAlive stub that says everything is dead", () => {
+    // selfPid=5 is the live claude-code session; pid 20 is its own MCP-server
+    // child. isAlive is stubbed to always report "dead" to prove the subtree
+    // exclusion — not liveness alone — protects the live session's own tree.
+    const procs = [
+      { pid: 5, ppid: 1, name: "node.exe", command: "claude-code" },
+      { pid: 20, ppid: 5, name: "node.exe", command: CACHE_CMD_GENERIC },
+    ];
+    const isAlive = () => false;
+    expect(findReapable(procs, { selfPid: 5, isAlive })).toHaveLength(0);
+  });
+
+  test("self-subtree exclusion also protects ancestors of selfPid", () => {
+    const procs = [
+      { pid: 1, ppid: 0, name: "node.exe", command: CACHE_CMD_GENERIC }, // ancestor, matches signature
+      { pid: 5, ppid: 1, name: "node.exe", command: "claude-code" }, // self
+    ];
+    const isAlive = () => false;
+    expect(findReapable(procs, { selfPid: 5, isAlive })).toHaveLength(0);
+  });
+
+  test("excludes selfPid itself even if it matches the MCP signature and looks orphaned", () => {
+    const procs = [{ pid: 5, ppid: 999999, name: "node.exe", command: CACHE_CMD_GENERIC }];
+    const isAlive = (pid) => pid !== 999999;
+    expect(findReapable(procs, { selfPid: 5, isAlive })).toHaveLength(0);
+  });
+
+  test("a sibling session's orphaned MCP server (unrelated subtree) IS flagged", () => {
+    const procs = [
+      { pid: 5, ppid: 1, name: "node.exe", command: "claude-code" }, // self, alive chain
+      { pid: 30, ppid: 999999, name: "node.exe", command: CACHE_CMD_GENERIC }, // unrelated orphan
+    ];
+    const isAlive = (pid) => pid !== 999999;
+    const result = findReapable(procs, { selfPid: 5, isAlive });
+    expect(result.map((r) => r.pid)).toEqual([30]);
+  });
+
+  test("empty process list -> empty result", () => {
+    expect(findReapable([], { selfPid: 5 })).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// reap — dry-run must never kill; apply mode kills via injected deps only
+// ---------------------------------------------------------------------------
+
+describe("reap", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("dry-run (default) never calls process.kill, even with reapable candidates", async () => {
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    const procs = [{ pid: 40, ppid: 999999, name: "node.exe", command: CACHE_CMD_GENERIC, rssBytes: 100 * 1024 * 1024 }];
+    const isAlive = (pid) => pid !== 999999;
+
+    const result = await reap({ selfPid: 5, listProcs: () => procs, isAlive }); // dryRun defaults true
+
+    expect(result.candidates).toHaveLength(1);
+    expect(result.killed).toEqual([]);
+    expect(killSpy).not.toHaveBeenCalled();
+  });
+
+  test("dry-run is the default even when dryRun is omitted entirely", async () => {
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    const result = await reap({ selfPid: 5, listProcs: () => [], isAlive: () => true });
+    expect(result.killed).toEqual([]);
+    expect(killSpy).not.toHaveBeenCalled();
+  });
+
+  test("apply mode (dryRun:false) kills candidates via SIGTERM only when it dies promptly", async () => {
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    const procs = [{ pid: 41, ppid: 999999, name: "node.exe", command: CACHE_CMD_GENERIC }];
+    // parent(999999) dead -> orphaned; pid 41 itself also reports dead after SIGTERM -> no SIGKILL needed
+    const isAlive = (pid) => pid !== 999999 && pid !== 41;
+
+    const result = await reap({ selfPid: 5, listProcs: () => procs, isAlive, dryRun: false, graceMs: 0 });
+
+    expect(killSpy).toHaveBeenCalledTimes(1);
+    expect(killSpy).toHaveBeenCalledWith(41, "SIGTERM");
+    expect(result.killed).toEqual([41]);
+    expect(result.errors).toEqual([]);
+  });
+
+  test("apply mode escalates to SIGKILL if the process survives the grace period", async () => {
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    const procs = [{ pid: 42, ppid: 999999, name: "node.exe", command: CACHE_CMD_GENERIC }];
+    // parent dead (orphaned), but pid 42 itself still reports alive post-SIGTERM
+    const isAlive = (pid) => pid !== 999999;
+
+    const result = await reap({ selfPid: 5, listProcs: () => procs, isAlive, dryRun: false, graceMs: 0 });
+
+    expect(killSpy).toHaveBeenCalledWith(42, "SIGTERM");
+    expect(killSpy).toHaveBeenCalledWith(42, "SIGKILL");
+    expect(result.killed).toEqual([42]);
+  });
+
+  test("guards kill errors in try/catch and reports them without throwing", async () => {
+    vi.spyOn(process, "kill").mockImplementation(() => { throw new Error("no such process"); });
+    const procs = [{ pid: 43, ppid: 999999, name: "node.exe", command: CACHE_CMD_GENERIC }];
+    const isAlive = (pid) => pid !== 999999;
+
+    const result = await reap({ selfPid: 5, listProcs: () => procs, isAlive, dryRun: false, graceMs: 0 });
+
+    expect(result.killed).toEqual([]);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toMatchObject({ pid: 43, stage: "SIGTERM" });
+  });
+
+  test("never touches the live session's own MCP server even in apply mode", async () => {
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    const procs = [
+      { pid: 5, ppid: 1, name: "node.exe", command: "claude-code" },
+      { pid: 20, ppid: 5, name: "node.exe", command: CACHE_CMD_GENERIC },
+    ];
+    const isAlive = () => false; // pathological: everything looks dead
+
+    const result = await reap({ selfPid: 5, listProcs: () => procs, isAlive, dryRun: false, graceMs: 0 });
+
+    expect(result.candidates).toHaveLength(0);
+    expect(result.killed).toEqual([]);
+    expect(killSpy).not.toHaveBeenCalled();
+  });
+
+  test("freedEstimateMb sums measured rssBytes when available", async () => {
+    const procs = [
+      { pid: 50, ppid: 999999, name: "node.exe", command: CACHE_CMD_GENERIC, rssBytes: 200 * 1024 * 1024 },
+      { pid: 51, ppid: 999999, name: "bun.exe", command: CACHE_CMD_DISCORD, rssBytes: 300 * 1024 * 1024 },
+    ];
+    const isAlive = (pid) => pid !== 999999;
+    const result = await reap({ selfPid: 5, listProcs: () => procs, isAlive });
+    expect(result.freedEstimateMb).toBe(500);
+  });
+});

--- a/plugins/devops/hooks/session-start/ss.mcp.reap.js
+++ b/plugins/devops/hooks/session-start/ss.mcp.reap.js
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+/**
+ * @hook ss.mcp.reap
+ * @version 0.1.0
+ * @event SessionStart
+ * @plugin devops
+ * @description Reclaim orphaned Claude Desktop MCP server processes leaked by
+ *   previously-closed sessions, in the background, without delaying session
+ *   start.
+ *
+ *   Spawns scripts/mcp-reap.js DETACHED, fire-and-forget, windowless
+ *   (`{ detached: true, stdio: 'ignore', windowsHide: true }` + `.unref()`)
+ *   in --apply mode, then exits 0 immediately — the hook never waits on the
+ *   child. The detached CLI persists its own JSON result to a temp status
+ *   file (dotclaude-mcp-reap-status.json in os.tmpdir(), see
+ *   scripts/mcp-reap.js) so a later "what did it reap?" is inspectable even
+ *   though stdout is discarded here.
+ *
+ *   Silent by design: no stdout, no startup noise — this is the
+ *   SessionStart half of the background reap mechanism. The periodic half
+ *   (subsequent turns, without a restart) is stop.mcp.reap.js, cooldown-
+ *   gated so it doesn't spawn a scan every turn.
+ *
+ *   Windows-gated cheaply: mcp-reaper.js's orphan detection is a documented
+ *   no-op on non-win32 platforms (dead-parent PID signal only means
+ *   anything on Windows — see that module's header), so spawning it
+ *   elsewhere would just be wasted process-creation cost.
+ *
+ *   Guarded end-to-end: any throw here is swallowed and the hook still
+ *   exits 0 — reaping is a nice-to-have, never allowed to block or fail a
+ *   session start.
+ */
+
+require('../lib/plugin-guard');
+
+try {
+  if (process.platform === 'win32') {
+    const path = require('path');
+    const { spawn } = require('child_process');
+
+    const pluginRoot = process.env.CLAUDE_PLUGIN_ROOT || path.resolve(__dirname, '..', '..');
+    const scriptPath = path.join(pluginRoot, 'scripts', 'mcp-reap.js');
+
+    const child = spawn(process.execPath, [scriptPath, '--apply', '--json'], {
+      detached: true,
+      stdio: 'ignore',
+      windowsHide: true,
+    });
+    child.unref();
+  }
+} catch {
+  // Never block session start — reaping is best-effort.
+}
+
+process.exit(0);

--- a/plugins/devops/hooks/stop/stop.mcp.reap.js
+++ b/plugins/devops/hooks/stop/stop.mcp.reap.js
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+/**
+ * @hook stop.mcp.reap
+ * @version 0.1.0
+ * @event Stop
+ * @plugin devops
+ * @description Periodic background reclaim of orphaned Claude Desktop MCP
+ *   server processes — the "runs on its own without a restart" half of the
+ *   mechanism (ss.mcp.reap.js only covers SessionStart, which happens once).
+ *
+ *   Cooldown-gated to ~20 minutes, per-worktree, using the exact same
+ *   atomic write-temp-then-rename marker pattern as
+ *   stop.flow.selfcalibration.js: the marker file is keyed to an md5 hash
+ *   of process.cwd() in os.tmpdir(), so parallel worktrees each get their
+ *   own independent cooldown clock.
+ *
+ *   When the cooldown has elapsed: refresh the marker FIRST (so a burst of
+ *   rapid Stop events can't all slip through before the first spawn lands),
+ *   then spawn scripts/mcp-reap.js DETACHED, fire-and-forget, windowless
+ *   (`{ detached: true, stdio: 'ignore', windowsHide: true }` + `.unref()`)
+ *   in --apply mode, and exit 0. Silent — no stdout either way.
+ *
+ *   Degrades safely if os.tmpdir() is unwritable: the marker write fails
+ *   silently (best-effort, non-fatal) and the cooldown check simply never
+ *   finds a marker, so the hook fires every turn instead of crashing —
+ *   same documented degrade as self-calibration's cooldown.
+ */
+
+require('../lib/plugin-guard');
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const crypto = require('crypto');
+
+const COOLDOWN_MS = 20 * 60 * 1000;
+
+function worktreeKey() {
+  const cwd = process.cwd().replace(/\\/g, '/');
+  return crypto.createHash('md5').update(cwd).digest('hex').slice(0, 12);
+}
+
+function markerFile() {
+  return path.join(os.tmpdir(), `dotclaude-devops-mcp-reap-wt-${worktreeKey()}`);
+}
+
+// Atomic write: write to a pid-suffixed temp file, then rename. Prevents a
+// concurrent Stop hook from observing a half-written marker.
+function atomicWrite(filePath, content) {
+  const tmp = `${filePath}.tmp.${process.pid}`;
+  try {
+    fs.writeFileSync(tmp, content, 'utf8');
+    fs.renameSync(tmp, filePath);
+  } catch {
+    try { fs.unlinkSync(tmp); } catch {}
+  }
+}
+
+function spawnReaper() {
+  try {
+    if (process.platform !== 'win32') return; // documented no-op elsewhere, see mcp-reaper.js
+    const { spawn } = require('child_process');
+    const pluginRoot = process.env.CLAUDE_PLUGIN_ROOT || path.resolve(__dirname, '..', '..');
+    const scriptPath = path.join(pluginRoot, 'scripts', 'mcp-reap.js');
+
+    const child = spawn(process.execPath, [scriptPath, '--apply', '--json'], {
+      detached: true,
+      stdio: 'ignore',
+      windowsHide: true,
+    });
+    child.unref();
+  } catch {
+    // Never block Stop — reaping is best-effort.
+  }
+}
+
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', () => {});
+process.stdin.on('end', () => {
+  try {
+    const file = markerFile();
+
+    try {
+      const stat = fs.statSync(file);
+      if (Date.now() - stat.mtimeMs < COOLDOWN_MS) {
+        process.exit(0);
+      }
+    } catch {
+      // No marker yet (or unreadable) — treat as cooldown elapsed, proceed.
+    }
+
+    atomicWrite(file, String(Date.now()));
+    spawnReaper();
+  } catch {
+    // Never block Stop.
+  }
+  process.exit(0);
+});

--- a/plugins/devops/scheduled-tasks/mcp-reap/SKILL.md
+++ b/plugins/devops/scheduled-tasks/mcp-reap/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: mcp-reap
+description: Reclaims orphaned Claude Desktop MCP server processes leaked by previously-closed sessions, in the background, without a restart.
+version: 0.1.0
+trigger: ss.mcp.reap.js (SessionStart, every session) AND stop.mcp.reap.js (Stop, ~20-minute per-worktree cooldown)
+scope: per-worktree (Stop cooldown), machine-wide (the scan itself)
+---
+
+# MCP Reap
+
+Reclaims orphaned Claude Desktop MCP server child processes — leftovers from
+previously-closed sessions that were never reliably terminated and linger,
+accumulating RAM. Driven by two hooks so it runs both once per session
+**and** periodically thereafter, without requiring a restart:
+
+- **`hooks/session-start/ss.mcp.reap.js`** — fires once, every `SessionStart`.
+- **`hooks/stop/stop.mcp.reap.js`** — fires on `Stop` (end of a response
+  turn), gated by a ~20-minute per-worktree cooldown so it doesn't scan
+  every turn. The cooldown marker uses the same atomic write-temp-then-
+  rename pattern as `self-calibration`, keyed to an md5 hash of
+  `process.cwd()` in `os.tmpdir()`.
+
+Both hooks spawn `scripts/mcp-reap.js --apply --json` **detached,
+fire-and-forget, windowless** (`{ detached: true, stdio: 'ignore',
+windowsHide: true }` + `.unref()`) and exit immediately — reaping never
+delays a session start or a response turn.
+
+## Safety model
+
+The scan-and-kill logic lives in `hooks/lib/mcp-reaper.js` (fully unit
+tested, 46/46 in `mcp-reaper.test.js`) and is **Windows-only** — the
+dead-parent-PID orphan signal only means anything on Windows, so the module
+is a documented no-op on macOS/Linux. A process is only ever a reap
+candidate when it matches an MCP-server launcher signature, its parent PID
+is confirmed dead, AND it falls outside the live-Claude census (every
+currently-live `claude`/`claude.exe` process plus its full descendant
+subtree) and the caller's own process subtree — an empty/unbuildable census
+means "protection unknown" and refuses to produce any candidates at all.
+Every candidate is re-validated against a fresh process snapshot immediately
+before both the SIGTERM and any SIGKILL escalation (TOCTOU-safe), so a pid
+reused for something else between scan and kill is skipped, never touched.
+The `reap()` module itself defaults to dry-run — nothing is ever terminated
+unless a caller explicitly passes `--apply`; both hooks opt into it
+deliberately, on the reasoning that a leaked orphan is safe to reclaim
+automatically once the safety net above holds. Any enumeration or kill
+failure fails safe (skip, never throw).
+
+## Run manually
+
+```
+node scripts/mcp-reap.js               # dry-run, human summary
+node scripts/mcp-reap.js --json        # dry-run, JSON output
+node scripts/mcp-reap.js --apply       # reclaim now — sofort ohne Neustart
+node scripts/mcp-reap.js --apply --json
+```
+
+Every run — including the detached ones spawned by the hooks — persists its
+result to `dotclaude-mcp-reap-status.json` in `os.tmpdir()`, so "what did it
+reap (or not)?" is inspectable after the fact even though the hooks discard
+stdout (`stdio: 'ignore'`).
+
+## Constraints
+
+- Silent unless it reaps — no console noise on a clean scan, no window ever
+  (windowless spawn on both the hook side and inside the reaper's own
+  `powershell.exe`/`wmic` process-enumeration calls).
+- Never blocks session start or a response turn — both hooks are wrapped in
+  try/catch and always exit 0, even if spawning the detached CLI fails.
+- Non-Windows platforms: both hooks Windows-gate cheaply before spawning
+  anything (the reaper is a no-op there anyway).
+- Cooldown degrades safely: if `os.tmpdir()` is unwritable, the Stop hook's
+  marker write fails silently and the hook simply fires every turn instead
+  of crashing.

--- a/plugins/devops/scripts/mcp-reap.js
+++ b/plugins/devops/scripts/mcp-reap.js
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+/**
+ * @script mcp-reap
+ * @version 0.1.0
+ * @plugin devops
+ * @description Thin CLI wrapper around hooks/lib/mcp-reaper.js. Scans for
+ *   orphaned Claude Desktop MCP server child processes (dead-parent +
+ *   MCP-signature match) and reports them. SAFE DEFAULT: dry-run — nothing
+ *   is ever terminated unless --apply (or --kill) is passed explicitly.
+ *   Intended callers: the SessionStart hook and a scheduled task.
+ *
+ *   Usage:
+ *     node scripts/mcp-reap.js               # dry-run, human summary
+ *     node scripts/mcp-reap.js --json         # dry-run, JSON output
+ *     node scripts/mcp-reap.js --apply        # actually terminate candidates
+ *     node scripts/mcp-reap.js --apply --json
+ */
+
+'use strict';
+
+const path = require('path');
+const { reap } = require(path.join(__dirname, '..', 'hooks', 'lib', 'mcp-reaper.js'));
+
+/**
+ * @param {string[]} argv  process.argv.slice(2)
+ * @returns {{apply: boolean, json: boolean}}
+ */
+function parseArgs(argv) {
+  const args = new Set(argv);
+  return {
+    apply: args.has('--apply') || args.has('--kill'),
+    json: args.has('--json'),
+  };
+}
+
+function formatMb(mb) {
+  return `${Number(mb).toLocaleString(undefined, { maximumFractionDigits: 0 })} MB`;
+}
+
+function printHuman(result, apply) {
+  const mode = apply ? 'APPLY (processes terminated)' : 'DRY-RUN (nothing terminated)';
+  process.stdout.write(`mcp-reap — mode: ${mode}\n`);
+  process.stdout.write(`  scanned:    ${result.scanned}\n`);
+  process.stdout.write(`  candidates: ${result.candidates.length}\n`);
+  for (const c of result.candidates) {
+    process.stdout.write(`    pid ${c.pid} (dead ppid ${c.ppid}) ${c.name}\n`);
+  }
+  if (apply) {
+    process.stdout.write(`  killed:     ${result.killed.length}\n`);
+    if (result.errors.length) {
+      process.stdout.write(`  errors:     ${result.errors.length}\n`);
+      for (const e of result.errors) {
+        process.stdout.write(`    pid ${e.pid} [${e.stage}]: ${e.error}\n`);
+      }
+    }
+  }
+  process.stdout.write(`  freed estimate: ~${formatMb(result.freedEstimateMb)}\n`);
+}
+
+async function main() {
+  const { apply, json } = parseArgs(process.argv.slice(2));
+  const result = await reap({ dryRun: !apply });
+
+  if (json) {
+    process.stdout.write(JSON.stringify({ ...result, dryRun: !apply }) + '\n');
+    return;
+  }
+  printHuman(result, apply);
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    process.stderr.write(`mcp-reap failed: ${err && err.message}\n`);
+    process.exit(1);
+  });
+}
+
+module.exports = { parseArgs, formatMb };

--- a/plugins/devops/scripts/mcp-reap.js
+++ b/plugins/devops/scripts/mcp-reap.js
@@ -1,13 +1,16 @@
 #!/usr/bin/env node
 /**
  * @script mcp-reap
- * @version 0.1.0
+ * @version 0.2.0
  * @plugin devops
  * @description Thin CLI wrapper around hooks/lib/mcp-reaper.js. Scans for
- *   orphaned Claude Desktop MCP server child processes (dead-parent +
- *   MCP-signature match) and reports them. SAFE DEFAULT: dry-run — nothing
- *   is ever terminated unless --apply (or --kill) is passed explicitly.
- *   Intended callers: the SessionStart hook and a scheduled task.
+ *   orphaned Claude Desktop MCP server child processes — MCP-signature
+ *   match, dead parent, AND outside the live-Claude census/self-subtree/
+ *   own-process guards (see mcp-reaper.js header) — and reports them.
+ *   Windows only; a documented no-op elsewhere. SAFE DEFAULT: dry-run —
+ *   nothing is ever terminated unless --apply (or --kill) is passed
+ *   explicitly. Intended callers: the SessionStart hook and a scheduled
+ *   task.
  *
  *   Usage:
  *     node scripts/mcp-reap.js               # dry-run, human summary
@@ -47,6 +50,12 @@ function printHuman(result, apply) {
   }
   if (apply) {
     process.stdout.write(`  killed:     ${result.killed.length}\n`);
+    if (result.skipped.length) {
+      process.stdout.write(`  skipped (TOCTOU re-check failed): ${result.skipped.length}\n`);
+      for (const s of result.skipped) {
+        process.stdout.write(`    pid ${s.pid} [${s.stage}]: ${s.reason}\n`);
+      }
+    }
     if (result.errors.length) {
       process.stdout.write(`  errors:     ${result.errors.length}\n`);
       for (const e of result.errors) {

--- a/plugins/devops/scripts/mcp-reap.js
+++ b/plugins/devops/scripts/mcp-reap.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * @script mcp-reap
- * @version 0.2.0
+ * @version 0.3.0
  * @plugin devops
  * @description Thin CLI wrapper around hooks/lib/mcp-reaper.js. Scans for
  *   orphaned Claude Desktop MCP server child processes — MCP-signature
@@ -9,8 +9,15 @@
  *   own-process guards (see mcp-reaper.js header) — and reports them.
  *   Windows only; a documented no-op elsewhere. SAFE DEFAULT: dry-run —
  *   nothing is ever terminated unless --apply (or --kill) is passed
- *   explicitly. Intended callers: the SessionStart hook and a scheduled
- *   task.
+ *   explicitly. Intended callers: ss.mcp.reap.js (SessionStart) and
+ *   stop.mcp.reap.js (Stop, cooldown-gated) — both spawn this CLI detached
+ *   with stdio:'ignore', so stdout/--json output never reaches anyone.
+ *
+ *   Every run also persists its result to a temp status file
+ *   (dotclaude-mcp-reap-status.json in os.tmpdir()) regardless of --json,
+ *   so a detached/backgrounded invocation still leaves an inspectable
+ *   trail for a later "what did it reap?" — same pattern as
+ *   hooks/session-start/ss.mcp.verify.js's status file.
  *
  *   Usage:
  *     node scripts/mcp-reap.js               # dry-run, human summary
@@ -21,8 +28,30 @@
 
 'use strict';
 
+const fs = require('fs');
+const os = require('os');
 const path = require('path');
 const { reap } = require(path.join(__dirname, '..', 'hooks', 'lib', 'mcp-reaper.js'));
+
+const STATUS_FILE = path.join(os.tmpdir(), 'dotclaude-mcp-reap-status.json');
+
+/**
+ * Best-effort persistence of the last run's result, so a detached invocation
+ * (stdio:'ignore' from the SessionStart/Stop hooks) still leaves a trail.
+ * Never throws — diagnostics only, must not affect the CLI's exit behavior.
+ * @param {object} result
+ * @param {boolean} dryRun
+ */
+function writeStatusFile(result, dryRun) {
+  try {
+    fs.writeFileSync(
+      STATUS_FILE,
+      JSON.stringify({ ...result, dryRun, ranAt: new Date().toISOString() }, null, 2)
+    );
+  } catch {
+    // Non-fatal — diagnostics only.
+  }
+}
 
 /**
  * @param {string[]} argv  process.argv.slice(2)
@@ -69,6 +98,8 @@ function printHuman(result, apply) {
 async function main() {
   const { apply, json } = parseArgs(process.argv.slice(2));
   const result = await reap({ dryRun: !apply });
+
+  writeStatusFile(result, !apply);
 
   if (json) {
     process.stdout.write(JSON.stringify({ ...result, dryRun: !apply }) + '\n');

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.119.2",
+  "version": "0.120.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary
Adds a census-guarded reaper that reclaims leaked MCP-server processes from closed Claude Desktop sessions — ending the multi-GB RAM creep (observed: ~16 GB across 11 sessions, most already closed).

- `hooks/lib/mcp-reaper.js` — Windows-only, census-guarded, TOCTOU-safe, dry-run by default. A process is reaped only when it matches an MCP-launcher signature, its parent is dead, AND it lies outside the live-Claude census (every live `claude`/`claude-code` subtree — protects a running session's own servers).
- `ss.mcp.reap` (SessionStart, detached/windowless/silent) + `stop.mcp.reap` (Stop, 20-min per-worktree cooldown) — background activation, no restart needed. `scripts/mcp-reap.js` is the manual entry (`--json` preview, `--apply` reclaim now).

## Safety
Hardened against an adversarial red-team pass (R1–R8: cousin false-positives, npx over-match, POSIX no-op, TOCTOU, own-process self-match) and proven live — a synthetic orphan was reaped while all 29 real session servers survived.

## Tests
46 new unit tests (838 total). Lint clean. Codex review gate unavailable this ship (external usage limit) — covered instead by the red-team pass + live synthetic-orphan verification.