### PR TITLE
fix(concept): feedback FAB bottom-right + 64px in design mode

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.125.1"
+    "version": "0.125.2"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.125.1",
+      "version": "0.125.2",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.125.1",
+      "version": "0.125.2",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.125.2] — 2026-08-04
+
+### Changed
+
+- **The feedback bubble in a fullscreen design concept now sits bottom-right and is bigger.** It used to live bottom-left at the same 56px as the burger; it moves to the bottom-right corner and grows to 64px so it reads as the primary way to leave feedback, while the ☰ decision panel keeps the top-right corner it collapses behind. The speech-bubble dock follows the FAB — its anchor, vertical offset and the 80px gap that keeps text clear of the button all flip to the right edge, on desktop and on narrow screens. The dock still opens on load and closes on first interaction. Position docs that had drifted to describe the burger as bottom-right and the bubble as bottom-left were corrected across the skill, its template reference and the validation gate.
+
 ## [0.125.1] — 2026-08-03
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.125.1**
+**Version: 0.125.2**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.125.1",
+  "version": "0.125.2",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/skills/concept/SKILL.md
+++ b/plugins/devops/skills/concept/SKILL.md
@@ -112,7 +112,7 @@ into 340px variant cards, so stop trying to fit them there.
 
 | Template | Layout signature |
 |---|---|
-| **design** | Fullscreen content, overlay decision panel (☰ FAB top right), speech-bubble feedback dock on the 💬 FAB bottom left (general / per-design / per-screen comments), design switcher when ≥2 designs |
+| **design** | Fullscreen content, overlay decision panel (☰ FAB top right, collapsed by default), speech-bubble feedback dock on the 64px 💬 FAB bottom right (general / per-design / per-screen comments), design switcher when ≥2 designs |
 | **decision** | Sidebar (~80/~20), variant cards, tri-state per variant |
 | **free** | Sidebar (~80/~20), Claude-authored freeform body, optional tri-state per section |
 
@@ -203,7 +203,7 @@ Panel layout depends on the template picked in Step 1a:
 | Template | Panel mode | Extras |
 |---|---|---|
 | **decision** | Fixed sticky sidebar (~20% screen width), always visible | — |
-| **design** | Overlay panel (360px slide-in from right), toggled by the ☰ FAB top right | **Feedback dock** as a speech bubble anchored to the 💬 FAB bottom left, with general / per-design / per-screen comments; design switcher when ≥2 designs |
+| **design** | Overlay panel (360px slide-in from right), toggled by the ☰ FAB top right | **Feedback dock** as a speech bubble anchored to the 64px 💬 FAB bottom right, with general / per-design / per-screen comments; design switcher when ≥2 designs |
 | **free** | Fixed sticky sidebar (~20%), always visible | — |
 
 On narrow screens (<768px), sidebar-mode panels collapse to a sticky bottom
@@ -290,7 +290,7 @@ findings I marked Miteinbeziehen").
 ### Design Feedback Dock
 
 The design template has no tri-state. Instead, a **speech-bubble feedback
-dock** anchored to the 💬 FAB (bottom-left) holds structured feedback:
+dock** anchored to the 💬 FAB (bottom-right) holds structured feedback:
 
 - A top-level textarea for general notes on the concept
 - One textarea per `data-design` (only when the iteration has ≥2 designs)

--- a/plugins/devops/skills/concept/deep-knowledge/templates.md
+++ b/plugins/devops/skills/concept/deep-knowledge/templates.md
@@ -6,7 +6,7 @@ picked **per iteration**, not per page — see § Per-Iteration Templates below:
 | Template | Layout | When to use |
 |---|---|---|
 | **decision** | Sidebar (~80/~20), multi-variant cards | Multi-option evaluation, trade-offs, architecture or tech decisions — the canonical "pick one" flow with bi-state (Verwerfen / Miteinbeziehen) per variant and multiple iterations |
-| **design** | Fullscreen content + overlay decision panel (☰ FAB right) + speech-bubble feedback dock anchored to the 💬 FAB (bottom-left), stops before the ☰ FAB so both stay clickable | UI mockups, wireframes, visual design concepts, click-through flows — one artefact that needs maximum screen real estate, plus structured per-screen feedback |
+| **design** | Fullscreen content + overlay decision panel (☰ FAB top-right, collapsed by default) + speech-bubble feedback dock anchored to the 64px 💬 FAB (bottom-right) | UI mockups, wireframes, visual design concepts, click-through flows — one artefact that needs maximum screen real estate, plus structured per-screen feedback |
 | **free** | Sidebar (~80/~20), freeform body content | Analysis, walkthrough, brainstorm, explainer, timeline — structured content without forced variant framing. Bi-state evaluation is optional (opt-in per section) |
 
 `prototype` is the **legacy alias** of `design`. Pages generated before the
@@ -956,8 +956,8 @@ Values:
 The wiring is a single delegated click handler installed alongside
 `showScreen` — see § Click-through Handler below.
 
-- `☰` (bottom-right) → Decision panel: iteration tabs, screen navigation, submit
-- `💬` (bottom-left) → Feedback dock: **context-sensitive** textarea for the
+- `☰` (top-right) → Decision panel: iteration tabs, screen navigation, submit
+- `💬` (bottom-right, 64px) → Feedback dock: **context-sensitive** textarea for the
   currently-visible screen + a persistent "general notes" textarea below
 
 ### Feedback behaviour (strict)
@@ -1137,7 +1137,7 @@ The wiring is a single delegated click handler installed alongside
          bottom: general → design → page. General sits at the top because
          it is the one field that never disappears or changes label as the
          user navigates — putting it first keeps the dock from jumping.
-         Anchored to the 💬 FAB (bottom-left): the FAB stays visible and
+         Anchored to the 💬 FAB (bottom-right): the FAB stays visible and
          clickable, the dock floats above/around it like a chat bubble.
          Now that ☰ lives top-right (Wave 3), the dock no longer reserves
          space for it — see Layout CSS geometry comment.
@@ -1364,9 +1364,13 @@ body.panel-open .design-switcher { opacity: 0; pointer-events: none; }
    scope anyway. Measured in Edge at 1280/768/375px: no overlap at any of
    the three. Before the caps existed the indicator overlapped the switcher
    by 21px at 768px and completely at 375px, where it also reached the ☰
-   FAB. 💬 stays bottom-left, unchanged. */
+   FAB. 💬 lives bottom-right (64px), clear of the top edge entirely. */
 .panel-fab { top: 2rem; right: 2rem; background: var(--accent-color, #58a6ff); }
-.feedback-fab { bottom: 2rem; left: 2rem; background: var(--warning-color, #d29922); }
+.feedback-fab {
+  bottom: 2rem; right: 2rem;
+  width: 64px; height: 64px; font-size: 1.7rem;
+  background: var(--warning-color, #d29922);
+}
 .panel-fab:hover,
 .feedback-fab:hover { transform: scale(1.1); }
 /* Only the ☰ panel FAB hides when its panel opens (the decision panel is
@@ -1427,19 +1431,18 @@ body.panel-open .design-switcher { opacity: 0; pointer-events: none; }
 .screen-nav-design-heading .has-notes { color: var(--warning-color); font-size: 0.75rem; }
 .screen-nav-group .screen-nav-item { margin-left: 0.75rem; }
 
-/* ── Feedback Dock — Speech-Bubble anchored to the 💬 FAB ──
-   Geometry (simplified, Wave 3): now that ☰ lives top-right, the dock no
-   longer needs to reserve horizontal space for it, nor lift itself above
-   it on narrow viewports (both existed only because ☰ used to share the
-   bottom-right corner with 💬). The dock now spans to the right edge minus
-   a normal margin.
-   * left = FAB.left (2rem)               → bubble's left edge aligns with FAB
-   * right = 2rem                         → normal margin, was reserved for ☰
-   * bottom = FAB.bottom + 56 + 6px       → bubble sits directly above the FAB
-                                            with a hair of overlap so the
+/* ── Feedback Dock — Speech-Bubble anchored to the 💬 FAB (bottom-right) ──
+   Geometry: ☰ lives top-right, 💬 bottom-right (64px). The dock spans the
+   full width (both side margins at 2rem) and reserves horizontal space on
+   the RIGHT — where the 💬 FAB now sits — so its fields never sit behind
+   the FAB it grows out of.
+   * left = 2rem                          → normal margin on the free (left) side
+   * right = FAB.right (2rem)             → bubble's right edge aligns with FAB
+   * bottom = FAB.bottom + 64 - 6px       → bubble sits directly above the 64px
+                                            FAB with a hair of overlap so the
                                             visual connection reads as "the
                                             bubble grows out of the FAB".
-   * padding-left = 80px                  → input fields start to the right
+   * padding-right = 80px                 → input fields stop to the left
                                             of where the FAB visually lives,
                                             so labels/textareas never sit
                                             behind it (the FAB stays clickable
@@ -1452,9 +1455,9 @@ body.panel-open .design-switcher { opacity: 0; pointer-events: none; }
   position: fixed;
   left: 2rem;
   right: 2rem;
-  bottom: calc(2rem + 56px - 6px);
+  bottom: calc(2rem + 64px - 6px);
   max-height: min(60vh, 520px);
-  padding: 1.25rem 1.5rem 1.5rem 80px;
+  padding: 1.25rem 80px 1.5rem 1.5rem;
   background: var(--panel-bg, #161b22);
   border: 1px solid var(--border-color, #30363d);
   border-radius: 18px;
@@ -1464,7 +1467,7 @@ body.panel-open .design-switcher { opacity: 0; pointer-events: none; }
   display: none;
   flex-direction: column;
   gap: 1.1rem;
-  transform-origin: 28px calc(100% + 22px); /* anchor: 💬 FAB centre below dock-bottom-left */
+  transform-origin: calc(100% - 32px) calc(100% + 26px); /* anchor: 💬 FAB centre below dock-bottom-right */
 }
 .feedback-dock[data-open="true"] {
   display: flex;
@@ -1520,7 +1523,7 @@ body.panel-open .design-switcher { opacity: 0; pointer-events: none; }
   .feedback-dock {
     left: 0.75rem;
     right: 0.75rem;
-    padding: 1rem 1rem 1rem 72px;
+    padding: 1rem 72px 1rem 1rem;
     border-radius: 14px;
   }
 }

--- a/plugins/devops/skills/concept/deep-knowledge/validation-gate.md
+++ b/plugins/devops/skills/concept/deep-knowledge/validation-gate.md
@@ -182,7 +182,7 @@ template instead. Reconsider the template pick before suppressing these.
 
 | # | Pattern | Purpose |
 |---|---------|---------|
-| P1 | `feedback-dock` | Speech-bubble dock anchored to the 💬 FAB (bottom-left) |
+| P1 | `feedback-dock` | Speech-bubble dock anchored to the 💬 FAB (bottom-right) |
 | P2 | `feedback-toggle` | FAB that opens the dock |
 | P3 | `screen-textareas` OR `feedback-screen-list` | Auto-populated per-page comment container (legacy pages use `feedback-screen-list`) |
 | P4 | `data-screen` | Marker on screen sections that feed the dock |

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.125.1",
+  "version": "0.125.2",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

Design-mode (mockup) chrome refinement for the `/concept` skill:

- The 💬 feedback-dock FAB moves bottom-left → bottom-right and grows 56px → 64px, so it reads as the primary feedback entry point, clear of the ☰ decision-panel FAB (top-right, collapsed by default).
- The speech-bubble dock geometry follows: bottom offset (64px), transform-origin and the 80px padding reservation flip to the right edge; mobile padding mirrored. The dock still opens on load and closes on first interaction.
- Fixed stale position docs across SKILL.md, templates.md and validation-gate.md that described the FABs as "☰ bottom-right / 💬 bottom-left".

Layout chosen via a preview comparison with the user (64px FAB, dock opens on load).

## Tests

- vitest full suite: 952/952 passed
- eslint: clean
- concept templates-reference: 3/3 passed