### PR TITLE
feat(scope): route plugin fixes upstream from consumer projects

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.125.3"
+    "version": "0.126.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.125.3",
+      "version": "0.126.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.125.3",
+      "version": "0.126.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.126.0] — 2026-08-15
+
+### Added
+
+- **A devops-plugin bug noticed while working in some other project now becomes an issue in the plugin repo instead of a fix in the wrong place.** The rule was already written down — in the `/claude-learn` skill body, which triggers only on explicit invocation. So it applied exactly when nobody needed it: notice a plugin defect mid-session in another project, and there was nothing in context saying where the fix belongs, so it got patched locally as a workaround, into that project's CLAUDE.md, or straight into the installed copy under `~/.claude/plugins/**` — where the next sync erases it and the actual defect stays live for every other consumer. The hierarchy now lives in `deep-knowledge/plugin-scope-routing.md`, surfaced through the session-start index in every project, and two hooks enforce it: `pre.plugin.scope` blocks Edit/Write into the managed install trees from a consumer project (and lets them through in the plugin's own repo, where repairing the install is expected), and `prompt.plugin.scope` injects the routing rule once per session when a consumer's prompt turns to the plugin itself. Three routes, no ambiguity: plugin defect → upstream issue, project concern → that project's own `.claude/` instructions, plugin source repo → implement directly.
+
+### Fixed
+
+- **`/claude-learn` no longer files a plugin issue against the wrong repository.** Its decision table routed by target project before topic, so a plugin-level learning aimed at a *third* project fell into the cross-project branch and created the issue there — in a repo that does not own the code. Topic now outranks target: a plugin defect goes upstream no matter which project surfaced it.
+
+- **The scope guard cannot be stood down from inside the tree it protects.** The marketplace clone at `~/.claude/plugins/marketplaces/dotclaude` carries the same `plugin.json` and `marketplace.json` the real source repo does, so a session opened there passed the "is this the plugin source repo?" check and unblocked edits to the managed install. A checkout living inside a managed install tree is now never treated as the source repo. Found by the Codex review gate, along with four narrower defects fixed in the same pass: the prompt matcher swallowed a project's own `/run-tests`-style commands, missed hook filenames with hyphenated segments, missed Windows-spelled `.claude\plugins` paths, and could throw on a non-string tool payload — a crash a PreToolUse hook shows to the user.
+
 ## [0.125.3] — 2026-08-12
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.125.3**
+**Version: 0.126.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ For the full extension guide with examples per skill, see `deep-knowledge/skill-
 
 ## Features
 
-- **<!--devops:count:hooks-->37<!--/devops:count:hooks--> Hooks** — automated guards and triggers across the full session lifecycle
+- **<!--devops:count:hooks-->39<!--/devops:count:hooks--> Hooks** — automated guards and triggers across the full session lifecycle
 - **<!--devops:count:skills-->22<!--/devops:count:skills--> Skills** — ship, promote, commit, fix, setup-issue, setup-project, setup-readme, auto-usage, claude-extend-skill, setup-cleanup, auto-update, claude-lint, concept, run-agents, run-autonomous, run-burn, run-backlog, claude-learn, tune-harden, tune-polish, tune-rethink, auto-graph
 - **<!--devops:count:agents-->12<!--/devops:count:agents--> Agents** — AI, Core, Designer, Feature, Frontend, Gamer, PO, QA, Redteam, Research, Windows
 - **Completion Flow** — mandatory card after every task (8 variants), visual verification, ship recommendation
@@ -178,7 +178,7 @@ For the full extension guide with examples per skill, see `deep-knowledge/skill-
 
 ### Hooks (automatic, no user action needed)
 
-<!--devops:count:hooks-->37<!--/devops:count:hooks--> hooks fire automatically across the session lifecycle — no user action needed.
+<!--devops:count:hooks-->39<!--/devops:count:hooks--> hooks fire automatically across the session lifecycle — no user action needed.
 
 <details>
 <summary><strong>By session lifecycle</strong> — when does it fire?</summary>
@@ -212,6 +212,7 @@ SessionStart  ──>  UserPromptSubmit  ──>  PreToolUse  ──>  PostToolU
 - `prompt.knowledge.dispatch` — On-demand deep-knowledge injection based on prompt keywords.
 - `prompt.git.sync` — Throttled git sync on user prompt — delegates to scripts/git-sync.js.
 - `prompt.issue.detect` — Detect issue references in user messages.
+- `prompt.plugin.scope` — Inject the scope-routing rule when a consumer project's session starts talking about…
 - `prompt.skill.enforce` — Detects inline skill commands (e.g.
 - `prompt.ship.detect` — Detect ship intent in user prompts and inject Skill('ship') instruction.
 - `prompt.flow.appstart` — Detect app start intent in user prompts.
@@ -223,6 +224,7 @@ SessionStart  ──>  UserPromptSubmit  ──>  PreToolUse  ──>  PostToolU
 - `pre.ship.guard` — Block manual PR creation/merging via Bash.
 - `pre.main.guard` — Prevent accidental writes on local main/master.
 - `pre.worktree.split-guard` — WARN (never block) on git-mutating work driven from the main repo root while an agent…
+- `pre.plugin.scope` — Block hand-edits of installed devops plugin artifacts from a consumer project.
 - `pre.edit.branch` — Prevent Edit/Write tool calls while HEAD is on local main/master.
 - `pre.mcp.health` — Detects dead or stale MCP servers before tool calls fail cryptically.
 
@@ -688,7 +690,7 @@ Wk  ━━──╏─────────   15% +1%   · 4d 22h left
 devops/
 ├── .claude-plugin/plugin.json     ← Plugin manifest
 ├── CONVENTIONS.md                 ← Naming, versioning, extension rules
-├── hooks/                         ← <!--devops:count:hooks-->37<!--/devops:count:hooks--> hooks (JS) registered in hooks.json
+├── hooks/                         ← <!--devops:count:hooks-->39<!--/devops:count:hooks--> hooks (JS) registered in hooks.json
 ├── skills/                        ← <!--devops:count:skills-->22<!--/devops:count:skills--> skill definitions (SKILL.md)
 ├── agents/                        ← <!--devops:count:agents-->12<!--/devops:count:agents--> agent definitions
 ├── deep-knowledge/                ← Cross-cutting reference docs

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.125.3",
+  "version": "0.126.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/deep-knowledge/INDEX.md
+++ b/plugins/devops/deep-knowledge/INDEX.md
@@ -9,7 +9,7 @@ Quick-reference for all deep-knowledge topics. Read this FIRST to find the right
 | [agent-conventions.md](agent-conventions.md) | Agent Naming & Collaboration Conventions | [role:X · Type] Task description |
 | [agent-orchestration.md](agent-orchestration.md) | Agent Orchestration | > **Single-Source-of-Truth for test autonomy decisions:** see [test-autonomy.... |
 | [agent-proactivity.md](agent-proactivity.md) | Proactive Agent Orchestration | Cross-cutting rule for when to involve specialized agents without explicit us... |
-| [autonomous-execution.md](autonomous-execution.md) | Autonomous Execution — Gate, Guardrails, Late-Permission Protocol | Detailed execution rules for `run-autonomous` Step 5. Read this at the... |
+| [autonomous-execution.md](autonomous-execution.md) | Autonomous Execution — Gate, Guardrails, Late-Permission Protocol | Detailed execution rules for `run-autonomous` Step 5. Read this at the start of |
 | [browser-file-urls.md](browser-file-urls.md) | Browser File URLs (Windows + Git-Bash) | Cross-cutting rule: whenever a skill opens a local HTML file in a browser |
 | [browser-tool-strategy.md](browser-tool-strategy.md) | Browser Tool Strategy | > **Single-Source-of-Truth for test autonomy decisions:** see [test-autonomy.... |
 | [claude-desktop-app-setup.md](claude-desktop-app-setup.md) | Claude Desktop App Setup (Windows) | Windows-specific reference for Claude Desktop App launcher configuration and ... |
@@ -22,13 +22,14 @@ Quick-reference for all deep-knowledge topics. Read this FIRST to find the right
 | [documentation-maintenance.md](documentation-maintenance.md) | Documentation Maintenance | Keep project docs in their target state as behavior, flows, and architecture ... |
 | [edge-profiles.md](edge-profiles.md) | Edge Profiles | Configuration and usage rules for the two Microsoft Edge profiles used by thi... |
 | [fact-verification.md](fact-verification.md) | Fact Verification | Cross-cutting rule for all web research, claims, and statistics. |
-| [git-hygiene.md](git-hygiene.md) | Git Hygiene | Cross-cutting git rules referenced by `/commit`, `/ship`, and h... |
-| [harden-polish-shared.md](harden-polish-shared.md) | Harden/Polish — Shared Reference | Cross-cutting reference for `/tune-harden` and `/tune-polish`. ... |
+| [git-hygiene.md](git-hygiene.md) | Git Hygiene | Cross-cutting git rules referenced by `/commit`, `/ship`, and hooks. |
+| [harden-polish-shared.md](harden-polish-shared.md) | Harden/Polish — Shared Reference | Cross-cutting reference for `/tune-harden` and `/tune-polish`. Covers |
 | [injection-hardening.md](injection-hardening.md) | Prompt-Injection Hardening — Untrusted Content & Egress Control | Cross-cutting defense for any skill or agent that reads untrusted content (fi... |
 | [local-llm-delegation.md](local-llm-delegation.md) | Local LLM Delegation | Cross-cutting rule for all implementation agents (core, frontend, feature, ai) |
 | [mcp-deferred-tools.md](mcp-deferred-tools.md) | MCP Deferred Tools | Cross-cutting rule: in sessions with a large tool inventory (Computer Use, Ch... |
 | [merge-safety.md](merge-safety.md) | Merge Safety — Parallel Development | Cross-cutting reference for preventing silent overwrites when multiple develo... |
 | [plugin-behavior.md](plugin-behavior.md) | Plugin Behavior Rules | Core behavioral rules enforced by the devops plugin. |
+| [plugin-scope-routing.md](plugin-scope-routing.md) | Plugin Scope Routing — Where a Fix Belongs | Cross-cutting rule for every skill, hook, and agent: a devops-plugin defect f... |
 | [pre-mortem.md](pre-mortem.md) | Pre-Mortem / Red-Team Self-Critique | Cross-cutting rule for reducing blind spots before non-trivial changes. |
 | [preview-testing.md](preview-testing.md) | Claude Preview — Capabilities & Hard Limits | Canonical reference for **Claude Preview** (`preview_*`), the primary localhost |
 | [responsive-testing.md](responsive-testing.md) | Responsive Testing — Multi-Viewport Verification | Multi-device web apps require verification at phone, tablet, and desktop |

--- a/plugins/devops/deep-knowledge/plugin-behavior.md
+++ b/plugins/devops/deep-knowledge/plugin-behavior.md
@@ -87,6 +87,16 @@ Plugin default → User global (~/.claude/) → Project ({project}/.claude/)
 ```
 Most specific wins. See `CONVENTIONS.md` for details.
 
+## Plugin Scope — Fix Upstream, Not Locally
+
+A devops-plugin defect noticed while working in **another** project becomes a
+GitHub issue in the plugin source repo — never a local workaround there, and
+never a hand-edit of the installed copy under `~/.claude/plugins/**` (blocked
+by `pre.plugin.scope`). Anything that is genuinely about the current project
+belongs in that project's own `.claude/` instructions. Inside the plugin source
+repo, direct implementation is the correct route and no issue is needed.
+Full hierarchy, detection, and exceptions: `plugin-scope-routing.md`.
+
 ## Issue Creation — Always Delegate
 
 When a skill or hook needs to create a GitHub issue, it MUST delegate to

--- a/plugins/devops/deep-knowledge/plugin-scope-routing.md
+++ b/plugins/devops/deep-knowledge/plugin-scope-routing.md
@@ -1,0 +1,87 @@
+# Plugin Scope Routing — Where a Fix Belongs
+
+Cross-cutting rule for every skill, hook, and agent: a devops-plugin defect found
+in some other project becomes an **issue in the plugin source repo**, never a
+local fix there.
+
+This is the single source of truth for the "which repo owns this change?"
+question. `/claude-learn` Step 4b/5 implements it for captured learnings; every
+other skill, agent, and ad-hoc turn follows the same hierarchy.
+
+## The hierarchy
+
+Two facts decide everything: **is this session the plugin source repo**, and
+**does the problem belong to the plugin or to this project**.
+
+| Session repo          | Problem belongs to  | Route                                                   |
+|-----------------------|---------------------|---------------------------------------------------------|
+| Plugin source repo    | plugin              | **Implement directly.** No issue needed.                |
+| Plugin source repo    | that same repo      | Same as above — it is one repo.                          |
+| Consumer project      | plugin              | **Issue in the plugin source repo.** Nothing local.     |
+| Consumer project      | this project        | **This project's own `.claude/` instructions.**          |
+| Consumer project      | deliberate override | Local skill extension — only with a stated reason.       |
+
+The failure mode this prevents: noticing a plugin bug while working in another
+project and fixing it *there* — as a local workaround, a CLAUDE.md patch, or a
+hand-edit of the installed copy. Every one of those leaves the actual defect
+live for every other consumer, and the installed-copy variant is erased on the
+next sync.
+
+## Detecting which repo you are in
+
+The session is the **plugin source repo** when `{git-root}/plugins/devops/.claude-plugin/plugin.json`
+exists and its `name` field is `devops`. Anything else is a **consumer project**
+— including a worktree of an unrelated repo and a session with no git root at all.
+
+Hooks share this detection via `hooks/lib/plugin-scope.js`
+(`isPluginSourceRepo`, `managedPluginArtifact`, `upstreamSlug`, `scopeFor`).
+Do not re-implement it.
+
+## Consumer project + plugin problem → upstream issue
+
+1. Resolve the upstream slug from the installed marketplace metadata
+   (`{owner.name}/{name}`); canonical value is `Jerry0022/dotclaude`.
+2. Invoke `/setup-issue` via the **Skill** tool — never `gh issue create`
+   directly (see `plugin-behavior.md` → "Issue Creation — Always Delegate").
+   Hand it a self-contained prompt:
+   - **title** — `[BUG] <short>` for a defect, `[FEAT] <short>` for a gap
+   - **body** — symptom, the affected plugin part (skill / hook / agent / MCP /
+     convention), and `Captured from a session in {current-project}.`
+   - **target repo** — the upstream slug, so it does not land in the consumer repo
+3. Persist nothing locally. The issue *is* the deliverable.
+
+Report the issue URL to the user in the same turn. "I filed it upstream" without
+a link is not a completed handoff.
+
+## Never hand-edit an installed plugin copy
+
+`~/.claude/plugins/cache/**`, `~/.claude/plugins/marketplaces/**`, and
+`~/.claude/plugins/repos/**` are installer-managed artifacts. Editing them from
+a consumer project is blocked by `pre.plugin.scope` (exit 2). The block is
+correct — route the defect upstream instead of bypassing it.
+
+**Exception:** in the plugin source repo, touching the local install is allowed
+(repairing or testing the installed copy). The hook lets it through there.
+
+## Consumer project + this project's problem → local instructions
+
+Build commands, architecture rules, business-logic conventions, and file layout
+belong to the project that owns them. Persist inside that project's `.claude/`,
+preferring the largest fitting container first: **deep-knowledge > skill
+extension > CLAUDE.md** (sizing rules: `content-conventions.md`).
+
+## Deliberate override — the narrow exception
+
+A local skill extension under `{project}/.claude/skills/<skill>/` is justified
+only when the rule must **not** become the plugin default: this project needs a
+deviation every other project would be wrong to inherit. Name that reason
+explicitly. If you cannot, it is an upstream issue.
+
+## Cross-project work
+
+When the target is a *third* project (neither this session's nor the plugin's),
+the topic still wins: a plugin problem goes upstream regardless of which project
+surfaced it. A genuinely project-specific rule for another repo becomes an issue
+in that repo (via `/setup-issue`), or — if it has no GitHub remote — a
+copy-pastable prompt for the user. Ask before writing files into another
+project's tree.

--- a/plugins/devops/docs/architecture.html
+++ b/plugins/devops/docs/architecture.html
@@ -169,7 +169,7 @@
 <section id="overview">
 <h1>Architecture Documentation <small>devops v0.87.0</small></h1>
 <p class="lead">
-  A comprehensive DevOps automation plugin for Claude Code &mdash; <!--devops:count:hooks-->37<!--/devops:count:hooks--> hooks, <!--devops:count:skills-->22<!--/devops:count:skills--> skills, <!--devops:count:agents-->12<!--/devops:count:agents--> agents,
+  A comprehensive DevOps automation plugin for Claude Code &mdash; <!--devops:count:hooks-->39<!--/devops:count:hooks--> hooks, <!--devops:count:skills-->22<!--/devops:count:skills--> skills, <!--devops:count:agents-->12<!--/devops:count:agents--> agents,
   2 MCP servers, a deterministic completion card engine, and a 3-layer extension system.
 </p>
 <div role="note" style="margin:.4rem 0 1.4rem;padding:.6rem .9rem;background:var(--bg2);border-left:3px solid var(--warn);border-radius:4px;color:var(--text2);font-size:.85rem;">
@@ -180,11 +180,11 @@
 
 <div class="card-grid">
   <div class="card">
-    <h4><!--devops:count:hooks-->37<!--/devops:count:hooks--> Hooks</h4>
+    <h4><!--devops:count:hooks-->39<!--/devops:count:hooks--> Hooks</h4>
     <p style="color:var(--text2);font-size:.85rem">Lifecycle guards across SessionStart, UserPromptSubmit, PreToolUse, PostToolUse, Stop</p>
     <span class="badge b-hook">SessionStart &times;<!--devops:count:hooks:ss-->15<!--/devops:count:hooks:ss--></span>
-    <span class="badge b-hook">Prompt &times;<!--devops:count:hooks:prompt-->8<!--/devops:count:hooks:prompt--></span>
-    <span class="badge b-hook">Pre &times;<!--devops:count:hooks:pre-->6<!--/devops:count:hooks:pre--></span>
+    <span class="badge b-hook">Prompt &times;<!--devops:count:hooks:prompt-->9<!--/devops:count:hooks:prompt--></span>
+    <span class="badge b-hook">Pre &times;<!--devops:count:hooks:pre-->7<!--/devops:count:hooks:pre--></span>
     <span class="badge b-hook">Post &times;<!--devops:count:hooks:post-->4<!--/devops:count:hooks:post--></span>
     <span class="badge b-hook">Stop &times;<!--devops:count:hooks:stop-->4<!--/devops:count:hooks:stop--></span>
   </div>
@@ -213,13 +213,13 @@
 │   ├── plugin.json            <span style="color:var(--text2)"># Plugin manifest (name, version, mcpServers, hooks)</span>
 │   └── marketplace.json       <span style="color:var(--text2)"># Marketplace registration</span>
 ├── agents/                    <span style="color:var(--accent2)"># <!--devops:count:agents-->12<!--/devops:count:agents--> agent definitions (*.md with YAML frontmatter)</span>
-├── deep-knowledge/            <span style="color:var(--warn)"># <!--devops:count:dk-->33<!--/devops:count:dk--> cross-cutting reference docs</span>
+├── deep-knowledge/            <span style="color:var(--warn)"># <!--devops:count:dk-->34<!--/devops:count:dk--> cross-cutting reference docs</span>
 ├── hooks/
 │   ├── hooks.json             <span style="color:var(--purple)"># Hook registry (event &rarr; command mapping)</span>
 │   ├── lib/                   <span style="color:var(--text2)"># plugin-guard, run-once, session-id</span>
 │   ├── session-start/         <span style="color:var(--purple)"># <!--devops:count:hooks:ss-->15<!--/devops:count:hooks:ss--> hooks (ss.*)</span>
-│   ├── user-prompt-submit/    <span style="color:var(--purple)"># <!--devops:count:hooks:prompt-->8<!--/devops:count:hooks:prompt--> hooks (prompt.*)</span>
-│   ├── pre-tool-use/          <span style="color:var(--purple)"># <!--devops:count:hooks:pre-->6<!--/devops:count:hooks:pre--> hooks (pre.*)</span>
+│   ├── user-prompt-submit/    <span style="color:var(--purple)"># <!--devops:count:hooks:prompt-->9<!--/devops:count:hooks:prompt--> hooks (prompt.*)</span>
+│   ├── pre-tool-use/          <span style="color:var(--purple)"># <!--devops:count:hooks:pre-->7<!--/devops:count:hooks:pre--> hooks (pre.*)</span>
 │   ├── post-tool-use/         <span style="color:var(--purple)"># <!--devops:count:hooks:post-->4<!--/devops:count:hooks:post--> hooks (post.*)</span>
 │   └── stop/                  <span style="color:var(--purple)"># <!--devops:count:hooks:stop-->4<!--/devops:count:hooks:stop--> hooks (stop.*)</span>
 ├── mcp-server/

--- a/plugins/devops/hooks/hooks.json
+++ b/plugins/devops/hooks/hooks.json
@@ -40,6 +40,7 @@
       },
       {
         "hooks": [
+          { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/pre-tool-use/pre.plugin.scope.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/pre-tool-use/pre.edit.branch.js" }
         ],
         "matcher": "Edit|Write|NotebookEdit"
@@ -88,6 +89,7 @@
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/user-prompt-submit/prompt.knowledge.dispatch.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/user-prompt-submit/prompt.git.sync.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/user-prompt-submit/prompt.issue.detect.js" },
+          { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/user-prompt-submit/prompt.plugin.scope.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/user-prompt-submit/prompt.skill.enforce.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/user-prompt-submit/prompt.ship.detect.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/user-prompt-submit/prompt.flow.appstart.js" },

--- a/plugins/devops/hooks/lib/plugin-scope.js
+++ b/plugins/devops/hooks/lib/plugin-scope.js
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+/**
+ * @module plugin-scope
+ * @version 0.1.0
+ * @description Answers "where does a fix belong?" for the devops plugin.
+ *
+ *   Two orthogonal facts every scope decision needs:
+ *     1. Is the current session running INSIDE the plugin source repo?
+ *        → direct fixes are expected, no upstream issue needed.
+ *     2. Is a write target a MANAGED plugin install artifact
+ *        (~/.claude/plugins/cache|marketplaces|repos/**)?
+ *        → never hand-edit; overwritten on the next sync.
+ *
+ *   Canonical routing rules: deep-knowledge/plugin-scope-routing.md
+ */
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { execFileSync } = require('node:child_process');
+
+/** Last-resort slug when no installed marketplace can be read. */
+const FALLBACK_SLUG = 'Jerry0022/dotclaude';
+
+/** Install roots that are managed by the plugin installer, never by hand. */
+const MANAGED_SUBDIRS = ['cache', 'marketplaces', 'repos'];
+
+function gitTopLevel(cwd) {
+  try {
+    return execFileSync('git', ['rev-parse', '--show-toplevel'], {
+      cwd, encoding: 'utf8', timeout: 15000, stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function readJson(file) {
+  try { return JSON.parse(fs.readFileSync(file, 'utf8')); } catch { return null; }
+}
+
+/**
+ * True when `repoRoot` is the devops plugin's own source repo.
+ * Matches the detection contract used by /claude-learn Step 2:
+ * `{root}/plugins/devops/.claude-plugin/plugin.json` with `name === 'devops'`.
+ * The root marketplace.json is accepted as a secondary signal so a repo layout
+ * change does not silently turn the source repo into a "consumer".
+ */
+function isPluginSourceRepo(repoRoot) {
+  if (!repoRoot) return false;
+
+  const pluginJson = readJson(
+    path.join(repoRoot, 'plugins', 'devops', '.claude-plugin', 'plugin.json')
+  );
+  if (pluginJson && pluginJson.name === 'devops') return true;
+
+  const marketplace = readJson(
+    path.join(repoRoot, '.claude-plugin', 'marketplace.json')
+  );
+  if (marketplace && Array.isArray(marketplace.plugins)) {
+    return marketplace.plugins.some(p => p && p.name === 'devops');
+  }
+  return false;
+}
+
+/** Normalize for comparison — Windows paths are case-insensitive. */
+function normalize(p) {
+  const abs = path.resolve(p);
+  return process.platform === 'win32' ? abs.toLowerCase() : abs;
+}
+
+function isUnder(parent, child) {
+  const rel = path.relative(normalize(parent), normalize(child));
+  return rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel));
+}
+
+/**
+ * True when `target` points into an installed (managed) plugin artifact.
+ * Those trees are rewritten by the installer on every sync, so a hand-edit
+ * masks the real defect and is silently lost.
+ *
+ * @param {string} target absolute or relative path
+ * @param {string} [home] override for tests
+ * @returns {string|null} the managed subdir that matched, or null
+ */
+function managedPluginArtifact(target, home = os.homedir()) {
+  if (!target) return null;
+  const pluginsRoot = path.join(home, '.claude', 'plugins');
+  for (const sub of MANAGED_SUBDIRS) {
+    const dir = path.join(pluginsRoot, sub);
+    // The directory itself is not an edit target — only paths beneath it.
+    if (isUnder(dir, target) && normalize(dir) !== normalize(target)) return sub;
+  }
+  return null;
+}
+
+/**
+ * Resolve the upstream GitHub slug (`owner/repo`) for the devops plugin from
+ * the installed marketplace metadata, falling back to the known canonical slug.
+ *
+ * @param {string} [home] override for tests
+ */
+function upstreamSlug(home = os.homedir()) {
+  const marketplacesDir = path.join(home, '.claude', 'plugins', 'marketplaces');
+  let entries = [];
+  try { entries = fs.readdirSync(marketplacesDir); } catch { return FALLBACK_SLUG; }
+
+  for (const entry of entries) {
+    const meta = readJson(
+      path.join(marketplacesDir, entry, '.claude-plugin', 'marketplace.json')
+    );
+    if (!meta || !Array.isArray(meta.plugins)) continue;
+    if (!meta.plugins.some(p => p && p.name === 'devops')) continue;
+    const owner = meta.owner && meta.owner.name;
+    if (owner && meta.name) return `${owner}/${meta.name}`;
+  }
+  return FALLBACK_SLUG;
+}
+
+/**
+ * Full scope snapshot for the current working directory.
+ *
+ * @param {string} cwd
+ * @param {string} [home] override for tests
+ * @returns {{repoRoot: string|null, isPluginRepo: boolean, slug: string}}
+ */
+function scopeFor(cwd, home = os.homedir()) {
+  const repoRoot = gitTopLevel(cwd);
+  return {
+    repoRoot,
+    isPluginRepo: isPluginSourceRepo(repoRoot),
+    slug: upstreamSlug(home),
+  };
+}
+
+module.exports = {
+  FALLBACK_SLUG,
+  MANAGED_SUBDIRS,
+  gitTopLevel,
+  isPluginSourceRepo,
+  managedPluginArtifact,
+  upstreamSlug,
+  scopeFor,
+};

--- a/plugins/devops/hooks/lib/plugin-scope.js
+++ b/plugins/devops/hooks/lib/plugin-scope.js
@@ -45,9 +45,15 @@ function readJson(file) {
  * `{root}/plugins/devops/.claude-plugin/plugin.json` with `name === 'devops'`.
  * The root marketplace.json is accepted as a secondary signal so a repo layout
  * change does not silently turn the source repo into a "consumer".
+ *
+ * A checkout that lives INSIDE a managed install tree is never the source repo,
+ * however true its metadata looks: the marketplace clone under
+ * `~/.claude/plugins/marketplaces/dotclaude` carries both signals, and treating
+ * it as the source would stand the guard down inside the very tree it protects.
  */
-function isPluginSourceRepo(repoRoot) {
+function isPluginSourceRepo(repoRoot, home = os.homedir()) {
   if (!repoRoot) return false;
+  if (managedPluginArtifact(repoRoot, home)) return false;
 
   const pluginJson = readJson(
     path.join(repoRoot, 'plugins', 'devops', '.claude-plugin', 'plugin.json')
@@ -84,12 +90,18 @@ function isUnder(parent, child) {
  * @returns {string|null} the managed subdir that matched, or null
  */
 function managedPluginArtifact(target, home = os.homedir()) {
-  if (!target) return null;
-  const pluginsRoot = path.join(home, '.claude', 'plugins');
-  for (const sub of MANAGED_SUBDIRS) {
-    const dir = path.join(pluginsRoot, sub);
-    // The directory itself is not an edit target — only paths beneath it.
-    if (isUnder(dir, target) && normalize(dir) !== normalize(target)) return sub;
+  // A non-string target (malformed hook stdin, a future tool payload shape)
+  // must never throw — a PreToolUse crash is user-visible.
+  if (typeof target !== 'string' || !target) return null;
+  try {
+    const pluginsRoot = path.join(home, '.claude', 'plugins');
+    for (const sub of MANAGED_SUBDIRS) {
+      const dir = path.join(pluginsRoot, sub);
+      // The directory itself is not an edit target — only paths beneath it.
+      if (isUnder(dir, target) && normalize(dir) !== normalize(target)) return sub;
+    }
+  } catch {
+    return null;
   }
   return null;
 }
@@ -128,7 +140,7 @@ function scopeFor(cwd, home = os.homedir()) {
   const repoRoot = gitTopLevel(cwd);
   return {
     repoRoot,
-    isPluginRepo: isPluginSourceRepo(repoRoot),
+    isPluginRepo: isPluginSourceRepo(repoRoot, home),
     slug: upstreamSlug(home),
   };
 }

--- a/plugins/devops/hooks/lib/plugin-scope.test.js
+++ b/plugins/devops/hooks/lib/plugin-scope.test.js
@@ -1,0 +1,143 @@
+import { describe, test, expect, beforeAll, afterAll } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  FALLBACK_SLUG,
+  isPluginSourceRepo,
+  managedPluginArtifact,
+  upstreamSlug,
+} from "./plugin-scope.js";
+
+let tmp;
+
+function write(file, content) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, content);
+}
+
+beforeAll(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), "plugin-scope-"));
+});
+
+afterAll(() => {
+  try { fs.rmSync(tmp, { recursive: true, force: true }); } catch {}
+});
+
+describe("isPluginSourceRepo", () => {
+  test("true when plugins/devops/.claude-plugin/plugin.json names devops", () => {
+    const root = path.join(tmp, "source-repo");
+    write(
+      path.join(root, "plugins", "devops", ".claude-plugin", "plugin.json"),
+      JSON.stringify({ name: "devops", version: "1.0.0" }),
+    );
+    expect(isPluginSourceRepo(root)).toBe(true);
+  });
+
+  test("true via root marketplace.json listing the devops plugin", () => {
+    const root = path.join(tmp, "marketplace-only");
+    write(
+      path.join(root, ".claude-plugin", "marketplace.json"),
+      JSON.stringify({ name: "dotclaude", plugins: [{ name: "devops" }] }),
+    );
+    expect(isPluginSourceRepo(root)).toBe(true);
+  });
+
+  test("false for a plain consumer project", () => {
+    const root = path.join(tmp, "consumer");
+    write(path.join(root, "package.json"), "{}");
+    expect(isPluginSourceRepo(root)).toBe(false);
+  });
+
+  test("false when plugin.json exists but names a different plugin", () => {
+    const root = path.join(tmp, "other-plugin");
+    write(
+      path.join(root, "plugins", "devops", ".claude-plugin", "plugin.json"),
+      JSON.stringify({ name: "something-else" }),
+    );
+    expect(isPluginSourceRepo(root)).toBe(false);
+  });
+
+  test("false for null / missing repo root (session outside any git repo)", () => {
+    expect(isPluginSourceRepo(null)).toBe(false);
+    expect(isPluginSourceRepo(path.join(tmp, "does-not-exist"))).toBe(false);
+  });
+
+  test("false when plugin.json is malformed JSON", () => {
+    const root = path.join(tmp, "broken-json");
+    write(
+      path.join(root, "plugins", "devops", ".claude-plugin", "plugin.json"),
+      "{ not json",
+    );
+    expect(isPluginSourceRepo(root)).toBe(false);
+  });
+});
+
+describe("managedPluginArtifact", () => {
+  const home = path.join("/", "home", "tester");
+  const cache = path.join(home, ".claude", "plugins", "cache");
+
+  test("detects the cache tree", () => {
+    expect(managedPluginArtifact(path.join(cache, "dotclaude", "devops", "hooks", "x.js"), home))
+      .toBe("cache");
+  });
+
+  test("detects the marketplaces tree", () => {
+    expect(managedPluginArtifact(
+      path.join(home, ".claude", "plugins", "marketplaces", "dotclaude", "README.md"), home,
+    )).toBe("marketplaces");
+  });
+
+  test("detects the repos tree", () => {
+    expect(managedPluginArtifact(
+      path.join(home, ".claude", "plugins", "repos", "x", "y.js"), home,
+    )).toBe("repos");
+  });
+
+  test("the managed directory itself is not an edit target", () => {
+    expect(managedPluginArtifact(cache, home)).toBe(null);
+  });
+
+  test("other ~/.claude paths are NOT managed (settings, skills, memory)", () => {
+    expect(managedPluginArtifact(path.join(home, ".claude", "settings.json"), home)).toBe(null);
+    expect(managedPluginArtifact(path.join(home, ".claude", "skills", "s", "SKILL.md"), home)).toBe(null);
+    expect(managedPluginArtifact(path.join(home, ".claude", "plugins", "config.json"), home)).toBe(null);
+  });
+
+  test("a normal project file is not managed", () => {
+    expect(managedPluginArtifact(path.join("/", "work", "app", "src", "index.ts"), home)).toBe(null);
+  });
+
+  test("path traversal out of the cache is not treated as managed", () => {
+    expect(managedPluginArtifact(path.join(cache, "..", "..", "settings.json"), home)).toBe(null);
+  });
+
+  test("empty / missing target → null", () => {
+    expect(managedPluginArtifact("", home)).toBe(null);
+    expect(managedPluginArtifact(null, home)).toBe(null);
+  });
+});
+
+describe("upstreamSlug", () => {
+  test("resolves owner/name from the installed marketplace that ships devops", () => {
+    const home = path.join(tmp, "home-with-marketplace");
+    write(
+      path.join(home, ".claude", "plugins", "marketplaces", "dotclaude", ".claude-plugin", "marketplace.json"),
+      JSON.stringify({ name: "dotclaude", owner: { name: "Jerry0022" }, plugins: [{ name: "devops" }] }),
+    );
+    expect(upstreamSlug(home)).toBe("Jerry0022/dotclaude");
+  });
+
+  test("ignores marketplaces that do not ship devops", () => {
+    const home = path.join(tmp, "home-unrelated-marketplace");
+    write(
+      path.join(home, ".claude", "plugins", "marketplaces", "other", ".claude-plugin", "marketplace.json"),
+      JSON.stringify({ name: "other", owner: { name: "someone" }, plugins: [{ name: "unrelated" }] }),
+    );
+    expect(upstreamSlug(home)).toBe(FALLBACK_SLUG);
+  });
+
+  test("falls back when no marketplaces directory exists", () => {
+    expect(upstreamSlug(path.join(tmp, "empty-home"))).toBe(FALLBACK_SLUG);
+  });
+});

--- a/plugins/devops/hooks/lib/plugin-scope.test.js
+++ b/plugins/devops/hooks/lib/plugin-scope.test.js
@@ -63,6 +63,33 @@ describe("isPluginSourceRepo", () => {
     expect(isPluginSourceRepo(path.join(tmp, "does-not-exist"))).toBe(false);
   });
 
+  test("false inside the managed marketplace clone, despite valid metadata", () => {
+    // The clone under ~/.claude/plugins/marketplaces/dotclaude carries BOTH
+    // signals. Trusting them would stand the guard down inside the very tree
+    // it protects.
+    const home = path.join(tmp, "home-clone");
+    const clone = path.join(home, ".claude", "plugins", "marketplaces", "dotclaude");
+    write(
+      path.join(clone, "plugins", "devops", ".claude-plugin", "plugin.json"),
+      JSON.stringify({ name: "devops" }),
+    );
+    write(
+      path.join(clone, ".claude-plugin", "marketplace.json"),
+      JSON.stringify({ name: "dotclaude", plugins: [{ name: "devops" }] }),
+    );
+    expect(isPluginSourceRepo(clone, home)).toBe(false);
+  });
+
+  test("false inside a managed repos/ checkout", () => {
+    const home = path.join(tmp, "home-repos");
+    const checkout = path.join(home, ".claude", "plugins", "repos", "dotclaude");
+    write(
+      path.join(checkout, "plugins", "devops", ".claude-plugin", "plugin.json"),
+      JSON.stringify({ name: "devops" }),
+    );
+    expect(isPluginSourceRepo(checkout, home)).toBe(false);
+  });
+
   test("false when plugin.json is malformed JSON", () => {
     const root = path.join(tmp, "broken-json");
     write(
@@ -115,6 +142,14 @@ describe("managedPluginArtifact", () => {
   test("empty / missing target → null", () => {
     expect(managedPluginArtifact("", home)).toBe(null);
     expect(managedPluginArtifact(null, home)).toBe(null);
+  });
+
+  test("non-string target returns null instead of throwing", () => {
+    // A PreToolUse crash is user-visible, so a malformed payload must not throw.
+    expect(() => managedPluginArtifact({ file_path: cache }, home)).not.toThrow();
+    expect(managedPluginArtifact({ file_path: cache }, home)).toBe(null);
+    expect(managedPluginArtifact(42, home)).toBe(null);
+    expect(managedPluginArtifact(["a"], home)).toBe(null);
   });
 });
 

--- a/plugins/devops/hooks/pre-tool-use/pre.plugin.scope.js
+++ b/plugins/devops/hooks/pre-tool-use/pre.plugin.scope.js
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+/**
+ * @hook pre.plugin.scope
+ * @version 0.1.0
+ * @event PreToolUse
+ * @plugin devops
+ * @matcher Edit|Write|NotebookEdit
+ * @description Block hand-edits of installed devops plugin artifacts from a
+ *   consumer project.
+ *
+ *   A plugin defect noticed while working in some other project belongs
+ *   upstream as a GitHub issue — not patched into the local install. The
+ *   install trees under ~/.claude/plugins/{cache,marketplaces,repos}/ are
+ *   rewritten on every sync, so a hand-edit masks the real defect and is
+ *   silently lost on the next update.
+ *
+ *   Bypass conditions (any one of them → exit 0):
+ *     - Target is not under a managed plugin install tree
+ *     - The current repo IS the plugin source repo (repairing/testing the
+ *       local install is expected there)
+ *     - DEVOPS_ALLOW_PLUGIN_EDIT=1 in environment
+ *
+ *   Rules: deep-knowledge/plugin-scope-routing.md
+ */
+
+require('../lib/plugin-guard');
+
+const {
+  managedPluginArtifact,
+  gitTopLevel,
+  isPluginSourceRepo,
+  upstreamSlug,
+} = require('../lib/plugin-scope');
+
+function extractTargetPath(toolName, input) {
+  if (!input) return null;
+  if (toolName === 'Edit' || toolName === 'Write') return input.file_path || null;
+  if (toolName === 'NotebookEdit') return input.notebook_path || null;
+  return null;
+}
+
+let inputData = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', d => { inputData += d; });
+process.stdin.on('end', () => {
+  let hook;
+  try { hook = JSON.parse(inputData); } catch { process.exit(0); }
+
+  const toolName = hook.tool_name || '';
+  if (!['Edit', 'Write', 'NotebookEdit'].includes(toolName)) process.exit(0);
+
+  const target = extractTargetPath(toolName, hook.tool_input || {});
+  if (!target) process.exit(0);
+
+  if (process.env.DEVOPS_ALLOW_PLUGIN_EDIT === '1') process.exit(0);
+
+  const managed = managedPluginArtifact(target);
+  if (!managed) process.exit(0);
+
+  const cwd = hook.cwd || process.cwd();
+  if (isPluginSourceRepo(gitTopLevel(cwd))) process.exit(0);
+
+  const slug = upstreamSlug();
+
+  process.stderr.write(
+    `BLOCKED: '${target}' is an installed plugin artifact (~/.claude/plugins/${managed}/**).\n` +
+    `Rule: this session is NOT the plugin source repo, so a plugin fix does not belong here.\n` +
+    `      Managed install trees are overwritten on the next sync — the edit would be lost\n` +
+    `      and the real defect would stay unfixed for every other project.\n` +
+    `Fix: invoke the /setup-issue skill and file the defect against ${slug}\n` +
+    `     ([BUG]/[FEAT], body = symptom + which skill/hook/agent + "captured from a session in <this project>").\n` +
+    `     Anything that is genuinely about THIS project belongs in this project's own\n` +
+    `     .claude/ instructions instead. See deep-knowledge/plugin-scope-routing.md.\n` +
+    `Bypass (only when the user explicitly asked to patch the local install): set env DEVOPS_ALLOW_PLUGIN_EDIT=1.\n`
+  );
+  process.exit(2);
+});

--- a/plugins/devops/hooks/user-prompt-submit/prompt.plugin.scope.js
+++ b/plugins/devops/hooks/user-prompt-submit/prompt.plugin.scope.js
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+/**
+ * @hook prompt.plugin.scope
+ * @version 0.1.0
+ * @event UserPromptSubmit
+ * @plugin devops
+ * @description Inject the scope-routing rule when a consumer project's session
+ *   starts talking about the devops plugin itself.
+ *
+ *   Without this, a plugin defect noticed mid-session in some other project
+ *   gets "fixed" right there — as a local workaround or a hand-edit of the
+ *   installed copy — instead of becoming an upstream issue. The rule only
+ *   reaches Claude when it is in context BEFORE the fix is attempted, so it
+ *   is injected on the first plugin-flavored prompt of the session.
+ *
+ *   Silent when: the session IS the plugin source repo (direct fixes expected),
+ *   the prompt carries no plugin signal, or the rule already fired this session.
+ *
+ *   Rules: deep-knowledge/plugin-scope-routing.md
+ */
+
+require('../lib/plugin-guard');
+
+const fs = require('fs');
+const { sessionFile, writeSessionFile } = require('../lib/session-id');
+const { gitTopLevel, isPluginSourceRepo, upstreamSlug } = require('../lib/plugin-scope');
+
+/**
+ * Signals that the user is talking about the plugin, not their own code.
+ * Deliberately narrow: bare "skill"/"hook"/"agent" are everyday words in most
+ * projects, so they only count next to an explicit plugin marker.
+ */
+const PLUGIN_SIGNALS = [
+  /\bdotclaude\b/i,
+  /\bdevops[- ]?plugin\b/i,
+  /\bdevops\s+(skill|hook|agent|command|mcp)\b/i,
+  /(^|\s)\/(ship|commit|promote|fix|concept)\b/,
+  /(^|\s)\/(setup|run|tune|claude|auto)-[a-z]+/,
+  /\bcompletion[- ]card\b/i,
+  /\b(ss|pre|post|prompt|stop)\.[a-z]+\.[a-z.]+\.js\b/,
+  /\bplugin\s+(cache|marketplace|install)\b/i,
+  /~\/\.claude\/plugins\b/,
+];
+
+function hasPluginSignal(message) {
+  if (typeof message !== 'string' || message.length === 0) return false;
+  return PLUGIN_SIGNALS.some(re => re.test(message));
+}
+
+let inputData = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', d => { inputData += d; });
+process.stdin.on('end', () => {
+  let hook;
+  try { hook = JSON.parse(inputData); } catch { process.exit(0); }
+
+  // `prompt` is what the runtime actually sends; the others are defensive.
+  const message = hook.prompt || hook.user_message || hook.message || '';
+  if (!hasPluginSignal(message)) process.exit(0);
+
+  const cwd = hook.cwd || process.cwd();
+  const repoRoot = gitTopLevel(cwd);
+
+  // Plugin source repo → direct implementation is the correct route, no nudge.
+  if (isPluginSourceRepo(repoRoot)) process.exit(0);
+
+  const marker = sessionFile('dotclaude-devops-scope-routed', hook.session_id);
+  try { if (fs.existsSync(marker)) process.exit(0); } catch {}
+  try { writeSessionFile(marker, '1'); } catch {}
+
+  const slug = upstreamSlug();
+  const project = repoRoot || cwd;
+
+  process.stdout.write(
+    `This session is a CONSUMER of the devops plugin (${project}), not its source repo. ` +
+    `Scope routing is therefore mandatory before any fix:\n` +
+    `1. Defect/gap in the devops plugin itself (skill, hook, agent, MCP server, ` +
+    `convention, installed copy under ~/.claude/plugins/**) → do NOT fix it here and ` +
+    `do NOT hand-edit the installed copy. Invoke the /setup-issue skill and file it ` +
+    `against ${slug}: [BUG] for a defect, [FEAT] for a gap, body = symptom + affected ` +
+    `plugin part + "Captured from a session in ${project}."\n` +
+    `2. Anything about THIS project (its build, architecture, conventions, or a ` +
+    `deliberate deviation from a plugin default) → persist it in this project's own ` +
+    `.claude/ instructions (deep-knowledge > skill extension > CLAUDE.md).\n` +
+    `Read deep-knowledge/plugin-scope-routing.md before deciding if the split is unclear. ` +
+    `Do not surface this note as its own message — apply it when routing the work.\n`
+  );
+});
+
+module.exports = { hasPluginSignal, PLUGIN_SIGNALS };

--- a/plugins/devops/hooks/user-prompt-submit/prompt.plugin.scope.js
+++ b/plugins/devops/hooks/user-prompt-submit/prompt.plugin.scope.js
@@ -34,12 +34,22 @@ const PLUGIN_SIGNALS = [
   /\bdotclaude\b/i,
   /\bdevops[- ]?plugin\b/i,
   /\bdevops\s+(skill|hook|agent|command|mcp)\b/i,
+  // Plugin slash commands, enumerated by name. A `/(setup|run|auto)-\w+`
+  // wildcard would also swallow a project's own /run-tests or /setup-db.
   /(^|\s)\/(ship|commit|promote|fix|concept)\b/,
-  /(^|\s)\/(setup|run|tune|claude|auto)-[a-z]+/,
+  /(^|\s)\/setup-(issue|project|readme|cleanup)\b/,
+  /(^|\s)\/run-(agents|autonomous|backlog|burn)\b/,
+  /(^|\s)\/tune-(harden|polish|rethink)\b/,
+  /(^|\s)\/claude-(learn|lint|extend-skill)\b/,
+  /(^|\s)\/auto-(update|usage|graph)\b/,
   /\bcompletion[- ]card\b/i,
-  /\b(ss|pre|post|prompt|stop)\.[a-z]+\.[a-z.]+\.js\b/,
+  // Hook filenames: {event}.{domain}.{action}.js — action segments may be
+  // hyphenated (prompt.flow.silent-turn.js, pre.worktree.split-guard.js).
+  /\b(ss|pre|post|prompt|stop)\.[a-z-]+\.[a-z.-]+\.js\b/,
   /\bplugin\s+(cache|marketplace|install)\b/i,
-  /~\/\.claude\/plugins\b/,
+  // Matches both the POSIX shorthand and a full Windows path
+  // (C:\Users\me\.claude\plugins\…, %USERPROFILE%\.claude\plugins\…).
+  /\.claude[/\\]plugins\b/i,
 ];
 
 function hasPluginSignal(message) {

--- a/plugins/devops/hooks/user-prompt-submit/prompt.plugin.scope.test.js
+++ b/plugins/devops/hooks/user-prompt-submit/prompt.plugin.scope.test.js
@@ -1,0 +1,56 @@
+import { describe, test, expect } from "vitest";
+import { hasPluginSignal } from "./prompt.plugin.scope.js";
+
+describe("hasPluginSignal — plugin-topic detector", () => {
+  test("names the plugin or its repo", () => {
+    expect(hasPluginSignal("der dotclaude ship flow ist kaputt")).toBe(true);
+    expect(hasPluginSignal("das devops-plugin rendert die Karte doppelt")).toBe(true);
+    expect(hasPluginSignal("die devops skill triggert nicht")).toBe(true);
+  });
+
+  test("references a plugin slash command", () => {
+    expect(hasPluginSignal("/ship bricht beim preflight ab")).toBe(true);
+    expect(hasPluginSignal("nach /commit fehlt die Karte")).toBe(true);
+    expect(hasPluginSignal("/setup-issue nimmt das Milestone nicht")).toBe(true);
+    expect(hasPluginSignal("/tune-harden läuft ins Leere")).toBe(true);
+    expect(hasPluginSignal("/claude-learn schreibt in die falsche Datei")).toBe(true);
+  });
+
+  test("references a hook file or the completion card", () => {
+    expect(hasPluginSignal("stop.flow.guard.js blockt jeden Turn")).toBe(true);
+    expect(hasPluginSignal("ss.git.sync.js hängt")).toBe(true);
+    expect(hasPluginSignal("die completion card fehlt am Ende")).toBe(true);
+    expect(hasPluginSignal("completion-card wird nicht gerendert")).toBe(true);
+  });
+
+  test("references the install trees", () => {
+    expect(hasPluginSignal("fix das im plugin cache")).toBe(true);
+    expect(hasPluginSignal("liegt unter ~/.claude/plugins/cache/dotclaude")).toBe(true);
+  });
+
+  test("ordinary project work does NOT signal (false-positive guard)", () => {
+    expect(hasPluginSignal("fix den Bug in src/auth.ts")).toBe(false);
+    expect(hasPluginSignal("add a skill dropdown to the settings page")).toBe(false);
+    expect(hasPluginSignal("our webhook handler drops events")).toBe(false);
+    expect(hasPluginSignal("write an agent that summarizes tickets")).toBe(false);
+    expect(hasPluginSignal("the plugin system in our app needs a registry")).toBe(false);
+  });
+
+  test("a project's own git hook file does not look like a devops hook", () => {
+    // Devops hooks match {event}.{domain}.{action}.js — a bare name must not.
+    expect(hasPluginSignal("update scripts/build.js")).toBe(false);
+    expect(hasPluginSignal("post.js needs a rewrite")).toBe(false);
+  });
+
+  test("a slash command that is not a plugin command does not signal", () => {
+    expect(hasPluginSignal("/help")).toBe(false);
+    expect(hasPluginSignal("/clear the context")).toBe(false);
+  });
+
+  test("empty / non-string input → false", () => {
+    expect(hasPluginSignal("")).toBe(false);
+    expect(hasPluginSignal(null)).toBe(false);
+    expect(hasPluginSignal(undefined)).toBe(false);
+    expect(hasPluginSignal(42)).toBe(false);
+  });
+});

--- a/plugins/devops/hooks/user-prompt-submit/prompt.plugin.scope.test.js
+++ b/plugins/devops/hooks/user-prompt-submit/prompt.plugin.scope.test.js
@@ -23,9 +23,25 @@ describe("hasPluginSignal — plugin-topic detector", () => {
     expect(hasPluginSignal("completion-card wird nicht gerendert")).toBe(true);
   });
 
-  test("references the install trees", () => {
+  test("references the install trees, POSIX and Windows spelling", () => {
     expect(hasPluginSignal("fix das im plugin cache")).toBe(true);
     expect(hasPluginSignal("liegt unter ~/.claude/plugins/cache/dotclaude")).toBe(true);
+    expect(hasPluginSignal("C:\\Users\\Jerem\\.claude\\plugins\\cache\\dotclaude ist stale")).toBe(true);
+    expect(hasPluginSignal("%USERPROFILE%\\.claude\\plugins\\marketplaces")).toBe(true);
+  });
+
+  test("hook filenames with hyphenated action segments still signal", () => {
+    expect(hasPluginSignal("prompt.flow.silent-turn.js schluckt meinen Turn")).toBe(true);
+    expect(hasPluginSignal("pre.worktree.split-guard.js meldet falsch")).toBe(true);
+    expect(hasPluginSignal("prompt.worktree.branch-guard.js nervt")).toBe(true);
+  });
+
+  test("a project's own slash commands do NOT signal", () => {
+    // A /(setup|run|auto)-\w+ wildcard would swallow these.
+    expect(hasPluginSignal("/run-tests schlägt fehl")).toBe(false);
+    expect(hasPluginSignal("/setup-db neu aufsetzen")).toBe(false);
+    expect(hasPluginSignal("/auto-format über das repo laufen lassen")).toBe(false);
+    expect(hasPluginSignal("/tune-cache anpassen")).toBe(false);
   });
 
   test("ordinary project work does NOT signal (false-positive guard)", () => {

--- a/plugins/devops/skills/claude-learn/SKILL.md
+++ b/plugins/devops/skills/claude-learn/SKILL.md
@@ -54,7 +54,9 @@ Determine whether the current project IS the devops plugin source repo:
   exists AND its `name` field equals `devops` (use Read on the JSON).
 - Otherwise it is a **consumer project**.
 
-Store as `{is_plugin_repo}`.
+Store as `{is_plugin_repo}`. This is the same detection the `pre.plugin.scope`
+and `prompt.plugin.scope` hooks apply — see
+`deep-knowledge/plugin-scope-routing.md`.
 
 ## Step 3 — Auto-detect target project from text
 
@@ -107,16 +109,11 @@ the rule must NOT become the plugin's default behavior. If unsure, treat it as
 `upstream` and create the issue. This is not set for plugin-repo or
 project-topic learnings.
 
-**Hard boundary in a consumer project:** this skill must NOT apply a plugin fix
-directly — not into the consumer's own tree, and **never** into the installed
-plugin copy under `~/.claude/plugins/cache/**` or
-`~/.claude/plugins/marketplaces/**`. Those are managed install artifacts; a
-hand-edit masks the real defect and is overwritten on the next sync. A plugin
-defect always leaves this skill as an **upstream issue** (5b). The only writes
-allowed here are a deliberate `local-override` extension (5b′). **Exception —
-plugin source repo:** when the current project IS the plugin's own repo, direct
-fixes are expected (5a) and touching the local cache is *optional* (e.g.
-repairing or testing the installed copy).
+**Hard boundary in a consumer project:** a plugin fix must never be applied
+directly here — not into the consumer's tree, and not into the installed copy
+under `~/.claude/plugins/**` (the `pre.plugin.scope` hook blocks the latter).
+The only local write allowed is a deliberate `local-override` extension (5b′).
+Full rule, exceptions, and detection: `deep-knowledge/plugin-scope-routing.md`.
 
 ## Step 5 — Route by target × topic
 
@@ -135,7 +132,8 @@ self-reference rule. Single source: `deep-knowledge/content-conventions.md`
 | current (consumer)     | plugin → upstream        | **5b.** Issue in plugin source repo (root-cause) |
 | current (consumer)     | plugin → local-override  | **5b′.** Skill-extension if it fits; else 5c     |
 | current (consumer)     | project                  | **5c.** Project-specific skill or deep-knowledge |
-| other project (any)    | any                      | **5d.** Cross-project — issue or prompt          |
+| other project          | plugin                   | **5b.** Topic wins — issue in the plugin repo    |
+| other project          | project                  | **5d.** Cross-project — issue or prompt          |
 | global / ambiguous     | any                      | **5e.** ASK FIRST — do not auto-write            |
 
 ### 5a — Plugin repo, plugin topic
@@ -222,7 +220,10 @@ single source of truth for size/structure checks.
 
 ### 5d — Different project (cross-project)
 
-This branch fires when `{target_project}` ≠ current project.
+This branch fires when `{target_project}` ≠ current project AND
+`{topic} == project`. **A plugin topic never lands here** — the topic outranks
+the target, so it goes to 5b and the issue is filed against the plugin source
+repo, not against `{target_project}`.
 
 1. Resolve the target's git root and check for a GitHub remote:
    ```bash
@@ -364,18 +365,12 @@ write this skill performs.
   — auto-memory owns that channel. The **only** permitted writes are Step 6
   duplicate-cleanup: deleting matched `feedback_*.md` files and removing
   their bullets from `MEMORY.md`, both requiring user confirmation per match.
-- **Default to the root cause's home.** A plugin defect/gap found in a consumer
-  project becomes an issue in the plugin source repo (5b), NOT a local
-  extension. Localize (5b′ / local dotclaude change) only for a deliberate
-  project-specific override you can justify keeping off upstream — and only when
-  it makes sense to implement in the current project at all.
-- **Never hand-edit installed plugin copies.** In a consumer project this skill
-  must not fix a plugin defect directly — not in the consumer's tree, and never
-  under `~/.claude/plugins/cache/**` or `~/.claude/plugins/marketplaces/**`
-  (managed artifacts, overwritten on the next sync). Route it upstream (5b);
-  the only local write allowed is a deliberate `local-override` extension (5b′).
-  **Exception:** when the current project IS the plugin source repo, direct
-  fixes are expected and touching the local cache is optional.
+- **Default to the root cause's home**, and **never hand-edit installed plugin
+  copies** — both rules, with their exceptions and the repo detection, live in
+  `deep-knowledge/plugin-scope-routing.md`. In short: a plugin defect/gap found
+  in a consumer project becomes an issue in the plugin source repo (5b), not a
+  local extension; localize (5b′) only for a deliberate project-specific
+  override you can justify keeping off upstream.
 - **Always** prefer deep-knowledge > skill/extension > CLAUDE.md.
 - **Respect the soft caps** above; re-route to the next-larger container
   before busting CLAUDE.md or SKILL.md targets.

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.125.3",
+  "version": "0.126.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

A devops-plugin bug noticed while working in some other project got fixed in the wrong place — as a local workaround, a CLAUDE.md patch, or a hand-edit of the installed copy under `~/.claude/plugins/**`, where the next sync erases it and the real defect stays live for every other consumer.

The rule against that already existed, but only inside the `/claude-learn` skill body — which triggers on explicit invocation. So it applied exactly when nobody needed it. This lifts it to the cross-cutting layer and enforces it.

## The hierarchy

| Session repo | Problem belongs to | Route |
|---|---|---|
| Plugin source repo | plugin | Implement directly, no issue |
| Consumer project | plugin | Issue in the plugin source repo |
| Consumer project | this project | That project's own `.claude/` instructions |

## Changes

- `deep-knowledge/plugin-scope-routing.md` — the canonical hierarchy, surfaced through the session-start index in every project
- `hooks/lib/plugin-scope.js` — shared detection: source repo, managed install artifacts, upstream slug
- `pre.plugin.scope` (PreToolUse) — blocks Edit/Write into `~/.claude/plugins/{cache,marketplaces,repos}/**` from a consumer project; allowed in the plugin's own repo, where repairing the install is expected. Bypass: `DEVOPS_ALLOW_PLUGIN_EDIT=1`
- `prompt.plugin.scope` (UserPromptSubmit) — injects the routing rule once per session when a consumer's prompt turns to the plugin itself
- `/claude-learn` — deduped against the new reference; a plugin topic aimed at a third project now routes upstream (5b) instead of into the wrong repo (5d)

## Codex review

Five findings, all fixed in this branch with regression tests. The substantive one: the marketplace clone at `~/.claude/plugins/marketplaces/dotclaude` carries the same metadata as the real source repo, so a session opened there passed the source-repo check and unblocked edits inside the tree the guard protects. A checkout living inside a managed install tree is now never the source repo.

## Verification

- `npm test` — 983 green (30 new)
- `npm run lint` — clean
- End-to-end hook payloads: 7 cases for `pre.plugin.scope` (block/allow/bypass, upstream slug resolved from the real install), 5 for `prompt.plugin.scope` (consumer-only, once per session, silent in the source repo)
