### PR TITLE
fix(ship): 60s network timeout for remote git calls

### DIFF
--- a/plugins/devops/mcp-server/ship/lib/git.js
+++ b/plugins/devops/mcp-server/ship/lib/git.js
@@ -6,8 +6,12 @@
 import { execSync, execFileSync } from "node:child_process";
 
 const DEFAULT_TIMEOUT = 15_000;
-// eslint-disable-next-line no-unused-vars -- reserved for push/fetch operations
-const PUSH_TIMEOUT = 60_000;
+// For every git call that talks to the remote (ls-remote, fetch, pull, push):
+// on Windows each of these includes a git-credential-manager roundtrip that
+// reproducibly takes ~30s under CPU load (parallel sessions, test runs). The
+// 15s DEFAULT_TIMEOUT turned that into a deterministic ETIMEDOUT — ship_promote
+// refused with "cannot reach remote" on a perfectly healthy remote.
+export const NETWORK_TIMEOUT = 60_000;
 
 /**
  * Run a git command and return trimmed stdout, or null on failure.
@@ -223,7 +227,7 @@ export function worktreePathForBranch(branch, opts) {
  */
 export function syncLocalBranch(branch, opts = {}) {
   // Refresh origin/branch first (best-effort; failure surfaces below as "none").
-  git(`fetch origin ${branch}`, opts);
+  git(`fetch origin ${branch}`, { ...opts, timeout: opts.timeout ?? NETWORK_TIMEOUT });
 
   const remoteRef = git(`rev-parse --verify refs/remotes/origin/${branch}`, opts);
   if (!remoteRef) {
@@ -260,7 +264,7 @@ export function syncLocalBranch(branch, opts = {}) {
 
   // Not checked out anywhere → update the ref directly (ff-only by git default).
   try {
-    gitStrict(`fetch origin ${branch}:${branch}`, opts);
+    gitStrict(`fetch origin ${branch}:${branch}`, { ...opts, timeout: opts.timeout ?? NETWORK_TIMEOUT });
     return { updated: true, method: "fetch-refspec" };
   } catch (e) {
     return {

--- a/plugins/devops/mcp-server/ship/tools/cleanup.js
+++ b/plugins/devops/mcp-server/ship/tools/cleanup.js
@@ -5,7 +5,7 @@
  */
 
 import { z } from "zod";
-import { git, gitStrict, isWorktree, getWorktreeBranches } from "../lib/git.js";
+import { git, gitStrict, isWorktree, getWorktreeBranches, NETWORK_TIMEOUT } from "../lib/git.js";
 import { dirtySessionWorktrees } from "../lib/worktree.js";
 import { clearSentinel } from "../lib/sentinel.js";
 
@@ -87,7 +87,7 @@ export async function handler(params) {
   // main stale ("ship succeeded but main not updated locally").
   // See skills/ship/deep-knowledge/cleanup.md §2.
   try {
-    gitStrict(`pull --ff-only origin ${base}`, opts);
+    gitStrict(`pull --ff-only origin ${base}`, { ...opts, timeout: NETWORK_TIMEOUT });
     cleaned.push(`sync:${base}`);
   } catch (e) {
     warnings.push(
@@ -106,10 +106,10 @@ export async function handler(params) {
   }
 
   // Verify remote branch is gone (merge step should have deleted it)
-  const remoteBranch = git(`ls-remote --heads origin ${branch}`, opts);
+  const remoteBranch = git(`ls-remote --heads origin ${branch}`, { ...opts, timeout: NETWORK_TIMEOUT });
   if (remoteBranch) {
     try {
-      gitStrict(`push origin --delete ${branch}`, opts);
+      gitStrict(`push origin --delete ${branch}`, { ...opts, timeout: NETWORK_TIMEOUT });
       cleaned.push(`remote-branch:${branch}`);
     } catch {
       warnings.push(`Could not delete remote branch ${branch} — may already be deleted`);

--- a/plugins/devops/mcp-server/ship/tools/cleanup.test.js
+++ b/plugins/devops/mcp-server/ship/tools/cleanup.test.js
@@ -10,6 +10,7 @@ vi.mock("zod", () => {
 
 vi.mock("../lib/git.js", () => ({
   git: vi.fn(() => ""),
+  NETWORK_TIMEOUT: 60_000,
   gitStrict: vi.fn(() => ""),
   isWorktree: vi.fn(() => false),
   getWorktreeBranches: vi.fn(() => new Set()),

--- a/plugins/devops/mcp-server/ship/tools/preflight.js
+++ b/plugins/devops/mcp-server/ship/tools/preflight.js
@@ -8,7 +8,7 @@ import { createHash } from "node:crypto";
 import { execFileSync } from "node:child_process";
 import { readdirSync, statSync, readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
-import { git, currentBranch, dirtyState, commitsAhead, unpushedCommits, isWorktree, detectParentBranch, detectDefaultBranch, branchExists, fileOverlap, getConfig } from "../lib/git.js";
+import { git, currentBranch, dirtyState, commitsAhead, unpushedCommits, isWorktree, detectParentBranch, detectDefaultBranch, branchExists, fileOverlap, getConfig, NETWORK_TIMEOUT } from "../lib/git.js";
 import { dirtySessionWorktrees } from "../lib/worktree.js";
 import { readVersion, verifyVersionFiles } from "../lib/version.js";
 import { writeSentinel } from "../lib/sentinel.js";
@@ -197,7 +197,7 @@ export async function handler(params) {
   checks.push({ name: "clean-tree", ok: !state.dirty, modified: state.modified.length, untracked: state.untracked.length });
 
   // 5. Fetch base from origin to ensure accurate commit count (skip when no remote)
-  if (!noRemote) git(`fetch origin ${base}`, opts);
+  if (!noRemote) git(`fetch origin ${base}`, { ...opts, timeout: NETWORK_TIMEOUT });
 
   // 6. Commits ahead (compare against origin/ ref for accuracy)
   const originBase = `origin/${base}`;

--- a/plugins/devops/mcp-server/ship/tools/preflight.test.js
+++ b/plugins/devops/mcp-server/ship/tools/preflight.test.js
@@ -14,6 +14,7 @@ vi.mock("zod", () => {
 // path that is NOT the plugin source repo, so docSyncChecks() no-ops.
 vi.mock("../lib/git.js", () => ({
   git: vi.fn(() => ""),
+  NETWORK_TIMEOUT: 60_000,
   currentBranch: vi.fn(() => "feat/topic"),
   dirtyState: vi.fn(() => ({ dirty: false, untracked: [], modified: [], lines: [] })),
   commitsAhead: vi.fn(() => 1),

--- a/plugins/devops/mcp-server/ship/tools/promote.js
+++ b/plugins/devops/mcp-server/ship/tools/promote.js
@@ -9,7 +9,7 @@
 
 import { z } from "zod";
 import { execFileSync } from "node:child_process";
-import { git, gitStrict } from "../lib/git.js";
+import { git, gitStrict, NETWORK_TIMEOUT } from "../lib/git.js";
 import { createRelease, releaseExists } from "../lib/github.js";
 import { parseChannelTag, compareVersions } from "../lib/channels.js";
 import { parseLsRemoteTagOutput } from "../lib/remote-tags.js";
@@ -42,7 +42,7 @@ function lsRemoteTag(tag, opts) {
   // Both patterns, both double-quoted: the second is required to surface the
   // peeled ^{} line at all (see parseLsRemoteTagOutput), and unquoted `^` is
   // cmd.exe's escape character (execSync runs through a shell on win32).
-  const out = git(`ls-remote --tags origin "${tag}" "${tag}^{}"`, opts);
+  const out = git(`ls-remote --tags origin "${tag}" "${tag}^{}"`, { ...opts, timeout: NETWORK_TIMEOUT });
   // FAIL-CLOSED (F2): git() returns null on a transient network/auth failure.
   // Distinguishing that from "tag absent" (an empty string that parses to null)
   // is load-bearing: a null swallowed as "absent" would let the source-tag
@@ -78,7 +78,7 @@ export function parseLsRemoteChannelTags(out) {
 }
 
 function listRemoteChannelTags(opts) {
-  const out = git(`ls-remote --tags origin`, opts);
+  const out = git(`ls-remote --tags origin`, { ...opts, timeout: NETWORK_TIMEOUT });
   // FAIL-CLOSED (F2): a null (network/auth failure) previously parsed to an
   // EMPTY tag list — targetLatest became null and BOTH the monotonicity guard
   // and the same-version/different-SHA immutability guard were skipped, letting
@@ -208,7 +208,7 @@ async function ensureTag(tag, sha, payload, opts, retry) {
     try {
       // Explicit refspec for the same reason as the rev-parse above: `push
       // origin <name>` would happily push a same-named BRANCH instead.
-      gitStrict(`push origin refs/tags/${tag}:refs/tags/${tag}`, { ...opts, timeout: 60_000 });
+      gitStrict(`push origin refs/tags/${tag}:refs/tags/${tag}`, { ...opts, timeout: NETWORK_TIMEOUT });
       pushError = null;
     } catch (e) {
       // Recorded, not trusted: the confirmation below has the final word.
@@ -290,7 +290,7 @@ export async function handler(params) {
 
     // 3. Ancestry guard: only commits reachable from origin/main are promotable.
     try {
-      gitStrict(`fetch origin main`, { ...opts, timeout: 30_000 });
+      gitStrict(`fetch origin main`, { ...opts, timeout: NETWORK_TIMEOUT });
       gitStrict(`merge-base --is-ancestor ${sha} origin/main`, opts);
     } catch {
       return { ...result, success: false, error: `ancestry: ${sha.slice(0, 12)} is not an ancestor of origin/main — refusing to promote an unmerged/foreign commit` };

--- a/plugins/devops/mcp-server/ship/tools/promote.test.js
+++ b/plugins/devops/mcp-server/ship/tools/promote.test.js
@@ -14,6 +14,7 @@ vi.mock("node:child_process", () => ({
 vi.mock("../lib/git.js", () => ({
   git: vi.fn(() => ""),
   gitStrict: vi.fn(() => ""),
+  NETWORK_TIMEOUT: 60_000,
 }));
 
 vi.mock("../lib/github.js", () => ({
@@ -252,6 +253,32 @@ describe("ship_promote — fail-closed on unreachable remote (F2)", () => {
     expect(r.success).toBe(false);
     expect(r.error).toMatch(/source-tag-not-found/);
     expect(r.error).not.toMatch(/cannot reach remote/i);
+  });
+});
+
+// Every remote read goes through git-credential-manager on Windows, and under
+// CPU load (parallel sessions, test runs) that roundtrip reproducibly takes
+// ~30s — the 15s DEFAULT_TIMEOUT then turns a perfectly healthy remote into a
+// deterministic ETIMEDOUT → "cannot reach remote — refusing to promote"
+// (10 consecutive promote failures on 2026-08-12). Pin the 60s network timeout
+// on every remote-touching call so the short default can never creep back in.
+describe("ship_promote — network timeouts", () => {
+  test("every ls-remote read and the ancestry fetch carry NETWORK_TIMEOUT", async () => {
+    mockRemote({ "alpha/v0.113.0": SHA });
+    const r = await handler(params());
+    expect(r.success).toBe(true);
+
+    const lsCalls = gitLib.git.mock.calls.filter(([cmd]) => cmd.startsWith("ls-remote"));
+    expect(lsCalls.length).toBeGreaterThan(0);
+    for (const [cmd, opts] of lsCalls) {
+      expect(opts?.timeout, `timeout missing on: git ${cmd}`).toBe(gitLib.NETWORK_TIMEOUT);
+    }
+
+    const fetchCalls = gitLib.gitStrict.mock.calls.filter(([cmd]) => cmd.startsWith("fetch "));
+    expect(fetchCalls.length).toBeGreaterThan(0);
+    for (const [cmd, opts] of fetchCalls) {
+      expect(opts?.timeout, `timeout missing on: git ${cmd}`).toBe(gitLib.NETWORK_TIMEOUT);
+    }
   });
 });
 

--- a/plugins/devops/mcp-server/ship/tools/release.js
+++ b/plugins/devops/mcp-server/ship/tools/release.js
@@ -5,7 +5,7 @@
 
 import { z } from "zod";
 import { execFileSync } from "node:child_process";
-import { git, gitStrict, gitArgs, currentBranch, headShort, dirtyState, isWorktree, isRebasedOnto, fileOverlap, syncLocalBranch, treeOf } from "../lib/git.js";
+import { git, gitStrict, gitArgs, currentBranch, headShort, dirtyState, isWorktree, isRebasedOnto, fileOverlap, syncLocalBranch, treeOf, NETWORK_TIMEOUT } from "../lib/git.js";
 import { createPR, mergePR, findExistingPR, watchPRChecks } from "../lib/github.js";
 import { detectRepoMode } from "../lib/repo-mode.js";
 import { remoteTagExists } from "../lib/remote-tags.js";
@@ -104,7 +104,7 @@ export async function handler(params) {
     }
 
     // Safety gate: verify branch is rebased onto latest base (prevents silent overwrites)
-    gitStrict(`fetch origin ${base}`, { cwd, timeout: 30_000 });
+    gitStrict(`fetch origin ${base}`, { cwd, timeout: NETWORK_TIMEOUT });
     if (!isRebasedOnto(`origin/${base}`, opts)) {
       // Check overlap to give actionable context
       const overlap = fileOverlap(`origin/${base}`, opts);
@@ -202,7 +202,7 @@ export async function handler(params) {
     // with --admin, the exact silent-overwrite vector #207 describes. Re-checking
     // here restores that guarantee at merge time. The skill's Step 1 loop rebases
     // and retries on rebaseRequired. (#207)
-    gitStrict(`fetch origin ${base}`, { cwd, timeout: 30_000 });
+    gitStrict(`fetch origin ${base}`, { cwd, timeout: NETWORK_TIMEOUT });
     if (!isRebasedOnto(`origin/${base}`, opts)) {
       const overlap = fileOverlap(`origin/${base}`, opts);
       result.success = false;
@@ -276,7 +276,7 @@ export async function handler(params) {
         // auth blip) used to read as "tag absent" and silently decide to create
         // one — the same fail-open the verification below was hardened against.
         const existing = await retryUntil(
-          () => git(`ls-remote --tags origin ${channelTag}`, opts),
+          () => git(`ls-remote --tags origin ${channelTag}`, { ...opts, timeout: NETWORK_TIMEOUT }),
           { attempts: tagVerifyAttempts, delayMs: tagRetryDelayMs },
         );
         if (!existing.ok) {
@@ -296,14 +296,12 @@ export async function handler(params) {
             "tag", "-a", channelTag, `origin/${base}`, "-m",
             JSON.stringify({ channel: "alpha", version: tag.replace(/^v/, "") }),
           ], { cwd, encoding: "utf8", timeout: 15_000, stdio: ["pipe", "pipe", "pipe"] });
-          // 60s like ship_promote's tag push — the 15s default is below a slow
-          // remote's worst case and turned a healthy push into a hard failure.
-          gitStrict(`push origin ${channelTag}`, { ...opts, timeout: 60_000 });
+          gitStrict(`push origin ${channelTag}`, { ...opts, timeout: NETWORK_TIMEOUT });
           // Retry the verification: one negative read right after a push proves
           // nothing (replica lag), which is the #251 false-negative class.
           const verified = await retryUntil(
             () => {
-              const out = git(`ls-remote --tags origin ${channelTag}`, opts);
+              const out = git(`ls-remote --tags origin ${channelTag}`, { ...opts, timeout: NETWORK_TIMEOUT });
               return out !== null && remoteTagExists(out, channelTag) ? true : null;
             },
             { attempts: tagVerifyAttempts, delayMs: tagRetryDelayMs },

--- a/plugins/devops/mcp-server/ship/tools/release.test.js
+++ b/plugins/devops/mcp-server/ship/tools/release.test.js
@@ -23,6 +23,7 @@ vi.mock("../lib/repo-mode.js", () => ({
 
 vi.mock("../lib/git.js", () => ({
   git: vi.fn(() => ""),
+  NETWORK_TIMEOUT: 60_000,
   gitStrict: vi.fn(() => ""),
   gitArgs: vi.fn(() => ""),
   currentBranch: vi.fn(() => "feature-x"),


### PR DESCRIPTION
Fixes the deterministic `ship_promote` failure "cannot reach remote — refusing to promote" under CPU load on Windows.

## Root cause
All remote-touching git calls (`ls-remote`, `fetch`, `pull`, `push`) in `mcp-server/ship` ran with `DEFAULT_TIMEOUT = 15_000`. On Windows each such call includes a git-credential-manager roundtrip that reproducibly takes ~30s when the machine is busy (parallel sessions, test runs). Evidence from 2026-08-12: 10 consecutive promote failures; Node repro shows `execSync` with 15s timeout → ETIMEDOUT, with 60s → OK in ~32s.

## Fix
- `lib/git.js` exports `NETWORK_TIMEOUT = 60_000` (replaces the unused, unexported `PUSH_TIMEOUT`).
- All network callsites pass it: `promote.js`, `release.js`, `cleanup.js`, `preflight.js`, and `syncLocalBranch`'s fetches. Existing hardcoded 60s push timeouts now reference the shared constant.
- New test in `promote.test.js` pins `NETWORK_TIMEOUT` on every `ls-remote` read and the ancestry fetch.

## Verification
- `npx vitest run` — 953/953 green
- `npx eslint .` — clean

Shipped manually: the dotclaude-ship MCP server was not registered in this session (guard hook's sanctioned `DOTCLAUDE_ALLOW_MANUAL_SHIP` recovery path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)