### PR TITLE
fix(concept): declare indicator mount points, guard panel wiring

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.125.0"
+    "version": "0.125.1"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.125.0",
+      "version": "0.125.1",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.125.0",
+      "version": "0.125.1",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.125.1] — 2026-08-03
+
+### Fixed
+
+- **The position indicator in a fullscreen design concept now actually shows which iteration and design you are in.** The code that fills it addressed four spans the reference markup never declared, so those segments rendered — never. Every lookup is null-guarded, which is exactly why nobody noticed: nothing threw, nothing warned, the indicator simply read "Page N / total" forever. That matters most where it was least visible: in the fullscreen layout the iteration tabs sit behind the burger, so this line is the only thing telling you where you are.
+
+- **A concept page missing one panel element no longer dies whole.** The panel wiring dereferenced `decision-panel`, `panel-toggle`, `panel-close` and `panel-backdrop` unguarded, and that wiring block also installs screen switching, the feedback dock and click-through navigation. One absent element threw at boot and took all of it down — with no visible error, leaving a mockup that silently ignores every click. The wiring is guarded now and names what is missing in the console; two further indicator writes got the same treatment.
+
+- **Three classes of "silently broken generated page" are now pinned by tests.** The templates reference is not prose: its fenced code blocks are copied verbatim into every concept page, so a defect there ships into other people's projects and shows up days later as "the page does nothing". The new test asserts that every JS block parses, that no block contains a literal closing `script` tag — valid JavaScript, fatal the moment it is embedded, which had already happened once during development — and that every id the JS looks up is declared in the reference markup, behind an exemption list that requires a written reason per entry. Checked against the pre-fix tree, the id assertion reports exactly the four missing mount points, so it fails when it should.
+
 ## [0.125.0] — 2026-08-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.125.0**
+**Version: 0.125.1**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.125.0",
+  "version": "0.125.1",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/skills/concept/deep-knowledge/templates.md
+++ b/plugins/devops/skills/concept/deep-knowledge/templates.md
@@ -1025,12 +1025,19 @@ The wiring is a single delegated click handler installed alongside
          when the iteration has >1 design. See buildDesignUI() below; the
          spans here are just the mount points it fills in. -->
     <div class="screen-indicator" id="screen-indicator">
-      <!-- Fully rebuilt by updateIndicator() (§ Layout JS) on every
-           iteration/design/screen switch — segments are joined with " · "
-           only for the ones that apply, so a hidden segment never leaves a
-           dangling separator. Static fallback below is the generation-time
-           first-paint value (3-screen, single-iteration, single-design
-           example) so the page never flashes empty before JS runs. -->
+      <!-- updateIndicator() (§ Layout JS) fills these mount points on every
+           iteration/design/screen switch. Each optional segment carries its
+           own trailing " · " INSIDE the span, so hiding the span removes the
+           separator with it and never leaves a dangling one.
+           Static values are the generation-time first-paint fallback
+           (3-screen, single-iteration, single-design example) so the page
+           never flashes empty before JS runs.
+           EVERY id below is required — updateIndicator() null-guards each
+           lookup, so a missing span does not throw; the segment simply never
+           appears. That failure is silent, which is why the reference markup
+           must carry all four. -->
+      <span id="indicator-iteration" hidden>{{design.position_iteration}} <strong id="active-iteration-idx">1</strong> · </span>
+      <span id="indicator-design" hidden><strong id="active-design-label">Dispatch</strong> · </span>
       {{design.position_page}} <strong id="active-screen-idx">1</strong> / <span id="total-screens">3</span>
       · <span id="active-screen-label">Welcome</span>
     </div>
@@ -1756,7 +1763,12 @@ change) via `harvestDockValues()`.
   // design switch.
   function updateScreenScope(design) {
     const screens = [...design.querySelectorAll('section[data-screen][id]')];
-    document.getElementById('total-screens').textContent = screens.length;
+    // Optional chaining throughout: the indicator is documented as
+    // "can be hidden or simplified" for single-screen designs, so its spans
+    // are genuinely optional — an unguarded write would turn that documented
+    // choice into a boot-time TypeError.
+    const totalEl = document.getElementById('total-screens');
+    if (totalEl) totalEl.textContent = screens.length;
     // Single-screen designs: hide screen-nav + per-screen feedback.
     // CSS keys off body[data-single-screen="true"].
     document.body.dataset.singleScreen = screens.length <= 1 ? 'true' : 'false';
@@ -1815,8 +1827,11 @@ change) via `harvestDockValues()`.
     // lookup: screen ids repeat across iterations.
     const screen = design.querySelector(`#${CSS.escape(id)}`);
     const label = screen?.dataset.navLabel || id;
-    document.getElementById('active-screen-label').textContent = label;
-    document.getElementById('active-screen-idx').textContent = idx + 1;
+    // Guarded like every other indicator write — see updateScreenScope().
+    const labelEl = document.getElementById('active-screen-label');
+    if (labelEl) labelEl.textContent = label;
+    const idxEl = document.getElementById('active-screen-idx');
+    if (idxEl) idxEl.textContent = idx + 1;
     const dockLabel = document.getElementById('dock-screen-label');
     if (dockLabel) dockLabel.textContent = label;
     // The dock holds every design's screen textareas, so match on the
@@ -1898,18 +1913,31 @@ change) via `harvestDockValues()`.
     });
   }
 
-  // Panel + dock toggles
+  // Panel + dock toggles.
+  // These four used to be dereferenced unguarded. A generated page missing
+  // any one of them died right here with a TypeError — and since this IIFE
+  // wires EVERYTHING below (screen switching, the dock, click-through), the
+  // whole page's JS went with it. Silently: no visible error, just a mockup
+  // that ignores every click. Guard the wiring and name what is missing.
   const panel = document.getElementById('decision-panel');
   const panelToggle = document.getElementById('panel-toggle');
   const panelCloseBtn = document.getElementById('panel-close');
   const backdrop = document.getElementById('panel-backdrop');
+  const missingPanelParts = [
+    ['decision-panel', panel], ['panel-toggle', panelToggle],
+    ['panel-close', panelCloseBtn], ['panel-backdrop', backdrop],
+  ].filter(([, el]) => !el).map(([id]) => id);
+  if (missingPanelParts.length) {
+    console.error('[concept] decision-panel markup incomplete, panel disabled — missing: '
+      + missingPanelParts.join(', '));
+  }
   // The switcher auto-hides while the panel is open (the panel carries the
   // same navigation) — driven by body.panel-open, see Layout CSS.
-  window.openPanel = () => { panel.classList.add('open'); backdrop.classList.add('visible'); panelToggle.classList.add('hidden'); document.body.classList.add('panel-open'); };
-  window.closePanel = () => { panel.classList.remove('open'); backdrop.classList.remove('visible'); panelToggle.classList.remove('hidden'); document.body.classList.remove('panel-open'); };
-  panelToggle.addEventListener('click', openPanel);
-  panelCloseBtn.addEventListener('click', closePanel);
-  backdrop.addEventListener('click', closePanel);
+  window.openPanel = () => { panel?.classList.add('open'); backdrop?.classList.add('visible'); panelToggle?.classList.add('hidden'); document.body.classList.add('panel-open'); };
+  window.closePanel = () => { panel?.classList.remove('open'); backdrop?.classList.remove('visible'); panelToggle?.classList.remove('hidden'); document.body.classList.remove('panel-open'); };
+  panelToggle?.addEventListener('click', openPanel);
+  panelCloseBtn?.addEventListener('click', closePanel);
+  backdrop?.addEventListener('click', closePanel);
 
   const dock = document.getElementById('feedback-dock');
   const dockToggle = document.getElementById('feedback-toggle');

--- a/plugins/devops/skills/concept/templates-reference.test.js
+++ b/plugins/devops/skills/concept/templates-reference.test.js
@@ -1,0 +1,89 @@
+import { describe, test, expect } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import vm from "node:vm";
+import { fileURLToPath } from "node:url";
+
+// The concept skill's templates reference is not documentation — Claude copies
+// its fenced code blocks verbatim into every generated concept page. A defect
+// in one of those blocks therefore ships into other people's projects, and the
+// failure is invariably silent: a page whose JS throws at boot renders fine and
+// simply ignores every click.
+//
+// Three defects of exactly this shape were found by review rather than by the
+// suite, after the code had already been committed:
+//   1. a literal closing </script> inside a JS comment, which terminates the
+//      host <script> element and kills the page — valid JS, invalid embedded;
+//   2. four ids the JS dereferenced unguarded, so a page missing any one of
+//      them lost the entire wiring IIFE;
+//   3. four indicator mount points the JS filled but the reference markup never
+//      declared, so those segments never rendered at all.
+// These tests pin all three classes.
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REFERENCE = path.join(__dirname, "deep-knowledge", "templates.md");
+
+const md = fs.readFileSync(REFERENCE, "utf8");
+
+function blocks(lang) {
+  const out = [];
+  const re = new RegExp("```(?:" + lang + ")\\n([\\s\\S]*?)```", "g");
+  let m;
+  while ((m = re.exec(md))) {
+    out.push({ code: m[1], line: md.slice(0, m.index).split("\n").length });
+  }
+  return out;
+}
+
+const jsBlocks = blocks("javascript|js");
+const htmlBlocks = blocks("html");
+const htmlSource = htmlBlocks.map((b) => b.code).join("\n");
+
+// Ids the JS looks up but the reference markup deliberately does not declare.
+// Every entry needs a reason: an unexplained exemption is how a real hole hides.
+const OPTIONAL_IDS = {
+  // Panel state block belonging to the decision/free layouts, whose markup
+  // lives in § Common Structure rather than in a fenced html block here.
+  "panel-frozen": "rendered by the shared panel-state markup, guarded at every use",
+  "panel-final-report": "final-report panel, appended only once a report exists",
+};
+
+describe("concept templates reference — embedded code integrity", () => {
+  test("every JS block parses", () => {
+    expect(jsBlocks.length).toBeGreaterThan(0);
+    const failures = [];
+    for (const [i, b] of jsBlocks.entries()) {
+      try {
+        new vm.Script(b.code);
+      } catch (e) {
+        failures.push(`block ${i + 1} (line ${b.line}): ${e.message.split("\n")[0]}`);
+      }
+    }
+    expect(failures).toEqual([]);
+  });
+
+  // Valid JS, fatal once embedded: the HTML parser ends the <script> element at
+  // the literal character sequence regardless of JS string or comment context.
+  test("no JS block contains a literal closing script tag", () => {
+    const offenders = jsBlocks
+      .filter((b) => /<\/script/i.test(b.code))
+      .map((b) => `line ${b.line}`);
+    expect(offenders).toEqual([]);
+  });
+
+  test("every id the JS looks up is declared in the reference markup", () => {
+    const used = new Set();
+    const re = /getElementById\(['"]([A-Za-z0-9_-]+)['"]\)/g;
+    let m;
+    while ((m = re.exec(md))) used.add(m[1]);
+    expect(used.size).toBeGreaterThan(0);
+
+    const undeclared = [...used]
+      .filter((id) => !(id in OPTIONAL_IDS))
+      .filter((id) => !htmlSource.includes(`id="${id}"`));
+
+    // A missing mount point does not throw — the JS null-guards its lookups —
+    // so the segment simply never appears. Nothing surfaces that at runtime.
+    expect(undeclared).toEqual([]);
+  });
+});

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.125.0",
+  "version": "0.125.1",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

Three silent defects in the concept templates reference, plus a test that pins the whole class.

## What was broken

**The position indicator never showed iteration or design.** `updateIndicator()` fills four spans — `indicator-iteration`, `active-iteration-idx`, `indicator-design`, `active-design-label` — that the reference markup never declared. Every lookup is null-guarded, so nothing threw and nothing warned; the segments just never rendered. In the fullscreen design layout that indicator is the only position readout, because the iteration tabs live behind the ☰ FAB.

**One missing panel element killed the whole page.** The wiring dereferenced `decision-panel`, `panel-toggle`, `panel-close` and `panel-backdrop` unguarded. That same IIFE installs screen switching, the feedback dock and click-through navigation — so a page missing any one element threw at boot and lost all of it, invisibly, leaving a mockup that ignores every click.

## The test

`plugins/devops/skills/concept/templates-reference.test.js` pins three classes:

1. every JS block parses
2. no JS block contains a literal closing `script` tag — valid JavaScript, fatal once embedded, which already happened once during this feature's development
3. every id the JS looks up is declared in the reference markup, behind an exemption list that requires a written reason per entry

Verified against the pre-fix tree: the id assertion reports exactly the four missing mount points, so it fails when it should rather than being green by construction.

## Verification

- `npm test` 952/952 (949 + 3 new), `npm run lint` clean
- Browser: injected the fixed mount points into the generated repro, switched design — `indicator-design` goes from hidden to visible carrying the active design's label, no page errors. Previously impossible, the span did not exist.
- Codex review gate could not run: the CLI reports its usage limit until Aug 13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)