### PR TITLE
fix(ship): let the remote decide whether a tag landed, not the push

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.123.2"
+    "version": "0.123.3"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.123.2",
+      "version": "0.123.3",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.123.2",
+      "version": "0.123.3",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.123.3] — 2026-07-28
+
+### Fixed
+
+- **A stable promotion no longer fails on a tag that actually landed, leaving the bare tag unpushed and the release un-built.** `ship_promote` pushed each tag once and verified it with a single `ls-remote` immediately afterwards. That read can hit a replica that has not caught up, so a tag that was genuinely on the remote came back as `tag stable/v0.39.2 not verifiable on remote after push` — `success: false`, `pushed: []`, and a `missing` list naming a tag `git ls-remote` could see. Worse, the failure broke the ordered plan before the bare `vX.Y.Z` tag was ever attempted, and only that bare tag triggers the consumer's `release.yml` — so the stable go-live silently did not build and needed manual tag surgery.
+
+  The remote now decides, and it gets asked more than once. Each push is followed by a *retrying* confirmation, and the confirmation — not the push's exit code — determines the outcome, so a client-side `ETIMEDOUT` fired after the ref already updated resolves as pushed rather than as a hard failure. No tag is reported in `missing` until a final re-query still fails to find it. A tag present on a **different** SHA is never retried: that is the immutability guard and it stays final, as does the fail-closed rule that an unreadable remote is never treated as "tag absent" — the error now says which of the two it was. Tunable via `tagPushAttempts` (3), `tagVerifyAttempts` (4) and `tagRetryDelayMs` (1000, ×3 per attempt), all bounded by a `tagBudgetMs` wall-clock cap (120 s) so the nested loops cannot hang a promotion for minutes on an unreachable remote. The ordering invariant (bare tag never before `stable/`) is unchanged.
+
+- **A local branch named like a version tag can no longer be mistaken for that tag — or pushed in its place.** The tag lookup and the tag push both used unqualified names, which git resolves against `refs/heads` as well as `refs/tags`. A branch called `v0.113.0` would have read as "the tag already exists", and the push could have published a branch under the tag's name. Both now use fully qualified refs (`refs/tags/…` and an explicit `refs/tags/x:refs/tags/x` refspec). `version` is additionally constrained to a semver shape, since it is interpolated into shell-executed git commands.
+
+- **A promotion re-run after a partial failure no longer fails permanently on its own leftover tag.** `git tag -a` refuses an existing name, so a local tag left behind by an interrupted run made every subsequent re-run fail — the opposite of the documented idempotency. A leftover tag pointing at the expected commit is now reused; one pointing anywhere else is refused before any push.
+
+- **`ship_release` no longer mistakes a tail-matching sibling for the channel tag it was asked about.** The channel-tag check used a substring test on `ls-remote` output, but `ls-remote` tail-matches per path component — a query for `alpha/v1.0.0` also returns `refs/tags/hotfix/alpha/v1.0.0`. It now compares exact refs, retries both the existence read and the post-push verification instead of trusting one negative result, no longer reads an unreachable remote as "tag absent" (it says so instead), and pushes with the same 60 s timeout `ship_promote` uses — the 15 s default sat below a slow remote's worst case.
+
 ## [0.123.2] — 2026-07-28
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.123.2**
+**Version: 0.123.3**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.123.2",
+  "version": "0.123.3",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/mcp-server/ship/lib/remote-tags.js
+++ b/plugins/devops/mcp-server/ship/lib/remote-tags.js
@@ -1,0 +1,52 @@
+/**
+ * @module ship/lib/remote-tags
+ * @description Exact-ref parsing of `git ls-remote --tags` output.
+ *   Shared by ship_promote (sha comparison) and ship_release (existence check)
+ *   so both speak the same, correct dialect of ls-remote.
+ */
+
+/**
+ * Parse `git ls-remote --tags` output for ONE tag and return the COMMIT sha it
+ * points at, or null when the tag is absent. Pure — exported for unit tests.
+ *
+ * Three ls-remote traps this must handle (all bit us on the 0.116.2 promotion):
+ * - An annotated tag has TWO refs: the tag OBJECT sha on `refs/tags/<tag>` and
+ *   the peeled COMMIT sha on `refs/tags/<tag>^{}`. Tag objects differ by
+ *   construction even when they point at the same commit (tagger/date/message),
+ *   so every promotion comparison MUST use the peeled commit sha. Prefer the
+ *   `^{}` line; fall back to the plain line (lightweight tags have no peeled
+ *   entry — their plain sha IS the commit).
+ * - A single-pattern query NEVER returns the `^{}` line: ls-remote tail-matches
+ *   each pattern per path component, and `refs/tags/<tag>^{}` does not end in
+ *   `/<tag>`. The CALLER must therefore query BOTH patterns
+ *   (`<tag>` AND `<tag>^{}`) — see lsRemoteTag in tools/promote.js. Verified
+ *   against a live GitHub remote; a mock that returns peeled lines for
+ *   plain-pattern queries is lying about git.
+ * - Tail-component matching also means querying `v0.116.2` returns
+ *   `alpha/v0.116.2` &c. — only an exact-ref match may count, never "first
+ *   line of the output".
+ */
+export function parseLsRemoteTagOutput(out, tag) {
+  let plain = null;
+  let peeled = null;
+  for (const line of (out || "").split("\n")) {
+    const [sha, ref] = line.trim().split(/\s+/);
+    if (!sha || !ref) continue;
+    if (ref === `refs/tags/${tag}`) plain = sha;
+    else if (ref === `refs/tags/${tag}^{}`) peeled = sha;
+  }
+  return peeled || plain;
+}
+
+/**
+ * Does `out` contain an EXACT ref for `tag`?
+ *
+ * The substring test this replaces (`out.includes(tag)`) is wrong in both
+ * directions because of ls-remote's tail-component matching: querying
+ * `v1.0.0` also returns `refs/tags/alpha/v1.0.0`, so a bare-tag check passed
+ * on a channel tag that was never pushed — and any tag whose name is a prefix
+ * of another matched too.
+ */
+export function remoteTagExists(out, tag) {
+  return parseLsRemoteTagOutput(out, tag) !== null;
+}

--- a/plugins/devops/mcp-server/ship/lib/remote-tags.test.js
+++ b/plugins/devops/mcp-server/ship/lib/remote-tags.test.js
@@ -1,0 +1,59 @@
+import { describe, test, expect } from "vitest";
+import { parseLsRemoteTagOutput, remoteTagExists } from "./remote-tags.js";
+
+const COMMIT = "a".repeat(40);
+const TAGOBJ = "b".repeat(40);
+
+const lines = (...rows) => rows.map(([sha, ref]) => `${sha}\t${ref}`).join("\n");
+
+describe("parseLsRemoteTagOutput", () => {
+  test("peeled ^{} line wins over the tag-object line", () => {
+    const out = lines([TAGOBJ, "refs/tags/v1.0.0"], [COMMIT, "refs/tags/v1.0.0^{}"]);
+    expect(parseLsRemoteTagOutput(out, "v1.0.0")).toBe(COMMIT);
+  });
+
+  test("lightweight tag (no peeled line) falls back to the plain sha", () => {
+    expect(parseLsRemoteTagOutput(lines([COMMIT, "refs/tags/v1.0.0"]), "v1.0.0")).toBe(COMMIT);
+  });
+
+  test("absent tag → null even when suffix-matched siblings are in the output", () => {
+    const out = lines([COMMIT, "refs/tags/alpha/v1.0.0"], [COMMIT, "refs/tags/beta/v1.0.0"]);
+    expect(parseLsRemoteTagOutput(out, "v1.0.0")).toBeNull();
+  });
+
+  test("empty / null / whitespace input → null", () => {
+    expect(parseLsRemoteTagOutput("", "v1.0.0")).toBeNull();
+    expect(parseLsRemoteTagOutput(null, "v1.0.0")).toBeNull();
+    expect(parseLsRemoteTagOutput("   \n  \n", "v1.0.0")).toBeNull();
+  });
+
+  test("malformed lines are skipped, not parsed as a match", () => {
+    expect(parseLsRemoteTagOutput("garbage\nrefs/tags/v1.0.0\n", "v1.0.0")).toBeNull();
+  });
+});
+
+describe("remoteTagExists — exact ref, never a substring", () => {
+  test("true only for an exact ref match", () => {
+    const out = lines([COMMIT, "refs/tags/alpha/v1.0.0"]);
+    expect(remoteTagExists(out, "alpha/v1.0.0")).toBe(true);
+  });
+
+  test("a channel tag does NOT satisfy a query for the bare tag (#251)", () => {
+    // ls-remote tail-matches per path component, so querying `v1.0.0` returns
+    // `refs/tags/alpha/v1.0.0`. The old `out.includes(tag)` check read that as
+    // "the bare tag is on the remote" — it is not.
+    const out = lines([COMMIT, "refs/tags/alpha/v1.0.0"]);
+    expect(out.includes("v1.0.0")).toBe(true); // the bug the substring check had
+    expect(remoteTagExists(out, "v1.0.0")).toBe(false);
+  });
+
+  test("a longer tag name does not satisfy a query for its prefix", () => {
+    const out = lines([COMMIT, "refs/tags/v1.0.0-rc1"]);
+    expect(remoteTagExists(out, "v1.0.0")).toBe(false);
+  });
+
+  test("false for empty output", () => {
+    expect(remoteTagExists("", "v1.0.0")).toBe(false);
+    expect(remoteTagExists(null, "v1.0.0")).toBe(false);
+  });
+});

--- a/plugins/devops/mcp-server/ship/lib/retry.js
+++ b/plugins/devops/mcp-server/ship/lib/retry.js
@@ -1,0 +1,67 @@
+/**
+ * @module ship/lib/retry
+ * @description Shared exponential-backoff retry for remote git / GitHub reads.
+ *
+ *   Every remote operation in the ship pipeline can lag or lie once:
+ *   `git push` can return before the ref is visible on the replica that the
+ *   next `ls-remote` happens to hit, and a client-side ETIMEDOUT can fire
+ *   *after* the ref already updated. A single-shot post-push verification
+ *   therefore produces false negatives — it reported `stable/v0.39.2` as
+ *   "not verifiable on remote" while the tag had in fact landed (#251).
+ *
+ *   The rule this module encodes: **the remote decides, and it gets asked more
+ *   than once.** A throw is evidence of nothing; only a confirmed read is.
+ */
+
+/**
+ * Delay before retry `attempt+1`, exponential with symmetric jitter.
+ * attempt is 1-based: 1 → delayMs, 2 → delayMs*factor, 3 → delayMs*factor².
+ * `random` is injectable so tests can pin the jitter.
+ */
+export function backoffMs(attempt, { delayMs = 1000, factor = 3, jitter = 0.1, random = Math.random } = {}) {
+  if (!(delayMs > 0)) return 0;
+  const base = delayMs * Math.pow(factor, Math.max(0, attempt - 1));
+  if (!jitter) return Math.round(base);
+  return Math.round(base * (1 - jitter + random() * 2 * jitter));
+}
+
+/** Async sleep; a non-positive duration resolves immediately (test-friendly). */
+export function sleep(ms) {
+  return ms > 0 ? new Promise((resolve) => setTimeout(resolve, ms)) : Promise.resolve();
+}
+
+/**
+ * Call `fn(attempt)` until it returns a non-null/undefined value.
+ *
+ * A returned `null`/`undefined` means "not yet — retry"; a throw is likewise
+ * retried and recorded as `error`. Returns
+ * `{ ok, value, error, attempts }` — `ok: false` means every attempt was
+ * exhausted without a settled value.
+ *
+ * `sleepFn` is injectable so tests never wait on real timers.
+ */
+export async function retryUntil(fn, opts = {}) {
+  const { attempts = 3, sleepFn = sleep, deadline = null, now = () => Date.now() } = opts;
+  const total = Math.max(1, attempts);
+  let lastError = null;
+  let used = 0;
+  for (let attempt = 1; attempt <= total; attempt++) {
+    used = attempt;
+    try {
+      const value = await fn(attempt);
+      if (value !== null && value !== undefined) return { ok: true, value, error: null, attempts: attempt };
+      lastError = null;
+    } catch (e) {
+      lastError = e;
+    }
+    if (attempt < total) {
+      // A wall-clock deadline bounds the loop regardless of how many attempts
+      // the caller asked for. Retry loops nest (a push loop around a verify
+      // loop), so an attempt budget alone multiplies into a worst case nobody
+      // sized; the deadline is the thing that actually caps it.
+      if (deadline !== null && now() >= deadline) break;
+      await sleepFn(backoffMs(attempt, opts));
+    }
+  }
+  return { ok: false, value: null, error: lastError, attempts: used, timedOut: deadline !== null && now() >= deadline };
+}

--- a/plugins/devops/mcp-server/ship/lib/retry.test.js
+++ b/plugins/devops/mcp-server/ship/lib/retry.test.js
@@ -1,0 +1,197 @@
+import { describe, test, expect, vi } from "vitest";
+import { backoffMs, sleep, retryUntil } from "./retry.js";
+
+// Deterministic jitter: random() = 0.5 → the multiplier is exactly 1.
+const mid = { random: () => 0.5 };
+
+describe("backoffMs", () => {
+  test("grows exponentially from the base delay", () => {
+    expect(backoffMs(1, { delayMs: 1000, ...mid })).toBe(1000);
+    expect(backoffMs(2, { delayMs: 1000, ...mid })).toBe(3000);
+    expect(backoffMs(3, { delayMs: 1000, ...mid })).toBe(9000);
+  });
+
+  test("honours a custom factor", () => {
+    expect(backoffMs(3, { delayMs: 100, factor: 2, ...mid })).toBe(400);
+  });
+
+  test("a zero or negative base disables the wait entirely", () => {
+    expect(backoffMs(1, { delayMs: 0 })).toBe(0);
+    expect(backoffMs(4, { delayMs: 0 })).toBe(0);
+    expect(backoffMs(2, { delayMs: -5 })).toBe(0);
+  });
+
+  test("jitter stays inside ±10% of the base by default", () => {
+    for (const r of [0, 0.25, 0.5, 0.75, 1]) {
+      const ms = backoffMs(2, { delayMs: 1000, random: () => r });
+      expect(ms).toBeGreaterThanOrEqual(2700);
+      expect(ms).toBeLessThanOrEqual(3300);
+    }
+  });
+
+  test("jitter can be switched off for an exact value", () => {
+    expect(backoffMs(2, { delayMs: 1000, jitter: 0 })).toBe(3000);
+  });
+
+  test("attempt 0 or below is treated as the first attempt", () => {
+    expect(backoffMs(0, { delayMs: 500, ...mid })).toBe(500);
+    expect(backoffMs(-3, { delayMs: 500, ...mid })).toBe(500);
+  });
+});
+
+describe("sleep", () => {
+  test("resolves immediately for a non-positive duration", async () => {
+    await expect(sleep(0)).resolves.toBeUndefined();
+    await expect(sleep(-1)).resolves.toBeUndefined();
+  });
+
+  test("resolves after the timer for a positive duration", async () => {
+    vi.useFakeTimers();
+    let done = false;
+    const p = sleep(50).then(() => { done = true; });
+    expect(done).toBe(false);
+    await vi.advanceTimersByTimeAsync(50);
+    await p;
+    expect(done).toBe(true);
+    vi.useRealTimers();
+  });
+});
+
+describe("retryUntil", () => {
+  const noSleep = { delayMs: 0, sleepFn: () => Promise.resolve() };
+
+  test("returns the first settled value without retrying", async () => {
+    const fn = vi.fn(() => "ok");
+    const r = await retryUntil(fn, { attempts: 3, ...noSleep });
+    expect(r).toMatchObject({ ok: true, value: "ok", attempts: 1 });
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  test("retries while fn returns null, then settles", async () => {
+    let n = 0;
+    const fn = vi.fn(() => (++n < 3 ? null : `settled-${n}`));
+    const r = await retryUntil(fn, { attempts: 5, ...noSleep });
+    expect(r).toMatchObject({ ok: true, value: "settled-3", attempts: 3 });
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  test("undefined is retried just like null", async () => {
+    let n = 0;
+    const fn = vi.fn(() => (++n < 2 ? undefined : "later"));
+    const r = await retryUntil(fn, { attempts: 3, ...noSleep });
+    expect(r.ok).toBe(true);
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  test("falsy-but-present values settle immediately (0, false, empty string)", async () => {
+    for (const v of [0, false, ""]) {
+      const r = await retryUntil(() => v, { attempts: 3, ...noSleep });
+      expect(r).toMatchObject({ ok: true, value: v, attempts: 1 });
+    }
+  });
+
+  test("a throw is retried and recorded as the last error", async () => {
+    const fn = vi.fn(() => { throw new Error("boom"); });
+    const r = await retryUntil(fn, { attempts: 3, ...noSleep });
+    expect(r.ok).toBe(false);
+    expect(r.value).toBeNull();
+    expect(r.attempts).toBe(3);
+    expect(r.error.message).toBe("boom");
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  test("a throw followed by a success still succeeds, with no stale error", async () => {
+    let n = 0;
+    const fn = vi.fn(() => { if (++n === 1) throw new Error("transient"); return "recovered"; });
+    const r = await retryUntil(fn, { attempts: 3, ...noSleep });
+    expect(r).toMatchObject({ ok: true, value: "recovered", error: null, attempts: 2 });
+  });
+
+  test("a null after an earlier throw clears the recorded error", async () => {
+    // Otherwise an exhausted run would blame an error that a later attempt
+    // did not actually reproduce.
+    let n = 0;
+    const fn = () => { if (++n === 1) throw new Error("first"); return null; };
+    const r = await retryUntil(fn, { attempts: 3, ...noSleep });
+    expect(r.ok).toBe(false);
+    expect(r.error).toBeNull();
+  });
+
+  test("awaits async fns", async () => {
+    let n = 0;
+    const fn = async () => (++n < 2 ? null : "async-ok");
+    const r = await retryUntil(fn, { attempts: 3, ...noSleep });
+    expect(r).toMatchObject({ ok: true, value: "async-ok", attempts: 2 });
+  });
+
+  test("sleeps between attempts but never after the last one", async () => {
+    const sleepFn = vi.fn(() => Promise.resolve());
+    await retryUntil(() => null, { attempts: 3, delayMs: 10, jitter: 0, sleepFn });
+    expect(sleepFn).toHaveBeenCalledTimes(2);
+    expect(sleepFn.mock.calls.map((c) => c[0])).toEqual([10, 30]);
+  });
+
+  test("attempts below 1 still run exactly once", async () => {
+    const fn = vi.fn(() => null);
+    const r = await retryUntil(fn, { attempts: 0, ...noSleep });
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(r.attempts).toBe(1);
+  });
+
+  test("passes the 1-based attempt number to fn", async () => {
+    const seen = [];
+    await retryUntil((a) => { seen.push(a); return null; }, { attempts: 3, ...noSleep });
+    expect(seen).toEqual([1, 2, 3]);
+  });
+});
+
+describe("retryUntil — wall-clock deadline", () => {
+  const noSleep = { delayMs: 0, sleepFn: () => Promise.resolve() };
+
+  test("stops retrying once the deadline has passed", async () => {
+    const fn = vi.fn(() => null);
+    let t = 0;
+    const r = await retryUntil(fn, {
+      attempts: 10,
+      ...noSleep,
+      deadline: 100,
+      now: () => (t += 60), // 60, 120 → over the deadline after the first attempt
+    });
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(r.ok).toBe(false);
+    expect(r.timedOut).toBe(true);
+    expect(r.attempts).toBe(2);
+  });
+
+  test("a deadline never truncates a run that settles in time", async () => {
+    let n = 0;
+    const r = await retryUntil(() => (++n < 3 ? null : "ok"), {
+      attempts: 10,
+      ...noSleep,
+      deadline: 1_000,
+      now: () => 0,
+    });
+    expect(r).toMatchObject({ ok: true, value: "ok", attempts: 3 });
+  });
+
+  test("no deadline means the attempt budget alone decides", async () => {
+    const fn = vi.fn(() => null);
+    const r = await retryUntil(fn, { attempts: 4, ...noSleep });
+    expect(fn).toHaveBeenCalledTimes(4);
+    expect(r.timedOut).toBe(false);
+  });
+
+  test("a deadline of 0 is honoured, not treated as 'disabled'", async () => {
+    // 0 is a legitimate already-expired deadline; only `null` disables the cap.
+    const fn = vi.fn(() => null);
+    await retryUntil(fn, { attempts: 5, ...noSleep, deadline: 0, now: () => 1 });
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  test("the deadline is checked BEFORE sleeping, not after", async () => {
+    // Otherwise an expired budget still burns a full backoff wait.
+    const sleepFn = vi.fn(() => Promise.resolve());
+    await retryUntil(() => null, { attempts: 5, delayMs: 10, sleepFn, deadline: 0, now: () => 1 });
+    expect(sleepFn).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/devops/mcp-server/ship/tools/promote.js
+++ b/plugins/devops/mcp-server/ship/tools/promote.js
@@ -12,51 +12,31 @@ import { execFileSync } from "node:child_process";
 import { git, gitStrict } from "../lib/git.js";
 import { createRelease, releaseExists } from "../lib/github.js";
 import { parseChannelTag, compareVersions } from "../lib/channels.js";
+import { parseLsRemoteTagOutput } from "../lib/remote-tags.js";
+import { retryUntil } from "../lib/retry.js";
+
+// Re-exported: the ls-remote dialect now lives in lib/remote-tags.js (shared
+// with ship_release), but this module is its established import site.
+export { parseLsRemoteTagOutput };
 
 export const schema = z.object({
-  version: z.string().describe("Bare version to promote, e.g. 0.113.0 (no v prefix, no channel)"),
+  // Constrained on purpose: `version` is interpolated into shell-executed git
+  // command strings (git()/gitStrict() run through cmd.exe on Windows), so an
+  // unvalidated string is a command-injection surface. Semver-shaped only.
+  version: z.string().regex(/^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/, "version must be semver-shaped, e.g. 0.113.0").describe("Bare version to promote, e.g. 0.113.0 (no v prefix, no channel)"),
   from: z.enum(["alpha", "beta"]).describe("Source channel the version currently lives in"),
   to: z.enum(["beta", "stable"]).describe("Target channel (must be more stable than source)"),
   releaseNotes: z.string().nullable().default(null).describe("CHANGELOG entry for the stable GitHub Release fallback — ignored for beta"),
   releasePollAttempts: z.number().int().min(1).max(30).default(6).describe("How often to poll for the release.yml-created GitHub Release before falling back"),
   releasePollDelayMs: z.number().int().min(0).max(60_000).default(10_000).describe("Delay between release polls"),
+  tagPushAttempts: z.number().int().min(1).max(10).default(3).describe("How often to (re-)push a tag whose remote presence could not be confirmed. NOTE: the verify loop nests inside this one, so the read budget per tag is tagPushAttempts × tagVerifyAttempts — bounded in wall-clock by tagBudgetMs"),
+  tagVerifyAttempts: z.number().int().min(1).max(20).default(4).describe("How often to re-query the remote per push attempt before declaring a pushed tag missing"),
+  tagRetryDelayMs: z.number().int().min(0).max(60_000).default(1_000).describe("Base delay for the tag push/verify backoff (exponential, ×3 per attempt)"),
+  tagBudgetMs: z.number().int().min(0).max(600_000).default(120_000).describe("Wall-clock cap for ALL tag push/verify retries in this call. 0 disables the cap. Bounds the nested loops so a promotion cannot hang for minutes on an unreachable remote"),
   cwd: z.string().describe("Working directory of the target repo (required — must be passed by the caller)"),
 });
 
 const ORDER = { alpha: 0, beta: 1, stable: 2 };
-
-/**
- * Parse `git ls-remote --tags` output for ONE tag and return the COMMIT sha it
- * points at, or null when the tag is absent. Pure — exported for unit tests.
- *
- * Three ls-remote traps this must handle (all bit us on the 0.116.2 promotion):
- * - An annotated tag has TWO refs: the tag OBJECT sha on `refs/tags/<tag>` and
- *   the peeled COMMIT sha on `refs/tags/<tag>^{}`. Tag objects differ by
- *   construction even when they point at the same commit (tagger/date/message),
- *   so every promotion comparison MUST use the peeled commit sha. Prefer the
- *   `^{}` line; fall back to the plain line (lightweight tags have no peeled
- *   entry — their plain sha IS the commit).
- * - A single-pattern query NEVER returns the `^{}` line: ls-remote tail-matches
- *   each pattern per path component, and `refs/tags/<tag>^{}` does not end in
- *   `/<tag>`. The CALLER must therefore query BOTH patterns
- *   (`<tag>` AND `<tag>^{}`) — see lsRemoteTag. Verified against a live
- *   GitHub remote; a mock that returns peeled lines for plain-pattern queries
- *   is lying about git.
- * - Tail-component matching also means querying `v0.116.2` returns
- *   `alpha/v0.116.2` &c. — only an exact-ref match may count, never "first
- *   line of the output".
- */
-export function parseLsRemoteTagOutput(out, tag) {
-  let plain = null;
-  let peeled = null;
-  for (const line of (out || "").split("\n")) {
-    const [sha, ref] = line.trim().split(/\s+/);
-    if (!sha || !ref) continue;
-    if (ref === `refs/tags/${tag}`) plain = sha;
-    else if (ref === `refs/tags/${tag}^{}`) peeled = sha;
-  }
-  return peeled || plain;
-}
 
 function lsRemoteTag(tag, opts) {
   // Both patterns, both double-quoted: the second is required to surface the
@@ -111,35 +91,144 @@ function listRemoteChannelTags(opts) {
 }
 
 /**
+ * One remote read for `tag`, classified into the four outcomes that decide
+ * what happens next. Never throws — the fail-closed throw from lsRemoteTag
+ * becomes `unreachable`, which is retryable, whereas `conflict` never is.
+ *
+ *   present     — tag is on the remote at the expected sha (idempotent success)
+ *   conflict    — tag is on the remote at a DIFFERENT sha (immutable, hard stop)
+ *   absent      — tag is not on the remote (retryable: may be replica lag)
+ *   unreachable — the ls-remote itself failed (retryable: transient network)
+ */
+function probeTag(tag, sha, opts) {
+  try {
+    const found = lsRemoteTag(tag, opts);
+    if (!found) return { state: "absent" };
+    return found === sha ? { state: "present" } : { state: "conflict", sha: found };
+  } catch (e) {
+    return { state: "unreachable", error: e.message?.slice(0, 200) };
+  }
+}
+
+function immutabilityError(tag, found, sha) {
+  return `tag ${tag} already exists on remote at ${found.slice(0, 12)} (expected ${sha.slice(0, 12)}) — published tags are immutable`;
+}
+
+/**
+ * Ask the remote about `tag` until it settles on present/conflict, or the
+ * attempts run out. `absent` and `unreachable` are both retried — the whole
+ * point of #251 is that ONE negative read proves nothing.
+ */
+async function confirmTag(tag, sha, opts, retry) {
+  let lastState = "absent";
+  const r = await retryUntil(
+    () => {
+      const p = probeTag(tag, sha, opts);
+      lastState = p.state;
+      return p.state === "present" || p.state === "conflict" ? p : null;
+    },
+    {
+      attempts: retry.verifyAttempts,
+      delayMs: retry.delayMs,
+      sleepFn: retry.sleepFn,
+      deadline: retry.deadline,
+    },
+  );
+  if (r.ok) return r.value;
+  // Budget exhausted. Keep WHY: an unreadable remote is not the same claim as
+  // "the tag is not there", and the caller's error text must not assert the
+  // stronger one. Both still resolve to "not confirmed" — fail-closed.
+  return { state: "absent", unreachable: lastState === "unreachable" };
+}
+
+/**
+ * Create the annotated tag locally, idempotently.
+ * A tag left behind by an earlier failed run must be reused, not re-created —
+ * `git tag -a` on an existing name fails, which used to turn a recoverable
+ * partial failure into a permanent one on every re-run.
+ */
+function ensureLocalTag(tag, sha, payload, opts) {
+  // FULLY QUALIFIED (`refs/tags/…`): a bare name goes through git's ref
+  // disambiguation, which also resolves `refs/heads/<name>` — a local BRANCH
+  // called `v0.113.0` would then read as "the tag already exists".
+  // Quoted: cmd.exe treats a bare `^` as its escape character (execSync shells out).
+  const local = git(`rev-parse -q --verify "refs/tags/${tag}^{commit}"`, opts);
+  if (local) {
+    if (local !== sha) {
+      throw new Error(
+        `local tag ${tag} points at ${local.slice(0, 12)}, expected ${sha.slice(0, 12)} — ` +
+        `a re-run cannot clear this; delete the stale local tag first (git tag -d ${tag})`,
+      );
+    }
+    return;
+  }
+  // Annotated (-a): promotion timestamp/actor live in the tag object —
+  // lightweight tags would collapse all channels onto the commit date (R4).
+  execFileSync("git", ["tag", "-a", tag, sha, "-m", JSON.stringify(payload)], {
+    cwd: opts.cwd,
+    encoding: "utf8",
+    timeout: 15_000,
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+}
+
+/**
  * Create + push one annotated tag, skip-if-exists. Returns
  * { ok: true } | { ok: true, existed: true } | { ok: false, error }.
  * An existing remote tag on a DIFFERENT SHA is a hard error — published
  * tags are immutable, never moved (spec §2).
+ *
+ * #251: neither the push's exit code nor a single post-push read is
+ * authoritative. A push can throw ETIMEDOUT after the ref already updated,
+ * and a push can succeed while the very next ls-remote hits a replica that
+ * has not caught up. So every push attempt is followed by a *retrying*
+ * confirmation, and the confirmation — not the push — decides the outcome.
  */
-function ensureTag(tag, sha, payload, opts) {
-  const existing = lsRemoteTag(tag, opts);
-  if (existing) {
-    if (existing !== sha) {
-      return { ok: false, error: `tag ${tag} already exists on remote at ${existing.slice(0, 12)} (expected ${sha.slice(0, 12)}) — published tags are immutable` };
-    }
-    return { ok: true, existed: true };
-  }
+async function ensureTag(tag, sha, payload, opts, retry) {
+  // 1. Pre-check: idempotency + the immutability gate, before touching anything.
+  const pre = probeTag(tag, sha, opts);
+  if (pre.state === "conflict") return { ok: false, conflict: true, error: immutabilityError(tag, pre.sha, sha) };
+  if (pre.state === "present") return { ok: true, existed: true };
+  if (pre.state === "unreachable") return { ok: false, error: `cannot reach remote — refusing to promote (${pre.error})` };
+
   try {
-    // Annotated (-a): promotion timestamp/actor live in the tag object —
-    // lightweight tags would collapse all channels onto the commit date (R4).
-    execFileSync("git", ["tag", "-a", tag, sha, "-m", JSON.stringify(payload)], {
-      cwd: opts.cwd,
-      encoding: "utf8",
-      timeout: 15_000,
-      stdio: ["pipe", "pipe", "pipe"],
-    });
-    gitStrict(`push origin ${tag}`, { ...opts, timeout: 60_000 });
-    const verify = lsRemoteTag(tag, opts);
-    if (verify !== sha) return { ok: false, error: `tag ${tag} not verifiable on remote after push` };
-    return { ok: true };
+    ensureLocalTag(tag, sha, payload, opts);
   } catch (e) {
     return { ok: false, error: e.message?.slice(0, 300) || "tag creation failed" };
   }
+
+  let pushError = null;
+  let timedOut = false;
+  let unreadable = false;
+  for (let attempt = 1; attempt <= retry.pushAttempts; attempt++) {
+    if (attempt > 1 && retry.deadline !== null && Date.now() >= retry.deadline) {
+      timedOut = true;
+      break;
+    }
+    try {
+      // Explicit refspec for the same reason as the rev-parse above: `push
+      // origin <name>` would happily push a same-named BRANCH instead.
+      gitStrict(`push origin refs/tags/${tag}:refs/tags/${tag}`, { ...opts, timeout: 60_000 });
+      pushError = null;
+    } catch (e) {
+      // Recorded, not trusted: the confirmation below has the final word.
+      pushError = e.message?.slice(0, 300) || "push failed";
+    }
+
+    const confirmed = await confirmTag(tag, sha, opts, retry);
+    if (confirmed.state === "present") return { ok: true, pushAttempts: attempt };
+    if (confirmed.state === "conflict") {
+      return { ok: false, conflict: true, error: immutabilityError(tag, confirmed.sha, sha) };
+    }
+    if (confirmed.unreachable) unreadable = true;
+  }
+
+  const why = unreadable
+    ? `remote could not be read to confirm tag ${tag}`
+    : `tag ${tag} not verifiable on remote`;
+  const bound = timedOut ? `the ${retry.budgetMs}ms retry budget` : `${retry.pushAttempts} push attempt(s)`;
+  const suffix = pushError ? ` (last push error: ${pushError})` : "";
+  return { ok: false, error: `${why} after ${bound}${suffix}` };
 }
 
 export async function handler(params) {
@@ -147,6 +236,20 @@ export async function handler(params) {
   const cwd = params.cwd;
   if (!cwd) throw new Error("cwd is required — MCP server runs in the plugin directory, not the target repo");
   const opts = { cwd };
+  // Schema defaults apply in production; the `??` fallbacks keep direct callers
+  // (and tests) working when the params are passed raw.
+  const budgetMs = params.tagBudgetMs ?? 120_000;
+  const retry = {
+    pushAttempts: params.tagPushAttempts ?? 3,
+    verifyAttempts: params.tagVerifyAttempts ?? 4,
+    delayMs: params.tagRetryDelayMs ?? 1_000,
+    sleepFn: params.sleepFn,
+    budgetMs,
+    // One wall-clock deadline for every tag retry in this call. The push loop
+    // nests the verify loop, so attempt counts alone multiply into a worst case
+    // nobody sized (3 × 4 reads/tag × 2 tags); this is what actually caps it.
+    deadline: budgetMs > 0 ? Date.now() + budgetMs : null,
+  };
 
   const result = { version, from, to };
 
@@ -202,28 +305,53 @@ export async function handler(params) {
     }
 
     const pushed = [];
-    const missing = [];
+    const failed = [];
     let anyCreated = false;
     for (const step of plan) {
-      const r = ensureTag(step.tag, sha, step.payload, opts);
+      const r = await ensureTag(step.tag, sha, step.payload, opts, retry);
       if (r.ok) {
         pushed.push(step.tag);
         if (!r.existed) anyCreated = true;
       } else {
-        missing.push(step.tag);
+        failed.push(step.tag);
         result.error = r.error;
         break; // keep ordering guarantee — don't create bare before stable succeeded
       }
     }
     result.tag = plan[0].tag;
     if (to === "stable") result.bareTag = `v${version}`;
-    result.pushed = pushed;
-    if (missing.length) {
-      // Remaining plan steps that were never attempted are also missing.
-      const attempted = new Set([...pushed, ...missing]);
-      for (const step of plan) if (!attempted.has(step.tag)) missing.push(step.tag);
-      return { ...result, success: false, missing };
+    if (failed.length) {
+      // #251: never declare a tag missing without one last look at the remote.
+      // The reported failure was exactly this — `stable/v0.39.2` listed as
+      // missing while `git ls-remote` showed it present. A tag confirmed on the
+      // remote at the right sha belongs in `pushed`, whatever the push said.
+      const missing = [];
+      for (const tag of failed) {
+        const probe = await confirmTag(tag, sha, opts, retry);
+        if (probe.state === "present") {
+          pushed.push(tag);
+          anyCreated = true; // it did land — the push report was the thing that lied
+        } else {
+          missing.push(tag);
+        }
+      }
+      // Steps we broke out before ever attempting are missing by construction.
+      const accounted = new Set([...pushed, ...missing]);
+      for (const step of plan) if (!accounted.has(step.tag)) missing.push(step.tag);
+      result.pushed = pushed;
+      if (missing.length) {
+        // Keep the original per-tag error only when that tag is still missing;
+        // otherwise it would name a tag we just confirmed as pushed.
+        if (!failed.some((t) => missing.includes(t))) {
+          result.error = `tag(s) not created: ${missing.join(", ")} — re-run ship_promote to complete them`;
+        }
+        return { ...result, success: false, missing };
+      }
+      // Everything reconciled as present after all — the failure was the false
+      // negative itself. Drop the stale error and continue as a success.
+      delete result.error;
     }
+    result.pushed = pushed;
 
     // 6. GitHub Release — stable only (beta is tags-only at launch, PO/O2).
     //    The bare tag push triggers release.yml; poll for its Release, create

--- a/plugins/devops/mcp-server/ship/tools/promote.test.js
+++ b/plugins/devops/mcp-server/ship/tools/promote.test.js
@@ -38,6 +38,11 @@ function params(overrides = {}) {
     // Keep tests fast — production defaults are 6 × 10s.
     releasePollAttempts: 1,
     releasePollDelayMs: 0,
+    // Same for the tag push/verify backoff (production: 3 pushes × 4 verifies,
+    // 1s×3^n). Individual retry tests override these to exercise the loop.
+    tagPushAttempts: 1,
+    tagVerifyAttempts: 1,
+    tagRetryDelayMs: 0,
     ...overrides,
   };
 }
@@ -66,12 +71,22 @@ function objSha(tag) {
 //   PUSH, not the creation;
 // - the ^{} sha peels RECURSIVELY: a nested tag (created on another tag's
 //   OBJECT sha — the 0.116.2 bug class) peels through to the ultimate commit.
-function mockRemote(tags, { annotated = true, pushFails = null } = {}) {
+//
+// Three further options model the #251 failure modes, all of which are about
+// the remote LYING once rather than about the push failing:
+// - pushFails(t)        → `git push` throws for tag t (client-side error);
+// - pushLandsAnyway(t)  → …but the ref updated on the remote regardless
+//                          (the ETIMEDOUT-after-success case);
+// - lsRemoteLag(t)      → the first N ls-remote calls omit t even though it IS
+//                          on the remote (replica lag / eventual consistency);
+// - preLocal            → local tags left behind by an earlier failed run.
+function mockRemote(tags, { annotated = true, pushFails = null, pushLandsAnyway = null, lsRemoteLag = null, preLocal = {} } = {}) {
   // remote: tag -> { obj|null, commit }; local: tag -> target sha given to `git tag -a`
   const remote = new Map(
     Object.entries(tags).map(([t, c]) => [t, annotated ? { obj: objSha(t), commit: c } : { obj: null, commit: c }]),
   );
-  const localTags = new Map();
+  const localTags = new Map(Object.entries(preLocal));
+  const lagLeft = new Map();
   const peelTo = (sha) => {
     for (const [, e] of remote) if (e.obj === sha) return e.commit; // recursive by construction (commit is already fully peeled)
     return sha;
@@ -82,13 +97,21 @@ function mockRemote(tags, { annotated = true, pushFails = null } = {}) {
     }
     return "";
   });
+  const land = (t) => {
+    if (localTags.has(t)) remote.set(t, { obj: objSha(t), commit: peelTo(localTags.get(t)) });
+  };
   gitLib.gitStrict.mockImplementation((cmd) => {
-    const m = /^push origin (\S+)$/.exec(cmd);
+    // Explicit refspec (`refs/tags/<t>:refs/tags/<t>`) so a same-named branch
+    // can never be pushed instead of the tag.
+    const m = /^push origin refs\/tags\/(\S+):refs\/tags\/\1$/.exec(cmd);
     if (m) {
-      if (pushFails && pushFails(m[1])) throw new Error("network");
-      if (localTags.has(m[1])) {
-        remote.set(m[1], { obj: objSha(m[1]), commit: peelTo(localTags.get(m[1])) });
+      if (pushFails && pushFails(m[1])) {
+        // The ref may still have updated before the client gave up — that is
+        // precisely why the push's exit code is not authoritative (#251).
+        if (pushLandsAnyway && pushLandsAnyway(m[1])) land(m[1]);
+        throw new Error("network");
       }
+      land(m[1]);
     }
     return "";
   });
@@ -104,12 +127,32 @@ function mockRemote(tags, { annotated = true, pushFails = null } = {}) {
     return lines;
   };
   gitLib.git.mockImplementation((cmd) => {
+    // Local-tag lookup used by the idempotent ensureLocalTag path. Fully
+    // qualified (`refs/tags/…`) so a same-named branch cannot answer for a tag;
+    // an absent ref makes real `git()` return NULL, not an empty string.
+    const rp = /^rev-parse -q --verify "refs\/tags\/(.+)\^\{commit\}"$/.exec(cmd);
+    if (rp) return localTags.has(rp[1]) ? peelTo(localTags.get(rp[1])) : null;
     if (!cmd.startsWith("ls-remote --tags origin")) return "";
+    // Replica lag: hide a tag that IS on the remote for its first N reads.
+    const hidden = new Set();
+    if (lsRemoteLag) {
+      for (const t of remote.keys()) {
+        if (!lagLeft.has(t)) lagLeft.set(t, lsRemoteLag(t) || 0);
+        if (lagLeft.get(t) > 0) {
+          hidden.add(t);
+          lagLeft.set(t, lagLeft.get(t) - 1);
+        }
+      }
+    }
+    const visible = refLines().filter(([, ref]) => {
+      const t = ref.replace(/^refs\/tags\//, "").replace(/\^\{\}$/, "");
+      return !hidden.has(t);
+    });
     const rest = cmd.slice("ls-remote --tags origin".length).trim();
     const pats = rest ? rest.split(/\s+/).map((p) => p.replace(/^"|"$/g, "")) : [];
     const selected = pats.length
-      ? refLines().filter(([, ref]) => pats.some((p) => ref === `refs/tags/${p}` || ref.endsWith(`/${p}`)))
-      : refLines();
+      ? visible.filter(([, ref]) => pats.some((p) => ref === `refs/tags/${p}` || ref.endsWith(`/${p}`)))
+      : visible;
     return selected.map(([sha, ref]) => `${sha}\t${ref}`).join("\n");
   });
 }
@@ -118,6 +161,9 @@ beforeEach(() => {
   vi.clearAllMocks();
   ghLib.releaseExists.mockReturnValue(true);
 });
+
+// The push command for a tag, in the explicit-refspec form the tool emits.
+const pushCmd = (t) => `push origin refs/tags/${t}:refs/tags/${t}`;
 
 function tagCreateCalls() {
   return execFileSync.mock.calls.filter((c) => c[0] === "git" && c[1][0] === "tag");
@@ -327,5 +373,219 @@ describe("ship_promote — annotated-tag sha resolution (0.116.2 regression)", (
     expect(r.error).toBeUndefined();
     const creates = tagCreateCalls().map((c) => c[1][2]);
     expect(creates).toEqual(["v0.116.2"]); // only the missing bare tag is completed
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #251 — push/verify flakiness: the remote lies once, the tool must not
+// ---------------------------------------------------------------------------
+
+describe("ship_promote — #251 push/verify flakiness", () => {
+  const retryParams = (o = {}) =>
+    params({ tagPushAttempts: 3, tagVerifyAttempts: 4, tagRetryDelayMs: 0, ...o });
+
+  test("a verification that lags once still reports the tag as pushed", async () => {
+    // The reported failure: `stable/v0.39.2` had landed, but the single
+    // post-push ls-remote came back stale → hard failure + wrong missing list.
+    //
+    // tagPushAttempts is pinned to 1 ON PURPOSE: with a push retry available,
+    // the second push would re-land the tag and mask a missing VERIFY retry.
+    // Only the verify loop can rescue this case, so only it is under test.
+    mockRemote({ "beta/v0.113.0": SHA }, { lsRemoteLag: (t) => (t === "stable/v0.113.0" ? 1 : 0) });
+    const r = await handler(retryParams({ from: "beta", to: "stable", tagPushAttempts: 1, tagVerifyAttempts: 3 }));
+    expect(r.success).toBe(true);
+    expect(r.pushed).toEqual(["stable/v0.113.0", "v0.113.0"]);
+    expect(r.missing).toBeUndefined();
+    expect(r.error).toBeUndefined();
+    // Exactly one push — the retry that mattered was the verification.
+    const stablePushes = gitLib.gitStrict.mock.calls
+      .map((c) => c[0])
+      .filter((cmd) => cmd === pushCmd("stable/v0.113.0"));
+    expect(stablePushes).toHaveLength(1);
+  });
+
+  test("the verification is actually re-queried before giving up", async () => {
+    // Counts the ls-remote reads for the tag: one pre-check + N verify attempts.
+    mockRemote({ "beta/v0.113.0": SHA }, { pushFails: (t) => t === "stable/v0.113.0" });
+    await handler(retryParams({ from: "beta", to: "stable", tagPushAttempts: 1, tagVerifyAttempts: 3 }));
+    const reads = gitLib.git.mock.calls
+      .map((c) => c[0])
+      .filter((cmd) => cmd === 'ls-remote --tags origin "stable/v0.113.0" "stable/v0.113.0^{}"');
+    // Exact: 1 pre-check + 3 verify attempts + 3 reconciliation attempts.
+    // The reconciliation deliberately gets the FULL verify budget — it is the
+    // last chance to notice a tag that landed, and tagBudgetMs caps the total.
+    // A >= assertion would still pass if an attempt were silently dropped.
+    expect(reads).toHaveLength(7);
+  });
+
+  test("a push that throws after the ref landed is idempotent, not a failure", async () => {
+    // Client-side ETIMEDOUT while the ref already updated remotely. The push's
+    // exit code must not decide — only the confirmation does.
+    mockRemote(
+      { "beta/v0.113.0": SHA },
+      { pushFails: (t) => t === "v0.113.0", pushLandsAnyway: (t) => t === "v0.113.0" },
+    );
+    const r = await handler(retryParams({ from: "beta", to: "stable" }));
+    expect(r.success).toBe(true);
+    expect(r.pushed).toContain("v0.113.0");
+    expect(r.missing).toBeUndefined();
+  });
+
+  test("a tag genuinely absent after every retry is still reported missing", async () => {
+    // No false positives: retrying must not turn a real failure into success.
+    mockRemote({ "beta/v0.113.0": SHA }, { pushFails: (t) => t === "v0.113.0" });
+    const r = await handler(retryParams({ from: "beta", to: "stable" }));
+    expect(r.success).toBe(false);
+    expect(r.pushed).toEqual(["stable/v0.113.0"]);
+    expect(r.missing).toEqual(["v0.113.0"]);
+    expect(r.error).toMatch(/not verifiable on remote after 3 push attempt/);
+  });
+
+  test("the push is actually retried before giving up", async () => {
+    mockRemote({ "beta/v0.113.0": SHA }, { pushFails: (t) => t === "v0.113.0" });
+    await handler(retryParams({ from: "beta", to: "stable", tagPushAttempts: 3 }));
+    const barePushes = gitLib.gitStrict.mock.calls
+      .map((c) => c[0])
+      .filter((cmd) => cmd === pushCmd("v0.113.0"));
+    expect(barePushes).toHaveLength(3);
+  });
+
+  test("a conflicting tag is never retried — immutability wins immediately", async () => {
+    // A published tag on a DIFFERENT commit is a hard stop, not a lag: retrying
+    // it would burn the whole backoff budget on a decision that cannot change.
+    const OTHER = "f".repeat(40);
+    mockRemote({ "beta/v0.113.0": SHA, "stable/v0.113.0": OTHER });
+    const r = await handler(retryParams({ from: "beta", to: "stable" }));
+    expect(r.success).toBe(false);
+    expect(r.error).toMatch(/immutable/);
+    // The monotonicity/immutability guard fires before any tag is created.
+    expect(tagCreateCalls()).toHaveLength(0);
+  });
+
+  test("a tag confirmed on the remote is never listed in `missing`", async () => {
+    // Reconciliation net: even if every push attempt reported failure, a tag
+    // the remote confirms belongs in `pushed`. Lag outlasts the verify budget
+    // here (2 verifies), so only the final re-probe can rescue it.
+    mockRemote(
+      { "beta/v0.113.0": SHA },
+      {
+        pushFails: (t) => t === "stable/v0.113.0",
+        pushLandsAnyway: (t) => t === "stable/v0.113.0",
+        lsRemoteLag: (t) => (t === "stable/v0.113.0" ? 2 : 0),
+      },
+    );
+    const r = await handler(retryParams({ from: "beta", to: "stable", tagPushAttempts: 1, tagVerifyAttempts: 2 }));
+    expect(r.pushed).toContain("stable/v0.113.0");
+    expect(r.missing || []).not.toContain("stable/v0.113.0");
+    // The bare tag was never attempted (ordering break) → genuinely missing,
+    // and the error must name IT, not the tag we just confirmed as pushed.
+    expect(r.success).toBe(false);
+    expect(r.missing).toEqual(["v0.113.0"]);
+    expect(r.error).toMatch(/v0\.113\.0/);
+    expect(r.error).not.toMatch(/not verifiable/);
+  });
+
+  test("ordering: the bare tag is never created before stable/vN succeeded", async () => {
+    mockRemote({ "beta/v0.113.0": SHA }, { pushFails: (t) => t === "stable/v0.113.0" });
+    const r = await handler(retryParams({ from: "beta", to: "stable" }));
+    expect(r.success).toBe(false);
+    const creates = tagCreateCalls().map((c) => c[1][2]);
+    expect(creates).not.toContain("v0.113.0");
+    expect(r.missing).toEqual(["stable/v0.113.0", "v0.113.0"]);
+  });
+
+  test("a local tag left over from a failed run is reused, not re-created", async () => {
+    // `git tag -a` on an existing name fails — which used to make every re-run
+    // after a partial failure fail permanently instead of completing.
+    mockRemote({ "beta/v0.113.0": SHA }, { preLocal: { "stable/v0.113.0": SHA } });
+    const r = await handler(retryParams({ from: "beta", to: "stable" }));
+    expect(r.success).toBe(true);
+    const creates = tagCreateCalls().map((c) => c[1][2]);
+    expect(creates).not.toContain("stable/v0.113.0"); // reused the leftover
+    expect(creates).toContain("v0.113.0");
+    expect(r.pushed).toEqual(["stable/v0.113.0", "v0.113.0"]);
+  });
+
+  test("a leftover local tag pointing at the WRONG commit is refused, not pushed", async () => {
+    const OTHER = "f".repeat(40);
+    mockRemote({ "beta/v0.113.0": SHA }, { preLocal: { "stable/v0.113.0": OTHER } });
+    const r = await handler(retryParams({ from: "beta", to: "stable" }));
+    expect(r.success).toBe(false);
+    expect(r.error).toMatch(/local tag stable\/v0\.113\.0 points at/);
+    expect(gitLib.gitStrict.mock.calls.map((c) => c[0])).not.toContain(pushCmd("stable/v0.113.0"));
+  });
+});
+
+describe("ship_promote — #251 reconciliation and fail-closed edges", () => {
+  test("reconciliation rescues the LAST failed tag → success:true, stale error dropped", async () => {
+    // The one branch that can flip a reported failure into success: every push
+    // attempt reported failure and the verify budget ran out, but the final
+    // re-probe finds the tag on the remote at the right sha.
+    mockRemote(
+      { "alpha/v0.113.0": SHA },
+      {
+        pushFails: (t) => t === "beta/v0.113.0",
+        pushLandsAnyway: (t) => t === "beta/v0.113.0",
+        lsRemoteLag: (t) => (t === "beta/v0.113.0" ? 1 : 0),
+      },
+    );
+    const r = await handler(params({ tagPushAttempts: 1, tagVerifyAttempts: 1, tagRetryDelayMs: 0 }));
+    expect(r.success).toBe(true);
+    expect(r.pushed).toEqual(["beta/v0.113.0"]);
+    expect(r.missing).toBeUndefined();
+    expect(r.error).toBeUndefined();
+    // It really was created this run — not an "already promoted" no-op.
+    expect(r.alreadyPromoted).toBeUndefined();
+  });
+
+  test("an unreadable remote inside ensureTag refuses to push — never 'absent, push away'", async () => {
+    // Fail-closed (F2): only the TARGET tag's read fails, so the source lookup
+    // and the channel listing still succeed and we reach ensureTag.
+    mockRemote({ "alpha/v0.113.0": SHA });
+    const inner = gitLib.git.getMockImplementation();
+    gitLib.git.mockImplementation((cmd, o) => (cmd.includes('"beta/v0.113.0"') ? null : inner(cmd, o)));
+
+    const r = await handler(params({ tagPushAttempts: 2, tagVerifyAttempts: 2, tagRetryDelayMs: 0 }));
+    expect(r.success).toBe(false);
+    expect(r.error).toMatch(/cannot reach remote/);
+    // Nothing was created or pushed on a remote we could not read.
+    expect(tagCreateCalls()).toHaveLength(0);
+    expect(gitLib.gitStrict.mock.calls.map((c) => c[0])).not.toContain(pushCmd("beta/v0.113.0"));
+    expect(r.missing).toEqual(["beta/v0.113.0"]);
+  });
+
+  test("a remote that goes unreadable only AFTER the push says so, instead of claiming the tag is absent", async () => {
+    mockRemote({ "alpha/v0.113.0": SHA });
+    const inner = gitLib.git.getMockImplementation();
+    let seen = 0;
+    gitLib.git.mockImplementation((cmd, o) => {
+      if (cmd.includes('"beta/v0.113.0"') && ++seen > 1) return null; // pre-check ok, verifies fail
+      return inner(cmd, o);
+    });
+
+    const r = await handler(params({ tagPushAttempts: 1, tagVerifyAttempts: 2, tagRetryDelayMs: 0 }));
+    expect(r.success).toBe(false);
+    expect(r.error).toMatch(/remote could not be read to confirm tag beta\/v0\.113\.0/);
+    expect(r.error).not.toMatch(/not verifiable/);
+  });
+
+  test("the wall-clock budget caps the nested retry loops", async () => {
+    // tagBudgetMs: 0 would disable the cap; a tiny budget must stop the loops
+    // early instead of burning pushAttempts × verifyAttempts reads.
+    mockRemote({ "alpha/v0.113.0": SHA }, { pushFails: () => true });
+    const r = await handler(params({ tagPushAttempts: 5, tagVerifyAttempts: 5, tagRetryDelayMs: 1, tagBudgetMs: 1 }));
+    expect(r.success).toBe(false);
+    const pushes = gitLib.gitStrict.mock.calls.map((c) => c[0]).filter((c) => c === pushCmd("beta/v0.113.0"));
+    expect(pushes.length).toBeLessThan(5);
+    expect(r.error).toMatch(/retry budget/);
+  });
+
+  test("a local BRANCH named like the tag is not mistaken for the tag", async () => {
+    // The rev-parse is fully qualified (refs/tags/…), so an unqualified name
+    // that git would also resolve against refs/heads cannot answer for it.
+    mockRemote({ "alpha/v0.113.0": SHA });
+    await handler(params());
+    const revParses = gitLib.git.mock.calls.map((c) => c[0]).filter((c) => c.startsWith("rev-parse"));
+    expect(revParses).toContain('rev-parse -q --verify "refs/tags/beta/v0.113.0^{commit}"');
   });
 });

--- a/plugins/devops/mcp-server/ship/tools/release.js
+++ b/plugins/devops/mcp-server/ship/tools/release.js
@@ -8,6 +8,8 @@ import { execFileSync } from "node:child_process";
 import { git, gitStrict, gitArgs, currentBranch, headShort, dirtyState, isWorktree, isRebasedOnto, fileOverlap, syncLocalBranch, treeOf } from "../lib/git.js";
 import { createPR, mergePR, findExistingPR, watchPRChecks } from "../lib/github.js";
 import { detectRepoMode } from "../lib/repo-mode.js";
+import { remoteTagExists } from "../lib/remote-tags.js";
+import { retryUntil } from "../lib/retry.js";
 
 export const schema = z.object({
   base: z.string().default("main").describe("Base branch for PR (may be a feature branch for intermediate merges)"),
@@ -20,11 +22,16 @@ export const schema = z.object({
   mergeStrategy: z.enum(["squash", "merge", "rebase"]).default("squash").describe("PR merge strategy. Use 'merge' for overlapping files to preserve ancestry chain."),
   skipChecks: z.boolean().default(false).describe("Skip the pre-merge CI checks gate. Use only for hot-fixes when CI is broken. Env DEVOPS_SHIP_SKIP_CHECKS=1 also forces skip."),
   checksTimeoutSec: z.number().int().min(30).max(3600).default(600).describe("Max seconds to wait for PR CI checks before merging. Default 10 min."),
+  tagVerifyAttempts: z.number().int().min(1).max(20).default(4).describe("How often to re-query the remote before declaring the pushed channel tag unverified"),
+  tagRetryDelayMs: z.number().int().min(0).max(60_000).default(1_000).describe("Base delay for the tag-verify backoff (exponential, ×3 per attempt)"),
   cwd: z.string().describe("Working directory of the target repo (required — must be passed by the caller)"),
 });
 
 export async function handler(params) {
   const { base, title, body, tag, releaseNotes, commitMessage, mergeStrategy, skipChecks, checksTimeoutSec } = params;
+  // Schema defaults apply in production; `??` keeps direct callers/tests working.
+  const tagVerifyAttempts = params.tagVerifyAttempts ?? 4;
+  const tagRetryDelayMs = params.tagRetryDelayMs ?? 1_000;
   const cwd = params.cwd;
   if (!cwd) throw new Error("cwd is required — MCP server runs in the plugin directory, not the target repo");
   const opts = { cwd };
@@ -265,8 +272,22 @@ export async function handler(params) {
     if (!intermediate && tag) {
       const channelTag = `alpha/${tag}`;
       try {
-        const remoteTag = git(`ls-remote --tags origin ${channelTag}`, opts);
-        if (remoteTag && remoteTag.includes(channelTag)) {
+        // Retry the existence read too: a single null here (transient network /
+        // auth blip) used to read as "tag absent" and silently decide to create
+        // one — the same fail-open the verification below was hardened against.
+        const existing = await retryUntil(
+          () => git(`ls-remote --tags origin ${channelTag}`, opts),
+          { attempts: tagVerifyAttempts, delayMs: tagRetryDelayMs },
+        );
+        if (!existing.ok) {
+          // Still unreadable. Creating + pushing is safe (git refuses a
+          // conflicting remote tag), but say so rather than implying we looked.
+          result.tagWarning = `Could not read remote tags to check for ${channelTag} — proceeding to create it.`;
+        }
+        const remoteTag = existing.ok ? existing.value : null;
+        // Exact ref, not a substring: ls-remote tail-matches per path component,
+        // so a query for `v1.0.0` also returns `refs/tags/alpha/v1.0.0` (#251).
+        if (remoteTag !== null && remoteTagExists(remoteTag, channelTag)) {
           result.tagWarning = `Tag ${channelTag} already exists on remote — skipping creation.`;
           result.tagVerified = true;
         } else {
@@ -275,9 +296,19 @@ export async function handler(params) {
             "tag", "-a", channelTag, `origin/${base}`, "-m",
             JSON.stringify({ channel: "alpha", version: tag.replace(/^v/, "") }),
           ], { cwd, encoding: "utf8", timeout: 15_000, stdio: ["pipe", "pipe", "pipe"] });
-          gitStrict(`push origin ${channelTag}`, opts);
-          const tagCheck = git(`ls-remote --tags origin ${channelTag}`, opts);
-          result.tagVerified = tagCheck !== null && tagCheck.includes(channelTag);
+          // 60s like ship_promote's tag push — the 15s default is below a slow
+          // remote's worst case and turned a healthy push into a hard failure.
+          gitStrict(`push origin ${channelTag}`, { ...opts, timeout: 60_000 });
+          // Retry the verification: one negative read right after a push proves
+          // nothing (replica lag), which is the #251 false-negative class.
+          const verified = await retryUntil(
+            () => {
+              const out = git(`ls-remote --tags origin ${channelTag}`, opts);
+              return out !== null && remoteTagExists(out, channelTag) ? true : null;
+            },
+            { attempts: tagVerifyAttempts, delayMs: tagRetryDelayMs },
+          );
+          result.tagVerified = verified.ok;
         }
         result.tag = channelTag;
         result.channel = "alpha";

--- a/plugins/devops/mcp-server/ship/tools/release.test.js
+++ b/plugins/devops/mcp-server/ship/tools/release.test.js
@@ -60,6 +60,9 @@ function params(overrides = {}) {
     skipChecks: false,
     checksTimeoutSec: 600,
     cwd: "/repo",
+    // Keep tests fast — production defaults are 4 attempts with a 1s×3^n backoff.
+    tagVerifyAttempts: 2,
+    tagRetryDelayMs: 0,
     ...overrides,
   };
 }
@@ -419,5 +422,89 @@ describe("ship_release — commitMessage staging (F1: no silent drop)", () => {
 
     expect(res.success).toBe(false);
     expect(ghLib.mergePR).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #251 — the channel-tag verification must not trust one negative read
+// ---------------------------------------------------------------------------
+
+describe("ship_release — #251 channel-tag verification", () => {
+  test("a verification that lags once still reports tagVerified", async () => {
+    // ls-remote calls: 1 = existence check (empty → create), 2 = first verify
+    // (still empty, replica lag), 3 = second verify (tag visible).
+    let lsCalls = 0;
+    gitLib.git.mockImplementation((cmd) => {
+      if (cmd.includes("ls-remote --tags")) {
+        lsCalls += 1;
+        return lsCalls >= 3 ? "abc\trefs/tags/alpha/v1.0.0" : "";
+      }
+      return "remoteSha";
+    });
+
+    const res = await handler(params({ tagVerifyAttempts: 3 }));
+    expect(res.success).toBe(true);
+    expect(res.tagVerified).toBe(true);
+    expect(res.tagError).toBeUndefined();
+  });
+
+  test("a tag genuinely absent after every attempt stays unverified", async () => {
+    gitLib.git.mockImplementation((cmd) => (cmd.includes("ls-remote --tags") ? "" : "remoteSha"));
+    const res = await handler(params({ tagVerifyAttempts: 2 }));
+    expect(res.success).toBe(true); // tag trouble never fails the ship
+    expect(res.tagVerified).toBe(false);
+  });
+
+  test("the existence check is an exact ref — a tail-matching sibling does not count", async () => {
+    // `ls-remote --tags origin alpha/v1.0.0` tail-matches per PATH COMPONENT,
+    // so real git can return `refs/tags/hotfix/alpha/v1.0.0` for this query.
+    // The old substring check (`out.includes("alpha/v1.0.0")`) said "already
+    // exists" and skipped creation; the exact-ref check must not. Picking a ref
+    // real git can actually produce is what makes this test discriminating —
+    // a made-up line both checks reject would prove nothing.
+    let lsCalls = 0;
+    gitLib.git.mockImplementation((cmd) => {
+      if (cmd.includes("ls-remote --tags")) {
+        lsCalls += 1;
+        return lsCalls === 1
+          ? "abc\trefs/tags/hotfix/alpha/v1.0.0" // sibling only — channel tag absent
+          : "abc\trefs/tags/alpha/v1.0.0";
+      }
+      return "remoteSha";
+    });
+
+    const res = await handler(params());
+    expect(res.tagWarning).toBeUndefined(); // did NOT mistake the sibling for the channel tag
+    const { execFileSync } = await import("node:child_process");
+    const tagCall = execFileSync.mock.calls.find((c) => c[0] === "git" && c[1][0] === "tag");
+    expect(tagCall).toBeDefined();
+    expect(tagCall[1][2]).toBe("alpha/v1.0.0");
+    expect(res.tagVerified).toBe(true);
+  });
+
+  test("an unreadable remote is not silently read as 'tag absent'", async () => {
+    // git() returns null on a transient failure. The existence read is retried,
+    // and a persisting null is reported rather than assumed to mean "absent".
+    gitLib.git.mockImplementation((cmd) => (cmd.includes("ls-remote --tags") ? null : "remoteSha"));
+    const res = await handler(params({ tagVerifyAttempts: 2 }));
+    expect(res.success).toBe(true); // tag trouble never fails the ship
+    expect(res.tagWarning).toMatch(/Could not read remote tags/);
+    expect(res.tagVerified).toBe(false);
+  });
+
+  test("the channel-tag push gets the 60s timeout, not the 15s default", async () => {
+    let lsCalls = 0;
+    gitLib.git.mockImplementation((cmd) => {
+      if (cmd.includes("ls-remote --tags")) {
+        lsCalls += 1;
+        return lsCalls === 1 ? "" : "abc\trefs/tags/alpha/v1.0.0";
+      }
+      return "remoteSha";
+    });
+
+    await handler(params());
+    const push = gitLib.gitStrict.mock.calls.find((c) => c[0] === "push origin alpha/v1.0.0");
+    expect(push).toBeDefined();
+    expect(push[1]).toMatchObject({ timeout: 60000 });
   });
 });

--- a/plugins/devops/skills/promote/SKILL.md
+++ b/plugins/devops/skills/promote/SKILL.md
@@ -92,6 +92,21 @@ skip-if-exists idempotent; an already-completed step returns
 `alreadyPromoted: true` and the missing tags are completed
 (`pushed`/`missing` in the result show exactly what happened).
 
+`pushed`/`missing` are decided by the **remote**, not by the push exit code
+(#251). Each tag push is followed by a retrying `ls-remote` confirmation, and
+no tag is reported in `missing` until a final re-query still fails to find it —
+a push that throws `ETIMEDOUT` after the ref already landed therefore reports
+as pushed, not as a failure. Tune with `tagPushAttempts` (default 3),
+`tagVerifyAttempts` (default 4, **per push attempt** — the read budget per tag
+is the product) and `tagRetryDelayMs` (default 1000, ×3 per attempt); all of it
+is capped in wall-clock by `tagBudgetMs` (default 120 000). A tag present on a
+**different** SHA is never retried — that is the immutability guard, and it is
+final. An unreadable remote is likewise never read as "tag absent"; the error
+distinguishes the two.
+
+One state a re-run cannot clear: a **local** tag left at the wrong commit. The
+error names it and the remedy (`git tag -d <tag>`) — delete it, then re-run.
+
 **Guard errors are final** — do not work around them:
 - `monotonicity: ...` → the target channel is already ahead; roll forward
   (ship a newer version) instead.

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.123.2",
+  "version": "0.123.3",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
Closes #251

## Summary

`ship_promote` pushed each tag once and verified it with a **single** `ls-remote` immediately afterwards. That read can hit a replica that has not caught up, so a tag genuinely on the remote came back as `tag stable/v0.39.2 not verifiable on remote after push` — `success: false`, `pushed: []`, and a `missing` list naming a tag `git ls-remote` could see. The failure then broke the ordered plan before the bare `vX.Y.Z` tag was ever attempted, and only that tag triggers the consumer's `release.yml` — so the stable go-live silently did not build and needed manual tag surgery.

Neither the push's exit code nor one post-push read is authoritative: a push can throw `ETIMEDOUT` *after* the ref already updated, and a push can succeed while the very next read hits a lagging replica. Every push is now followed by a *retrying* confirmation, and the confirmation decides. Nothing is reported missing until a final re-query still fails to find it.

## Changes

- **New `lib/retry.js`** — exponential backoff with jitter, `retryUntil`, and a wall-clock `deadline`. **New `lib/remote-tags.js`** — exact-ref `ls-remote` parsing, shared with `ship_release`.
- **Guards kept exactly as strict.** A tag on a *different* sha is never retried (immutability is final, and retrying could not change it). An unreadable remote is never read as "tag absent" — and the error now says which of the two it was. The bare tag still never precedes `stable/vN`.
- **Re-runs are idempotent again.** `git tag -a` refuses an existing name, so a local tag left by an interrupted run made every later re-run fail permanently — the opposite of the documented recovery. A leftover at the expected commit is reused; one anywhere else is refused, with `git tag -d <tag>` named in the message.
- **Fully qualified refs.** The lookup and the push both used unqualified names, which git resolves against `refs/heads` too — a branch called `v0.113.0` would have answered for the tag, and the push could have published a branch under it. Now `refs/tags/…` and an explicit `refs/tags/x:refs/tags/x` refspec. `version` is constrained to a semver shape since it reaches shell-executed git commands.
- **`tagBudgetMs` (120 s)** caps the nested push×verify loops. The attempt counts alone multiplied into a worst case nobody had sized (3×4 reads per tag, ~17 min on an unreachable remote) — strictly worse than the bug being fixed.
- **`ship_release` hardening**, same defect family: exact-ref check instead of substring (`ls-remote` tail-matches per path component, so a query for `alpha/v1.0.0` also returns `refs/tags/hotfix/alpha/v1.0.0`), retried existence read *and* verification, no more silent "unreadable ⇒ absent", and the 60 s push timeout `ship_promote` already used.

## Verification

- 946 tests green (52 files), eslint clean. 33 new tests across `retry`, `remote-tags`, `promote` and `release`.
- **Mutation-verified** — three separate reverts each fail tests that pass on the real implementation: a single-shot verify (1 test), trusting the push exit code (3 tests), dropping the reconciliation re-probe (1 test). The first verify-mutation attempt *passed*, revealing that the push retry masked it; the test was tightened to pin `tagPushAttempts: 1` and assert exactly one push.
- The `mockRemote` harness gained `pushLandsAnyway`, `lsRemoteLag` and `preLocal` so the ETIMEDOUT-after-success, replica-lag and leftover-tag cases are modelled rather than asserted.
- Adversarial red-team pass; its four substantive findings (unbounded retry time, ref ambiguity, shell interpolation of `version`, `ship_release` fail-open) are all fixed above, plus the four test gaps it identified.
- Codex review gate unavailable this ship (external usage limit), non-blocking.

## Deviation from the refined plan

The issue refinement proposed extracting `mergePR`'s inline backoff (`lib/github.js`) into the shared helper. Not done: converting the merge-verification path to async would ripple through the entire ship path during an unattended run, and its tests neutralize the sleep via the `execSync` mock. New code uses `lib/retry.js`; `mergePR` keeps its own loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)