### PR TITLE
feat(concept): live scroll position marker in the panel TOC

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.123.3"
+    "version": "0.124.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.123.3",
+      "version": "0.124.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.123.3",
+      "version": "0.124.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.124.0] — 2026-07-28
+
+### Fixed
+
+- **The concept feedback panel's table of contents now shows where you are while scrolling — reliably, and without making you hunt for the marker in a long list.** The "you are here" highlight existed but was effectively dead in the two situations that matter most. It was bound once at `DOMContentLoaded`, while `buildSectionNav()` replaces the entire nav DOM on every iteration switch — so after clicking any tab, the observer pointed at detached nodes and nothing was ever highlighted again. And its `IntersectionObserver` band (`rootMargin: -30% 0px -60% 0px`) was only about a tenth of the viewport tall: a section shorter than the gap between two entries never won it, and neither did the last section, which on most pages cannot scroll far enough to reach the band at all.
+
+  The marker now follows a reading line at 28% viewport height — the last section starting above it wins — with the first and last entry pinned at the scroll extremes so both ends of the page are reachable. The spy rebinds from inside `buildSectionNav()`, so an iteration switch carries it along. In a TOC too long to fit the panel, the active entry auto-reveals: only the panel's own scroll box moves, never the content column, so it cannot fight your scrolling. The marker itself is a 3px inset accent bar plus tint and bold weight — an inset box-shadow rather than a border, so the entry does not shift horizontally when it activates. Two new validation-gate patterns (39, 40) keep the rebinding and the panel-only reveal from regressing.
+
 ## [0.123.3] — 2026-07-28
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.123.3**
+**Version: 0.124.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.123.3",
+  "version": "0.124.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/skills/concept/deep-knowledge/templates.md
+++ b/plugins/devops/skills/concept/deep-knowledge/templates.md
@@ -1733,6 +1733,11 @@ current iteration gets a clickable nav entry — not just variants. Sections
 with a bi-state radio group additionally display the current evaluation
 state.
 
+A scroll spy marks the section the user is currently reading with
+`.is-active` (accent bar + tint), and auto-scrolls the TOC so that marker
+stays visible even in a long list. Without it, a 20-entry TOC forces the user
+to hunt for their own position on every scroll.
+
 ```css
 .section-nav {
   display: flex;
@@ -1751,7 +1756,7 @@ state.
   text-decoration: none;
   color: var(--text-color, #c9d1d9);
   font-size: 0.9rem;
-  transition: background 0.15s;
+  transition: background 0.15s, box-shadow 0.15s;
   cursor: pointer;
 }
 .section-nav-item:hover {
@@ -1768,9 +1773,17 @@ state.
 }
 .section-nav-state.state-discard { color: var(--danger-color, #f85149); }
 .section-nav-state.state-only { color: var(--success-color, #3fb950); }
+/* "You are here" marker — driven by the scroll spy, NOT by :target or click
+   alone. The accent bar is an inset box-shadow (not a border) so the entry
+   never shifts horizontally when it becomes active. */
 .section-nav-item.is-active {
   background: color-mix(in srgb, var(--accent-color, #58a6ff) 18%, transparent);
+  box-shadow: inset 3px 0 0 var(--accent-color, #58a6ff);
   font-weight: 600;
+}
+.section-nav-item.is-active .section-nav-label { opacity: 1; }
+@media (prefers-reduced-motion: reduce) {
+  .section-nav-item { transition: none; }
 }
 ```
 
@@ -1787,6 +1800,12 @@ Sections without `data-nav-label` are skipped by the TOC auto-populator.
 
 ```javascript
 // --- Section Navigation (Decision Panel as TOC) ---
+// Rebuilt by installScrollSpy() on EVERY nav rebuild. An iteration switch
+// replaces the whole nav DOM, so a spy bound once at load would silently stop
+// highlighting on every tab except the one that existed at DOMContentLoaded.
+let scrollSpyEntries = [];
+let scrollSpyFrame = 0;
+
 function buildSectionNav() {
   const nav = document.getElementById('section-nav');
   if (!nav) return;
@@ -1817,6 +1836,7 @@ function buildSectionNav() {
     nav.appendChild(link);
   });
   updateSectionNavState();
+  installScrollSpy();   // nav DOM was replaced → rebind the spy
 }
 
 function updateSectionNavState() {
@@ -1838,41 +1858,106 @@ document.addEventListener('click', e => {
   if (!link) return;
   e.preventDefault();
   const target = document.querySelector(link.getAttribute('href'));
-  if (target) target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  if (!target) return;
+  setActiveNavItem(link);   // instant feedback; the spy confirms it once the smooth scroll settles
+  target.scrollIntoView({ behavior: 'smooth', block: 'start' });
 });
 
 function installScrollSpy() {
-  const items = document.querySelectorAll('.section-nav-item');
-  if (!items.length) return;
-  const byId = new Map();
-  items.forEach(i => byId.set(i.dataset.sectionId, i));
-  const io = new IntersectionObserver(entries => {
-    entries.forEach(en => {
-      const item = byId.get(en.target.id);
-      if (!item) return;
-      if (en.isIntersecting) {
-        items.forEach(i => i.classList.remove('is-active'));
-        item.classList.add('is-active');
-      }
-    });
-  }, { rootMargin: '-30% 0px -60% 0px', threshold: 0 });
-  byId.forEach((_, id) => {
-    const sec = document.getElementById(id);
-    if (sec) io.observe(sec);
+  scrollSpyEntries = [];
+  document.querySelectorAll('.section-nav-item').forEach(item => {
+    const sec = document.getElementById(item.dataset.sectionId);
+    if (sec) scrollSpyEntries.push({ item, section: sec });
+  });
+  updateScrollSpy();
+}
+
+function setActiveNavItem(item) {
+  if (!item || item.classList.contains('is-active')) return;
+  scrollSpyEntries.forEach(({ item: other }) => {
+    other.classList.remove('is-active');
+    other.removeAttribute('aria-current');
+  });
+  item.classList.add('is-active');
+  item.setAttribute('aria-current', 'true');
+  revealNavItem(item);
+}
+
+// Nearest ancestor that actually scrolls. Returns null when nothing between
+// `el` and <body> scrolls, so callers can fall back to the document.
+function nearestScrollBox(el) {
+  for (let n = el; n && n !== document.body; n = n.parentElement) {
+    const oy = getComputedStyle(n).overflowY;
+    if (/(auto|scroll|overlay)/.test(oy) && n.scrollHeight > n.clientHeight + 1) return n;
+  }
+  return null;
+}
+
+// Keeps the active entry inside the visible part of a long TOC. Scrolls ONLY
+// the panel's own scroll box — never the content column — and only when the
+// entry is genuinely out of view, so it can't fight the user's scrolling.
+function revealNavItem(item) {
+  const box = nearestScrollBox(item.parentElement);
+  if (!box) return;
+  const boxRect = box.getBoundingClientRect();
+  const itemRect = item.getBoundingClientRect();
+  const pad = 12;
+  if (itemRect.top < boxRect.top + pad) {
+    box.scrollTop -= (boxRect.top + pad) - itemRect.top;
+  } else if (itemRect.bottom > boxRect.bottom - pad) {
+    box.scrollTop += itemRect.bottom - (boxRect.bottom - pad);
+  }
+}
+
+// Picks the section that owns the "reading line" (28% down the viewport):
+// the LAST section whose top is above the line. This is deliberately not
+// IntersectionObserver's isIntersecting — a section taller than the observer
+// band, or shorter than the gap between two entries, produces gaps and
+// flicker there. Two edge cases are pinned explicitly: above the first
+// section the first entry stays active, and at the very bottom of the scroll
+// container the last entry wins (a short trailing section may never reach
+// the line on its own).
+function updateScrollSpy() {
+  if (!scrollSpyEntries.length) return;
+  const line = window.innerHeight * 0.28;
+  let active = null;
+  for (const entry of scrollSpyEntries) {
+    if (entry.section.getBoundingClientRect().top <= line) active = entry;
+  }
+  if (!active) active = scrollSpyEntries[0];
+  const box = nearestScrollBox(scrollSpyEntries[0].section.parentElement)
+    || document.documentElement;
+  if (box.scrollHeight - box.scrollTop - box.clientHeight < 4) {
+    active = scrollSpyEntries[scrollSpyEntries.length - 1];
+  }
+  setActiveNavItem(active.item);
+}
+
+function scheduleScrollSpy() {
+  if (scrollSpyFrame) return;
+  scrollSpyFrame = requestAnimationFrame(() => {
+    scrollSpyFrame = 0;
+    updateScrollSpy();
   });
 }
 
+// Capture phase: scroll events do NOT bubble, so a listener on document only
+// sees them during capture. This covers both the document scroll and an inner
+// .concept-content scroll box without knowing which one is in play.
+document.addEventListener('scroll', scheduleScrollSpy, { capture: true, passive: true });
+window.addEventListener('resize', scheduleScrollSpy, { passive: true });
+
 document.addEventListener('change', updateSectionNavState);
-document.addEventListener('DOMContentLoaded', () => {
-  buildSectionNav();
-  installScrollSpy();
-});
+document.addEventListener('DOMContentLoaded', buildSectionNav);
 ```
 
 **Important:**
 - Every navigable `<section>` needs `id` AND `data-nav-label`.
 - If a section has a bi-state radio group, its `name` MUST be `eval-{section-id}`.
 - `buildSectionNav()` must run again after every iteration switch.
+- Never call `installScrollSpy()` on its own — `buildSectionNav()` calls it as
+  its last step. Binding it independently is how the highlight goes stale
+  after a tab switch.
 
 ## Decision Panel State CSS
 

--- a/plugins/devops/skills/concept/deep-knowledge/validation-gate.md
+++ b/plugins/devops/skills/concept/deep-knowledge/validation-gate.md
@@ -33,7 +33,7 @@ no legitimate matches — do not "keep it as a convenience". The decision panel
 
 ## Phase 1 — Shared patterns (ALL templates)
 
-Every concept page must contain these 38 patterns, regardless of template:
+Every concept page must contain these 40 patterns, regardless of template:
 
 | # | Pattern to grep | Purpose |
 |---|----------------|---------|

--- a/plugins/devops/skills/concept/deep-knowledge/validation-gate.md
+++ b/plugins/devops/skills/concept/deep-knowledge/validation-gate.md
@@ -76,6 +76,8 @@ Every concept page must contain these 38 patterns, regardless of template:
 | 36 | `status-channel` | Persistent status channel on the final-report panel — the always-visible pipeline recap (Übermittelt → verarbeitet → implementiert → Bereit) that leads to the ship CTA. DOM-driven so it survives reload + stale heartbeat. See templates.md § Final Report Panel. |
 | 37 | `ship-btn` | The persistent channel's primary "🚀 Shippen" CTA. Fires `action: "ship"` (real release pipeline). |
 | 38 | `submitShip` | JS handler wired to `#ship-btn`. POSTs `action: "ship"` with the current disposition. Dropping it leaves the ship button visible but inert (no console error, no network request on click). |
+| 39 | `installScrollSpy` called from **inside** `buildSectionNav` | Scroll-position marker for the panel TOC. `buildSectionNav()` replaces the nav DOM on every iteration switch, so the spy MUST be rebound as its last step. Binding it once from `DOMContentLoaded` instead leaves the highlight dead on every tab except the initially loaded one. See templates.md § Section Navigation. |
+| 40 | `revealNavItem` | Auto-scrolls the TOC's own scroll box so the active entry stays visible in long lists. Must scroll only `nearestScrollBox(item.parentElement)` — never `scrollIntoView()` on the item, which drags the content column along and fights the user's scrolling. |
 
 **Failure for 21 / 22:** if either pattern is missing, the page is rejected
 at the post-generation gate. See § Generic Form Collection below for the

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.123.3",
+  "version": "0.124.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

The concept feedback panel's TOC highlighted the section you are reading, but the highlight was effectively dead in the two situations that matter most — and even when it worked, a long TOC could scroll the marker out of the visible panel area, which is exactly the "where am I again?" problem it was supposed to solve.

## What was broken

1. **Iteration switches killed it.** `installScrollSpy()` was bound once from `DOMContentLoaded`, but `buildSectionNav()` replaces the entire nav DOM on every iteration switch. After clicking any tab, the observer held detached nodes — no entry was ever highlighted again.
2. **The observer band was too thin.** `rootMargin: -30% 0px -60% 0px` leaves a band ~10% of the viewport tall. A section shorter than the gap between two entries never won it, and the trailing section — which on most pages cannot scroll far enough to reach the band — never won it either.

## What changed

- **Reading-line resolver** replaces `isIntersecting`: the last section whose top is above 28% viewport height wins, with the first and last entry pinned at the scroll extremes so both ends of the page are reachable.
- **Rebind from inside `buildSectionNav()`** so a tab switch carries the spy along.
- **Auto-reveal in long TOCs**: when the active entry leaves the panel's visible area, only `nearestScrollBox(item.parentElement)` moves — the content column is never dragged, so the reveal cannot fight the user's scrolling.
- **Marker style**: 3px inset accent bar + tint + bold. An inset `box-shadow`, not a border, so the entry does not shift horizontally when it activates.
- **Validation gate 39/40** pin the rebinding and the panel-only reveal so both regressions stay fixed.

## Verification

Driven in a real browser against the reference layout (sticky `overflow-y: auto` panel, two iterations, mixed 900px/120px sections):

- highlight tracks scroll across long and short sections
- top of page pins the first entry, bottom of page pins the last
- survives an iteration switch (nav rebuilt to 6 entries, highlight live on the new tab)
- auto-reveal moved the panel (`scrollTop` 0 → 127) with `window.scrollY` untouched
- exactly one `.is-active` at all times; `aria-current` set; computed `box-shadow` is `rgb(88, 166, 255) 3px 0px 0px 0px inset`

`npm run lint` clean, 946 tests pass.

> Codex review gate: unavailable this run (`ERROR: You've hit your usage limit`) — proceeded per the skill's non-zero-exit rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)