### PR TITLE
fix(hooks): surface workspace findings independently of the ask

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.123.1"
+    "version": "0.123.2"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.123.1",
+      "version": "0.123.2",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.123.1",
+      "version": "0.123.2",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.123.2] — 2026-07-28
+
+### Fixed
+
+- **A scheduled or headless session no longer silently swallows the loose ends the session-start check found.** The workspace check rendered the current repo's uncommitted/unpushed findings only inside its `AskUserQuestion` block, and actively suppressed them from the plain report section whenever a workspace issue was present. A cron routine or headless run correctly skips the question it cannot answer — and the entire finding disappeared with it: neither acted on nor mentioned in the run's report. In one observed case 13 unpushed commits sat invisible on a branch with no PR until a later interactive session happened to ask.
+
+  Fixed by decoupling rather than by detecting the session type. No non-interactive signal exists at `SessionStart` (nothing in the hooks reads one, and the cron detector `prompt.flow.silent-turn` fires at `UserPromptSubmit` — after this hook has already emitted), so any detection would have been new, unverified, and able to fail open into the exact same bug. Findings are now emitted unconditionally and instruct the assistant to restate them in its final message, before any completion card; the `AskUserQuestion` block is layered on top, its "FIRST action of this turn" mandate unchanged, so interactive sessions behave exactly as before. Composition moved into the new `hooks/lib/git-check-output.js` so the decision is unit-testable — 31 colocated tests, mutation-verified: reintroducing the old suppression fails 5 of them. Codex review gate unavailable this ship (external usage limit) — covered by an adversarial red-team pass whose two findings (the ask mandate demoted below the findings; "final report" naming no landing zone compatible with the card-must-be-last rule) were both folded in before merge.
+
 ## [0.123.1] — 2026-07-24
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.123.1**
+**Version: 0.123.2**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.123.1",
+  "version": "0.123.2",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/hooks/lib/git-check-output.js
+++ b/plugins/devops/hooks/lib/git-check-output.js
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+/**
+ * @module git-check-output
+ * @version 0.1.0
+ * @description Pure output composition for the ss.git.check SessionStart hook.
+ *   Takes the already-collected findings and renders the hook's stdout lines.
+ *   No git, no fs — so the decision logic is unit-testable.
+ *
+ *   Central invariant (issue #268): **a finding is never coupled to the ask.**
+ *   The hook used to render current-repo `uncommitted`/`unpushed` findings only
+ *   inside the AskUserQuestion block, and actively suppressed them from the
+ *   plain report section whenever a workspace issue was present. In a session
+ *   that cannot prompt — a scheduled task, a cron routine, a headless run —
+ *   skipping AskUserQuestion is the correct behaviour, so the entire finding
+ *   evaporated: neither acted on nor mentioned in the run's final report.
+ *
+ *   Detection of "is this session interactive?" was deliberately NOT used as the
+ *   fix. No such signal exists anywhere in the plugin's hooks, and the one
+ *   cron/background detector that does exist (prompt.flow.silent-turn) fires at
+ *   UserPromptSubmit — i.e. after SessionStart, so its flag does not yet exist
+ *   when this hook runs. Any new detection could fail open and reproduce the
+ *   exact bug. Instead the findings are emitted unconditionally and the ask is
+ *   layered on top: a session that can prompt, prompts; one that cannot, still
+ *   reports.
+ */
+
+/** Render one findings line per issue type. */
+function issueLine(issue) {
+  if (!issue || typeof issue !== 'object') return null;
+  switch (issue.type) {
+    case 'uncommitted':
+    case 'unpushed':
+      return `- ${issue.label} → run \`/ship\` to commit, push & create PR`;
+    case 'stash':
+      return `- ${issue.label} → review with \`git stash list\`, then \`git stash pop\` or \`git stash drop\``;
+    default:
+      return null;
+  }
+}
+
+/**
+ * The must-surface directive. States BOTH obligations, in this order:
+ *
+ *   1. the AskUserQuestion mandate, VERBATIM and first — interactive behaviour
+ *      must not be weakened, and an assistant reading only the first sentence
+ *      has to come away with "ask", not with "reporting is enough";
+ *   2. the report obligation, with an explicit landing zone. "Your final
+ *      report" alone is undefined in a turn that ends in a completion card
+ *      (stop.flow.guard requires the card to be the LAST thing in the
+ *      response), so the directive names *where*: in the final message,
+ *      before any card. Prose before the card is permitted; content after it
+ *      is not.
+ */
+function header(workspace) {
+  if (workspace) {
+    return 'Workspace check at session start. Show this summary AS-IS and call AskUserQuestion as the FIRST action of this turn. If this turn cannot ask (scheduled, cron or headless run), you MUST still restate the findings below verbatim in your final message, before any completion card — never drop them.';
+  }
+  return 'Stale changes found at session start. Show this summary AS-IS. You MUST restate these findings verbatim in your final message, before any completion card — also in a scheduled, cron or headless run.';
+}
+
+function workspaceLines(workspace) {
+  const branch = workspace.branch || 'unknown branch';
+  switch (workspace.type) {
+    case 'on-main-no-worktree':
+      return [`- ⚠ On \`${branch}\` in repo root (not in a worktree) — write ops will be blocked by pre.main.guard / pre.edit.branch`];
+    case 'detached-no-worktree':
+      return ['- ⚠ Detached HEAD in repo root (not in a worktree) — commits will not belong to any branch'];
+    default:
+      return [`- On \`${branch}\` in repo root (not in a worktree)`];
+  }
+}
+
+/**
+ * The interactive half. Unchanged in substance from before — the
+ * "FIRST action of this turn" mandate is intentionally kept verbatim so
+ * interactive sessions behave exactly as they did.
+ */
+function askLines(workspace, hasChanges) {
+  const out = [];
+  out.push('Call AskUserQuestion as the FIRST action of this turn. Ask the user (in their language). Suggested options:');
+  if (hasChanges) {
+    out.push('  - Worktree + Feature-Branch anlegen');
+    out.push('  - Erst aktuelle Changes shippen (commit + push), dann Worktree anlegen (recommended)');
+    out.push('  - Changes mitnehmen in neuen Worktree (git stash → create → pop)');
+  } else {
+    out.push('  - Worktree + Feature-Branch anlegen (recommended)');
+  }
+  if (workspace.severity === 'high' && workspace.type === 'on-main-no-worktree') {
+    out.push('  - Hier bleiben (bypass: DEVOPS_ALLOW_MAIN=1 für diese Session)');
+  } else {
+    out.push('  - Hier bleiben (Warning bleibt informativ — kein Bypass-Flag nötig)');
+  }
+  out.push('');
+  out.push('Resolution per option:');
+  out.push('  - Worktree+branch: `git worktree add ../<feature> -b claude/<feature>` then cd there');
+  if (hasChanges) {
+    out.push('  - Ship-first: invoke /ship, then create worktree');
+    out.push('  - Take-along: `git stash`, create worktree, `cd <worktree>`, `git stash pop`');
+  }
+  if (workspace.type === 'on-main-no-worktree') {
+    out.push('  - Stay: set env `DEVOPS_ALLOW_MAIN=1` for this session to silence main-branch checks');
+  }
+  out.push('');
+  return out;
+}
+
+/**
+ * Compose the hook's stdout lines.
+ *
+ * @param {object} input
+ * @param {Array<{label:string, dir:string, issues:Array<{type:string,count:number,label:string}>}>} [input.dirty]
+ * @param {{type:string, branch:string, severity:string}|null} [input.workspace]
+ * @param {string|null} [input.staleNote]
+ * @param {string} [input.cwd] — used only to label the current repo's block
+ * @returns {string[]} lines; empty array means "stay silent"
+ */
+function compose({ dirty = [], workspace = null, staleNote = null, cwd } = {}) {
+  const repos = (Array.isArray(dirty) ? dirty : []).filter(r => r && typeof r === 'object');
+  const issuesOf = (r) => (Array.isArray(r.issues) ? r.issues : []);
+  const hasFindings = repos.some(r => issuesOf(r).some(i => issueLine(i)));
+
+  if (!hasFindings && !workspace && !staleNote) return [];
+
+  const out = [];
+
+  if (hasFindings || workspace) {
+    out.push(header(workspace));
+    out.push('');
+  }
+
+  if (workspace) {
+    out.push('**Workspace setup**');
+    out.push(...workspaceLines(workspace));
+    out.push('');
+  }
+
+  // Findings — ALWAYS rendered, for every repo including the current one.
+  // The former `workspace && r.dir === cwd` suppression lived here and is the
+  // reason findings could vanish; it is gone on purpose. Do not reintroduce a
+  // conditional around this block.
+  for (const r of repos) {
+    const lines = issuesOf(r).map(issueLine).filter(Boolean);
+    if (lines.length === 0) continue;
+    out.push(r.dir === cwd ? '**current repo**' : `**${r.label}**`);
+    out.push(...lines);
+    out.push('');
+  }
+
+  if (workspace) {
+    const stagedTypes = new Set(['uncommitted', 'unpushed']);
+    const currentDirty = repos.find(r => r.dir === cwd);
+    const hasChanges = currentDirty
+      ? issuesOf(currentDirty).some(i => i && stagedTypes.has(i.type))
+      : false;
+    out.push(...askLines(workspace, hasChanges));
+  }
+
+  if (staleNote) {
+    if (out.length > 0) out.push('');
+    out.push(staleNote);
+  }
+
+  return out;
+}
+
+module.exports = { compose, issueLine, header, workspaceLines, askLines };

--- a/plugins/devops/hooks/lib/git-check-output.test.js
+++ b/plugins/devops/hooks/lib/git-check-output.test.js
@@ -1,0 +1,368 @@
+import { describe, test, expect } from "vitest";
+import { compose } from "./git-check-output.js";
+
+const CWD = "/repo";
+
+function issue(type, count, label) {
+  return { type, count, label };
+}
+
+function currentRepo(...issues) {
+  return { label: "current repo", dir: CWD, issues };
+}
+
+function otherRepo(label, ...issues) {
+  return { label, dir: `/other/${label}`, issues };
+}
+
+const onMain = { type: "on-main-no-worktree", branch: "main", severity: "high" };
+const detached = { type: "detached-no-worktree", branch: "detached HEAD", severity: "high" };
+const featureNoWorktree = { type: "no-worktree", branch: "feat/x", severity: "low" };
+
+const text = (lines) => lines.join("\n");
+
+// ---------------------------------------------------------------------------
+// Silence invariant — the hook must stay quiet on a clean workspace
+// ---------------------------------------------------------------------------
+
+describe("silence", () => {
+  test("returns [] when there is nothing to report", () => {
+    expect(compose({ dirty: [], workspace: null, staleNote: null, cwd: CWD })).toEqual([]);
+    expect(compose({ cwd: CWD })).toEqual([]);
+    expect(compose()).toEqual([]);
+  });
+
+  test("returns [] when dirty entries carry only unrenderable issue types", () => {
+    const out = compose({
+      dirty: [currentRepo(issue("something-else", 1, "1 whatever"))],
+      cwd: CWD,
+    });
+    expect(out).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #268 regression — findings must never be coupled to the ask
+// ---------------------------------------------------------------------------
+
+describe("#268 — findings survive a session that never asks", () => {
+  test("current-repo unpushed/stash findings are rendered even though a workspace issue is present", () => {
+    const out = text(compose({
+      dirty: [currentRepo(
+        issue("unpushed", 13, "13 unpushed commit(s)"),
+        issue("stash", 7, "7 stash entries"),
+      )],
+      workspace: onMain,
+      cwd: CWD,
+    }));
+
+    // The exact findings from the issue report must be present as their own lines,
+    // not merely summarised inside the ask block.
+    expect(out).toContain("- 13 unpushed commit(s) → run `/ship` to commit, push & create PR");
+    expect(out).toContain("- 7 stash entries → review with `git stash list`");
+    expect(out).toContain("**current repo**");
+  });
+
+  test("uncommitted findings are not suppressed by a workspace issue either", () => {
+    const out = text(compose({
+      dirty: [currentRepo(issue("uncommitted", 4, "4 uncommitted file(s)"))],
+      workspace: onMain,
+      cwd: CWD,
+    }));
+    expect(out).toContain("- 4 uncommitted file(s) → run `/ship` to commit, push & create PR");
+  });
+
+  test("the directive demands the findings be restated in the final message", () => {
+    const out = compose({
+      dirty: [currentRepo(issue("unpushed", 2, "2 unpushed commit(s)"))],
+      workspace: onMain,
+      cwd: CWD,
+    });
+    expect(out[0]).toContain("restate the findings below verbatim in your final message");
+    // Names the landing zone: prose before the card is allowed, after it is not.
+    expect(out[0]).toContain("before any completion card");
+    expect(out[0]).toContain("scheduled, cron or headless run");
+  });
+
+  test("the report directive is present without a workspace issue too", () => {
+    const out = compose({
+      dirty: [currentRepo(issue("unpushed", 2, "2 unpushed commit(s)"))],
+      workspace: null,
+      cwd: CWD,
+    });
+    expect(out[0]).toContain("Stale changes found at session start");
+    expect(out[0]).toContain("restate these findings verbatim in your final message");
+    expect(out[0]).toContain("before any completion card");
+  });
+
+  test("no input combination drops a current-repo finding — full rendered line, in the repo block", () => {
+    const cases = [
+      [issue("uncommitted", 1, "1 uncommitted file(s)"), "- 1 uncommitted file(s) → run `/ship` to commit, push & create PR"],
+      [issue("unpushed", 1, "1 unpushed commit(s)"), "- 1 unpushed commit(s) → run `/ship` to commit, push & create PR"],
+      [issue("stash", 1, "1 stash entry"), "- 1 stash entry → review with `git stash list`, then `git stash pop` or `git stash drop`"],
+    ];
+    for (const workspace of [null, onMain, detached, featureNoWorktree]) {
+      for (const [i, rendered] of cases) {
+        const out = compose({ dirty: [currentRepo(i)], workspace, cwd: CWD });
+        const label = `type=${i.type} workspace=${workspace ? workspace.type : "none"}`;
+        // The line must exist as its OWN line — an aggregate summary elsewhere
+        // (the old `- Pending: …` line) must not be able to satisfy this.
+        expect(out, label).toContain(rendered);
+        // …and it must sit inside the current-repo findings block, immediately
+        // after its header, not folded into the ask block.
+        const blockIdx = out.indexOf("**current repo**");
+        expect(blockIdx, label).toBeGreaterThan(-1);
+        expect(out[blockIdx + 1], label).toBe(rendered);
+      }
+    }
+  });
+
+  test("findings block precedes the ask block", () => {
+    const out = compose({
+      dirty: [currentRepo(issue("unpushed", 3, "3 unpushed commit(s)"))],
+      workspace: onMain,
+      cwd: CWD,
+    });
+    const findingsIdx = out.indexOf("**current repo**");
+    const askIdx = out.findIndex(l => l.startsWith("Call AskUserQuestion"));
+    expect(findingsIdx).toBeGreaterThan(-1);
+    expect(askIdx).toBeGreaterThan(findingsIdx);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Interactive behaviour is preserved
+// ---------------------------------------------------------------------------
+
+describe("ask block", () => {
+  test("keeps the FIRST-action AskUserQuestion mandate verbatim", () => {
+    const out = text(compose({ dirty: [], workspace: onMain, cwd: CWD }));
+    expect(out).toContain("Call AskUserQuestion as the FIRST action of this turn.");
+  });
+
+  test("the ask mandate is stated in the very first line, ahead of the report obligation", () => {
+    // Regression guard: demoting the mandate below the findings lets an
+    // assistant that reads only the opening sentence treat "report it" as a
+    // sufficient substitute for asking.
+    const out = compose({
+      dirty: [currentRepo(issue("unpushed", 1, "1 unpushed commit(s)"))],
+      workspace: onMain,
+      cwd: CWD,
+    });
+    expect(out[0]).toContain("call AskUserQuestion as the FIRST action of this turn");
+    expect(out[0].indexOf("AskUserQuestion"))
+      .toBeLessThan(out[0].indexOf("final message"));
+  });
+
+  test("every truthy workspace type gets an ask block", () => {
+    for (const workspace of [onMain, detached, featureNoWorktree]) {
+      const out = text(compose({ dirty: [], workspace, cwd: CWD }));
+      expect(out, workspace.type).toContain("Call AskUserQuestion as the FIRST action of this turn.");
+      expect(out, workspace.type).toContain("Resolution per option:");
+    }
+  });
+
+  test("offers all four resolutions when the repo has pending changes", () => {
+    const out = text(compose({
+      dirty: [currentRepo(issue("uncommitted", 2, "2 uncommitted file(s)"))],
+      workspace: onMain,
+      cwd: CWD,
+    }));
+    expect(out).toContain("Worktree + Feature-Branch anlegen");
+    expect(out).toContain("Erst aktuelle Changes shippen");
+    expect(out).toContain("Changes mitnehmen in neuen Worktree");
+    expect(out).toContain("Hier bleiben (bypass: DEVOPS_ALLOW_MAIN=1");
+    expect(out).toContain("Ship-first: invoke /ship");
+    expect(out).toContain("Take-along: `git stash`");
+    expect(out).toContain("Stay: set env `DEVOPS_ALLOW_MAIN=1`");
+  });
+
+  test("offers only the worktree option when there are no pending changes", () => {
+    const out = text(compose({ dirty: [], workspace: onMain, cwd: CWD }));
+    expect(out).toContain("Worktree + Feature-Branch anlegen (recommended)");
+    expect(out).not.toContain("Ship-first: invoke /ship");
+    expect(out).not.toContain("Take-along: `git stash`");
+  });
+
+  test("a stash-only repo does not count as pending changes", () => {
+    const out = text(compose({
+      dirty: [currentRepo(issue("stash", 3, "3 stash entries"))],
+      workspace: onMain,
+      cwd: CWD,
+    }));
+    expect(out).toContain("- 3 stash entries → review with `git stash list`");
+    expect(out).toContain("Worktree + Feature-Branch anlegen (recommended)");
+    expect(out).not.toContain("Ship-first: invoke /ship");
+  });
+
+  test("non-main workspace types get the informative bypass wording and no DEVOPS_ALLOW_MAIN resolution", () => {
+    const out = text(compose({ dirty: [], workspace: featureNoWorktree, cwd: CWD }));
+    expect(out).toContain("Hier bleiben (Warning bleibt informativ");
+    expect(out).not.toContain("Stay: set env");
+  });
+
+  test("no ask block at all when there is no workspace issue", () => {
+    const out = text(compose({
+      dirty: [currentRepo(issue("unpushed", 1, "1 unpushed commit(s)"))],
+      workspace: null,
+      cwd: CWD,
+    }));
+    expect(out).not.toContain("AskUserQuestion");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Workspace rendering
+// ---------------------------------------------------------------------------
+
+describe("workspace section", () => {
+  test("on-main renders the guard warning", () => {
+    const out = text(compose({ dirty: [], workspace: onMain, cwd: CWD }));
+    expect(out).toContain("**Workspace setup**");
+    expect(out).toContain("⚠ On `main` in repo root (not in a worktree)");
+    expect(out).toContain("pre.main.guard / pre.edit.branch");
+  });
+
+  test("detached HEAD renders its own warning", () => {
+    const out = text(compose({ dirty: [], workspace: detached, cwd: CWD }));
+    expect(out).toContain("⚠ Detached HEAD in repo root");
+  });
+
+  test("feature branch without worktree renders the mild note", () => {
+    const out = text(compose({ dirty: [], workspace: featureNoWorktree, cwd: CWD }));
+    expect(out).toContain("- On `feat/x` in repo root (not in a worktree)");
+    expect(out).not.toContain("⚠");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Multi-repo + stale note
+// ---------------------------------------------------------------------------
+
+describe("other repos and stale note", () => {
+  test("other repos keep their own labelled block alongside the current repo", () => {
+    const out = text(compose({
+      dirty: [
+        currentRepo(issue("unpushed", 2, "2 unpushed commit(s)")),
+        otherRepo("sidecar", issue("uncommitted", 5, "5 uncommitted file(s)")),
+      ],
+      workspace: onMain,
+      cwd: CWD,
+    }));
+    expect(out).toContain("**current repo**");
+    expect(out).toContain("- 2 unpushed commit(s)");
+    expect(out).toContain("**sidecar**");
+    expect(out).toContain("- 5 uncommitted file(s)");
+  });
+
+  test("stale note alone is emitted without any header", () => {
+    const out = compose({ dirty: [], workspace: null, staleNote: "📝 README stale", cwd: CWD });
+    expect(out).toEqual(["📝 README stale"]);
+  });
+
+  test("stale note is appended after findings", () => {
+    const out = compose({
+      dirty: [currentRepo(issue("unpushed", 1, "1 unpushed commit(s)"))],
+      workspace: null,
+      staleNote: "📝 README stale",
+      cwd: CWD,
+    });
+    expect(out[out.length - 1]).toBe("📝 README stale");
+    expect(text(out)).toContain("- 1 unpushed commit(s)");
+  });
+
+  test("stale note comes last, after the ask block", () => {
+    const out = compose({
+      dirty: [currentRepo(issue("unpushed", 1, "1 unpushed commit(s)"))],
+      workspace: onMain,
+      staleNote: "📝 README stale",
+      cwd: CWD,
+    });
+    expect(out[out.length - 1]).toBe("📝 README stale");
+    const askIdx = out.findIndex(l => l.startsWith("Call AskUserQuestion"));
+    expect(askIdx).toBeGreaterThan(-1);
+    expect(askIdx).toBeLessThan(out.length - 1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Silence contract with the caller
+// ---------------------------------------------------------------------------
+
+describe("silence contract vs ss.git.check.js", () => {
+  // The hook exits early on `dirty.length === 0 && !workspace && !staleNote`,
+  // then again on `out.length === 0`. Both gates must agree with compose():
+  // never emit where the hook used to be silent, never go silent where the
+  // hook would have proceeded with real content.
+  const matrix = [];
+  for (const dirty of [[], [currentRepo()], [currentRepo(issue("unpushed", 1, "1 unpushed commit(s)"))]]) {
+    for (const workspace of [null, onMain]) {
+      for (const staleNote of [null, "📝 note"]) {
+        matrix.push({ dirty, workspace, staleNote, cwd: CWD });
+      }
+    }
+  }
+
+  test("compose() is empty whenever the hook's own early-exit condition holds", () => {
+    for (const input of matrix) {
+      const callerExitsEarly = input.dirty.length === 0 && !input.workspace && !input.staleNote;
+      if (callerExitsEarly) {
+        expect(compose(input), JSON.stringify(input)).toEqual([]);
+      }
+    }
+  });
+
+  test("compose() is never non-empty without a real reason", () => {
+    for (const input of matrix) {
+      const out = compose(input);
+      if (out.length === 0) continue;
+      const hasRenderable = input.dirty.some(r => (r.issues || []).some(i =>
+        ["uncommitted", "unpushed", "stash"].includes(i.type)));
+      expect(hasRenderable || !!input.workspace || !!input.staleNote, JSON.stringify(input)).toBe(true);
+    }
+  });
+
+  test("a repo entry with no renderable issues stays silent", () => {
+    expect(compose({ dirty: [currentRepo()], cwd: CWD })).toEqual([]);
+    expect(compose({ dirty: [{ label: "x", dir: "/x" }], cwd: CWD })).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Malformed input — the hook must never crash a session start
+// ---------------------------------------------------------------------------
+
+describe("robustness", () => {
+  test("tolerates dirty entries that are not arrays / objects", () => {
+    expect(() => compose({ dirty: null, cwd: CWD })).not.toThrow();
+    expect(() => compose({ dirty: "nope", cwd: CWD })).not.toThrow();
+    expect(() => compose({ dirty: [null, undefined], cwd: CWD })).not.toThrow();
+    expect(compose({ dirty: [null, undefined], cwd: CWD })).toEqual([]);
+  });
+
+  test("tolerates a repo whose issues field is missing or malformed", () => {
+    expect(compose({ dirty: [{ label: "x", dir: "/x", issues: null }], cwd: CWD })).toEqual([]);
+    expect(compose({ dirty: [{ label: "x", dir: "/x", issues: "bad" }], cwd: CWD })).toEqual([]);
+    expect(compose({ dirty: [{ label: "x", dir: "/x", issues: [null] }], cwd: CWD })).toEqual([]);
+  });
+
+  test("a malformed issue does not suppress its healthy siblings", () => {
+    const out = text(compose({
+      dirty: [{ label: "current repo", dir: CWD, issues: [null, issue("stash", 1, "1 stash entry")] }],
+      cwd: CWD,
+    }));
+    expect(out).toContain("- 1 stash entry → review with `git stash list`");
+  });
+
+  test("an unknown workspace type still renders a branch line and an ask block", () => {
+    const out = text(compose({ dirty: [], workspace: { type: "brand-new", branch: "x" }, cwd: CWD }));
+    expect(out).toContain("- On `x` in repo root (not in a worktree)");
+    expect(out).toContain("Call AskUserQuestion as the FIRST action of this turn.");
+  });
+
+  test("a workspace without a branch does not render `undefined`", () => {
+    const out = text(compose({ dirty: [], workspace: { type: "no-worktree" }, cwd: CWD }));
+    expect(out).not.toContain("undefined");
+    expect(out).toContain("unknown branch");
+  });
+});

--- a/plugins/devops/hooks/session-start/ss.git.check.js
+++ b/plugins/devops/hooks/session-start/ss.git.check.js
@@ -1,12 +1,18 @@
 #!/usr/bin/env node
 /**
  * @hook ss.git.check
- * @version 0.4.0
+ * @version 0.5.0
  * @event SessionStart
  * @plugin devops
  * @description Check for stale changes AND workspace setup issues at session
  *   start. Filters out active worktree branches to avoid false positives.
  *   Silent when clean. Outputs structured CTAs when issues are found.
+ *
+ *   Findings are emitted unconditionally and instruct the assistant to carry
+ *   them into its final report; the AskUserQuestion block is layered on top for
+ *   sessions that can prompt. A scheduled/headless run therefore still reports
+ *   what was found instead of dropping it with the skipped question (#268).
+ *   Composition lives in ../lib/git-check-output.js.
  *
  *   Workspace check (current repo only):
  *     - On main/master without worktree → high-priority warning, suggests
@@ -25,6 +31,7 @@
 require('../lib/plugin-guard');
 const { isActive: sentinelActive } = require('../lib/ship-sentinel');
 const { runOnce } = require('../lib/run-once');
+const { compose } = require('../lib/git-check-output');
 
 const { execSync } = require('child_process');
 const fs = require('fs');
@@ -243,97 +250,10 @@ if (dirty.length === 0 && !workspace && !staleNote) {
   process.exit(0);
 }
 
-// Build structured output with CTAs
-const out = [];
-
-if (workspace) {
-  const stagedTypes = new Set(['uncommitted', 'unpushed']);
-  const currentDirty = dirty.find(d => d.dir === cwd);
-  const pendingIssues = currentDirty
-    ? currentDirty.issues.filter(i => stagedTypes.has(i.type))
-    : [];
-  const hasChanges = pendingIssues.length > 0;
-
-  out.push('Workspace check at session start. Show this summary AS-IS and call AskUserQuestion as the FIRST action of this turn:');
-  out.push('');
-  out.push('**Workspace setup**');
-  switch (workspace.type) {
-    case 'on-main-no-worktree':
-      out.push(`- ⚠ On \`${workspace.branch}\` in repo root (not in a worktree) — write ops will be blocked by pre.main.guard / pre.edit.branch`);
-      break;
-    case 'detached-no-worktree':
-      out.push('- ⚠ Detached HEAD in repo root (not in a worktree) — commits will not belong to any branch');
-      break;
-    default:
-      out.push(`- On \`${workspace.branch}\` in repo root (not in a worktree)`);
-  }
-  if (hasChanges) {
-    out.push(`- Pending: ${pendingIssues.map(i => i.label).join(', ')}`);
-  }
-  out.push('');
-  out.push('Ask the user (in their language) via AskUserQuestion. Suggested options:');
-  if (hasChanges) {
-    out.push('  - Worktree + Feature-Branch anlegen');
-    out.push('  - Erst aktuelle Changes shippen (commit + push), dann Worktree anlegen (recommended)');
-    out.push('  - Changes mitnehmen in neuen Worktree (git stash → create → pop)');
-  } else {
-    out.push('  - Worktree + Feature-Branch anlegen (recommended)');
-  }
-  if (workspace.severity === 'high' && workspace.type === 'on-main-no-worktree') {
-    out.push('  - Hier bleiben (bypass: DEVOPS_ALLOW_MAIN=1 für diese Session)');
-  } else {
-    out.push('  - Hier bleiben (Warning bleibt informativ — kein Bypass-Flag nötig)');
-  }
-  out.push('');
-  out.push('Resolution per option:');
-  out.push('  - Worktree+branch: `git worktree add ../<feature> -b claude/<feature>` then cd there');
-  if (hasChanges) {
-    out.push('  - Ship-first: invoke /ship, then create worktree');
-    out.push('  - Take-along: `git stash`, create worktree, `cd <worktree>`, `git stash pop`');
-  }
-  if (workspace.type === 'on-main-no-worktree') {
-    out.push('  - Stay: set env `DEVOPS_ALLOW_MAIN=1` for this session to silence main-branch checks');
-  }
-  out.push('');
-}
-
-const staleHeaderShown = !workspace && dirty.length > 0;
-if (staleHeaderShown) {
-  out.push('Stale changes found at session start. Show the user this summary as-is:');
-  out.push('');
-}
-
-for (const r of dirty) {
-  const lines = [];
-  for (const issue of r.issues) {
-    if (workspace && r.dir === cwd
-        && (issue.type === 'uncommitted' || issue.type === 'unpushed')) {
-      continue;
-    }
-    switch (issue.type) {
-      case 'uncommitted':
-      case 'unpushed':
-        lines.push(`- ${issue.label} → run \`/ship\` to commit, push & create PR`);
-        break;
-      case 'stash':
-        lines.push(`- ${issue.label} → review with \`git stash list\`, then \`git stash pop\` or \`git stash drop\``);
-        break;
-    }
-  }
-  if (lines.length > 0) {
-    const header = workspace && r.dir === cwd
-      ? 'Additional in current repo:'
-      : `**${r.label}**`;
-    out.push(header);
-    out.push(...lines);
-    out.push('');
-  }
-}
-
-if (staleNote) {
-  if (out.length > 0) out.push('');
-  out.push(staleNote);
-}
+// Build structured output with CTAs.
+// Composition lives in hooks/lib/git-check-output.js so it is unit-testable and
+// so the "findings are never coupled to the ask" invariant (#268) has one home.
+const out = compose({ dirty, workspace, staleNote, cwd });
 
 if (out.length === 0) process.exit(0);
 

--- a/plugins/devops/scheduled-tasks/stale-changes-check/SKILL.md
+++ b/plugins/devops/scheduled-tasks/stale-changes-check/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: stale-changes-check
 description: Session-start hook that checks for uncommitted/unpushed changes and warns the user only when issues exist.
-version: 0.2.0
-trigger: SessionStart (hook ss.stale.check.js)
+version: 0.3.0
+trigger: SessionStart (hook ss.git.check.js)
 ---
 
 # Stale Changes Check
 
-Runs automatically at every session start via `hooks/session-start/ss.stale.check.js`.
+Runs automatically at every session start via `hooks/session-start/ss.git.check.js`.
 Silent when everything is clean. Only surfaces a brief warning when issues are found.
 
 ## What the hook checks
@@ -28,8 +28,16 @@ defined in `~/.claude/scheduled-tasks/stale-changes-check/reference.md`:
 ## Output behaviour
 
 - **Clean** → hook exits silently, nothing shown to user.
-- **Issues found** → hook writes a one-line prompt to stdout; Claude relays a
+- **Issues found** → hook writes a structured summary to stdout; Claude relays a
   brief inline warning to the user (no full report, no table).
+
+Findings are **never coupled to a question**. The hook always emits them and
+instructs the assistant to restate them in its final message, before any
+completion card. When a workspace issue is also present, the AskUserQuestion
+block is layered on top — so an interactive session asks, while a scheduled,
+cron or headless session (which cannot answer a modal) still reports what was
+found instead of dropping it with the skipped question. See
+`hooks/lib/git-check-output.js`.
 
 ## Constraints
 

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.123.1",
+  "version": "0.123.2",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
Closes #268

## Summary

A scheduled, cron or headless session silently swallowed the loose ends the SessionStart workspace check found. The hook rendered the current repo's `uncommitted`/`unpushed` findings **only** inside its `AskUserQuestion` block, and actively suppressed them from the plain report section whenever a workspace issue was present. A run that cannot answer a modal correctly skips it — and the entire finding disappeared with it: neither acted on nor mentioned in the report. In the reported case 13 unpushed commits sat invisible on a branch with no PR until a later interactive session happened to ask.

## Approach — decouple, don't detect

Detecting "is this session interactive?" was investigated and rejected. No such signal exists at `SessionStart`: nothing in `plugins/**/hooks/` reads one, and the only cron/background detector (`prompt.flow.silent-turn`) fires at `UserPromptSubmit` — i.e. **after** this hook has already emitted, so its flag does not yet exist. Any new detection would be unverified and could fail open, reproducing the exact bug.

Instead the finding is made unconditional and the ask is layered on top: a session that can prompt, prompts; one that cannot, still reports.

## Changes

- **New `hooks/lib/git-check-output.js`** — pure output composition, so the decision is unit-testable (the hook body is self-executing and exports nothing). The `workspace && r.dir === cwd` suppression that caused the drop is gone, with a comment marking it as load-bearing.
- **Findings always render**, in their own `**current repo**` block, and the directive names its landing zone: *restate them in your final message, before any completion card*. Prose before the card is permitted by `stop.flow.guard`; content after it is not — so "include it in your final report" now points somewhere real.
- **Interactive behaviour unchanged** — the `call AskUserQuestion as the FIRST action of this turn` mandate stays verbatim and stays in the first line, ahead of the report obligation, so an assistant reading only the opening sentence still comes away with "ask".
- **Docs** — `scheduled-tasks/stale-changes-check/SKILL.md` documents the new contract and drops a stale reference to the pre-rename filename `ss.stale.check.js`.

## Verification

- 31 colocated tests in `git-check-output.test.js`: the #268 regression, ask-block integrity, ordering, per-workspace-type coverage, the silence contract against the hook's own early-exit gates, and malformed input.
- **Mutation-verified** — reintroducing the old suppression fails 5 of them, so the guard genuinely bites.
- Full suite green: 50 files / 893 tests. eslint clean.
- Hook smoke-tested end-to-end in both paths: worktree (stale-only output) and repo root on `main` (workspace + ask output).
- Adversarial red-team pass; both high findings folded in before merge — the ask mandate had been demoted below the findings, and "final report" named no landing zone compatible with the card-must-be-last rule.
- Codex review gate unavailable this ship (external usage limit), non-blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)