### PR TITLE
feat(concept): per-iteration layout and fullscreen design mode

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.124.1"
+    "version": "0.125.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.124.1",
+      "version": "0.125.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.124.1",
+      "version": "0.125.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.125.0] — 2026-08-03
+
+### Added
+
+- **A concept page can now switch layout per iteration, and design work finally gets the whole screen.** Until now a page picked one layout and kept it: sidebar with variant cards, or fullscreen mockup, for its entire life. Real concept work does not divide that cleanly — a round of "which data source do we use" is followed by a round of "which of these three looks right", and the second one needs the viewport that the first one spends on pros and cons. Each `<section data-iteration>` now carries its own `data-iteration-template`, and `<html data-template>` became a projection of whichever iteration is active. Clicking a tab switches the layout with it. Decision round, design round, decision round again — any order, as often as the work needs.
+
+  The fullscreen layout gained the structure that was missing for comparing designs: an iteration holds several `<section data-design>`, each owning its own pages, so three competing directions with two screens each are one iteration rather than three pages or eighteen variant cards. A switcher sits at the top centre at 18% opacity and expands on hover or keyboard focus — present enough to find, faint enough that the mockup owns the screen. Each design remembers the page you last looked at, so switching away to compare and back does not dump you on page one. Feedback comes in three levels — on the concept, on this design, on this page — in a dock that opens on load so you can see what it collects, then gets out of the way the first time you touch the mockup and never interrupts again. The burger moved to the top right, which freed the bottom-right corner the feedback bubble used to reserve.
+
+### Fixed
+
+- **Concepts that compare visual directions no longer get forced into the sidebar layout.** A tie-breaker rule said that a page with variants *and* mockups is a decision page with mockups inlined, and rethink runs hard-wired the decision template on top of it. Between them, the fullscreen layout was unreachable for exactly the work it was built for. The observed result was a page with 21 variants where the same three layout options appeared **twice** — once with pros and cons, once again labelled "visual" — because a mockup does not fit in a 340px card, so the model wrote the decision out a second time. The tie-breaker is gone with no replacement, the layout check runs per iteration, and rethink defers to it: visual directions get a design iteration with real mockups, everything else gets a decision iteration.
+
+- **Feedback typed into a design page survives switching designs.** The dock rebuilt its page textareas from scratch on every design switch, and the state writer serialises only what is currently in the DOM — so switching away deleted the note *and* its stored copy, and the submit payload silently carried only the design you happened to be looking at. Page textareas for every design of the iteration are now built once and shown or hidden, which also makes the payload complete: comment on four pages across two designs, submit, and all four arrive. The dock's auto-close had a second, unconditional listener behind the deliberately one-shot one, so it kept closing on every outside click even after you had reopened it by hand; there is one path now, and it honours the one-shot flag.
+
+- **The concept validation gate stopped failing pages for elements that no longer exist.** The gate is blocking and still required two ids the dock rebuild had renamed, so every freshly generated design page hard-failed its own check — with the plausible "repair" being two dead elements added to satisfy the checker. Both patterns accept the new and the legacy id now, and the design-level textarea got the pattern it never had. Alongside: a frozen design iteration stays navigable and shows its submitted feedback read-only instead of empty editable fields, click-through links inside a mockup can no longer reach into another design's pages, and the top-bar elements no longer overlap at 768px and 375px — measured at 0px, where the previous claim of "verified" was off by 21px and a full overlap respectively.
+
 ## [0.124.1] — 2026-07-30
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.124.1**
+**Version: 0.125.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/docs/superpowers/specs/2026-08-03-concept-per-iteration-design-mode-design.md
+++ b/docs/superpowers/specs/2026-08-03-concept-per-iteration-design-mode-design.md
@@ -1,0 +1,358 @@
+# Concept — Per-Iteration Layout & Fullscreen Design Mode
+
+*Date: 2026-08-03 · Skill: `plugins/devops/skills/concept`*
+
+## Problem
+
+Fullscreen design-concepting is unreachable in practice. Two rules force every
+concept that mixes design directions with mockups into the sidebar `decision`
+layout:
+
+1. `skills/concept/SKILL.md:93` — tie-breaker: *"A page with variants AND
+   mockups (rare) is a `decision` with inline mockups, not a `prototype` —
+   prototype is reserved for single-artefact presentation."*
+2. `skills/tune-rethink/SKILL.md:138` — *"Invoke `concept` (decision
+   template). Each approach is a variant."* Hard-wired.
+
+Observed failure: a concept page with 21 variants rendered as `decision`, where
+the layout options `A1/A2/A3` appear **twice** — once conceptually with
+pros/cons, once again labelled `— visuell` — because mockups do not fit into
+340px variant cards. The same decision, written twice.
+
+Second gap: even when `prototype` *is* chosen, it models `concept → screens`.
+There is no notion of several competing **designs**, each owning its own set of
+pages.
+
+## Goal
+
+A concept is a stack of iterations. **Each iteration independently picks its own
+layout** — `decision`, `free`, or `design` — in any order, as often as needed.
+Iteration 1 may be a decision round, iteration 2 a fullscreen design round,
+iteration 3 a decision round again.
+
+The `design` layout gives the entire viewport to the mockup, carries several
+designs per iteration (each with 1..n pages), and collects feedback on three
+levels: general, per design, per page.
+
+## Non-goals
+
+- No fourth template with duplicated layout/JS. `design` is the existing
+  `prototype` path, extended.
+- No variant tri-state inside the design layout. Non-visual decisions belong in
+  a `decision` iteration, not squeezed into the overlay panel.
+- No change to the bridge server, submit protocol, or persistence contract
+  beyond additive payload fields.
+
+---
+
+## Architecture
+
+### Per-iteration layout
+
+`data-template` on `<html>` stays as the single source of truth *for CSS
+selectors and JS branches*, but becomes a **projection** of the active
+iteration rather than a page-level constant:
+
+```html
+<html data-template="decision">              <!-- mirrors the ACTIVE iteration -->
+  <section data-iteration="1" data-iteration-template="decision" data-active>
+  <section data-iteration="2" data-iteration-template="design" hidden>
+  <section data-iteration="3" data-iteration-template="decision" hidden>
+```
+
+`data-iteration-template` on the section is authoritative. A new
+`applyIterationTemplate(section)` copies its value onto
+`document.documentElement.dataset.template` and is called from `showIteration()`
+(`templates.md:3546`) **before** `buildSectionNav()` — every existing CSS rule
+(`.concept-layout[data-template="design"]`) and JS branch
+(`collectDecisions`, `templates.md:2632`) then works unchanged.
+
+**Canonical value is `design`.** `prototype` is accepted as a legacy alias and
+normalised to `design` inside `applyIterationTemplate()` (one line), so existing
+pages such as `2026-06-03-sc-org-vereinsseite.html` keep working.
+
+If `data-iteration-template` is absent, fall back to the `<html data-template>`
+value written at generation time. Pages generated before this change keep their
+current behaviour with zero edits.
+
+### What the switch toggles
+
+| | `decision` / `free` | `design` |
+|---|---|---|
+| Layout | grid `1fr 340px` | fullscreen, `overflow: hidden` |
+| Panel | docked, always visible | overlay behind ☰ |
+| ☰ FAB | absent | **top right** |
+| 💬 FAB | absent | bottom left |
+| Feedback dock | absent | present, three levels |
+| Design switcher | absent | ghost bar, top centre, only when ≥2 designs |
+| Body scroll | normal | locked |
+
+The switch is CSS-driven off `<html data-template>`; `applyIterationTemplate()`
+only sets the attribute and locks/unlocks `body` scroll. No layout code runs per
+iteration beyond that.
+
+### Frozen design iterations
+
+A frozen `design` iteration stays navigable: design switcher and page navigation
+keep working (the user must be able to revisit mockups), textareas are
+`readonly`, submit is not armed. Same freeze rules as
+`iteration-rules.md:24`, with navigation explicitly exempt from the
+`disabled`-everything sweep — freeze must skip `.design-switch-item`,
+`.screen-nav-item`, `#panel-toggle`, `#feedback-toggle` and `#feedback-close`.
+
+---
+
+## The design layer
+
+### Markup
+
+```html
+<section data-iteration="2" data-iteration-template="design" data-active>
+  <section data-design="dispatch" data-nav-label="Dispatch and Apparatus" data-design-active="true">
+    <section id="d1-s1" data-screen data-nav-label="Übersicht" data-screen-active="true">
+      <div class="device-frame">…mock…</div>
+    </section>
+    <section id="d1-s2" data-screen data-nav-label="Detail" hidden>…</div>
+  </section>
+  <section data-design="holotable" data-nav-label="Holotable" hidden>
+    <section id="d2-s1" data-screen data-nav-label="Übersicht" data-screen-active="true">…</section>
+  </section>
+</section>
+```
+
+Rules:
+
+- Exactly one `data-design` carries `data-design-active="true"`; the others are
+  `hidden`.
+- Within the active design, exactly one `data-screen` carries
+  `data-screen-active="true"`.
+- Each design remembers its own last-viewed page. Switching away and back
+  returns to that page, not to page 1.
+- **One design** → degenerates to today's behaviour: no switcher, no per-design
+  feedback field. The `data-design` wrapper is still required so the markup
+  shape stays uniform.
+- `data-screen-link` click-dummy wiring (`templates.md:874`) is scoped to the
+  active design — a link may only target screens within its own design.
+
+### Design switcher — ghost bar
+
+Top centre, horizontally centred, `top: 0.75rem`. Must never collide with the ☰
+FAB (top right) or the screen indicator (top left).
+
+- **Resting state:** `opacity: 0.18`, backdrop blur, the active design's label
+  only, no separators, no background fill. Deliberately barely there — the
+  viewport belongs to the mockup.
+- **On hover / keyboard focus:** transitions to `opacity: 1` over 160ms and
+  expands to the full segmented control (one segment per design).
+- Focus-visible must reveal it for keyboard users; it is not hover-only.
+- Hidden entirely when the iteration has fewer than two designs.
+- Auto-hides while the ☰ panel is open (the panel carries the same navigation).
+
+### Screen indicator
+
+Extended from `Screen N / Total · Label` to carry the full position, since the
+iteration tabs live inside the now-hidden panel:
+
+```
+Iteration 2 · Dispatch · Seite 1 / 3 · Übersicht
+```
+
+The iteration segment renders only when the concept has more than one
+iteration; the design segment only when the iteration has more than one design.
+
+### Panel navigation
+
+`screen-nav` becomes two-level: a design heading per `data-design`, its pages
+nested beneath. The existing `●` unsubmitted-notes marker applies at both
+levels — a design heading shows it when any of its pages or its own design-level
+field carries unsubmitted text. Clicking either level switches and closes the
+panel, as today.
+
+Panel content is otherwise **unchanged** from what `templates.md:961-1023`
+already renders: iteration tabs, connection pill, submit-iterate,
+submit-implement, submitted progress list.
+
+---
+
+## Feedback dock
+
+### Three levels
+
+```
+┌─ Feedback ──────────────── − ┐
+│ Allgemein                    │  data-comment="general"
+│ ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ │
+│ ──────────────────────────── │
+│ Zu Design: Dispatch          │  data-comment="design-{id}"
+│ ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ │  data-design-comment="{id}"
+│ ──────────────────────────── │
+│ Zu Seite: Übersicht          │  data-comment="{screen-id}"
+│ ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ │  data-screen-comment="{screen-id}"
+└──────────────────────────────┘
+```
+
+One hidden textarea per design and per screen; only the ones matching the
+current position are visible. Same swap mechanism the screen textareas already
+use (`templates.md:1042`). The design row is omitted when the iteration has one
+design.
+
+Order is general → design → page: the stable field sits at the top so it does
+not jump when the user navigates.
+
+### Open by default, closes on first interaction
+
+`data-open="true"` at load. It closes automatically on the **first** of:
+
+- a click anywhere inside the mockup (`.device-frame` or any `data-screen`),
+- a design switch,
+- a page switch.
+
+After that first auto-close the dock behaves exactly as today — manual toggle
+via 💬 only, never auto-closing again. A `data-auto-close-armed` flag on the
+dock tracks this; it is cleared on first fire.
+
+Auto-close must **not** trigger on clicks inside the dock itself, on either FAB,
+or on the design switcher.
+
+The auto-close is not applied to frozen iterations (nothing to type there, the
+dock opens read-only for review).
+
+### FAB positions
+
+- ☰ `panel-fab`: **top right** (`top: 2rem; right: 2rem`) — was
+  `bottom: 2rem; right: 2rem` (`templates.md:1133`).
+- 💬 `feedback-fab`: unchanged, bottom left.
+
+Moving ☰ out of the bottom-right corner **simplifies** the dock geometry: the
+current bubble reserves horizontal space for the ☰ FAB
+(`right: FAB.right + 56 + 1rem`, `templates.md:1181`) and lifts itself above the
+FAB on narrow viewports (`templates.md:1257`). Both reservations are removed —
+the dock may now span to the right edge minus a normal margin. The
+`transform-origin` anchoring to the 💬 FAB stays.
+
+Verify at 1280px, 768px and 375px that dock, switcher, indicator and both FABs
+do not overlap.
+
+---
+
+### Locale keys
+
+Localisation is mandatory (`SKILL.md` § Localisation) — nothing below may be
+hard-coded in German or English. Existing `proto.*` keys (`templates.md:109-115`)
+are reused under a `design.*` namespace, with the `proto.*` names kept as aliases
+so legacy pages resolve. New keys required:
+
+| Key | en | de |
+|---|---|---|
+| `design.feedback_design` | Notes on this design | Anmerkungen zu diesem Design |
+| `design.feedback_design_placeholder` | Write a note on this design… | Notiz zu diesem Design… |
+| `design.switch_label` | Switch design | Design wechseln |
+| `design.position` | Iteration {i} · {design} · Page {n} / {total} | Iteration {i} · {design} · Seite {n} / {total} |
+
+`proto.feedback_general` currently reads "General notes on this **prototype**".
+Reword to "on this concept" / "zu diesem Konzept" — with several designs on
+screen, "prototype" no longer names the thing being commented on.
+
+### Single-design collapse
+
+The existing `body[data-single-screen="true"]` mechanism (`templates.md:1278`)
+gains a sibling `body[data-single-design="true"]`, set by the same wiring pass.
+It hides the design switcher and the design feedback row via CSS only — no JS
+branching, matching how single-screen is already handled.
+
+## Payload
+
+`collectPrototypeDecisions()` (`templates.md:1567`) is renamed
+`collectDesignDecisions()` and extended. Additive only — existing consumers keep
+working:
+
+```json
+{
+  "submitted": true,
+  "template": "design",
+  "iteration": 2,
+  "decisions": [],
+  "comments": {
+    "general": "…",
+    "designs": { "dispatch": "…", "holotable": "…" },
+    "screens": { "d1-s1": "…", "d1-s2": "…" }
+  }
+}
+```
+
+`comments.screens` keeps the existing flat screen-id keying, so no consumer
+needs to learn the design nesting to read page feedback. The dispatcher at
+`templates.md:2632` reads the active iteration's template instead of
+`<html>`'s — behaviour is identical whenever a page has one iteration.
+
+The generic collection gate (`iteration-rules.md:59`) still applies: collection
+must stay a `querySelectorAll('input, select, textarea')` scoped to
+`[data-active]`, never hand-listed selectors.
+
+---
+
+## Selection rules
+
+### `skills/concept/SKILL.md`
+
+- Step 1a becomes **per-iteration**: the ordered check runs when an iteration is
+  created, not once per page.
+- The tie-breaker at `:93` ("variants AND mockups → decision") is **deleted**.
+  It is the direct cause of the observed failure.
+- New wording for step 1: if the options an iteration puts up for decision are
+  primarily visual — layouts, design directions, screen composition, visual
+  arrangement — the iteration is `design`. If they are ≥2 substantive
+  non-visual alternatives → `decision`. Otherwise → `free`.
+- Add: a concept whose visual and non-visual questions are entangled should
+  **split them across iterations**, not mix them into one layout.
+- `:98` updated: `data-template` on `<html>` mirrors the active iteration;
+  `data-iteration-template` on each section is authoritative.
+
+### `skills/tune-rethink/SKILL.md:138`
+
+No longer hard-wired to `decision`. Rethink emits the approaches as one or more
+iterations, each picking its layout by the rule above — visual design directions
+land in a `design` iteration with real mockups instead of being flattened into
+variant cards.
+
+### `deep-knowledge/validation-gate.md`
+
+`:7`, `:145`, `:213` — validate `data-iteration-template` on every
+`section[data-iteration]`, and `<html data-template>` matching the active
+section. Missing `data-iteration-template` is a warning (legacy fallback), a
+mismatch between `<html>` and the active section is an error.
+
+---
+
+## Testing
+
+The concept skill has no unit-test harness; verification is the existing
+`validation-gate.md` gate plus a rendered page opened in the browser.
+
+1. **Regression:** open `2026-06-03-sc-org-vereinsseite.html` (legacy
+   `prototype`, no `data-iteration-template`). Must render and navigate exactly
+   as before.
+2. **Mixed concept:** generate a three-iteration page — decision, design (2
+   designs × 2 pages), decision. Verify each tab switches the layout, the dock
+   appears only in iteration 2, and the panel docks/undocks correctly.
+3. **Freeze:** submit iteration 2, append iteration 3, click back to tab 2.
+   Mockups navigable, textareas read-only, submit not armed.
+4. **Payload:** fill all three feedback levels, submit, inspect
+   `#concept-decisions`. Every textarea from the active iteration must appear.
+5. **Viewports:** 1280 / 768 / 375 — no overlap between dock, switcher,
+   indicator and FABs.
+
+## Risks
+
+- **`showIteration()` is load-bearing.** It already drives panel state, section
+  nav and the final-report gate. Adding the layout switch there is correct but
+  must not reorder the existing calls — `applyIterationTemplate()` runs first,
+  everything else keeps its order.
+- **`templates.md` is 3899 lines.** The design-layout section must be edited in
+  place, not appended, or the file grows a second competing description of the
+  same layout.
+- **Legacy pages.** Anything relying on `<html data-template>` being constant
+  breaks if the projection is not set before first paint. `DOMContentLoaded`
+  already calls `showIteration()` (`templates.md:3583`); the initial value
+  written at generation time must already match the active iteration so there is
+  no flash of the wrong layout.

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.124.1",
+  "version": "0.125.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/skills/concept/SKILL.md
+++ b/plugins/devops/skills/concept/SKILL.md
@@ -112,7 +112,7 @@ into 340px variant cards, so stop trying to fit them there.
 
 | Template | Layout signature |
 |---|---|
-| **design** | Fullscreen content, overlay decision panel (FAB right), bottom feedback dock (general / per-design / per-screen comments), design switcher when ≥2 designs |
+| **design** | Fullscreen content, overlay decision panel (☰ FAB top right), speech-bubble feedback dock on the 💬 FAB bottom left (general / per-design / per-screen comments), design switcher when ≥2 designs |
 | **decision** | Sidebar (~80/~20), variant cards, tri-state per variant |
 | **free** | Sidebar (~80/~20), Claude-authored freeform body, optional tri-state per section |
 
@@ -203,7 +203,7 @@ Panel layout depends on the template picked in Step 1a:
 | Template | Panel mode | Extras |
 |---|---|---|
 | **decision** | Fixed sticky sidebar (~20% screen width), always visible | — |
-| **design** | Overlay panel (360px slide-in from right), FAB-toggled | Collapsible **feedback dock** at the bottom with general / per-design / per-screen comments; design switcher when ≥2 designs |
+| **design** | Overlay panel (360px slide-in from right), toggled by the ☰ FAB top right | **Feedback dock** as a speech bubble anchored to the 💬 FAB bottom left, with general / per-design / per-screen comments; design switcher when ≥2 designs |
 | **free** | Fixed sticky sidebar (~20%), always visible | — |
 
 On narrow screens (<768px), sidebar-mode panels collapse to a sticky bottom
@@ -246,7 +246,7 @@ Variant/section evaluation uses a **bi-state selector** (not tri-state):
 | Template | Evaluation behavior |
 |---|---|
 | **decision** | **Mandatory per variant card.** Every variant MUST carry the bi-state selector. |
-| **design** | **No evaluation.** Feedback is collected via the bottom feedback dock (general + per-design + per-screen textareas). |
+| **design** | **No evaluation.** Feedback is collected via the feedback dock on the 💬 FAB (general + per-design + per-screen textareas). |
 | **free** | **Opt-in per section.** Claude decides per section whether user evaluation is useful; sections with an `eval-{id}` radio group get evaluated, plain sections just show content. |
 
 **The two states:**

--- a/plugins/devops/skills/concept/SKILL.md
+++ b/plugins/devops/skills/concept/SKILL.md
@@ -31,26 +31,36 @@ Do NOT call Read on files that may not exist — skip missing files silently (no
 
 ## Step 1 — Pick Template, then Content Variant
 
-### 1a. Pick the page template (layout mode)
+### 1a. Pick the template — per iteration
 
-Every concept page uses one of three layout **templates**. Pick via the
-**strict ordered check below** — first matching template wins, free is the
-explicit fallback when neither of the first two applies. Do NOT skip the
-order; `free` must never be chosen while `prototype` or `decision` would
-also fit.
+A concept page is a **stack of iterations**, and each iteration independently
+picks its own layout **template** — `decision`, `free`, or `design`. This
+check runs every time an iteration is created (the first one, and every one
+appended later via tune/rethink/iterate) — it is NOT a one-time, page-level
+decision. Iteration 1 may be a decision round, iteration 2 a fullscreen
+design round, iteration 3 a decision round again; nothing forces the page to
+stay on one template throughout.
 
-**Order of evaluation (mandatory):**
+Pick via the **strict ordered check below** — first matching template wins,
+free is the explicit fallback when neither of the first two applies. Do NOT
+skip the order; `free` must never be chosen while `design` or `decision`
+would also fit.
 
-1. **Is this a PROTOTYPE?**
-   Visual mockup, wireframe, click-through flow, screen-by-screen UI design,
-   any "design me / sketch / lay out a UI" task. If the output needs maximum
-   viewport real estate and per-screen feedback → `prototype`. **Stop.**
+**Order of evaluation (mandatory, per iteration):**
 
-   **Prototype is almost always a click-dummy.** If there are 2+ screens,
+1. **Is this iteration primarily VISUAL?**
+   The options this iteration puts up for decision are primarily visual —
+   layouts, design directions, screen composition, visual arrangement, a
+   click-through flow, screen-by-screen UI design, any "design me / sketch /
+   lay out a UI" task. If the output needs maximum viewport real estate and
+   per-screen (and, with 2+ competing designs, per-design) feedback →
+   `design`. **Stop.**
+
+   **`design` is almost always a click-dummy.** If a design has 2+ screens,
    the mockup's own buttons/links MUST be wired to navigate between screens
    (not just styled rectangles) — clicking "Continue" on screen 1 lands on
    screen 2, "Back" returns, etc. See `deep-knowledge/templates.md`
-   § Template: prototype for the `data-screen-link` attribute pattern.
+   § Template: design for the `data-screen-link` attribute pattern.
 
    **"Screen" is a logical state, not a full page.** A screen can be a
    distinct view (welcome → credentials → success), but it can also be a
@@ -59,19 +69,28 @@ also fit.
    list → populated list). Every state the user should be able to give
    feedback on separately becomes its own `<section data-screen>`.
 
-   **Single-screen prototype (exactly one `data-screen`):** no screen-nav,
-   no per-screen feedback textarea — the dock shows ONLY the general-notes
-   textarea. A static single-screen prototype needs no click-dummy wiring.
-   Do NOT invent artificial "screens" to justify the template; if the
-   artefact has no meaningful secondary states, one screen is correct.
+   **Several competing visual directions** (e.g. 21 layout variants that
+   don't fit a 340px card) are several **designs within the same `design`
+   iteration**, each with its own `data-design` wrapper and its own 1..n
+   screens — not variant cards, and not a second, duplicate "— visuell"
+   pass through a `decision` iteration. See the Architecture spec
+   (`docs/superpowers/specs/2026-08-03-concept-per-iteration-design-mode-design.md`)
+   for the markup shape.
 
-   **Design system:** the prototype MUST follow the project's existing
-   design system (colors, typography, component shapes, spacing) unless
-   the user explicitly asks for a different style in the request. Check
+   **Single-screen, single-design (exactly one `data-screen`):** no
+   screen-nav, no per-screen feedback textarea — the dock shows ONLY the
+   general-notes textarea. A static single-screen design needs no
+   click-dummy wiring. Do NOT invent artificial "screens" to justify the
+   template; if the artefact has no meaningful secondary states, one screen
+   is correct.
+
+   **Design system:** the mockup MUST follow the project's existing design
+   system (colors, typography, component shapes, spacing) unless the user
+   explicitly asks for a different style in the request. Check
    `design-tokens.*`, `theme.*`, `tailwind.config.*`, Figma tokens via
    the design MCP, or the existing UI code before inventing a look.
 
-2. **Is this a DECISION?**
+2. **Are there ≥2 substantive non-visual alternatives?**
    Multi-option evaluation where the user must pick from 2+ mutually-exclusive
    alternatives (architecture, tech, strategy, library, approach, …). If there
    are explicit variants A/B/C with pros/cons to weigh → `decision`. **Stop.**
@@ -83,21 +102,32 @@ also fit.
    Tri-state is opt-in per section (Claude adds it only where a finding
    genuinely needs user evaluation).
 
+**Entangled questions split across iterations.** If a concept's visual
+questions (which layout / design direction) and its non-visual questions
+(which architecture / which library / which strategy) are entangled, do NOT
+mix them into one layout. Split them: a `decision` iteration for the
+non-visual call, a separate `design` iteration for the visual one. This is
+the fix for the "same decision, written twice" failure — mockups do not fit
+into 340px variant cards, so stop trying to fit them there.
+
 | Template | Layout signature |
 |---|---|
-| **prototype** | Fullscreen content, overlay decision panel (FAB right), bottom feedback dock (per-screen comments) |
+| **design** | Fullscreen content, overlay decision panel (FAB right), bottom feedback dock (general / per-design / per-screen comments), design switcher when ≥2 designs |
 | **decision** | Sidebar (~80/~20), variant cards, tri-state per variant |
 | **free** | Sidebar (~80/~20), Claude-authored freeform body, optional tri-state per section |
 
-**Tie-breakers:**
-- A page with variants AND mockups (rare) is a `decision` with inline mockups,
-  not a `prototype` — prototype is reserved for single-artefact presentation.
-- A page that presents one recommended approach (no alternatives) is `free`,
-  not `decision` — decision requires ≥2 mutually-exclusive options.
+`design` is the canonical name; `prototype` is accepted as a legacy alias
+(older pages/prompts) and is normalised to `design` — see
+`deep-knowledge/templates.md` § `applyIterationTemplate()`.
 
-Set `<html data-template="...">` on the generated file so `collectDecisions`
-picks the right branch and template-specific CSS/JS activates. See
-`deep-knowledge/templates.md` for the full layout reference.
+Set `data-iteration-template="..."` on each `<section data-iteration="N">` —
+this is the **authoritative** value per iteration.
+`applyIterationTemplate()` copies the active iteration's value onto
+`<html data-template="...">` on every `showIteration()` call, so `<html
+data-template>` always **mirrors the active iteration** rather than being a
+page-level constant. This projection is what lets `collectDecisions` and all
+existing template-scoped CSS/JS keep branching on `<html data-template>`
+unchanged. See `deep-knowledge/templates.md` for the full layout reference.
 
 ### 1b. If template is `decision`: pick a content variant
 
@@ -113,8 +143,8 @@ cards:
 | **dashboard** | Status overviews, metric dashboards, health checks | Filters, toggles, expandable sections |
 | **creative** | Brainstorming, ideation, mind maps | Add/remove ideas, grouping, voting |
 
-Prototype and free templates have no sub-variants — their body is
-content-specific (prototype = visual mockup; free = Claude-authored).
+Design and free templates have no sub-variants — their body is
+content-specific (design = visual mockup(s); free = Claude-authored).
 
 These are **recommendations, not rigid categories**. Mix elements across
 variants, create hybrid layouts, or invent new structures when the content
@@ -173,7 +203,7 @@ Panel layout depends on the template picked in Step 1a:
 | Template | Panel mode | Extras |
 |---|---|---|
 | **decision** | Fixed sticky sidebar (~20% screen width), always visible | — |
-| **prototype** | Overlay panel (360px slide-in from right), FAB-toggled | Collapsible **feedback dock** at the bottom with per-screen comments |
+| **design** | Overlay panel (360px slide-in from right), FAB-toggled | Collapsible **feedback dock** at the bottom with general / per-design / per-screen comments; design switcher when ≥2 designs |
 | **free** | Fixed sticky sidebar (~20%), always visible | — |
 
 On narrow screens (<768px), sidebar-mode panels collapse to a sticky bottom
@@ -216,7 +246,7 @@ Variant/section evaluation uses a **bi-state selector** (not tri-state):
 | Template | Evaluation behavior |
 |---|---|
 | **decision** | **Mandatory per variant card.** Every variant MUST carry the bi-state selector. |
-| **prototype** | **No evaluation.** Feedback is collected via the bottom feedback dock (per-screen textareas + general notes). |
+| **design** | **No evaluation.** Feedback is collected via the bottom feedback dock (general + per-design + per-screen textareas). |
 | **free** | **Opt-in per section.** Claude decides per section whether user evaluation is useful; sections with an `eval-{id}` radio group get evaluated, plain sections just show content. |
 
 **The two states:**
@@ -253,25 +283,25 @@ mandatory: the user must move the mouse deliberately to reach it.
 based on which button was clicked. Claude reads that field and either runs
 another iteration (Step 5c) or executes code changes (Step 5b).
 
-This applies to **all three templates** — even prototype (implement = "build
-what we prototyped with the feedback") and free (implement = "act on the
+This applies to **all three templates** — even design (implement = "build
+what we designed with the feedback") and free (implement = "act on the
 findings I marked Miteinbeziehen").
 
-### Prototype Feedback Dock
+### Design Feedback Dock
 
-The prototype template has no tri-state. Instead, a **speech-bubble feedback
+The design template has no tri-state. Instead, a **speech-bubble feedback
 dock** anchored to the 💬 FAB (bottom-left) holds structured feedback:
 
-- A top-level textarea for general notes on the prototype
-- One textarea per `<section data-screen>` inside the active iteration,
+- A top-level textarea for general notes on the concept
+- One textarea per `data-design` (only when the iteration has ≥2 designs)
+- One textarea per `<section data-screen>` inside the active design,
   auto-populated by the dock (label = `data-nav-label` of that screen)
 
 The dock is toggled via the 💬 FAB. The FAB stays visible AND clickable
-while the dock is open (clicking it toggles closed again), and the dock's
-right edge stops before the ☰ Menü-FAB so decisions remain reachable
-during feedback. The close button is a **minimise** (`−`), not a destroy:
-text content stays intact in `localStorage` when the dock is closed. See
-`deep-knowledge/templates.md` § Template: prototype for the full HTML/CSS/JS.
+while the dock is open (clicking it toggles closed again). The close button
+is a **minimise** (`−`), not a destroy: text content stays intact in
+`localStorage` when the dock is closed. See `deep-knowledge/templates.md`
+§ Template: design for the full HTML/CSS/JS and current FAB/dock geometry.
 
 ### Reload Resilience
 
@@ -573,7 +603,7 @@ Branch on it:
    - For comparisons: proceed with the implicitly-selected winner (all
      others marked Verwerfen)
    - For free-template findings: apply the Miteinbeziehen findings as fixes
-   - For prototypes: build the designed UI/flow with the feedback applied
+   - For design iterations: build the designed UI/flow with the feedback applied
 3. **Signal completion to the panel.** Right after the implementation work
    is done — and BEFORE the final-report append + `/reload` in Step 5c — POST
    the implemented phase so the submit panel's third progress step lights

--- a/plugins/devops/skills/concept/deep-knowledge/iteration-rules.md
+++ b/plugins/devops/skills/concept/deep-knowledge/iteration-rules.md
@@ -28,11 +28,12 @@ selections, read-only comments).
   - **Exemption for `design` iterations:** freezing must NOT disable
     navigation — the user still has to be able to revisit the mockups. The
     `disabled`-everything sweep MUST skip `.design-switch-item`,
-    `.screen-nav-item`, `#panel-toggle`, `#feedback-toggle`, and
-    `#feedback-close`. Textareas still go `readonly` (never `disabled`, so
-    their submitted text stays legible and copyable) and submit stays
-    unarmed — only navigation controls are exempt, not the form/comment
-    surface. See § Freezing Design Iterations below.
+    `.screen-nav-item`, `.screen-nav-design-heading`, `[data-screen-link]`,
+    `#panel-toggle`, `#feedback-toggle`, and `#feedback-close`. Textareas
+    still go `readonly` (never `disabled`, so their submitted text stays
+    legible and copyable) and submit stays unarmed — only navigation
+    controls are exempt, not the form/comment surface.
+    See § Freezing Design Iterations below.
 - Only the active tab runs the heartbeat / submit UI ("music"). Clicking
   an older tab shows its frozen snapshot but does not re-arm submit.
 - Tab bar must stay compact — vertical chip list in the panel header.
@@ -52,6 +53,13 @@ and revisit their own submitted notes:
 - `.design-switch-item` — the design switcher segments (switching between
   competing designs must keep working)
 - `.screen-nav-item` — per-screen navigation entries in the panel
+- `.screen-nav-design-heading` — the design-level entries those items are
+  nested under; disabling them while their children stay live makes the
+  nav half-navigable
+- `[data-screen-link]` — click-dummy navigation INSIDE the mockup. These
+  are ordinary `<button>`s living inside `section[data-iteration]`, so a
+  naive sweep hits them and kills exactly the walkthrough the frozen tab
+  exists to preserve
 - `#panel-toggle` — the ☰ FAB that opens the panel/switcher
 - `#feedback-toggle` — the 💬 FAB that opens the feedback dock
 - `#feedback-close` — the dock's minimise control
@@ -63,6 +71,22 @@ inert — no re-arming iterate/implement from a frozen tab. `readonly`, not
 `disabled`, is important here: a `disabled` textarea's value can render as
 unreadable/greyed-out in some browsers, defeating the "revisit past
 feedback" purpose that exists for every template.
+
+**The feedback dock needs explicit handling.** Its textareas are built by
+JS and live OUTSIDE `section[data-iteration]`, so the freeze sweep never
+reaches them — a frozen tab would otherwise show empty, editable fields and
+imply the user submitted nothing. Freezing a `design` iteration therefore
+also requires embedding the submitted comments in the frozen section:
+
+```html
+<script type="application/json" data-frozen-feedback>
+  {"general": "…", "designs": {"dispatch": "…"}, "screens": {"d1-s1": "…"}}
+</script>
+```
+
+`applyDockFreezeState()` (templates.md § Layout JS) reads that blob whenever
+`body.viewing-frozen` is set, fills the dock read-only, and restores the live
+iteration's unsent text when the user switches back.
 
 ## Iteration append checklist
 

--- a/plugins/devops/skills/concept/deep-knowledge/iteration-rules.md
+++ b/plugins/devops/skills/concept/deep-knowledge/iteration-rules.md
@@ -25,6 +25,14 @@ selections, read-only comments).
   which state the user submitted, read-only comment fields with the text
   the user entered. Users can click back to earlier tabs to review their
   own past feedback at any time.
+  - **Exemption for `design` iterations:** freezing must NOT disable
+    navigation — the user still has to be able to revisit the mockups. The
+    `disabled`-everything sweep MUST skip `.design-switch-item`,
+    `.screen-nav-item`, `#panel-toggle`, `#feedback-toggle`, and
+    `#feedback-close`. Textareas still go `readonly` (never `disabled`, so
+    their submitted text stays legible and copyable) and submit stays
+    unarmed — only navigation controls are exempt, not the form/comment
+    surface. See § Freezing Design Iterations below.
 - Only the active tab runs the heartbeat / submit UI ("music"). Clicking
   an older tab shows its frozen snapshot but does not re-arm submit.
 - Tab bar must stay compact — vertical chip list in the panel header.
@@ -32,6 +40,29 @@ selections, read-only comments).
   bottom on narrow screens.
 
 See `templates.md` § Iteration Tabs for the reference HTML/CSS/JS.
+
+## Freezing Design Iterations
+
+A frozen `design` iteration (`data-iteration-template="design"`, legacy
+alias `prototype`) is navigable, not inert. When freeze logic walks the
+section applying `disabled` to every interactive descendant, it MUST
+explicitly skip these selectors so the user can still browse the mockups
+and revisit their own submitted notes:
+
+- `.design-switch-item` — the design switcher segments (switching between
+  competing designs must keep working)
+- `.screen-nav-item` — per-screen navigation entries in the panel
+- `#panel-toggle` — the ☰ FAB that opens the panel/switcher
+- `#feedback-toggle` — the 💬 FAB that opens the feedback dock
+- `#feedback-close` — the dock's minimise control
+
+Everything else in a frozen `design` iteration follows the same rule as any
+other frozen iteration: comment textareas become `readonly` (so the
+submitted text stays visible but not editable), and the submit block is
+inert — no re-arming iterate/implement from a frozen tab. `readonly`, not
+`disabled`, is important here: a `disabled` textarea's value can render as
+unreadable/greyed-out in some browsers, defeating the "revisit past
+feedback" purpose that exists for every template.
 
 ## Iteration append checklist
 

--- a/plugins/devops/skills/concept/deep-knowledge/templates.md
+++ b/plugins/devops/skills/concept/deep-knowledge/templates.md
@@ -1126,33 +1126,47 @@ The wiring is a single delegated click handler installed alongside
     </aside>
     <div class="panel-backdrop" id="panel-backdrop"></div>
 
-    <!-- Feedback dock (💬) — context-sensitive Speech-Bubble overlay.
+    <!-- Feedback dock (💬) — three-level Speech-Bubble overlay, top to
+         bottom: general → design → page. General sits at the top because
+         it is the one field that never disappears or changes label as the
+         user navigates — putting it first keeps the dock from jumping.
          Anchored to the 💬 FAB (bottom-left): the FAB stays visible and
          clickable, the dock floats above/around it like a chat bubble.
-         The right edge stops before the ☰ Menü-FAB so the user can still
-         reach decisions while the dock is open.
+         Now that ☰ lives top-right (Wave 3), the dock no longer reserves
+         space for it — see Layout CSS geometry comment.
          The close button minimises (does not destroy state) — user input
          is preserved on close, no value is lost.
-         * Top: ONE textarea for the active screen (swapped on navigation).
-         * Bottom: ONE textarea for general notes, always visible. -->
-    <aside class="feedback-dock" id="feedback-dock" data-open="false">
+         Open by default (data-open="true") — see Layout JS § Auto-close for
+         the "closes on first interaction, then manual-only" behaviour
+         driven by data-auto-close-armed. -->
+    <aside class="feedback-dock" id="feedback-dock" data-open="true" data-auto-close-armed="true">
       <div class="feedback-dock-header">
         <strong>Feedback</strong>
         <button id="feedback-close" class="feedback-close-btn" aria-label="{{panel.minimize}}" title="{{panel.minimize}}">−</button>
       </div>
       <div class="feedback-section">
-        <label>Aktueller Screen: <strong id="dock-screen-label">Welcome</strong></label>
+        <label>{{proto.feedback_general}}</label>
+        <textarea id="design-general-feedback" data-comment="general"
+                  placeholder="{{proto.feedback_general}}"></textarea>
+      </div>
+      <div class="feedback-divider"></div>
+      <!-- Design row — omitted for single-design iterations via
+           body[data-single-design="true"] (Layout CSS), no JS branching.
+           One hidden textarea per design; only the active one is shown,
+           same swap mechanism as the per-screen row below. Each carries
+           data-comment="design-{id}" AND data-design-comment="{id}". -->
+      <div class="feedback-section">
+        <label>{{design.feedback_design}}: <strong id="dock-design-label">Dispatch</strong></label>
+        <div id="design-textareas" data-placeholder="{{design.feedback_design_placeholder}}"><!-- auto-populated --></div>
+      </div>
+      <div class="feedback-divider"></div>
+      <div class="feedback-section">
+        <label>{{proto.feedback_current}}: <strong id="dock-screen-label">Welcome</strong></label>
         <!-- One hidden textarea per screen. Only the active one is shown.
              Each carries data-comment="{screen-id}" AND
              data-screen-comment="{screen-id}" — so saveState/restoreState
              treats it like any comment field. -->
-        <div id="screen-textareas"><!-- auto-populated --></div>
-      </div>
-      <div class="feedback-divider"></div>
-      <div class="feedback-section">
-        <label>{{proto.feedback_general}}</label>
-        <textarea id="proto-general-feedback" data-comment="general"
-                  placeholder="{{proto.feedback_general}}"></textarea>
+        <div id="screen-textareas" data-placeholder="{{proto.feedback_placeholder}}"><!-- auto-populated --></div>
       </div>
     </aside>
   </div>
@@ -1302,7 +1316,10 @@ body.panel-open .design-switcher { opacity: 0; pointer-events: none; }
   z-index: 100;
   transition: transform 0.2s, opacity 0.2s;
 }
-.panel-fab { bottom: 2rem; right: 2rem; background: var(--accent-color, #58a6ff); }
+/* ☰ lives top-right (Wave 3) — clear of the design switcher (top centre)
+   and the screen indicator (top left) at every viewport; verified at
+   1280/768/375px. 💬 stays bottom-left, unchanged. */
+.panel-fab { top: 2rem; right: 2rem; background: var(--accent-color, #58a6ff); }
 .feedback-fab { bottom: 2rem; left: 2rem; background: var(--warning-color, #d29922); }
 .panel-fab:hover,
 .feedback-fab:hover { transform: scale(1.1); }
@@ -1365,9 +1382,13 @@ body.panel-open .design-switcher { opacity: 0; pointer-events: none; }
 .screen-nav-group .screen-nav-item { margin-left: 0.75rem; }
 
 /* ── Feedback Dock — Speech-Bubble anchored to the 💬 FAB ──
-   Geometry:
+   Geometry (simplified, Wave 3): now that ☰ lives top-right, the dock no
+   longer needs to reserve horizontal space for it, nor lift itself above
+   it on narrow viewports (both existed only because ☰ used to share the
+   bottom-right corner with 💬). The dock now spans to the right edge minus
+   a normal margin.
    * left = FAB.left (2rem)               → bubble's left edge aligns with FAB
-   * right = FAB.right + 56 + 1rem        → reserves the ☰ Menü-FAB area
+   * right = 2rem                         → normal margin, was reserved for ☰
    * bottom = FAB.bottom + 56 + 6px       → bubble sits directly above the FAB
                                             with a hair of overlap so the
                                             visual connection reads as "the
@@ -1377,12 +1398,14 @@ body.panel-open .design-switcher { opacity: 0; pointer-events: none; }
                                             so labels/textareas never sit
                                             behind it (the FAB stays clickable
                                             on top via higher z-index).
-   The FAB keeps its z-index above the dock so it remains visible and
-   clickable while the dock is open — clicking the FAB toggles the dock. */
+   transform-origin still anchors to the 💬 FAB so the bubble reads as
+   growing out of it. The FAB keeps its z-index above the dock so it remains
+   visible and clickable while the dock is open — clicking the FAB toggles
+   the dock. */
 .feedback-dock {
   position: fixed;
   left: 2rem;
-  right: calc(2rem + 56px + 1rem);
+  right: 2rem;
   bottom: calc(2rem + 56px - 6px);
   max-height: min(60vh, 520px);
   padding: 1.25rem 1.5rem 1.5rem 80px;
@@ -1443,30 +1466,32 @@ body.panel-open .design-switcher { opacity: 0; pointer-events: none; }
 .feedback-section textarea:focus { outline: none; border-color: var(--accent-color); }
 .feedback-divider { height: 1px; background: var(--border-color); margin: 0.25rem 0; }
 
-/* Narrow viewports (≤560px): lift the bubble ABOVE the 💬 FAB instead
-   of having it overlap. With ~150px reserved for FAB + Menü-FAB on a
-   320px phone the inner content column would otherwise collapse to an
-   unusable width. The FAB ends up below the dock, still visible and
-   still toggleable. */
+/* Narrow viewports (≤560px): just tighten the margins/padding. The old
+   "lift above the FAB" override is gone — it only existed to compensate
+   for the ☰ FAB's right-side reservation, which no longer exists now that
+   ☰ moved top-right (Wave 3). */
 @media (max-width: 560px) {
   .feedback-dock {
     left: 0.75rem;
-    right: calc(0.75rem + 56px + 0.5rem);
-    bottom: calc(1rem + 56px + 8px);
-    padding: 1rem;
+    right: 0.75rem;
+    padding: 1rem 1rem 1rem 72px;
     border-radius: 14px;
-    transform-origin: 28px calc(100% + 28px);
   }
 }
 
-/* Hidden per-screen textareas inside #screen-textareas: only active shown */
-#screen-textareas textarea[hidden] { display: none; }
+/* Hidden per-screen / per-design textareas: only the active one shown */
+#screen-textareas textarea[hidden],
+#design-textareas textarea[hidden] { display: none; }
 
-/* Single-screen design: hide screen-nav + per-screen feedback section.
-   Only general notes remain visible. */
+/* Single-screen design: hide screen-nav + per-screen feedback section +
+   its own leading divider. Order is general -> design -> page, so the
+   divider that must disappear with the page row is the one immediately
+   BEFORE it, not the one before general (which is always first, no
+   leading divider). Only general (and, if >=2 designs, per-design) notes
+   remain visible. */
 body[data-single-screen="true"] #screen-nav,
 body[data-single-screen="true"] .feedback-section:has(#screen-textareas),
-body[data-single-screen="true"] .feedback-divider:has(+ .feedback-section #proto-general-feedback) {
+body[data-single-screen="true"] .feedback-divider:has(+ .feedback-section #screen-textareas) {
   display: none;
 }
 
@@ -1551,7 +1576,10 @@ one's value persists independently via `localStorage` (same mechanism as any
       btn.dataset.designId = d.dataset.design;
       btn.dataset.active = String(d === active);
       btn.textContent = d.dataset.navLabel || d.dataset.design;
-      btn.addEventListener('click', () => showDesign(d.dataset.design));
+      // "a design switch" is one of the three auto-close triggers (§ Dock
+      // open/close below) — fired here, not from the generic mockup-click
+      // listener, so the switcher itself is exempt from that listener.
+      btn.addEventListener('click', () => { showDesign(d.dataset.design); fireAutoClose(); });
       switcher.appendChild(btn);
     });
 
@@ -1570,7 +1598,7 @@ one's value persists independently via `localStorage` (same mechanism as any
       heading.dataset.active = String(d === active);
       heading.innerHTML = `<span>${d.dataset.navLabel || d.dataset.design}</span>
         <span class="has-notes" data-design-note-marker="${d.dataset.design}"></span>`;
-      heading.addEventListener('click', () => { showDesign(d.dataset.design); closePanel(); });
+      heading.addEventListener('click', () => { showDesign(d.dataset.design); fireAutoClose(); closePanel(); });
       group.appendChild(heading);
 
       const screens = [...d.querySelectorAll('section[data-screen][id]')];
@@ -1585,6 +1613,7 @@ one's value persists independently via `localStorage` (same mechanism as any
         btn.addEventListener('click', () => {
           if (d !== active) showDesign(d.dataset.design, sec.id);
           else showScreen(sec.id);
+          fireAutoClose();
           closePanel();
         });
         group.appendChild(btn);
@@ -1592,7 +1621,29 @@ one's value persists independently via `localStorage` (same mechanism as any
       nav.appendChild(group);
     });
 
+    buildDesignTextareas(allDesigns, active);
     buildScreenUI(active);
+  }
+
+  // Per-design textareas (💬) — one per design, only the active one shown.
+  // Rebuilt whenever the design SET changes (buildDesignUI), unlike
+  // buildScreenUI which rebuilds on every design switch: the design list
+  // itself only changes across iteration switches, not screen switches.
+  function buildDesignTextareas(allDesigns, active) {
+    const container = document.getElementById('design-textareas');
+    if (!container) return;
+    const placeholder = container.dataset.placeholder || '';
+    container.innerHTML = '';
+    allDesigns.forEach(d => {
+      const ta = document.createElement('textarea');
+      ta.dataset.comment = `design-${d.dataset.design}`;
+      ta.dataset.designComment = d.dataset.design;
+      ta.placeholder = placeholder;
+      ta.hidden = d !== active;
+      container.appendChild(ta);
+    });
+    const label = document.getElementById('dock-design-label');
+    if (label && active) label.textContent = active.dataset.navLabel || active.dataset.design;
   }
 
   // Per-screen textareas (💬) for the design currently active.
@@ -1605,12 +1656,13 @@ one's value persists independently via `localStorage` (same mechanism as any
     document.body.dataset.singleScreen = screens.length <= 1 ? 'true' : 'false';
 
     const container = document.getElementById('screen-textareas');
+    const placeholder = container.dataset.placeholder || '';
     container.innerHTML = '';
     screens.forEach(sec => {
       const ta = document.createElement('textarea');
       ta.dataset.comment = sec.id;
       ta.dataset.screenComment = sec.id;
-      ta.placeholder = `Notiz zu ${sec.dataset.navLabel || sec.id}…`;
+      ta.placeholder = placeholder;
       ta.hidden = true;
       container.appendChild(ta);
     });
@@ -1633,6 +1685,14 @@ one's value persists independently via `localStorage` (same mechanism as any
     document.querySelectorAll('.screen-nav-design-heading').forEach(h => {
       h.dataset.active = String(h.dataset.designId === designId);
     });
+    // Swap the per-design textarea (built once by buildDesignTextareas —
+    // only its `hidden` state and the dock label change on switch, same
+    // pattern as showScreen swapping [data-screen-comment] below).
+    document.querySelectorAll('[data-design-comment]').forEach(ta => {
+      ta.hidden = ta.dataset.designComment !== designId;
+    });
+    const dockDesignLabel = document.getElementById('dock-design-label');
+    if (dockDesignLabel) dockDesignLabel.textContent = targets.find(d => d.dataset.design === designId)?.dataset.navLabel || designId;
     const design = document.querySelector(`section[data-design="${CSS.escape(designId)}"]`);
     if (!design) return;
     buildScreenUI(design);
@@ -1777,6 +1837,46 @@ one's value persists independently via `localStorage` (same mechanism as any
   });
   dockClose.addEventListener('click', closeDock);
 
+  // ── Open by default, closes on first interaction ──
+  // The dock starts open (data-open="true" in markup) so a first-time user
+  // sees all three feedback fields immediately. It auto-closes itself on the
+  // FIRST of: a click inside the mockup, a design switch, a page switch —
+  // tracked by data-auto-close-armed, cleared on first fire so the manual
+  // 💬 toggle governs everything afterwards (never auto-closes twice).
+  // Frozen iterations are exempt entirely: nothing to type, so the dock
+  // just stays open for read-only review (see primeDock()).
+  let autoCloseUsed = false;
+  function fireAutoClose() {
+    if (dock.dataset.autoCloseArmed !== 'true') return;
+    dock.dataset.autoCloseArmed = 'false';
+    autoCloseUsed = true;
+    if (dock.dataset.open === 'true') closeDock();
+  }
+  function primeDock() {
+    const frozen = document.body.classList.contains('viewing-frozen');
+    if (frozen) {
+      // Frozen: always (re-)open for review, never arm the auto-close —
+      // there is nothing to type, so nothing to hide the fields for.
+      openDock();
+      dock.dataset.autoCloseArmed = 'false';
+      return;
+    }
+    if (autoCloseUsed) return; // already fired once this session — manual-only from here
+    openDock();
+    dock.dataset.autoCloseArmed = 'true';
+  }
+
+  // Click inside the mockup itself (trigger #1 above). Explicitly excludes
+  // the dock, both FABs and the design switcher — those clicks are either
+  // not "inside the mockup" at all, or (design switcher) already fire
+  // fireAutoClose() from their own handler above, via the "design switch"
+  // trigger rather than this generic one.
+  document.addEventListener('click', e => {
+    if (e.target.closest('#feedback-dock') || e.target.closest('.panel-fab')
+      || e.target.closest('.feedback-fab') || e.target.closest('.design-switcher')) return;
+    if (e.target.closest('.device-frame') || e.target.closest('[data-screen]')) fireAutoClose();
+  });
+
   // Click outside the dock (anywhere on the design screen) closes it.
   // The ✕ button still works — this just adds click-away as an alternative
   // dismissal. Uses capture so it runs before the screen-link handler,
@@ -1808,6 +1908,11 @@ one's value persists independently via `localStorage` (same mechanism as any
     }
     updateIndicator();
     document.addEventListener('input', updateNoteMarkers);
+    // Runs last: the initial buildDesignUI()/showScreen() calls above are
+    // programmatic setup, not user interaction, so priming the dock here
+    // (not inside showScreen) keeps boot-time restore from being
+    // misread as the "first interaction" that auto-closes it.
+    primeDock();
   });
 
   // Rebuild after iteration switches (fresh designs, fresh screens, fresh
@@ -1826,6 +1931,11 @@ one's value persists independently via `localStorage` (same mechanism as any
       : (remembered && design.querySelector(`#${CSS.escape(remembered)}`)) ? remembered
       : first?.id;
     if (target) showScreen(target);
+    // Same boot-vs-interaction distinction as DOMContentLoaded: this rebuild
+    // is a consequence of the tab switch, not itself the "page switch"
+    // trigger (that already fired, if at all, from the tab-click handler
+    // elsewhere) — but frozen tabs must still (re-)open for review here.
+    primeDock();
   });
 
   // Keyboard: Arrow Left/Right (and Space) jump between screens (within the
@@ -1947,17 +2057,22 @@ with `data-screen`:
 
 ## Decision schema
 
-The design submit payload has **no variant evaluations** — only comments:
+The design submit payload has **no variant evaluations** — only comments,
+keyed by feedback level (general / designs / screens). `comments.screens`
+keeps flat screen-id keying regardless of which design a screen belongs to,
+so no consumer needs to learn the design nesting to read page feedback:
 
 ```json
 {
+  "submitted": true,
   "template": "design",
+  "iteration": 2,
   "decisions": [],
-  "comments": [
-    { "id": "general", "text": "..." },
-    { "id": "screen-welcome", "label": "Welcome", "text": "..." },
-    { "id": "screen-credentials", "label": "Credentials", "text": "..." }
-  ]
+  "comments": {
+    "general": "...",
+    "designs": { "dispatch": "...", "holotable": "..." },
+    "screens": { "d1-s1": "...", "d1-s2": "..." }
+  }
 }
 ```
 
@@ -1965,25 +2080,30 @@ The design submit payload has **no variant evaluations** — only comments:
 
 ```javascript
 // Called by the shared submit handler; `data-template` picks the branch.
+// Generic querySelectorAll('input, select, textarea') per the coverage gate
+// (iteration-rules.md § coverage gate) — no hand-listed field ids. Scoped to
+// #feedback-dock rather than [data-active]: the dock is an overlay that
+// lives outside section[data-iteration] in the DOM, but buildDesignUI() /
+// buildScreenUI() tear down and rebuild its textareas for the active
+// iteration/design on every switch, so this scan already only ever sees the
+// active iteration's fields.
 function collectDesignDecisions() {
-  const comments = [];
-  // General notes
-  const general = document.getElementById('proto-general-feedback');
-  if (general && general.value.trim()) {
-    comments.push({ id: 'general', text: general.value.trim() });
-  }
-  // Per-screen comments
-  document.querySelectorAll('[data-screen-comment]').forEach(el => {
-    if (!el.value.trim()) return;
-    const id = el.dataset.screenComment;
-    const screenEl = document.getElementById(id);
-    comments.push({
-      id,
-      label: screenEl ? (screenEl.dataset.navLabel || id) : id,
-      text: el.value.trim()
-    });
+  const comments = { general: '', designs: {}, screens: {} };
+  document.querySelectorAll('#feedback-dock input, #feedback-dock select, #feedback-dock textarea').forEach(el => {
+    const value = (el.value || '').trim();
+    if (!value) return;
+    if (el.dataset.designComment) comments.designs[el.dataset.designComment] = value;
+    else if (el.dataset.screenComment) comments.screens[el.dataset.screenComment] = value;
+    else if (el.dataset.comment === 'general') comments.general = value;
   });
-  return { submitted: true, template: 'design', decisions: [], comments };
+  const active = document.querySelector('section[data-iteration][data-active]');
+  return {
+    submitted: true,
+    template: 'design',
+    iteration: active ? Number(active.dataset.iteration) : undefined,
+    decisions: [],
+    comments
+  };
 }
 ```
 

--- a/plugins/devops/skills/concept/deep-knowledge/templates.md
+++ b/plugins/devops/skills/concept/deep-knowledge/templates.md
@@ -1,12 +1,17 @@
 # Concept HTML Templates
 
-Three page-level **templates** (layout modes) cover every concept use case:
+Three **templates** (layout modes) cover every concept use case. A template is
+picked **per iteration**, not per page — see § Per-Iteration Templates below:
 
 | Template | Layout | When to use |
 |---|---|---|
 | **decision** | Sidebar (~80/~20), multi-variant cards | Multi-option evaluation, trade-offs, architecture or tech decisions — the canonical "pick one" flow with bi-state (Verwerfen / Miteinbeziehen) per variant and multiple iterations |
-| **prototype** | Fullscreen content + overlay decision panel (☰ FAB right) + speech-bubble feedback dock anchored to the 💬 FAB (bottom-left), stops before the ☰ FAB so both stay clickable | UI mockups, wireframes, visual design concepts, click-through flows — one artefact that needs maximum screen real estate, plus structured per-screen feedback |
+| **design** | Fullscreen content + overlay decision panel (☰ FAB right) + speech-bubble feedback dock anchored to the 💬 FAB (bottom-left), stops before the ☰ FAB so both stay clickable | UI mockups, wireframes, visual design concepts, click-through flows — one artefact that needs maximum screen real estate, plus structured per-screen feedback |
 | **free** | Sidebar (~80/~20), freeform body content | Analysis, walkthrough, brainstorm, explainer, timeline — structured content without forced variant framing. Bi-state evaluation is optional (opt-in per section) |
+
+`prototype` is the **legacy alias** of `design`. Pages generated before the
+rename keep working — `applyIterationTemplate()` normalises it. Never emit
+`prototype` in new pages.
 
 **Content variants (analysis, plan, concept, comparison, dashboard, creative)
 are sub-structures of the decision template** — they describe how to lay out
@@ -108,7 +113,7 @@ must see their own language. The locale hint is authoritative.
 | `final.view_iterations`        | Review iterations              | Iterationen ansehen |
 | `proto.feedback_title`         | Feedback                       | Feedback |
 | `proto.feedback_toggle`        | Open feedback                  | Feedback öffnen |
-| `proto.feedback_general`       | General notes on this prototype | Allgemeine Anmerkungen zum Prototyp |
+| `proto.feedback_general`       | General notes on this concept  | Allgemeine Anmerkungen zum Konzept |
 | `proto.feedback_general_hint`  | Persists across all screens    | Screen-übergreifend persistent |
 | `proto.feedback_current`       | Current screen                 | Aktueller Screen |
 | `proto.feedback_placeholder`   | Write a note on this screen…   | Notiz zu diesem Screen… |
@@ -122,6 +127,10 @@ the `[ui-locale: ...]` hint produced.
 
 ```html
 <!DOCTYPE html>
+<!-- data-template is a PROJECTION of the ACTIVE iteration, not a page constant.
+     It MUST be written at generation time with the active iteration's
+     data-iteration-template value (normalised), otherwise the page paints the
+     wrong layout for one frame before showIteration() runs. -->
 <html lang="en" data-theme="dark" data-page-version="{generation-timestamp}" data-template="decision">
 <head>
   <meta charset="UTF-8">
@@ -159,7 +168,7 @@ the `[ui-locale: ...]` hint produced.
 
     <!-- Decision panel. Layout varies per template:
          decision: sticky sidebar, always visible.
-         prototype: overlay, FAB-toggled.
+         design: overlay, FAB-toggled.
          free: sticky sidebar (same as decision). -->
     <aside class="concept-decision-panel">
       <!-- All visible strings are referenced by key in the locale table above.
@@ -411,7 +420,37 @@ the `[ui-locale: ...]` hint produced.
 </html>
 ```
 
-Set `data-template` on the `<html>` element to one of `decision` | `prototype` | `free`. This is the single source of truth that drives template-specific CSS (`.concept-layout[data-template="prototype"]`) and JS branches (`collectDecisions`).
+## Per-Iteration Templates
+
+The template is chosen **per iteration**. Every `<section data-iteration="N">`
+MUST carry `data-iteration-template="decision|design|free"` — that attribute is
+authoritative:
+
+```html
+<html data-template="decision">              <!-- mirrors the ACTIVE iteration -->
+  <section data-iteration="1" data-iteration-template="decision" data-active>
+  <section data-iteration="2" data-iteration-template="design" hidden>
+  <section data-iteration="3" data-iteration-template="decision" hidden>
+```
+
+`data-template` on `<html>` stays the single source of truth *for CSS selectors
+and JS branches* (`[data-template="design"] …`, `collectDecisions`), but it is a
+**projection** of the currently shown iteration, not a page-level constant.
+`applyIterationTemplate(section)` writes it on every iteration switch (see
+Shared Systems § Tab Switch JS).
+
+Rules:
+
+- Iterations may mix templates freely and in any order — a `decision` round may
+  be followed by a `design` round and another `decision` round.
+- `prototype` is accepted as a **legacy alias** for `design` and normalised on
+  read. Never write it in new pages.
+- A missing `data-iteration-template` falls back to the current
+  `<html data-template>`, so pages generated before the rename keep working
+  unchanged.
+- The `<html data-template>` value written at generation time MUST already
+  equal the active iteration's (normalised) template — otherwise the first
+  paint shows the wrong layout.
 
 ---
 
@@ -821,7 +860,9 @@ additional `weight-*` entries for weight sliders.
 
 ---
 
-# Template: prototype
+# Template: design
+
+*(legacy alias: `prototype` — normalised to `design` on read)*
 
 **One visual artefact, one screen at a time, 100 % viewport.** The body shows
 exactly one screen from the flow. The user switches between screens via the
@@ -849,7 +890,7 @@ buttons:
   Each such state becomes its own `<section data-screen>`. The click-dummy
   wiring with `data-screen-link` handles the transition like any other
   screen switch.
-- **Single-screen prototype (exactly one `<section data-screen>`):**
+- **Single-screen design (exactly one `<section data-screen>`):**
   - No screen-nav rendered inside the ☰ panel
   - Feedback dock shows ONLY the general-notes textarea (no
     per-screen section, no "Aktueller Screen" label)
@@ -863,7 +904,7 @@ buttons:
 - **Do NOT invent artificial screens** to make the template fit. If the
   artefact has no meaningful secondary state, leave it as a single screen
   and let the dock collapse to general notes only.
-- **Design system alignment:** the prototype MUST use the project's existing
+- **Design system alignment:** the mockup MUST use the project's existing
   design tokens (colors, typography, spacing, component shapes) unless the
   user explicitly requests a different look. Read `design-tokens.*`,
   Tailwind config, Figma variables via the design MCP, or the existing UI
@@ -916,12 +957,15 @@ The wiring is a single delegated click handler installed alongside
 ## Layout — Fullscreen single-screen + Overlay Panel + Feedback Dock
 
 ```html
-<html data-template="prototype">
+<!-- data-template mirrors the ACTIVE iteration; applyIterationTemplate()
+     rewrites it on every tab switch. body overflow is set by that function,
+     the inline style below is only the first-paint value. -->
+<html data-template="design">
 <body style="overflow: hidden">
-  <div class="concept-layout prototype fullscreen">
+  <div class="concept-layout design fullscreen">
     <div class="concept-content">
       <main>
-        <section data-iteration="1" data-active>
+        <section data-iteration="1" data-iteration-template="design" data-active>
           <!-- All screens live here. Exactly one carries data-screen-active="true"
                (others get `hidden`). Every screen is position: absolute; inset: 0
                so it fills the viewport. A <div class="device-frame"> inside
@@ -959,7 +1003,7 @@ The wiring is a single delegated click handler installed alongside
             data-label-close="{{panel.minimize}}">💬</button>
 
     <!-- Decision panel (☰) — contains: iteration-tabs, screen-nav, submit.
-         No section-TOC here: the screen-nav replaces it for prototype. -->
+         No section-TOC here: the screen-nav replaces it for design. -->
     <aside class="concept-decision-panel overlay" id="decision-panel">
       <button id="panel-close" class="panel-close-btn" aria-label="{{panel.close}}">✕</button>
       <nav class="iteration-tabs" role="tablist" aria-label="{{iteration.label}}"><!-- chips --></nav>
@@ -1066,16 +1110,25 @@ The wiring is a single delegated click handler installed alongside
 ## Layout CSS
 
 ```css
-/* Fullscreen prototype — no body scroll, exactly one screen fills viewport */
-html, body { margin: 0; padding: 0; height: 100%; overflow: hidden; }
-.concept-layout.prototype.fullscreen { display: block; width: 100vw; height: 100vh; overflow: hidden; }
-.concept-layout.prototype .concept-content { position: absolute; inset: 0; overflow: hidden; }
+/* EVERY rule below is scoped to html[data-template="design"]. That attribute
+   is a projection of the ACTIVE iteration (see § Per-Iteration Templates), so
+   flipping it flips the whole layout: a decision/free iteration on the same
+   page falls back to the normal grid + document scroll with zero JS. Never
+   write these rules unscoped — an unscoped `html, body { overflow: hidden }`
+   would lock scrolling for the sidebar iterations too. */
+html { margin: 0; padding: 0; }
+body { margin: 0; padding: 0; }
+html[data-template="design"],
+html[data-template="design"] body { height: 100%; overflow: hidden; }
+[data-template="design"] .concept-layout.design.fullscreen { display: block; width: 100vw; height: 100vh; overflow: hidden; }
+[data-template="design"] .concept-layout.design .concept-content { position: absolute; inset: 0; overflow: hidden; }
 
 /* Iteration sections fill the viewport. Screens inside do too —
-   only the active one is visible (hidden attribute on the others). */
-section[data-iteration] { position: absolute; inset: 0; }
+   only the active one is visible (hidden attribute on the others).
+   Outside design mode iterations stay in normal document flow. */
+[data-template="design"] section[data-iteration] { position: absolute; inset: 0; }
 section[data-iteration][hidden] { display: none; }
-section[data-screen] {
+[data-template="design"] section[data-screen] {
   position: absolute; inset: 0;
   display: flex; align-items: center; justify-content: center;
   padding: 2rem; overflow-y: auto;
@@ -1083,6 +1136,16 @@ section[data-screen] {
 }
 section[data-screen][hidden] { display: none; }
 @keyframes screen-in { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: translateY(0); } }
+
+/* Design-only chrome: FABs, screen indicator and feedback dock exist in the
+   DOM on every page but must only render in design mode. The `html` type
+   selector is REQUIRED — a bare `:not([data-template="design"])` also matches
+   <body> (which never carries the attribute) and would hide the chrome in
+   design mode too. */
+html:not([data-template="design"]) .screen-indicator,
+html:not([data-template="design"]) .panel-fab,
+html:not([data-template="design"]) .feedback-fab,
+html:not([data-template="design"]) .feedback-dock { display: none !important; }
 
 /* Minimal screen counter — NOT a header bar */
 .screen-indicator {
@@ -1095,8 +1158,10 @@ section[data-screen][hidden] { display: none; }
 }
 .screen-indicator strong { color: var(--text); }
 
-/* Overlay decision panel — hidden by default, same slide-in as non-prototype overlay */
-.concept-layout.prototype .concept-decision-panel {
+/* Overlay decision panel — hidden by default, same slide-in as the non-design
+   overlay. Scoped: in a decision/free iteration the very same <aside> must
+   dock back into the sidebar grid. */
+[data-template="design"] .concept-layout.design .concept-decision-panel {
   display: flex;
   flex-direction: column;
   position: fixed;
@@ -1112,7 +1177,7 @@ section[data-screen][hidden] { display: none; }
   overflow-y: auto;
   transition: right 0.3s ease;
 }
-.concept-layout.prototype .concept-decision-panel.open {
+[data-template="design"] .concept-layout.design .concept-decision-panel.open {
   right: 0;
 }
 
@@ -1273,7 +1338,7 @@ section[data-screen][hidden] { display: none; }
 /* Hidden per-screen textareas inside #screen-textareas: only active shown */
 #screen-textareas textarea[hidden] { display: none; }
 
-/* Single-screen prototype: hide screen-nav + per-screen feedback section.
+/* Single-screen design: hide screen-nav + per-screen feedback section.
    Only general notes remain visible. */
 body[data-single-screen="true"] #screen-nav,
 body[data-single-screen="true"] .feedback-section:has(#screen-textareas),
@@ -1291,8 +1356,14 @@ DOM (just hidden), so each one's value persists independently via
 `localStorage` (same mechanism as any `data-comment` field).
 
 ```javascript
-(function wirePrototypeLayout() {
-  if (document.documentElement.dataset.template !== 'prototype') return;
+(function wireDesignLayout() {
+  // Guard on the PAGE, not on the current projection: a page whose first
+  // iteration is `decision` may still contain a `design` iteration further
+  // down, and this IIFE only runs once at load.
+  const hasDesign = document.documentElement.dataset.template === 'design'
+    || !!document.querySelector('section[data-iteration][data-iteration-template="design"],'
+                              + 'section[data-iteration][data-iteration-template="prototype"]');
+  if (!hasDesign) return;
 
   // Build screen-nav buttons (☰) and per-screen textareas (💬) from every
   // <section data-screen> inside the VISIBLE iteration (may be a frozen
@@ -1303,7 +1374,7 @@ DOM (just hidden), so each one's value persists independently via
     const screens = [...visible.querySelectorAll('section[data-screen][id]')];
     document.getElementById('total-screens').textContent = screens.length;
 
-    // Single-screen prototypes: hide screen-nav + per-screen feedback.
+    // Single-screen designs: hide screen-nav + per-screen feedback.
     // CSS keys off body[data-single-screen="true"].
     document.body.dataset.singleScreen = screens.length <= 1 ? 'true' : 'false';
     if (screens.length <= 1) {
@@ -1417,7 +1488,7 @@ DOM (just hidden), so each one's value persists independently via
   });
   dockClose.addEventListener('click', closeDock);
 
-  // Click outside the dock (anywhere on the prototype screen) closes it.
+  // Click outside the dock (anywhere on the design screen) closes it.
   // The ✕ button still works — this just adds click-away as an alternative
   // dismissal. Uses capture so it runs before the screen-link handler,
   // which is fine: the click also triggers navigation if it hit a
@@ -1478,7 +1549,7 @@ DOM (just hidden), so each one's value persists independently via
 })();
 ```
 
-**Persistence extension:** the prototype's `saveState()` must also write
+**Persistence extension:** the design layout's `saveState()` must also write
 `_activeScreen: '{current-screen-id}'` into the localStorage payload so the
 restore path on page load lands the user back on the last-viewed screen.
 
@@ -1509,7 +1580,7 @@ document.addEventListener('click', e => {
 
 ## Screen-pattern markup
 
-Each logical screen in the prototype is a `<section>` with `data-screen`:
+Each logical screen in a design is a `<section>` with `data-screen`:
 
 ```html
 <section data-iteration="1" data-active>
@@ -1519,15 +1590,15 @@ Each logical screen in the prototype is a `<section>` with `data-screen`:
   </header>
 
   <section id="screen-welcome" data-nav-label="Welcome" data-screen>
-    <div class="prototype-frame">…mockup HTML for welcome screen…</div>
+    <div class="device-frame">…mockup HTML for welcome screen…</div>
   </section>
 
   <section id="screen-credentials" data-nav-label="Credentials" data-screen>
-    <div class="prototype-frame">…mockup HTML for credentials screen…</div>
+    <div class="device-frame">…mockup HTML for credentials screen…</div>
   </section>
 
   <section id="screen-success" data-nav-label="Success" data-screen>
-    <div class="prototype-frame">…mockup HTML for success screen…</div>
+    <div class="device-frame">…mockup HTML for success screen…</div>
   </section>
 </section>
 ```
@@ -1537,7 +1608,7 @@ Each logical screen in the prototype is a `<section>` with `data-screen`:
   per-screen textarea in the dock. Use it only for screens worth commenting on.
 - Every `data-screen` section MUST also have `id` and `data-nav-label` so
   the panel TOC and the feedback dock can reference it.
-- The prototype iteration section can still contain non-screen `<section>`s
+- A design iteration section can still contain non-screen `<section>`s
   (e.g. `id="design-notes" data-nav-label="Design notes"`). Those appear in
   the TOC but NOT in the feedback dock.
 - Iteration tabs still apply — when Claude iterates on feedback, a new
@@ -1546,11 +1617,11 @@ Each logical screen in the prototype is a `<section>` with `data-screen`:
 
 ## Decision schema
 
-Prototype submit payload has **no variant evaluations** — only comments:
+The design submit payload has **no variant evaluations** — only comments:
 
 ```json
 {
-  "template": "prototype",
+  "template": "design",
   "decisions": [],
   "comments": [
     { "id": "general", "text": "..." },
@@ -1560,11 +1631,11 @@ Prototype submit payload has **no variant evaluations** — only comments:
 }
 ```
 
-## collectDecisions (prototype branch)
+## collectDecisions (design branch)
 
 ```javascript
 // Called by the shared submit handler; `data-template` picks the branch.
-function collectPrototypeDecisions() {
+function collectDesignDecisions() {
   const comments = [];
   // General notes
   const general = document.getElementById('proto-general-feedback');
@@ -1582,7 +1653,7 @@ function collectPrototypeDecisions() {
       text: el.value.trim()
     });
   });
-  return { submitted: true, template: 'prototype', decisions: [], comments };
+  return { submitted: true, template: 'design', decisions: [], comments };
 }
 ```
 
@@ -2586,8 +2657,11 @@ function ensureCommentSlots() {
 
 ## collectDecisions (dispatcher)
 
-The submit handler picks the branch based on `data-template` on `<html>`.
-An `action` (`iterate` | `implement`) is passed in from the button that was
+The submit handler picks the branch from the **active iteration's**
+`data-iteration-template` (via `resolveIterationTemplate()`, § Tab Switch JS),
+not from the `<html data-template>` projection — that projection follows the
+tab the user is *looking at* and would mis-route the payload when a frozen tab
+of a different template is open. An `action` (`iterate` | `implement`) is passed in from the button that was
 clicked and merged into the payload.
 
 The dispatcher ALSO runs a generic catch-all scoped to the active
@@ -2629,9 +2703,12 @@ function collectDecisions(action = 'iterate') {
               || document.body;
   const allFields = collectAllFormFields(active);
 
-  const template = document.documentElement.dataset.template || 'decision';
+  // Resolve the template from the ACTIVE iteration, never from <html>: the
+  // projection there could be stale (e.g. the user is viewing a frozen tab
+  // with a different layout) and would mis-route the payload.
+  const template = resolveIterationTemplate(active);
   let payload;
-  if (template === 'prototype') payload = collectPrototypeDecisions();
+  if (template === 'design') payload = collectDesignDecisions();
   else if (template === 'free') payload = collectFreeDecisions();
   else payload = collectDecisionDecisions();
   payload.action = action;
@@ -3433,7 +3510,7 @@ Iterations of a concept page are appended as `<section data-iteration="N">`
 blocks inside the same HTML file. The tab bar lives **at the top of the
 right-side decision panel** (a compact vertical chip list, rendered above
 the section TOC and submit block). All three templates support iterations —
-prototype and free include them identically.
+design and free include them identically.
 
 ### Tab Bar HTML
 
@@ -3543,7 +3620,33 @@ When appending iteration N+1, Claude must freeze the previous section:
 ### Tab Switch JS
 
 ```javascript
+// Resolve the template of ONE iteration section. Authoritative source is
+// data-iteration-template; `prototype` is the legacy alias of `design`;
+// a missing attribute falls back to the current <html data-template> so
+// pages generated before per-iteration templates behave exactly as before.
+function resolveIterationTemplate(section) {
+  const raw = (section && section.dataset && section.dataset.iterationTemplate)
+    || document.documentElement.dataset.template
+    || 'decision';
+  return raw === 'prototype' ? 'design' : raw;
+}
+
+// Project the shown iteration's template onto <html> and lock/unlock body
+// scroll. Everything else (layout, panel docking, FABs, dock) is pure CSS off
+// [data-template="design"] — no per-iteration layout code beyond these two
+// lines. Called FIRST from showIteration().
+function applyIterationTemplate(section) {
+  const template = resolveIterationTemplate(section);
+  document.documentElement.dataset.template = template;
+  document.body.style.overflow = template === 'design' ? 'hidden' : '';
+  return template;
+}
+
 function showIteration(n) {
+  // MUST run first: the layout must be correct before buildSectionNav() or
+  // any iteration:changed listener measures/renders against it.
+  applyIterationTemplate([...document.querySelectorAll('section[data-iteration]')]
+    .find(sec => String(sec.dataset.iteration) === String(n)));
   document.querySelectorAll('section[data-iteration]').forEach(sec => {
     const match = String(sec.dataset.iteration) === String(n);
     sec.hidden = !match;

--- a/plugins/devops/skills/concept/deep-knowledge/templates.md
+++ b/plugins/devops/skills/concept/deep-knowledge/templates.md
@@ -118,6 +118,21 @@ must see their own language. The locale hint is authoritative.
 | `proto.feedback_current`       | Current screen                 | Aktueller Screen |
 | `proto.feedback_placeholder`   | Write a note on this screen…   | Notiz zu diesem Screen… |
 | `proto.screen_counter`         | Screen {n} / {total}           | Screen {n} / {total} |
+| `design.feedback_design`       | Notes on this design           | Anmerkungen zu diesem Design |
+| `design.feedback_design_placeholder` | Write a note on this design… | Notiz zu diesem Design… |
+| `design.switch_label`          | Switch design                  | Design wechseln |
+| `design.position_iteration`    | Iteration                      | Iteration |
+| `design.position_page`         | Page                           | Seite |
+
+**`design.position_iteration` and `design.position_page` are label words,
+not full sentences** — the numbers (`N`, `total`) are live spans the JS
+updates on every switch, exactly like the pre-existing `active-screen-idx`
+span, so only the word is baked in at generation time. They compose the
+screen indicator (§ Screen indicator, design template) as
+`{position_iteration} {i} · {design-nav-label} · {position_page} {n} /
+{total} · {screen-nav-label}`, with the iteration segment dropped when the
+concept has one iteration and the design segment dropped when the iteration
+has one design — see the indicator JS for the exact assembly.
 
 **Locale tag example on `<html>`:** `<html lang="de">`, `<html lang="en">`,
 `<html lang="fr">`, `<html lang="hi">`, `<html lang="ja">`. Match whatever
@@ -901,6 +916,14 @@ buttons:
     per-screen UI. CSS adds: `body[data-single-screen="true"] #screen-nav,
     body[data-single-screen="true"] .feedback-section:has(#screen-textareas)
     { display: none }`.
+- **Single-design iteration (exactly one `<section data-design>`):**
+  degenerates to today's behaviour — no design switcher, no per-design
+  feedback row, `#screen-nav` renders as a flat list (no design heading).
+  `buildDesignUI()` detects `designs.length === 1` and sets
+  `document.body.dataset.singleDesign = 'true'`, the sibling of
+  `data-single-screen` above, so CSS hides the same way. The `data-design`
+  wrapper is still required in the markup even when there's only one — see
+  § Screen-pattern markup.
 - **Do NOT invent artificial screens** to make the template fit. If the
   artefact has no meaningful secondary state, leave it as a single screen
   and let the dock collapse to general notes only.
@@ -966,30 +989,61 @@ The wiring is a single delegated click handler installed alongside
     <div class="concept-content">
       <main>
         <section data-iteration="1" data-iteration-template="design" data-active>
-          <!-- All screens live here. Exactly one carries data-screen-active="true"
-               (others get `hidden`). Every screen is position: absolute; inset: 0
-               so it fills the viewport. A <div class="device-frame"> inside
-               holds the actual mock content. -->
-          <section id="screen-1" data-screen data-nav-label="Welcome" data-screen-active="true">
-            <div class="device-frame">…mock…</div>
+          <!-- One or more designs. Exactly one <section data-design> carries
+               data-design-active="true" (others get `hidden`). A single
+               design still needs this wrapper for markup uniformity — it
+               just degenerates to today's behaviour (see body[data-single-design]
+               below). -->
+          <section data-design="dispatch" data-nav-label="Dispatch and Apparatus" data-design-active="true">
+            <!-- All pages of THIS design live here. Exactly one carries
+                 data-screen-active="true" (others get `hidden`). Every screen
+                 is position: absolute; inset: 0 so it fills the viewport. A
+                 <div class="device-frame"> inside holds the actual mock content. -->
+            <section id="d1-s1" data-screen data-nav-label="Welcome" data-screen-active="true">
+              <div class="device-frame">…mock…</div>
+            </section>
+            <section id="d1-s2" data-screen data-nav-label="Credentials" hidden>
+              <div class="device-frame">…mock…</div>
+            </section>
+            <section id="d1-s3" data-screen data-nav-label="Success" hidden>
+              <div class="device-frame">…mock…</div>
+            </section>
           </section>
-          <section id="screen-2" data-screen data-nav-label="Credentials" hidden>
-            <div class="device-frame">…mock…</div>
-          </section>
-          <section id="screen-3" data-screen data-nav-label="Success" hidden>
-            <div class="device-frame">…mock…</div>
+          <section data-design="holotable" data-nav-label="Holotable" hidden>
+            <section id="d2-s1" data-screen data-nav-label="Welcome" data-screen-active="true">
+              <div class="device-frame">…mock…</div>
+            </section>
           </section>
         </section>
       </main>
     </div>
 
-    <!-- Minimal screen counter (top-left overlay) — NOT a header bar.
-         Shows "Screen N / Total · {label}" so the user always knows where
-         they are. -->
-    <div class="screen-indicator">
-      Screen <strong id="active-screen-idx">1</strong> / <span id="total-screens">3</span>
+    <!-- Minimal position indicator (top-left overlay) — NOT a header bar.
+         Built entirely in JS from {{design.position_iteration}} and
+         {{design.position_page}} (§ UI Locale) — the iteration segment only
+         renders when the concept has >1 iteration, the design segment only
+         when the iteration has >1 design. See buildDesignUI() below; the
+         spans here are just the mount points it fills in. -->
+    <div class="screen-indicator" id="screen-indicator">
+      <!-- Fully rebuilt by updateIndicator() (§ Layout JS) on every
+           iteration/design/screen switch — segments are joined with " · "
+           only for the ones that apply, so a hidden segment never leaves a
+           dangling separator. Static fallback below is the generation-time
+           first-paint value (3-screen, single-iteration, single-design
+           example) so the page never flashes empty before JS runs. -->
+      {{design.position_page}} <strong id="active-screen-idx">1</strong> / <span id="total-screens">3</span>
       · <span id="active-screen-label">Welcome</span>
     </div>
+
+    <!-- Design switcher (ghost bar, top centre) — one segment per
+         <section data-design>, only rendered when the iteration has ≥2
+         designs (hidden via body[data-single-design], see Layout CSS).
+         Auto-populated by buildDesignUI(); resting state shows only the
+         active label (CSS collapses the rest), hover/:focus-within expands
+         to the full segmented control. -->
+    <nav class="design-switcher" id="design-switcher" aria-label="{{design.switch_label}}">
+      <!-- auto-populated: one <button class="design-switch-item"> per design -->
+    </nav>
 
     <!-- Two FABs — the only floating UI besides the screen itself.
          The 💬 FAB carries two labels: the dock toggle swaps aria-label
@@ -1008,10 +1062,15 @@ The wiring is a single delegated click handler installed alongside
       <button id="panel-close" class="panel-close-btn" aria-label="{{panel.close}}">✕</button>
       <nav class="iteration-tabs" role="tablist" aria-label="{{iteration.label}}"><!-- chips --></nav>
       <nav class="screen-nav" id="screen-nav" aria-label="Screens">
-        <!-- auto-populated: one button per <section data-screen>.
-             Each shows the screen index, label, and a ● marker when that
-             screen has unsubmitted notes. Clicking switches the active screen
-             AND closes the panel. -->
+        <!-- auto-populated, two levels: one .screen-nav-group per
+             <section data-design>, a .screen-nav-design-heading button at
+             the top of each group, then one .screen-nav-item per page
+             nested beneath. Single-design pages skip the heading (CSS,
+             body[data-single-design]) and render as today's flat list.
+             The ● marker applies at both levels: a design heading shows it
+             when ANY of its pages, or its own design-level comment field,
+             carries unsubmitted text. Clicking either level switches and
+             closes the panel. -->
       </nav>
       <div id="panel-ready">
         <!-- Connection status pill — same inline, non-blocking contract as the
@@ -1145,7 +1204,8 @@ section[data-screen][hidden] { display: none; }
 html:not([data-template="design"]) .screen-indicator,
 html:not([data-template="design"]) .panel-fab,
 html:not([data-template="design"]) .feedback-fab,
-html:not([data-template="design"]) .feedback-dock { display: none !important; }
+html:not([data-template="design"]) .feedback-dock,
+html:not([data-template="design"]) .design-switcher { display: none !important; }
 
 /* Minimal screen counter — NOT a header bar */
 .screen-indicator {
@@ -1157,6 +1217,53 @@ html:not([data-template="design"]) .feedback-dock { display: none !important; }
   backdrop-filter: blur(6px);
 }
 .screen-indicator strong { color: var(--text); }
+
+/* ── Design switcher — ghost bar, top centre ──
+   Deliberately barely-there at rest: the viewport belongs to the mockup, not
+   to chrome. Only the active design's label shows, no background fill, no
+   separators. Hover AND :focus-visible reveal the full segmented control —
+   focus-visible matters because this must be reachable without a mouse.
+   Never collides with the screen indicator (top-left) or the ☰ FAB
+   (top-right once Wave 3 moves it there): it sits centred and is hidden
+   entirely below two designs (body[data-single-design="true"], see below). */
+.design-switcher {
+  position: fixed; top: 0.75rem; left: 50%; transform: translateX(-50%);
+  z-index: 95;
+  display: flex; gap: 2px;
+  padding: 0.3rem; border-radius: 999px;
+  background: transparent;
+  backdrop-filter: blur(6px);
+  opacity: 0.18;
+  transition: opacity 0.16s ease;
+}
+.design-switcher:hover,
+.design-switcher:focus-within { opacity: 1; }
+.design-switch-item {
+  border: none; background: transparent; cursor: pointer;
+  padding: 0.35rem 0.85rem; border-radius: 999px;
+  font-size: 0.8rem; color: var(--text-secondary);
+  white-space: nowrap; transition: background 0.15s, color 0.15s;
+}
+/* Resting state shows ONLY the active label — siblings collapse to width 0
+   so no separators/background are visible until the bar expands on hover. */
+.design-switcher:not(:hover):not(:focus-within) .design-switch-item:not([data-active="true"]) {
+  width: 0; padding: 0; margin: 0; overflow: hidden; pointer-events: none;
+}
+.design-switcher:not(:hover):not(:focus-within) {
+  background: transparent; border: none;
+}
+.design-switcher:hover,
+.design-switcher:focus-within {
+  background: color-mix(in srgb, var(--panel-bg) 85%, transparent);
+  border: 1px solid var(--border-color);
+}
+.design-switch-item[data-active="true"] {
+  color: var(--text); font-weight: 600;
+  background: color-mix(in srgb, var(--accent-color) 18%, transparent);
+}
+.design-switch-item:hover { background: color-mix(in srgb, var(--accent-color) 10%, transparent); }
+/* Auto-hides while the ☰ panel is open — the panel carries the same nav. */
+body.panel-open .design-switcher { opacity: 0; pointer-events: none; }
 
 /* Overlay decision panel — hidden by default, same slide-in as the non-design
    overlay. Scoped: in a decision/free iteration the very same <aside> must
@@ -1239,6 +1346,23 @@ html:not([data-template="design"]) .feedback-dock { display: none !important; }
 }
 .screen-nav-item .screen-idx { color: var(--accent-color); font-weight: 600; margin-right: 0.5rem; }
 .screen-nav-item .has-notes { color: var(--warning-color); font-size: 0.75rem; }
+
+/* Two-level nav: a design heading per <section data-design>, its pages
+   nested/indented beneath. Single-design pages never render the heading
+   (see body[data-single-design="true"] below), so this stays invisible
+   until it's needed. */
+.screen-nav-group { display: flex; flex-direction: column; gap: 2px; }
+.screen-nav-group + .screen-nav-group { margin-top: 0.5rem; }
+.screen-nav-design-heading {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 0.5rem 0.85rem; border-radius: 8px; border: none;
+  background: transparent; color: var(--text); font-size: 0.9rem;
+  font-weight: 700; cursor: pointer; text-align: left; transition: background 0.15s;
+}
+.screen-nav-design-heading:hover { background: color-mix(in srgb, var(--accent-color) 10%, transparent); }
+.screen-nav-design-heading[data-active="true"] { color: var(--accent-color); }
+.screen-nav-design-heading .has-notes { color: var(--warning-color); font-size: 0.75rem; }
+.screen-nav-group .screen-nav-item { margin-left: 0.75rem; }
 
 /* ── Feedback Dock — Speech-Bubble anchored to the 💬 FAB ──
    Geometry:
@@ -1345,15 +1469,32 @@ body[data-single-screen="true"] .feedback-section:has(#screen-textareas),
 body[data-single-screen="true"] .feedback-divider:has(+ .feedback-section #proto-general-feedback) {
   display: none;
 }
+
+/* Single-design iteration: sibling mechanism to single-screen above, set by
+   the same wiring pass (buildDesignUI()). Hides the design switcher and the
+   per-design feedback row via CSS only — no JS branching needed at the call
+   site, matching how single-screen already collapses. The design heading
+   level of #screen-nav also collapses back to a flat list since there is
+   nothing to group. */
+body[data-single-design="true"] .design-switcher,
+body[data-single-design="true"] .screen-nav-design-heading,
+body[data-single-design="true"] .feedback-section:has([data-design-comment]),
+body[data-single-design="true"] .feedback-divider:has(+ .feedback-section [data-design-comment]) {
+  display: none;
+}
+body[data-single-design="true"] .screen-nav-group .screen-nav-item { margin-left: 0; }
 ```
 
 ## Layout JS — single-screen navigation + context-sensitive feedback
 
-Only one screen is visible at a time. `showScreen(id)` swaps the active
-screen, updates the counter overlay, and swaps the feedback-dock textarea
-to the matching per-screen `<textarea>`. Per-screen textareas stay in the
-DOM (just hidden), so each one's value persists independently via
-`localStorage` (same mechanism as any `data-comment` field).
+Only one screen is visible at a time, scoped to the one active design. Each
+design remembers its own last-viewed page (`lastScreenByDesign`, persisted
+via `saveState()`), so switching designs and back returns to that page, not
+page 1. `showScreen(id)` swaps the active screen, rebuilds the position
+indicator, and swaps the feedback-dock textarea to the matching per-screen
+`<textarea>`. Per-screen textareas stay in the DOM (just hidden), so each
+one's value persists independently via `localStorage` (same mechanism as any
+`data-comment` field).
 
 ```javascript
 (function wireDesignLayout() {
@@ -1365,34 +1506,103 @@ DOM (just hidden), so each one's value persists independently via
                               + 'section[data-iteration][data-iteration-template="prototype"]');
   if (!hasDesign) return;
 
-  // Build screen-nav buttons (☰) and per-screen textareas (💬) from every
-  // <section data-screen> inside the VISIBLE iteration (may be a frozen
-  // tab the user clicked back to, not necessarily the live one).
-  function buildScreenUI() {
-    const visible = document.querySelector('section[data-iteration]:not([hidden])');
-    if (!visible) return;
-    const screens = [...visible.querySelectorAll('section[data-screen][id]')];
+  // Per-design "last viewed page" memory, keyed by design id. Restored from
+  // localStorage's `_activeScreenByDesign` on load (see saveState below) so
+  // it survives reloads, not just in-session switches.
+  let lastScreenByDesign = {};
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw) lastScreenByDesign = JSON.parse(raw)._activeScreenByDesign || {};
+  } catch (e) {}
+
+  function visibleIteration() {
+    return document.querySelector('section[data-iteration]:not([hidden])');
+  }
+  function activeDesign() {
+    const it = visibleIteration();
+    return it ? it.querySelector('section[data-design][data-design-active="true"]') : null;
+  }
+  function designs() {
+    const it = visibleIteration();
+    return it ? [...it.querySelectorAll('section[data-design]')] : [];
+  }
+
+  // Build screen-nav (two-level: design heading + nested pages), the design
+  // switcher ghost bar, and per-screen textareas — all scoped to the
+  // VISIBLE iteration (may be a frozen tab the user clicked back to, not
+  // necessarily the live one).
+  function buildDesignUI() {
+    const allDesigns = designs();
+    const active = activeDesign();
+    if (!active) return;
+
+    // Single-design collapse: CSS keys off body[data-single-design="true"]
+    // to hide the switcher + design-level feedback row, mirroring
+    // body[data-single-screen] below.
+    document.body.dataset.singleDesign = allDesigns.length <= 1 ? 'true' : 'false';
+
+    // Design switcher (ghost bar) — one segment per design.
+    const switcher = document.getElementById('design-switcher');
+    switcher.innerHTML = '';
+    allDesigns.forEach(d => {
+      const btn = document.createElement('button');
+      btn.className = 'design-switch-item';
+      btn.type = 'button';
+      btn.dataset.designId = d.dataset.design;
+      btn.dataset.active = String(d === active);
+      btn.textContent = d.dataset.navLabel || d.dataset.design;
+      btn.addEventListener('click', () => showDesign(d.dataset.design));
+      switcher.appendChild(btn);
+    });
+
+    // Two-level screen-nav inside the ☰ panel: one .screen-nav-group per
+    // design, a heading button, then nested .screen-nav-item per page.
+    const nav = document.getElementById('screen-nav');
+    nav.innerHTML = '';
+    allDesigns.forEach(d => {
+      const group = document.createElement('div');
+      group.className = 'screen-nav-group';
+
+      const heading = document.createElement('button');
+      heading.className = 'screen-nav-design-heading';
+      heading.type = 'button';
+      heading.dataset.designId = d.dataset.design;
+      heading.dataset.active = String(d === active);
+      heading.innerHTML = `<span>${d.dataset.navLabel || d.dataset.design}</span>
+        <span class="has-notes" data-design-note-marker="${d.dataset.design}"></span>`;
+      heading.addEventListener('click', () => { showDesign(d.dataset.design); closePanel(); });
+      group.appendChild(heading);
+
+      const screens = [...d.querySelectorAll('section[data-screen][id]')];
+      screens.forEach((sec, idx) => {
+        const btn = document.createElement('button');
+        btn.className = 'screen-nav-item';
+        btn.type = 'button';
+        btn.dataset.screenId = sec.id;
+        btn.dataset.designId = d.dataset.design;
+        btn.innerHTML = `<span><span class="screen-idx">${idx + 1}.</span>${sec.dataset.navLabel || sec.id}</span>
+          <span class="has-notes" data-note-marker></span>`;
+        btn.addEventListener('click', () => {
+          if (d !== active) showDesign(d.dataset.design, sec.id);
+          else showScreen(sec.id);
+          closePanel();
+        });
+        group.appendChild(btn);
+      });
+      nav.appendChild(group);
+    });
+
+    buildScreenUI(active);
+  }
+
+  // Per-screen textareas (💬) for the design currently active.
+  function buildScreenUI(design) {
+    const screens = [...design.querySelectorAll('section[data-screen][id]')];
     document.getElementById('total-screens').textContent = screens.length;
 
     // Single-screen designs: hide screen-nav + per-screen feedback.
     // CSS keys off body[data-single-screen="true"].
     document.body.dataset.singleScreen = screens.length <= 1 ? 'true' : 'false';
-    if (screens.length <= 1) {
-      const indicator = document.querySelector('.screen-indicator');
-      if (indicator) indicator.style.display = 'none';
-    }
-
-    const nav = document.getElementById('screen-nav');
-    nav.innerHTML = '';
-    screens.forEach((sec, idx) => {
-      const btn = document.createElement('button');
-      btn.className = 'screen-nav-item';
-      btn.dataset.screenId = sec.id;
-      btn.innerHTML = `<span><span class="screen-idx">${idx + 1}.</span>${sec.dataset.navLabel || sec.id}</span>
-        <span class="has-notes" data-note-marker></span>`;
-      btn.addEventListener('click', () => { showScreen(sec.id); closePanel(); });
-      nav.appendChild(btn);
-    });
 
     const container = document.getElementById('screen-textareas');
     container.innerHTML = '';
@@ -1406,9 +1616,37 @@ DOM (just hidden), so each one's value persists independently via
     });
   }
 
+  // Switches the active design (and, within it, the given page or its
+  // remembered last-viewed page). Closes over showScreen defined below.
+  window.showDesign = function(designId, screenId) {
+    const it = visibleIteration();
+    if (!it) return;
+    const targets = [...it.querySelectorAll('section[data-design]')];
+    targets.forEach(d => {
+      const match = d.dataset.design === designId;
+      d.hidden = !match;
+      d.dataset.designActive = match ? 'true' : 'false';
+    });
+    document.querySelectorAll('.design-switch-item').forEach(item => {
+      item.dataset.active = String(item.dataset.designId === designId);
+    });
+    document.querySelectorAll('.screen-nav-design-heading').forEach(h => {
+      h.dataset.active = String(h.dataset.designId === designId);
+    });
+    const design = document.querySelector(`section[data-design="${CSS.escape(designId)}"]`);
+    if (!design) return;
+    buildScreenUI(design);
+    const remembered = screenId || lastScreenByDesign[designId];
+    const first = design.querySelector('section[data-screen]');
+    const target = (remembered && design.querySelector(`#${CSS.escape(remembered)}`)) ? remembered : first?.id;
+    if (target) showScreen(target);
+    updateDesignNoteMarkers();
+  };
+
   window.showScreen = function(id) {
-    const screens = document.querySelectorAll(
-      'section[data-iteration]:not([hidden]) section[data-screen][id]');
+    const design = activeDesign();
+    if (!design) return;
+    const screens = design.querySelectorAll('section[data-screen][id]');
     let idx = 0;
     screens.forEach((s, i) => {
       const match = s.id === id;
@@ -1420,16 +1658,48 @@ DOM (just hidden), so each one's value persists independently via
     const label = screen?.dataset.navLabel || id;
     document.getElementById('active-screen-label').textContent = label;
     document.getElementById('active-screen-idx').textContent = idx + 1;
-    document.getElementById('dock-screen-label').textContent = label;
+    const dockLabel = document.getElementById('dock-screen-label');
+    if (dockLabel) dockLabel.textContent = label;
     document.querySelectorAll('[data-screen-comment]').forEach(ta => {
       ta.hidden = ta.dataset.screenComment !== id;
     });
     document.querySelectorAll('.screen-nav-item').forEach(item => {
       item.dataset.active = String(item.dataset.screenId === id);
     });
+    lastScreenByDesign[design.dataset.design] = id;
+    updateIndicator();
     updateNoteMarkers();
     if (typeof saveState === 'function') saveState();
   };
+
+  // Rebuilds the position indicator from the locale word-primitives +
+  // live numbers: "{iteration} · {design} · {page} N/total · {label}",
+  // dropping the iteration segment when there is one iteration and the
+  // design segment when the active iteration has one design. Never a
+  // fixed-shape string — each segment is toggled `hidden` independently so
+  // a missing one leaves no dangling " · ".
+  function updateIndicator() {
+    const totalIterations = document.querySelectorAll('section[data-iteration]').length;
+    const iterEl = document.getElementById('indicator-iteration');
+    if (iterEl) {
+      iterEl.hidden = totalIterations <= 1;
+      if (!iterEl.hidden) {
+        const activeIter = document.querySelector('section[data-iteration]:not([hidden])');
+        const idxEl = document.getElementById('active-iteration-idx');
+        if (idxEl && activeIter) idxEl.textContent = activeIter.dataset.iteration;
+      }
+    }
+    const designEl = document.getElementById('indicator-design');
+    if (designEl) {
+      const total = designs().length;
+      designEl.hidden = total <= 1;
+      if (!designEl.hidden) {
+        const active = activeDesign();
+        const labelEl = document.getElementById('active-design-label');
+        if (labelEl && active) labelEl.textContent = active.dataset.navLabel || active.dataset.design;
+      }
+    }
+  }
 
   function updateNoteMarkers() {
     document.querySelectorAll('.screen-nav-item').forEach(item => {
@@ -1438,16 +1708,35 @@ DOM (just hidden), so each one's value persists independently via
       const marker = item.querySelector('[data-note-marker]');
       if (marker) marker.textContent = (ta && ta.value.trim()) ? '● Notiz' : '';
     });
+    updateDesignNoteMarkers();
   }
   window.updateNoteMarkers = updateNoteMarkers;
+
+  // Design heading marker: lights up when ANY of its pages, or its own
+  // design-level comment field (Feedback dock, Wave "design feedback row"
+  // — `[data-design-comment="{id}"]`, may not exist yet on older pages),
+  // carries unsubmitted text.
+  function updateDesignNoteMarkers() {
+    document.querySelectorAll('[data-design-note-marker]').forEach(marker => {
+      const id = marker.dataset.designNoteMarker;
+      const design = document.querySelector(`section[data-design="${CSS.escape(id)}"]`);
+      const pageHasNotes = design && [...design.querySelectorAll('[data-screen-comment]')]
+        .some(ta => ta.value.trim());
+      const designTa = document.querySelector(`[data-design-comment="${CSS.escape(id)}"]`);
+      const designHasNotes = designTa && designTa.value.trim();
+      marker.textContent = (pageHasNotes || designHasNotes) ? '●' : '';
+    });
+  }
 
   // Panel + dock toggles
   const panel = document.getElementById('decision-panel');
   const panelToggle = document.getElementById('panel-toggle');
   const panelCloseBtn = document.getElementById('panel-close');
   const backdrop = document.getElementById('panel-backdrop');
-  window.openPanel = () => { panel.classList.add('open'); backdrop.classList.add('visible'); panelToggle.classList.add('hidden'); };
-  window.closePanel = () => { panel.classList.remove('open'); backdrop.classList.remove('visible'); panelToggle.classList.remove('hidden'); };
+  // The switcher auto-hides while the panel is open (the panel carries the
+  // same navigation) — driven by body.panel-open, see Layout CSS.
+  window.openPanel = () => { panel.classList.add('open'); backdrop.classList.add('visible'); panelToggle.classList.add('hidden'); document.body.classList.add('panel-open'); };
+  window.closePanel = () => { panel.classList.remove('open'); backdrop.classList.remove('visible'); panelToggle.classList.remove('hidden'); document.body.classList.remove('panel-open'); };
   panelToggle.addEventListener('click', openPanel);
   panelCloseBtn.addEventListener('click', closePanel);
   backdrop.addEventListener('click', closePanel);
@@ -1501,42 +1790,52 @@ DOM (just hidden), so each one's value persists independently via
   }, true);
 
   document.addEventListener('DOMContentLoaded', () => {
-    buildScreenUI();
+    buildDesignUI();
     const active = document.querySelector('section[data-iteration][data-active]');
     if (active) {
-      // Restore last active screen from localStorage if available,
-      // otherwise default to the first screen.
-      let restored = null;
-      try {
-        const raw = localStorage.getItem(STORAGE_KEY);
-        if (raw) restored = JSON.parse(raw)._activeScreen;
-      } catch (e) {}
-      const first = active.querySelector('section[data-screen]');
-      showScreen(restored && document.getElementById(restored) ? restored : (first ? first.id : ''));
+      const design = active.querySelector('section[data-design][data-design-active="true"]');
+      if (design) {
+        // Restore last active screen from localStorage if available,
+        // otherwise default to the first screen of the active design.
+        let restored = null;
+        try {
+          const raw = localStorage.getItem(STORAGE_KEY);
+          if (raw) restored = JSON.parse(raw)._activeScreen;
+        } catch (e) {}
+        const first = design.querySelector('section[data-screen]');
+        showScreen(restored && design.querySelector(`#${CSS.escape(restored)}`) ? restored : (first ? first.id : ''));
+      }
     }
+    updateIndicator();
     document.addEventListener('input', updateNoteMarkers);
   });
 
-  // Rebuild after iteration switches (fresh screens, fresh textareas).
-  // Preserve the previously active screen if it still exists in the newly
-  // visible iteration; otherwise fall back to the first screen.
+  // Rebuild after iteration switches (fresh designs, fresh screens, fresh
+  // textareas). Preserve the previously active screen if it still exists in
+  // the newly visible design; otherwise fall back to that design's
+  // remembered page, or its first page.
   document.addEventListener('iteration:changed', () => {
-    buildScreenUI();
-    const visible = document.querySelector('section[data-iteration]:not([hidden])');
+    buildDesignUI();
+    const design = activeDesign();
+    if (!design) return;
     const prevId = document.querySelector('[data-screen][data-screen-active="true"]')?.id;
-    const stillThere = prevId && visible?.querySelector(`section[data-screen]#${CSS.escape(prevId)}`);
-    const first = visible?.querySelector('section[data-screen]');
-    const target = stillThere ? prevId : first?.id;
+    const stillThere = prevId && design.querySelector(`section[data-screen]#${CSS.escape(prevId)}`);
+    const remembered = lastScreenByDesign[design.dataset.design];
+    const first = design.querySelector('section[data-screen]');
+    const target = stillThere ? prevId
+      : (remembered && design.querySelector(`#${CSS.escape(remembered)}`)) ? remembered
+      : first?.id;
     if (target) showScreen(target);
   });
 
-  // Keyboard: Arrow Left/Right (and Space) jump between screens when no
-  // textarea/input is focused and no overlay is open.
+  // Keyboard: Arrow Left/Right (and Space) jump between screens (within the
+  // active design) when no textarea/input is focused and no overlay is open.
   document.addEventListener('keydown', e => {
     if (dock.dataset.open === 'true' || panel.classList.contains('open')) return;
     if (e.target.matches('textarea, input')) return;
-    const screens = [...document.querySelectorAll(
-      'section[data-iteration]:not([hidden]) section[data-screen]')];
+    const design = activeDesign();
+    if (!design) return;
+    const screens = [...design.querySelectorAll('section[data-screen]')];
     const currentIdx = screens.findIndex(s => s.dataset.screenActive === 'true');
     if (currentIdx < 0) return;
     let nextIdx = currentIdx;
@@ -1550,28 +1849,38 @@ DOM (just hidden), so each one's value persists independently via
 ```
 
 **Persistence extension:** the design layout's `saveState()` must also write
-`_activeScreen: '{current-screen-id}'` into the localStorage payload so the
-restore path on page load lands the user back on the last-viewed screen.
+`_activeScreen: '{current-screen-id}'` AND `_activeScreenByDesign: {designId:
+screenId, …}` into the localStorage payload — the former for the currently
+active design (kept for backward compatibility with the single-design
+degenerate case), the latter so EVERY design's last-viewed page survives a
+reload, not just the one on screen at save time.
 
 ## Click-through Handler
 
 Single delegated listener that interprets `data-screen-link` on any element
-inside a `[data-screen]` section. Closes the ☰ panel (harmless no-op if
-it's not open) and fires `showScreen()`.
+inside a `[data-screen]` section, **scoped to the active design** — a link
+may only target screens within its own design, never reach across into
+another design's pages. Closes the ☰ panel (harmless no-op if it's not open)
+and fires `showScreen()`.
 
 ```javascript
 document.addEventListener('click', e => {
   const link = e.target.closest('[data-screen-link]');
   if (!link) return;
+  const activeDesignEl = document.querySelector(
+    'section[data-iteration]:not([hidden]) section[data-design][data-design-active="true"]');
+  if (!activeDesignEl) return;
   const dest = link.dataset.screenLink;
-  const screens = [...document.querySelectorAll(
-    'section[data-iteration]:not([hidden]) section[data-screen]')];
+  const screens = [...activeDesignEl.querySelectorAll('section[data-screen]')];
   const currentIdx = screens.findIndex(s => s.dataset.screenActive === 'true');
   let targetId = null;
   if (dest === 'next') targetId = screens[Math.min(currentIdx + 1, screens.length - 1)]?.id;
   else if (dest === 'prev') targetId = screens[Math.max(currentIdx - 1, 0)]?.id;
   else targetId = dest;
-  if (!targetId || !document.getElementById(targetId)) return;
+  // Guard against cross-design links: the target id must resolve to a
+  // <section data-screen> INSIDE the active design, not merely exist
+  // somewhere on the page.
+  if (!targetId || !activeDesignEl.querySelector(`#${CSS.escape(targetId)}`)) return;
   e.preventDefault();
   if (typeof closePanel === 'function') closePanel();
   showScreen(targetId);
@@ -1580,7 +1889,9 @@ document.addEventListener('click', e => {
 
 ## Screen-pattern markup
 
-Each logical screen in a design is a `<section>` with `data-screen`:
+A design iteration holds one or more `<section data-design>`, each owning
+its own set of pages. Each logical page inside a design is a `<section>`
+with `data-screen`:
 
 ```html
 <section data-iteration="1" data-active>
@@ -1589,16 +1900,24 @@ Each logical screen in a design is a `<section>` with `data-screen`:
     <p>High-fidelity walkthrough of the three-step sign-in flow.</p>
   </header>
 
-  <section id="screen-welcome" data-nav-label="Welcome" data-screen>
-    <div class="device-frame">…mockup HTML for welcome screen…</div>
+  <section data-design="dispatch" data-nav-label="Dispatch and Apparatus" data-design-active="true">
+    <section id="d1-s1" data-nav-label="Welcome" data-screen data-screen-active="true">
+      <div class="device-frame">…mockup HTML for welcome screen…</div>
+    </section>
+
+    <section id="d1-s2" data-nav-label="Credentials" data-screen hidden>
+      <div class="device-frame">…mockup HTML for credentials screen…</div>
+    </section>
+
+    <section id="d1-s3" data-nav-label="Success" data-screen hidden>
+      <div class="device-frame">…mockup HTML for success screen…</div>
+    </section>
   </section>
 
-  <section id="screen-credentials" data-nav-label="Credentials" data-screen>
-    <div class="device-frame">…mockup HTML for credentials screen…</div>
-  </section>
-
-  <section id="screen-success" data-nav-label="Success" data-screen>
-    <div class="device-frame">…mockup HTML for success screen…</div>
+  <section data-design="holotable" data-nav-label="Holotable" hidden>
+    <section id="d2-s1" data-nav-label="Welcome" data-screen data-screen-active="true">
+      <div class="device-frame">…mockup HTML for welcome screen…</div>
+    </section>
   </section>
 </section>
 ```
@@ -1607,13 +1926,24 @@ Each logical screen in a design is a `<section>` with `data-screen`:
 - `data-screen` marks a block as a "feedback target" — it appears as a
   per-screen textarea in the dock. Use it only for screens worth commenting on.
 - Every `data-screen` section MUST also have `id` and `data-nav-label` so
-  the panel TOC and the feedback dock can reference it.
-- A design iteration section can still contain non-screen `<section>`s
-  (e.g. `id="design-notes" data-nav-label="Design notes"`). Those appear in
-  the TOC but NOT in the feedback dock.
+  the panel TOC and the feedback dock can reference it. Screen ids only need
+  to be unique across the whole page — `d{design-index}-s{page-index}`
+  (e.g. `d1-s1`, `d2-s1`) keeps them readable and collision-free without
+  coordinating names across designs.
+- Exactly one `data-design` carries `data-design-active="true"`; the others
+  are `hidden`. Within the active design, exactly one `data-screen` carries
+  `data-screen-active="true"`.
+- **One design** → the wrapper is still required (markup shape stays
+  uniform across single- and multi-design concepts) but degenerates to
+  today's behaviour: no switcher, no per-design feedback field. Do not omit
+  `data-design` just because there's only one.
+- A design iteration section can still contain non-screen, non-design
+  `<section>`s (e.g. `id="design-notes" data-nav-label="Design notes"`)
+  directly under the iteration. Those appear in the TOC but NOT in the
+  feedback dock.
 - Iteration tabs still apply — when Claude iterates on feedback, a new
-  `<section data-iteration="N+1">` is appended with updated screens and the
-  old one is frozen (see Shared Systems § Iteration Tabs).
+  `<section data-iteration="N+1">` is appended with updated designs/screens
+  and the old one is frozen (see Shared Systems § Iteration Tabs).
 
 ## Decision schema
 

--- a/plugins/devops/skills/concept/deep-knowledge/templates.md
+++ b/plugins/devops/skills/concept/deep-knowledge/templates.md
@@ -911,7 +911,7 @@ buttons:
     per-screen section, no "Aktueller Screen" label)
   - No click-dummy wiring required — nothing to navigate to
   - The screen-indicator overlay can be hidden or simplified
-  - `buildScreenUI()` detects `screens.length === 1` and sets
+  - `updateScreenScope()` detects `screens.length === 1` and sets
     `document.body.dataset.singleScreen = 'true'` so CSS can hide the
     per-screen UI. CSS adds: `body[data-single-screen="true"] #screen-nav,
     body[data-single-screen="true"] .feedback-section:has(#screen-textareas)
@@ -1221,7 +1221,16 @@ html:not([data-template="design"]) .feedback-fab,
 html:not([data-template="design"]) .feedback-dock,
 html:not([data-template="design"]) .design-switcher { display: none !important; }
 
-/* Minimal screen counter — NOT a header bar */
+/* Minimal screen counter — NOT a header bar.
+   Left-anchored at 1rem and content-sized, so its natural width grows with
+   the page label while the switcher stays centred. Without a cap the two
+   overlap on narrow viewports (measured: 21px overlap at 768px, full
+   overlap at 375px). The cap is derived from the switcher's own geometry
+   below — switcher max-width 34vw, centred ⇒ its left edge is at 33vw, so
+   the indicator may occupy at most 33vw minus its 1rem offset minus a
+   0.5rem gap. Truncation with an ellipsis is the right degradation here:
+   the leading "page N/total" segment is the load-bearing part, the trailing
+   screen label is not. */
 .screen-indicator {
   position: fixed; top: 1rem; left: 1rem; z-index: 90;
   padding: 0.4rem 0.75rem; border-radius: 999px;
@@ -1229,17 +1238,30 @@ html:not([data-template="design"]) .design-switcher { display: none !important; 
   border: 1px solid var(--border-color);
   color: var(--text-secondary); font-size: 0.8rem;
   backdrop-filter: blur(6px);
+  /* border-box is REQUIRED: with the default content-box the 0.75rem
+     padding and the border are added ON TOP of max-width and the element
+     still runs into the switcher (measured: 25px over budget at 375px). */
+  box-sizing: border-box;
+  max-width: calc(33vw - 1.5rem);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
 }
+/* No switcher to avoid when the iteration has a single design — the only
+   neighbour left is the ☰ FAB at the top right (left edge 100vw - 88px). */
+body[data-single-design="true"] .screen-indicator { max-width: calc(100vw - 8rem); }
 .screen-indicator strong { color: var(--text); }
 
 /* ── Design switcher — ghost bar, top centre ──
    Deliberately barely-there at rest: the viewport belongs to the mockup, not
    to chrome. Only the active design's label shows, no background fill, no
-   separators. Hover AND :focus-visible reveal the full segmented control —
-   focus-visible matters because this must be reachable without a mouse.
+   separators. Hover AND :focus-within reveal the full segmented control —
+   :focus-within (not :focus-visible) is deliberate: the expanding element is
+   the container, and it must expand as soon as focus lands on ANY of its
+   segment buttons, which is exactly what keyboard tabbing produces. That
+   keeps the control reachable without a mouse.
    Never collides with the screen indicator (top-left) or the ☰ FAB
-   (top-right once Wave 3 moves it there): it sits centred and is hidden
-   entirely below two designs (body[data-single-design="true"], see below). */
+   (top-right once Wave 3 moves it there) — guaranteed by the width bands
+   documented at .panel-fab below, not by the labels happening to be short.
+   Hidden entirely below two designs (body[data-single-design="true"]). */
 .design-switcher {
   position: fixed; top: 0.75rem; left: 50%; transform: translateX(-50%);
   z-index: 95;
@@ -1249,6 +1271,14 @@ html:not([data-template="design"]) .design-switcher { display: none !important; 
   backdrop-filter: blur(6px);
   opacity: 0.18;
   transition: opacity 0.16s ease;
+  /* Hard width budget so the expanded (hover/focus) state cannot grow into
+     the screen indicator on the left or the ☰ FAB on the right — it spans
+     33vw…67vw at every viewport. Segments shrink and ellipsise instead;
+     min-width:0 is required or flex refuses to shrink below content width
+     because the labels are nowrap. */
+  box-sizing: border-box;
+  max-width: 34vw;
+  overflow: hidden;
 }
 .design-switcher:hover,
 .design-switcher:focus-within { opacity: 1; }
@@ -1257,6 +1287,7 @@ html:not([data-template="design"]) .design-switcher { display: none !important; 
   padding: 0.35rem 0.85rem; border-radius: 999px;
   font-size: 0.8rem; color: var(--text-secondary);
   white-space: nowrap; transition: background 0.15s, color 0.15s;
+  min-width: 0; overflow: hidden; text-overflow: ellipsis;
 }
 /* Resting state shows ONLY the active label — siblings collapse to width 0
    so no separators/background are visible until the bar expands on hover. */
@@ -1316,9 +1347,17 @@ body.panel-open .design-switcher { opacity: 0; pointer-events: none; }
   z-index: 100;
   transition: transform 0.2s, opacity 0.2s;
 }
-/* ☰ lives top-right (Wave 3) — clear of the design switcher (top centre)
-   and the screen indicator (top left) at every viewport; verified at
-   1280/768/375px. 💬 stays bottom-left, unchanged. */
+/* ☰ lives top-right (Wave 3). The three top-edge overlays partition the
+   width by construction rather than by hope:
+     screen indicator  1rem … 33vw - 0.5rem   (max-width cap + ellipsis)
+     design switcher   33vw … 67vw            (max-width: 34vw, centred)
+     ☰ FAB             100vw - 88px … 100vw - 2rem
+   Those bands cannot intersect for any viewport width where
+   67vw < 100vw - 88px, i.e. above 267px — below that the layout is out of
+   scope anyway. Measured in Edge at 1280/768/375px: no overlap at any of
+   the three. Before the caps existed the indicator overlapped the switcher
+   by 21px at 768px and completely at 375px, where it also reached the ☰
+   FAB. 💬 stays bottom-left, unchanged. */
 .panel-fab { top: 2rem; right: 2rem; background: var(--accent-color, #58a6ff); }
 .feedback-fab { bottom: 2rem; left: 2rem; background: var(--warning-color, #d29922); }
 .panel-fab:hover,
@@ -1517,16 +1556,38 @@ design remembers its own last-viewed page (`lastScreenByDesign`, persisted
 via `saveState()`), so switching designs and back returns to that page, not
 page 1. `showScreen(id)` swaps the active screen, rebuilds the position
 indicator, and swaps the feedback-dock textarea to the matching per-screen
-`<textarea>`. Per-screen textareas stay in the DOM (just hidden), so each
-one's value persists independently via `localStorage` (same mechanism as any
-`data-comment` field).
+`<textarea>`.
+
+The dock holds **one textarea per screen of EVERY design in the iteration**,
+built once per iteration by `buildScreenTextareas()` — never per design
+switch. Switching design or page only flips `hidden`; no node is ever
+destroyed. This is load-bearing in three ways:
+
+1. Values survive a design switch. `restoreState()` runs once on
+   `DOMContentLoaded` and is never re-invoked, so a node destroyed later is
+   never rehydrated.
+2. `saveState()` serialises only nodes present in the DOM — destroying a
+   textarea would DELETE its `text:{screen-id}` localStorage key on the next
+   input event, making the note unrecoverable rather than merely invisible.
+3. `collectDesignDecisions()` scans the dock; only a dock holding all designs'
+   screens produces a complete `comments.screens` payload.
+
+Same rule, same reason as `buildDesignTextareas()` for the design-level row.
+Both builders carry values across the one rebuild they do have (iteration
+change) via `harvestDockValues()`.
 
 ```javascript
 (function wireDesignLayout() {
   // Guard on the PAGE, not on the current projection: a page whose first
   // iteration is `decision` may still contain a `design` iteration further
   // down, and this IIFE only runs once at load.
-  const hasDesign = document.documentElement.dataset.template === 'design'
+  // The legacy alias `prototype` is normalised FIRST — a page that carries
+  // data-template="prototype" on <html> and no data-iteration-template at
+  // all (the documented legacy shape) must still wire up. Comparing the raw
+  // value against 'design' only would fail both disjuncts and leave the
+  // page inert.
+  const DESIGN_TEMPLATES = new Set(['design', 'prototype']);
+  const hasDesign = DESIGN_TEMPLATES.has(document.documentElement.dataset.template || '')
     || !!document.querySelector('section[data-iteration][data-iteration-template="design"],'
                               + 'section[data-iteration][data-iteration-template="prototype"]');
   if (!hasDesign) return;
@@ -1622,17 +1683,32 @@ one's value persists independently via `localStorage` (same mechanism as any
     });
 
     buildDesignTextareas(allDesigns, active);
-    buildScreenUI(active);
+    buildScreenTextareas(allDesigns);
+    updateScreenScope(active);
+  }
+
+  // Snapshot the dock's current values, keyed by data-comment, so the one
+  // rebuild these builders still perform (iteration change) does not drop
+  // text. restoreState() only runs on DOMContentLoaded, so anything lost
+  // here is lost for good — and the next saveState() would delete its
+  // localStorage key too.
+  function harvestDockValues() {
+    const values = {};
+    document.querySelectorAll('#feedback-dock [data-comment]').forEach(el => {
+      if (el.value) values[el.dataset.comment] = el.value;
+    });
+    return values;
   }
 
   // Per-design textareas (💬) — one per design, only the active one shown.
-  // Rebuilt whenever the design SET changes (buildDesignUI), unlike
-  // buildScreenUI which rebuilds on every design switch: the design list
-  // itself only changes across iteration switches, not screen switches.
+  // Rebuilt only when the design SET changes (buildDesignUI, i.e. iteration
+  // switches). A design switch never rebuilds anything: showDesign() just
+  // flips `hidden`.
   function buildDesignTextareas(allDesigns, active) {
     const container = document.getElementById('design-textareas');
     if (!container) return;
     const placeholder = container.dataset.placeholder || '';
+    const carried = harvestDockValues();
     container.innerHTML = '';
     allDesigns.forEach(d => {
       const ta = document.createElement('textarea');
@@ -1640,32 +1716,50 @@ one's value persists independently via `localStorage` (same mechanism as any
       ta.dataset.designComment = d.dataset.design;
       ta.placeholder = placeholder;
       ta.hidden = d !== active;
+      if (carried[ta.dataset.comment]) ta.value = carried[ta.dataset.comment];
       container.appendChild(ta);
     });
     const label = document.getElementById('dock-design-label');
     if (label && active) label.textContent = active.dataset.navLabel || active.dataset.design;
   }
 
-  // Per-screen textareas (💬) for the design currently active.
-  function buildScreenUI(design) {
+  // Per-screen textareas (💬) — one per screen of EVERY design in the
+  // iteration, all hidden until showScreen() reveals the active one. Built
+  // ONCE per iteration, exactly like buildDesignTextareas above; never on a
+  // design switch. Destroying and rebuilding them per design lost user text
+  // (restoreState never re-runs) and truncated the submit payload
+  // (collectDesignDecisions scans this container).
+  // data-screen-design carries the owning design id — the dock lives outside
+  // section[data-design], so that attribute is the only link back.
+  function buildScreenTextareas(allDesigns) {
+    const container = document.getElementById('screen-textareas');
+    if (!container) return;
+    const placeholder = container.dataset.placeholder || '';
+    const carried = harvestDockValues();
+    container.innerHTML = '';
+    allDesigns.forEach(d => {
+      d.querySelectorAll('section[data-screen][id]').forEach(sec => {
+        const ta = document.createElement('textarea');
+        ta.dataset.comment = sec.id;
+        ta.dataset.screenComment = sec.id;
+        ta.dataset.screenDesign = d.dataset.design;
+        ta.placeholder = placeholder;
+        ta.hidden = true;
+        if (carried[sec.id]) ta.value = carried[sec.id];
+        container.appendChild(ta);
+      });
+    });
+  }
+
+  // Counters + single-screen collapse for the design currently active.
+  // Pure projection — touches no textarea, so it is safe to call on every
+  // design switch.
+  function updateScreenScope(design) {
     const screens = [...design.querySelectorAll('section[data-screen][id]')];
     document.getElementById('total-screens').textContent = screens.length;
-
     // Single-screen designs: hide screen-nav + per-screen feedback.
     // CSS keys off body[data-single-screen="true"].
     document.body.dataset.singleScreen = screens.length <= 1 ? 'true' : 'false';
-
-    const container = document.getElementById('screen-textareas');
-    const placeholder = container.dataset.placeholder || '';
-    container.innerHTML = '';
-    screens.forEach(sec => {
-      const ta = document.createElement('textarea');
-      ta.dataset.comment = sec.id;
-      ta.dataset.screenComment = sec.id;
-      ta.placeholder = placeholder;
-      ta.hidden = true;
-      container.appendChild(ta);
-    });
   }
 
   // Switches the active design (and, within it, the given page or its
@@ -1693,9 +1787,12 @@ one's value persists independently via `localStorage` (same mechanism as any
     });
     const dockDesignLabel = document.getElementById('dock-design-label');
     if (dockDesignLabel) dockDesignLabel.textContent = targets.find(d => d.dataset.design === designId)?.dataset.navLabel || designId;
-    const design = document.querySelector(`section[data-design="${CSS.escape(designId)}"]`);
+    // Scoped to the VISIBLE iteration — design ids repeat across iterations,
+    // so an unscoped lookup would resolve to a frozen iteration's node and
+    // navigate the wrong section.
+    const design = it.querySelector(`section[data-design="${CSS.escape(designId)}"]`);
     if (!design) return;
-    buildScreenUI(design);
+    updateScreenScope(design);
     const remembered = screenId || lastScreenByDesign[designId];
     const first = design.querySelector('section[data-screen]');
     const target = (remembered && design.querySelector(`#${CSS.escape(remembered)}`)) ? remembered : first?.id;
@@ -1714,14 +1811,20 @@ one's value persists independently via `localStorage` (same mechanism as any
       s.dataset.screenActive = match ? 'true' : 'false';
       if (match) idx = i;
     });
-    const screen = document.getElementById(id);
+    // Scoped to the active design for the same reason as showDesign's
+    // lookup: screen ids repeat across iterations.
+    const screen = design.querySelector(`#${CSS.escape(id)}`);
     const label = screen?.dataset.navLabel || id;
     document.getElementById('active-screen-label').textContent = label;
     document.getElementById('active-screen-idx').textContent = idx + 1;
     const dockLabel = document.getElementById('dock-screen-label');
     if (dockLabel) dockLabel.textContent = label;
-    document.querySelectorAll('[data-screen-comment]').forEach(ta => {
-      ta.hidden = ta.dataset.screenComment !== id;
+    // The dock holds every design's screen textareas, so match on the
+    // owning design too — screen ids are unique per iteration, but this
+    // keeps the swap correct even if a page reuses ids across designs.
+    document.querySelectorAll('#feedback-dock [data-screen-comment]').forEach(ta => {
+      ta.hidden = !(ta.dataset.screenComment === id
+        && (!ta.dataset.screenDesign || ta.dataset.screenDesign === design.dataset.design));
     });
     document.querySelectorAll('.screen-nav-item').forEach(item => {
       item.dataset.active = String(item.dataset.screenId === id);
@@ -1761,10 +1864,19 @@ one's value persists independently via `localStorage` (same mechanism as any
     }
   }
 
+  // Every per-screen textarea belongs to the DOCK, not to the mockup
+  // section — `section[data-design]` never contains one. Note markers must
+  // therefore query the dock and filter by the owning design id.
+  function dockScreenTextareas(designId) {
+    return [...document.querySelectorAll('#feedback-dock [data-screen-comment]')]
+      .filter(ta => !designId || !ta.dataset.screenDesign || ta.dataset.screenDesign === designId);
+  }
+
   function updateNoteMarkers() {
     document.querySelectorAll('.screen-nav-item').forEach(item => {
       const id = item.dataset.screenId;
-      const ta = document.querySelector(`[data-screen-comment="${id}"]`);
+      const ta = dockScreenTextareas(item.dataset.designId)
+        .find(t => t.dataset.screenComment === id);
       const marker = item.querySelector('[data-note-marker]');
       if (marker) marker.textContent = (ta && ta.value.trim()) ? '● Notiz' : '';
     });
@@ -1779,9 +1891,7 @@ one's value persists independently via `localStorage` (same mechanism as any
   function updateDesignNoteMarkers() {
     document.querySelectorAll('[data-design-note-marker]').forEach(marker => {
       const id = marker.dataset.designNoteMarker;
-      const design = document.querySelector(`section[data-design="${CSS.escape(id)}"]`);
-      const pageHasNotes = design && [...design.querySelectorAll('[data-screen-comment]')]
-        .some(ta => ta.value.trim());
+      const pageHasNotes = dockScreenTextareas(id).some(ta => ta.value.trim());
       const designTa = document.querySelector(`[data-design-comment="${CSS.escape(id)}"]`);
       const designHasNotes = designTa && designTa.value.trim();
       marker.textContent = (pageHasNotes || designHasNotes) ? '●' : '';
@@ -1852,7 +1962,68 @@ one's value persists independently via `localStorage` (same mechanism as any
     autoCloseUsed = true;
     if (dock.dataset.open === 'true') closeDock();
   }
+  // Dock content is per-iteration, but the dock itself is ONE shared overlay
+  // that lives outside section[data-iteration]. Entering a frozen tab
+  // stashes the live iteration's unsent values, shows the frozen
+  // iteration's SUBMITTED values read-only (never `disabled` — see
+  // iteration-rules.md § Freezing Design Iterations), and returning to the
+  // live tab restores the stash. Both directions write EVERY dock field,
+  // empty string included: screen ids repeat across iterations, so leaving a
+  // field untouched would leak the other iteration's text into it.
+  // The frozen payload is the JSON blob the freeze step writes into the
+  // section as a script[type="application/json"][data-frozen-feedback]
+  // element — same shape collectDesignDecisions() submitted
+  // ({general, designs, screens}); see iteration-rules.md § Freezing Design
+  // Iterations for the exact markup. Never write that closing script tag
+  // literally inside this JS, not even in a comment: the HTML parser ends
+  // the surrounding script element at it. Missing blob (older pages)
+  // degrades to empty read-only fields rather than editable ones.
+  let liveDockValues = null;
+  function frozenFeedback() {
+    const it = visibleIteration();
+    const node = it && it.querySelector('script[type="application/json"][data-frozen-feedback]');
+    if (!node) return null;
+    try { return JSON.parse(node.textContent); } catch (e) { return null; }
+  }
+  function applyDockFreezeState() {
+    const frozen = document.body.classList.contains('viewing-frozen');
+    const fields = [...document.querySelectorAll('#feedback-dock textarea')];
+    if (frozen) {
+      if (liveDockValues === null) liveDockValues = harvestDockValues();
+      const data = frozenFeedback() || {};
+      fields.forEach(ta => {
+        if (ta.dataset.designComment) ta.value = (data.designs || {})[ta.dataset.designComment] || '';
+        else if (ta.dataset.screenComment) ta.value = (data.screens || {})[ta.dataset.screenComment] || '';
+        else if (ta.dataset.comment === 'general') ta.value = data.general || '';
+        ta.readOnly = true;
+      });
+    } else {
+      const stash = liveDockValues;
+      liveDockValues = null;
+      fields.forEach(ta => {
+        ta.readOnly = false;
+        if (stash) ta.value = stash[ta.dataset.comment] || '';
+      });
+    }
+  }
+
+  // Called by the submit handler once the payload is accepted. The dock is
+  // shared across iterations and its ids are per-design-index (`d1-s1`), so
+  // iteration N+1 would otherwise open pre-filled with — and re-send —
+  // iteration N's text. Clearing on submit is preferred over namespacing the
+  // keys per iteration: the values have just been persisted server-side in
+  // the payload and mirrored into the frozen section's data-frozen-feedback
+  // blob, so nothing is lost, and the localStorage keys stay stable for the
+  // ordinary reload case.
+  window.clearDock = function() {
+    document.querySelectorAll('#feedback-dock textarea').forEach(ta => { ta.value = ''; });
+    liveDockValues = null;
+    updateNoteMarkers();
+    if (typeof saveState === 'function') saveState();
+  };
+
   function primeDock() {
+    applyDockFreezeState();
     const frozen = document.body.classList.contains('viewing-frozen');
     if (frozen) {
       // Frozen: always (re-)open for review, never arm the auto-close —
@@ -1871,23 +2042,18 @@ one's value persists independently via `localStorage` (same mechanism as any
   // not "inside the mockup" at all, or (design switcher) already fire
   // fireAutoClose() from their own handler above, via the "design switch"
   // trigger rather than this generic one.
+  //
+  // This is the ONLY click-away path. There must never be a second,
+  // unconditional "close on outside click" listener: it would bypass
+  // data-auto-close-armed and close the dock on EVERY mockup click, so a
+  // dock the user deliberately re-opened after the first auto-close would
+  // not survive the next click. The contract is one auto-close, then
+  // manual 💬 toggle only — enforced entirely by fireAutoClose().
   document.addEventListener('click', e => {
     if (e.target.closest('#feedback-dock') || e.target.closest('.panel-fab')
       || e.target.closest('.feedback-fab') || e.target.closest('.design-switcher')) return;
     if (e.target.closest('.device-frame') || e.target.closest('[data-screen]')) fireAutoClose();
   });
-
-  // Click outside the dock (anywhere on the design screen) closes it.
-  // The ✕ button still works — this just adds click-away as an alternative
-  // dismissal. Uses capture so it runs before the screen-link handler,
-  // which is fine: the click also triggers navigation if it hit a
-  // data-screen-link element, and dismissing the dock first is harmless.
-  document.addEventListener('click', (e) => {
-    if (dock.dataset.open !== 'true') return;
-    if (e.target.closest('#feedback-dock')) return;
-    if (e.target.closest('#feedback-toggle')) return;
-    closeDock();
-  }, true);
 
   document.addEventListener('DOMContentLoaded', () => {
     buildDesignUI();
@@ -2083,10 +2249,15 @@ so no consumer needs to learn the design nesting to read page feedback:
 // Generic querySelectorAll('input, select, textarea') per the coverage gate
 // (iteration-rules.md § coverage gate) — no hand-listed field ids. Scoped to
 // #feedback-dock rather than [data-active]: the dock is an overlay that
-// lives outside section[data-iteration] in the DOM, but buildDesignUI() /
-// buildScreenUI() tear down and rebuild its textareas for the active
-// iteration/design on every switch, so this scan already only ever sees the
-// active iteration's fields.
+// lives outside section[data-iteration] in the DOM.
+// The dock holds a textarea for EVERY screen of EVERY design in the active
+// iteration (buildScreenTextareas), not just the design on screen — the
+// non-active ones are `hidden`, which does not affect querySelectorAll. That
+// is what makes this scan complete: an earlier version rebuilt the container
+// per design switch, so submitting a 2-design iteration shipped only the
+// design the user happened to be looking at and silently dropped the rest.
+// The dock is emptied on submit (clearDock), so it never carries a previous
+// iteration's text into the next payload.
 function collectDesignDecisions() {
   const comments = { general: '', designs: {}, screens: {} };
   document.querySelectorAll('#feedback-dock input, #feedback-dock select, #feedback-dock textarea').forEach(el => {
@@ -3327,6 +3498,12 @@ async function submitWithAction(action) {
   const data = collectDecisions(action);
   const container = document.getElementById('concept-decisions');
   container.textContent = JSON.stringify(data);
+  // design template only: the feedback dock is a single overlay shared by
+  // every iteration and its field ids repeat per iteration (`d1-s1`), so it
+  // must be emptied once the payload is captured — otherwise the appended
+  // iteration N+1 opens pre-filled with iteration N's notes and re-sends
+  // them. Runs AFTER collectDecisions(), never before. See § Layout JS.
+  if (typeof clearDock === 'function') clearDock();
   document.body.classList.add('concept-submitted', 'content-dimmed');
   showContentDimmer();
   _submittedAt = Date.now();

--- a/plugins/devops/skills/concept/deep-knowledge/validation-gate.md
+++ b/plugins/devops/skills/concept/deep-knowledge/validation-gate.md
@@ -4,7 +4,11 @@ After writing the HTML file, validate that all mandatory interactive patterns
 are present. **Grep the generated file** for each required pattern. The check
 runs in three phases: first the forbidden patterns (hard fail), then the
 shared patterns (all templates), then the template-specific extras selected
-by `<html data-template="...">`.
+by the **active iteration's** template — `data-iteration-template` on
+`section[data-iteration]`, projected onto `<html data-template="...">` by
+`applyIterationTemplate()`. Each iteration on the page may carry a different
+template; validate every iteration's section against its own
+`data-iteration-template`, not just the one currently mirrored onto `<html>`.
 
 > **Deterministic backstop:** the `post.concept.gate` PostToolUse hook
 > re-checks a critical subset of this gate (the live decision panel + bridge
@@ -50,11 +54,12 @@ Every concept page must contain these 40 patterns, regardless of template:
 | 10 | `localStorage` | Reload resilience (state persistence with TTL) |
 | 11 | `data-page-version` | Page version tag for localStorage invalidation |
 | 12 | `data-iteration` | Iteration section marker |
+| 12b | `data-iteration-template` on every `section[data-iteration]` | Authoritative per-iteration template. **Missing → warning, not a hard fail** — the legacy fallback (page-level `<html data-template>` written at generation time) still works for pages predating this attribute. New pages MUST carry it on every iteration section. |
 | 13 | `iteration-tabs` | Tab bar container in the decision panel |
 | 14 | `pollReload` | Reload-signal poller (picks up file rewrites) |
 | 15 | `sec.hidden` | Tab-switch JS toggles the `hidden` attribute |
 | 16 | `pollProcessedState` | Auto-reset poll handler |
-| 17 | `section-nav` OR `screen-nav` | Panel navigation (TOC for decision/free, screen list for prototype) |
+| 17 | `section-nav` OR `screen-nav` | Panel navigation (TOC for decision/free, screen/design list for `design`, legacy alias `prototype`) |
 | 18 | `data-nav-label` | Marker on nav-eligible sections |
 | 19 | `submit-iterate-btn` | Primary submit: iterate action (no code changes) |
 | 20 | `submit-implement-btn` | Secondary submit: implement action (real changes) |
@@ -102,7 +107,7 @@ per field. Specific selectors (for grouped sub-objects like `decisions[]`,
 `comments[]`) are allowed *in addition* but must never replace the
 catch-all.
 
-### Required pattern (free, decision, and prototype branches)
+### Required pattern (free, decision, and design branches)
 
 ```javascript
 function collectAllFormFields(scope) {
@@ -142,14 +147,21 @@ function collectDecisions(action) {
 See `templates.md` § collectDecisions (dispatcher) for the live reference
 implementation that wires this into the per-template branches.
 
-Additionally, the `<html>` element MUST carry `data-template="decision"` (or
-`prototype`, or `free`) so `collectDecisions()` dispatches to the correct
-branch. The submit payload MUST include an `action` field with value
-`"iterate"` or `"implement"`.
+Additionally, every `section[data-iteration]` MUST carry
+`data-iteration-template="decision"` (or `design`, or `free`; `prototype` is
+accepted as a legacy alias for `design`), and `applyIterationTemplate()`
+MUST mirror the active iteration's value onto `<html data-template="...">`
+so `collectDecisions()` dispatches to the correct branch. **`<html
+data-template>` not matching the active iteration's
+`data-iteration-template` is an error** — it means the projection did not
+run before first paint (see § Frozen/Active Mismatch below). The submit
+payload MUST include an `action` field with value `"iterate"` or
+`"implement"`.
 
 ## Phase 2 — Template-specific patterns
 
-Run the subset matching the template picked in Step 1a of `SKILL.md`.
+Run the subset matching the template picked per-iteration in Step 1a of
+`SKILL.md`, using each iteration's own `data-iteration-template`.
 
 ### Template: decision
 
@@ -166,7 +178,7 @@ If the page contains no variants (unusual for the decision template), D1–D5
 may be skipped — but in that case the content likely belongs in the `free`
 template instead. Reconsider the template pick before suppressing these.
 
-### Template: prototype
+### Template: design (legacy alias: prototype)
 
 | # | Pattern | Purpose |
 |---|---------|---------|
@@ -174,14 +186,27 @@ template instead. Reconsider the template pick before suppressing these.
 | P2 | `feedback-toggle` | FAB that opens the dock |
 | P3 | `feedback-screen-list` | Auto-populated per-screen comment list |
 | P4 | `data-screen` | Marker on screen sections that feed the dock |
-| P5 | `proto-general-feedback` | General-notes textarea |
+| P5 | `proto-general-feedback` | General-notes textarea (kept name for legacy compatibility) |
 | P6 | `panel-fab` | FAB that opens the decision overlay |
 | P7 | `panel-backdrop` | Overlay backdrop element |
-| P8 | `collectPrototypeDecisions` | Prototype branch of `collectDecisions` |
+| P8 | `collectDesignDecisions` OR `collectPrototypeDecisions` | Design branch of `collectDecisions` (legacy pages may still name it `collectPrototypeDecisions`) |
+| P9 | `data-design` | Design wrapper marker — required even for a single design (uniform markup shape) |
 
 At least one `<section data-screen id="…" data-nav-label="…">` MUST exist
-inside the active iteration. A prototype with zero screens can't collect
-per-screen feedback.
+inside the active design. A design iteration with zero screens can't collect
+per-screen feedback. With ≥2 `data-design` wrappers, exactly one MUST carry
+`data-design-active="true"` and the rest `hidden`.
+
+### Frozen/Active Mismatch
+
+For every `section[data-iteration]`: if it carries `data-active`, its
+`data-iteration-template` MUST equal `<html data-template>` at validation
+time (simulate a tab switch to it, or check the generation-time initial
+state if it is the only active one). A mismatch is a **hard-fail error** —
+it means either `applyIterationTemplate()` was not wired into
+`showIteration()`, or the initial `<html data-template>` written at
+generation time does not match the active iteration, which produces a
+flash-of-wrong-layout on load.
 
 ### Template: free
 
@@ -211,7 +236,12 @@ enforces the same on write.
 - Panel states missing → no visual transition on submit/reset cycle
 - localStorage missing → user selections lost on reload or tab close
 - `data-template` missing → `collectDecisions` can't pick the right branch
-- Prototype without `data-screen` → feedback dock renders empty
+- `data-iteration-template` missing on a section → warning; legacy fallback
+  used, but new pages should always carry it
+- `<html data-template>` mismatched with the active section's
+  `data-iteration-template` → error; `applyIterationTemplate()` not wired or
+  fired too late, causing a flash of the wrong layout
+- Design iteration without `data-screen` → feedback dock renders empty
 - Heartbeat poller does an HTTP-only check (no `await r.json()` + `claude_ts` assignment) → indicator stays green forever because the server self-pulse always returns 200, even when Claude's cron is dead
 - Disconnected classified before the first `/heartbeat` response (no `_everPolled` guard) → a fresh page flashes connecting→disconnected→connected; with the old overlay it also forced two "Got it" clicks
 - Cache hint not wired to the disconnected state (`_setCacheHints` missing from `checkClaudeConnection`) → a click made while Claude is offline looks lost instead of visibly queued (the Offline Submit Queue still delivers it on reconnect, but the user gets no signal)
@@ -219,5 +249,5 @@ enforces the same on write.
 - `submitCreateIssues` / `collectDisposition` missing → final-report panel renders correctly but the "Issues erstellen" button does nothing on click (silent failure — no console error, no network request); same silent failure for "Concept beenden" if `collectDisposition` is missing from `submitDisposeConcept`
 
 The patterns in `templates.md` (§ Claude Connection Heartbeat, § Submit
-Handler, § State Persistence, § Template: prototype, § Template: free)
+Handler, § State Persistence, § Template: design, § Template: free)
 provide the reference implementations.

--- a/plugins/devops/skills/concept/deep-knowledge/validation-gate.md
+++ b/plugins/devops/skills/concept/deep-knowledge/validation-gate.md
@@ -182,15 +182,23 @@ template instead. Reconsider the template pick before suppressing these.
 
 | # | Pattern | Purpose |
 |---|---------|---------|
-| P1 | `feedback-dock` | Collapsible bottom dock container |
+| P1 | `feedback-dock` | Speech-bubble dock anchored to the 💬 FAB (bottom-left) |
 | P2 | `feedback-toggle` | FAB that opens the dock |
-| P3 | `feedback-screen-list` | Auto-populated per-screen comment list |
+| P3 | `screen-textareas` OR `feedback-screen-list` | Auto-populated per-page comment container (legacy pages use `feedback-screen-list`) |
 | P4 | `data-screen` | Marker on screen sections that feed the dock |
-| P5 | `proto-general-feedback` | General-notes textarea (kept name for legacy compatibility) |
+| P5 | `design-general-feedback` OR `proto-general-feedback` | General-notes textarea (legacy pages use the `proto-` name) |
 | P6 | `panel-fab` | FAB that opens the decision overlay |
 | P7 | `panel-backdrop` | Overlay backdrop element |
 | P8 | `collectDesignDecisions` OR `collectPrototypeDecisions` | Design branch of `collectDecisions` (legacy pages may still name it `collectPrototypeDecisions`) |
 | P9 | `data-design` | Design wrapper marker — required even for a single design (uniform markup shape) |
+| P10 | `data-design-comment` | Design-level feedback textarea — required only when the iteration has ≥2 `data-design` wrappers |
+
+**Why P3/P5 carry alternates:** the dock was rebuilt for the design layer and
+its ids changed (`feedback-screen-list` → `screen-textareas`,
+`proto-general-feedback` → `design-general-feedback`). A gate pinned to the old
+ids alone hard-fails every freshly generated page, and the likely "repair" is
+Claude inventing two dead elements to satisfy the checker. Accept both, prefer
+the new ones.
 
 At least one `<section data-screen id="…" data-nav-label="…">` MUST exist
 inside the active design. A design iteration with zero screens can't collect

--- a/plugins/devops/skills/tune-rethink/SKILL.md
+++ b/plugins/devops/skills/tune-rethink/SKILL.md
@@ -135,13 +135,32 @@ Persist the reconciled set to `.claude/rethink/<date>-<slug>/approaches.md`.
 
 ## Step 6 — Concept Page
 
-Invoke `concept` (decision template). Each approach is a variant
-with: pros/cons, blast-radius label, effort estimate, migration sketch, and
-which success criteria it serves. The page offers two decision actions:
+Invoke `concept`. Do not hard-wire the template: apply `concept`'s own
+per-iteration template rule (`skills/concept/SKILL.md` § Step 1a) to the
+reconciled set of approaches.
+
+- If the approaches are substantive non-visual alternatives (architecture,
+  strategy, library, migration path — the common case for rethink) →
+  a `decision` iteration. Each approach is a variant with: pros/cons,
+  blast-radius label, effort estimate, migration sketch, and which success
+  criteria it serves.
+- If one or more approaches are primarily visual — competing UX/layout/
+  visual directions surfaced by the `ux-design` lens — those land in a
+  separate `design` iteration with real mockups per approach, not flattened
+  into variant cards. `enduser-feel`/`architecture` alternatives that are
+  entangled with the visual ones still get their own `decision` iteration;
+  split them rather than mixing layout and non-visual tradeoffs on one page.
+- A run that surfaces both kinds of approaches renders **both iterations on
+  the same concept page** — a `decision` iteration for the non-visual call
+  and a `design` iteration for the visual one — not two separate pages.
+
+Whichever iteration(s) result, the page offers two decision actions per
+iteration:
 
 - **Iterate** — feedback flows back: revise via Step 5, or run a new fresh
   round (Step 4) when the feedback changes direction fundamentally. Then
-  re-render. Nothing is implemented.
+  re-render (append a new iteration; the existing ones stay as frozen
+  history). Nothing is implemented.
 - **Implement** — locks the chosen approach and proceeds to Step 7. Only
   this explicit action starts implementation.
 

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.124.1",
+  "version": "0.125.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

Concept pages picked one layout for the whole page. Now each iteration picks its own — decision, free, or design — in any order, as often as the work needs. The fullscreen `design` layout gained a design layer: several designs per iteration, each owning its own pages, plus three-level feedback (concept / design / page).

## What was broken

A tie-breaker in `SKILL.md` said a page with variants *and* mockups is a `decision` page with mockups inlined, and `tune-rethink` hard-wired the decision template on top of it. Between them the fullscreen layout was unreachable for exactly the work it was built for.

The observed failure: a generated page with 21 variants where the same three layout options appear **twice** — once with pros and cons, once again labelled "visuell" — because a mockup does not fit into a 340px variant card, so the decision got written out a second time.

## What changed

- `data-iteration-template` on each `<section data-iteration>` is authoritative; `<html data-template>` became a projection of the active iteration, set by `applyIterationTemplate()` first thing in `showIteration()`. Every existing CSS selector and JS branch keeps working unchanged.
- `<section data-design>` groups pages. Ghost switcher at top centre (18% opacity, expands on hover and keyboard focus), per-design page memory, two-level panel navigation.
- Feedback dock: general / per-design / per-page, open at load, auto-closes once on first mockup contact.
- ☰ FAB moved to top right, which freed the corner the feedback bubble reserved.
- The tie-breaker is deleted with no replacement; the layout check runs per iteration.
- `prototype` remains an accepted legacy alias — pages generated before this change are unaffected.

## Review

An adversarial review pass produced ten findings, verdict `rework`; a Playwright QA pass found three more and corrected one of the redteam's. All are fixed and re-verified in a browser:

- page-level feedback was destroyed on design switch, taking its localStorage copy with it, and silently dropped from the submit payload
- a second unconditional listener kept auto-closing the dock after the deliberate one-shot had disarmed
- the validation gate still required two ids the dock rebuild had renamed — every fresh page would have hard-failed its own gate
- top-bar elements overlapped by 21px at 768px and fully at 375px, under a comment claiming all three viewports were verified

Verified after the fixes: note survives design round-trip, payload carries all four page keys across two designs, dock stays open after manual reopen, overlap 0/0/0 at 1280/768/375.

Codex review gate could not run — the CLI reported its usage limit. The adversarial agent pass above covers the same ground.

## Tests

`npm test` 949/949, `npm run lint` clean.

Spec: `docs/superpowers/specs/2026-08-03-concept-per-iteration-design-mode-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)