### PR TITLE
fix(hooks): stop token guard blocking path-passing commands

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.126.0"
+    "version": "0.126.1"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.126.0",
+      "version": "0.126.1",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.126.0",
+      "version": "0.126.1",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.126.1] — 2026-08-15
+
+### Fixed
+
+- **A command that only hands a large file's path to another program is no longer blocked as if it read the file.** The token guard matched any known expensive path anywhere in a Bash command with a plain substring test, so starting a server with `--html <big>.html`, and equally `ls -la <big>.html` or even `echo "wrote <big>.html"`, were all refused — none of which pulls a single byte into context. A per-segment classifier now decides per command: it splits on `&&`, `||`, `|`, `;`, `&` and newlines, lifts `$(…)` and backtick substitutions out quote-aware so a read hidden inside `echo "$(cat <big>)"` is still caught, resolves each segment's real command head through environment assignments and wrappers like `sudo`/`timeout`/`xargs`, and only counts the file when that head actually reads it. Anything it cannot positively recognise as content-free stays blocked — an unresolvable head, a segment that is only variable assignments, a `/dev/stdout` sink, or a known multiplexer in a mode outside its allowlist (`git diff`, `gh api`, `npm exec`). The single deliberate exemption is a detached `run_in_background` command whose head is unrecognised, which is what unblocks a server start; a backgrounded `cat` stays blocked, because its buffer is still retrievable. If the classifier fails for any reason it falls back to the old substring match rather than letting the operation through, and every sibling `require` is now guarded so a half-updated plugin cache can no longer disable the guard silently on every tool call.
+
+- **"To proceed, retry the same operation" now actually releases.** The confirmation flag was keyed on a hash of the entire tool input, so a reworded description — model-authored, rewritten every turn — or an added `run_in_background` produced a different key, and the retry was treated as a first attempt and blocked again, indefinitely. The key now covers only the fields that determine the token cost, plus the working directory; the hook also stopped writing its own scratch fields back onto the tool input before computing it. Two side effects fall out of the same change: a block in one project no longer pre-authorises the identical command in another, and a confirmation expires after 30 minutes instead of silently approving a command abandoned weeks ago. `session_id` is deliberately not part of the key — it can arrive changed or missing between hook invocations, and this path has no escape hatch, so keying on it could wedge the retry permanently. The graphify gate's escape-hatch flag had the identical defect and gets the identical fix, so a broad search retried with an added `-i` or `head_limit` is no longer gated twice.
+
 ## [0.126.0] — 2026-08-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.126.0**
+**Version: 0.126.1**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.126.0",
+  "version": "0.126.1",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/deep-knowledge/plugin-behavior.md
+++ b/plugins/devops/deep-knowledge/plugin-behavior.md
@@ -61,7 +61,16 @@ the `redteam` agent in Wave 0.
 ## Token Awareness
 
 - `ss.tokens.scan` scans for expensive files at session start
-- `pre.tokens.guard` blocks operations exceeding 2% of session limit
+- `pre.tokens.guard` blocks operations exceeding the plan-scaled share of the
+  context window (`plan-defaults`: 5% pro · 8% max_5 · 10% max_20)
+- For Bash, an expensive file only counts when a command actually READS it
+  (`hooks/lib/bash-context-cost`). Passing the path as an argument — a server
+  start, `ls`, `mv`, `echo`, `git add` — is free. A command that cannot be
+  reasoned about stays costly; the one exception is a detached
+  `run_in_background` non-reader
+- A block is a confirm-once gate: retrying the same operation releases it for
+  30 minutes, keyed per project. Reword the description or flip
+  `run_in_background` freely — neither affects the key
 - Never refuse work — surface the cost trade-off, let the user decide
 - Usage data displayed only in completion card battery line
 

--- a/plugins/devops/hooks/lib/bash-context-cost.js
+++ b/plugins/devops/hooks/lib/bash-context-cost.js
@@ -1,0 +1,415 @@
+/**
+ * @module bash-context-cost
+ * @version 0.2.0
+ * @plugin devops
+ * @description Decide which large-file references inside a Bash command
+ *   actually cost Claude context. Used by pre.tokens.guard to stop blocking
+ *   commands that merely PASS a big file's path as an argument (server start,
+ *   `ls`, `mv`, `echo`) while still blocking commands that READ the file into
+ *   context (`cat`, `grep`, `jq`, `python -c`).
+ *
+ *   Three verdicts, and the difference between two of them carries the whole
+ *   safety argument:
+ *   - `reader`  — content demonstrably flows out, OR the segment could not be
+ *                 reasoned about (assignments only, an unparsable tail, a
+ *                 stdout sink). ALWAYS costly.
+ *   - `passer`  — positively recognised as content-free.
+ *   - `unknown` — a command whose behaviour cannot be reasoned about at all:
+ *                 an unrecognised binary, or a recognised interpreter running
+ *                 a SCRIPT. Costly, EXCEPT under `run_in_background: true`.
+ *
+ *   That background exemption is the single deliberate hole, and it rests on
+ *   something narrower than "detached output never reaches context" — Claude
+ *   can pull a background buffer with BashOutput. What it actually rests on:
+ *   every recognised content emitter — including a known multiplexer in a
+ *   non-allowlisted mode (`git diff`, `gh api`, `npm exec`) — is classified
+ *   `reader` and stays blocked regardless of backgrounding. So the residual
+ *   exposure is exactly the `unknown` set above: something we cannot reason
+ *   about that dumps a large file AND is then deliberately read back. That is
+ *   accepted; blocking every detached server start is the worse trade
+ *   (issue #277). Fail-safe verdicts must never route through `unknown`.
+ *
+ *   Design rule — fail safe. Anything not positively recognised as
+ *   content-free is treated as context-reading, so the guard is never weaker
+ *   than the plain substring match it replaces. That includes an unrecognised
+ *   command head, a segment that is only variable assignments, and the tail of
+ *   a command too pathological to parse.
+ *
+ *   Known limits (deliberate, documented rather than half-fixed):
+ *   - Path matching is still a substring test, so `cd docs && cat big.html`
+ *     evades it. Splitting the path across `cd` boundaries is out of scope.
+ *   - A trailing shell `&` is not treated as backgrounding: `cat f &` still
+ *     inherits stdout, so it is genuinely NOT free. Use the tool's
+ *     `run_in_background` flag, which is the signal this module honours.
+ *   - stdout redirection (`> out.txt`) is not credited as free. Detecting it
+ *     without quote-aware parsing of every `>` would be an evasion vector
+ *     (`grep "a>b" big.html`), and the gain does not justify that risk.
+ *   - An unterminated apostrophe outside double quotes (`echo don't $(cat f)`)
+ *     swallows the rest of the line. That command is invalid shell and never
+ *     runs, so nothing reaches context.
+ */
+
+// Segments too pathological to parse get this synthetic head. It is in
+// READER_HEADS so an unparsed tail is always costly — never silently dropped.
+const OVERFLOW_HEAD = '__unparsed__';
+
+// Commands whose stdout contains file CONTENT.
+const READER_HEADS = new Set([
+  OVERFLOW_HEAD,
+  'cat', 'bat', 'tac', 'head', 'tail', 'less', 'more', 'nl', 'fold',
+  'grep', 'egrep', 'fgrep', 'rg', 'ag', 'ack', 'select-string', 'sls',
+  'jq', 'yq', 'xmllint', 'awk', 'gawk', 'mawk', 'sed', 'cut', 'paste',
+  'sort', 'uniq', 'tr', 'column', 'diff', 'comm', 'join',
+  'strings', 'od', 'xxd', 'hexdump', 'base64', 'zcat', 'gunzip',
+  'type', 'get-content', 'gc', 'import-csv', 'convertfrom-json',
+]);
+
+// Commands that only ever take a path as an operand — their output never
+// contains the file's contents.
+const PASSER_HEADS = new Set([
+  'ls', 'dir', 'stat', 'file', 'du', 'basename', 'dirname', 'realpath',
+  'readlink', 'pwd', 'cd', 'pushd', 'popd',
+  'touch', 'mkdir', 'rmdir', 'rm', 'del', 'erase', 'cp', 'copy', 'mv',
+  'move', 'ren', 'rename', 'ln', 'mklink', 'chmod', 'chown', 'attrib',
+  'echo', 'true', 'false', 'which', 'where', 'test', 'sleep',
+  'start', 'explorer', 'open', 'cygpath', 'kill', 'taskkill',
+]);
+
+// Wrappers: the real command head is the next token.
+const WRAPPER_HEADS = new Set([
+  'sudo', 'nohup', 'command', 'builtin', 'exec', 'env', 'time', 'nice',
+  'stdbuf', 'timeout', 'winpty', 'xargs', 'setsid',
+]);
+
+// Interpreters and shells: safe when running a SCRIPT, context-reading when
+// handed inline code, which can print a file to stdout.
+const INTERPRETER_HEADS = new Set([
+  'python', 'python3', 'py', 'node', 'deno', 'bun', 'perl', 'ruby', 'php',
+  'bash', 'sh', 'zsh', 'ksh', 'dash', 'pwsh', 'powershell', 'cmd',
+]);
+const INLINE_CODE_FLAG = /^(-c|-e|-w|--eval|--command|-command|-encodedcommand|\/c|\/k)$/i;
+
+// Writing a file to a stdout-equivalent sink defeats any head-based reasoning
+// (`cp big.html /dev/stdout`), so a segment naming one is always a reader.
+// stderr counts too — the Bash tool captures it into the same result.
+const STDOUT_SINK = /(^|[\s=("'>])(\/dev\/(stdout|stderr|fd\/[12])|\/proc\/self\/fd\/[12])(["')\s]|$)/i;
+
+// git subcommands that emit no file content — provided patch mode is off.
+// `git show|diff|log|blame|cat-file` are deliberately absent.
+const GIT_SAFE_SUB = /^(push|fetch|remote|prune|worktree|branch|checkout|switch|pull|merge|rebase|tag|stash|rm|add|commit|status|init|clone|config|reset|restore|mv)$/;
+const GIT_PATCH_FLAG = /^(-p|--patch)$/;
+
+// gh is allowlisted at VERB granularity: the nouns alone are far too broad
+// (`gh pr diff`, `gh run view --log`, `gh release view`, `gh repo view` and
+// `gh api .../contents/<path>` all emit content). `gh api` is never safe.
+const GH_SAFE_SUB = {
+  pr: /^(create|comment|merge|close|reopen|edit|ready|checkout|lock|unlock)$/,
+  issue: /^(create|comment|close|reopen|edit|pin|unpin|transfer|lock|unlock|develop)$/,
+  release: /^(create|upload|delete|edit)$/,
+  repo: /^(create|clone|fork|rename|delete|archive|unarchive|sync|set-default)$/,
+  run: /^(rerun|cancel|delete)$/,
+  auth: /^(status|login|logout|refresh|setup-git)$/,
+  label: /^(create|delete|edit|clone)$/,
+  workflow: /^(enable|disable|run)$/,
+  project: /^(create|edit|close|copy|link|unlink|item-add|item-edit|item-archive|item-delete)$/,
+};
+
+/** Strip a leading directory and a trailing `.exe`, then lowercase. */
+function baseName(token) {
+  const bare = String(token).replace(/^["']|["']$/g, '');
+  const tail = bare.split(/[\\/]/).pop() || '';
+  return tail.replace(/\.(exe|cmd|bat|ps1)$/i, '').toLowerCase();
+}
+
+/**
+ * Index of the `)` closing the `(` at `open`, skipping quoted spans so a
+ * literal paren inside quotes (`grep ')' f`) cannot end the body early.
+ * Returns -1 when unbalanced.
+ */
+function matchingParen(text, open) {
+  let depth = 1;
+  let quote = null;
+  for (let i = open + 1; i < text.length; i++) {
+    const ch = text[i];
+    if (ch === '\\' && quote !== "'") { i++; continue; }
+    if (quote) { if (ch === quote) quote = null; continue; }
+    if (ch === "'" || ch === '"') { quote = ch; continue; }
+    if (ch === '(') depth++;
+    else if (ch === ')' && --depth === 0) return i;
+  }
+  return -1;
+}
+
+/**
+ * Pull every command-substitution body out of `text`, quote-aware. The bodies
+ * become segments in their own right so `echo "$(cat big.json)"` is still
+ * recognised as a read even though its outer head (`echo`) is a passer.
+ * Returns the text with each substitution replaced by a space.
+ */
+function extractSubstitutions(text, sink) {
+  let out = '';
+  let quote = null;
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (ch === '\\' && quote !== "'") {
+      out += ch;
+      if (i + 1 < text.length) out += text[++i];
+      continue;
+    }
+    if (quote === "'") {           // single quotes suppress expansion entirely
+      if (ch === "'") quote = null;
+      out += ch;
+      continue;
+    }
+    if (ch === '$' && text[i + 1] === '(') {
+      const close = matchingParen(text, i + 1);
+      const end = close === -1 ? text.length : close;
+      sink.push(text.slice(i + 2, end));
+      out += ' ';
+      i = end;
+      continue;
+    }
+    if (ch === '`') {
+      let j = i + 1;
+      while (j < text.length && text[j] !== '`') { if (text[j] === '\\') j++; j++; }
+      sink.push(text.slice(i + 1, Math.min(j, text.length)));
+      out += ' ';
+      i = j;
+      continue;
+    }
+    if (ch === '"') { quote = quote === '"' ? null : '"'; out += ch; continue; }
+    // An apostrophe INSIDE double quotes is literal — opening single-quote
+    // state here would swallow every later `$(...)` in the string, e.g.
+    // `gh pr create --title "Claude's fix" --body "$(cat big.html)"`.
+    if (ch === "'" && quote === null) { quote = "'"; out += ch; continue; }
+    out += ch;
+  }
+  return out;
+}
+
+const SPLIT_RE = /\s*(?:&&|\|\||[|;&\n])\s*/;
+const MAX_PASSES = 2000;
+// Second bound, on work rather than iterations: this hook runs before every
+// Bash call, so a pathological command must not cost more than a fixed budget.
+const MAX_CHARS = 200_000;
+
+/** Split a command into individually classifiable segments. */
+function segmentize(command) {
+  const pending = [String(command || '')];
+  const segments = [];
+  let passes = 0;
+  let chars = 0;
+  while (pending.length) {
+    if (passes++ >= MAX_PASSES || chars >= MAX_CHARS) {
+      // Never silently drop the tail — keep it, forced costly.
+      for (const rest of pending) {
+        if (rest.trim()) segments.push(`${OVERFLOW_HEAD} ${rest.trim()}`);
+      }
+      break;
+    }
+    const next = pending.shift();
+    chars += next.length;
+    const nested = [];
+    const flat = extractSubstitutions(next, nested);
+    for (const part of flat.split(SPLIT_RE)) {
+      if (part.trim()) segments.push(part.trim());
+    }
+    pending.push(...nested);
+  }
+  return segments;
+}
+
+/** Resolve a segment's effective command head, skipping env vars and wrappers. */
+function commandHead(segment) {
+  const tokens = segment.split(/\s+/).filter(Boolean);
+  let strippedAssignment = false;
+  let strippedWrapper = false;
+  let consumedWrapperFlag = false;
+  while (tokens.length) {
+    const head = tokens[0];
+    if (/^[A-Za-z_][A-Za-z0-9_]*=/.test(head)) {   // VAR=value prefixes
+      tokens.shift();
+      strippedAssignment = true;
+      continue;
+    }
+    if (WRAPPER_HEADS.has(baseName(head))) {
+      tokens.shift();
+      strippedWrapper = true;
+      // Skip the wrapper's own flags AND their numeric values, plus bare
+      // durations/limits (`timeout -k 2 30 cat f`, `nice -n 10 cat f`).
+      while (tokens.length && (/^-/.test(tokens[0]) || /^\d+(\.\d+)?[smhd]?$/i.test(tokens[0]))) {
+        // A FLAG may have taken the real command as its value
+        // (`sudo -u root cat f` leaves `root` as the head). A bare number is
+        // just a duration and derails nothing, so it must not poison the
+        // verdict for `timeout 3600 ./server`.
+        if (tokens[0].startsWith('-')) consumedWrapperFlag = true;
+        tokens.shift();
+      }
+      continue;
+    }
+    break;
+  }
+  return {
+    head: tokens.length ? baseName(tokens[0]) : '',
+    args: tokens.slice(1),
+    strippedAssignment,
+    strippedWrapper,
+    consumedWrapperFlag,
+  };
+}
+
+/** First non-flag argument — a command's subcommand, when it has one. */
+function subCommand(args) {
+  return (args.find(a => !a.startsWith('-')) || '').toLowerCase();
+}
+
+// git global flags that take a SEPARATE value, so the next token is not the
+// subcommand: `git -C dir status`, `git -c user.name=x commit`.
+const GIT_GLOBAL_WITH_VALUE = /^(-C|-c|--git-dir|--work-tree|--exec-path|--namespace|--super-prefix)$/;
+
+/** git's subcommand, skipping global flags and the values they consume. */
+function gitSubCommand(args) {
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (GIT_GLOBAL_WITH_VALUE.test(a)) { i++; continue; }   // flag + its value
+    if (a.startsWith('-')) continue;
+    return a.toLowerCase();
+  }
+  return '';
+}
+
+/**
+ * gh accepts global flags before the noun (`gh --repo o/r pr create`), so the
+ * noun cannot be "first non-flag token". Scan for the first token that IS a
+ * known noun instead; the next non-flag token after it is the verb.
+ */
+function ghNounVerb(args) {
+  const idx = args.findIndex(a =>
+    Object.prototype.hasOwnProperty.call(GH_SAFE_SUB, a.toLowerCase()));
+  if (idx === -1) return { noun: '', verb: '' };
+  return { noun: args[idx].toLowerCase(), verb: subCommand(args.slice(idx + 1)) };
+}
+
+/**
+ * Classify one segment.
+ *
+ * `reader` is not only "this command prints file contents" — it is also the
+ * verdict for anything we could not reason about, because `unknown` carries
+ * the `run_in_background` exemption and a fail-safe path must never be
+ * defeatable by backgrounding the command.
+ *
+ * @returns {'reader'|'passer'|'unknown'}
+ */
+function classifySegment(segment) {
+  const kind = baseClassify(segment);
+  // Monotone upgrade: naming a stdout/stderr sink defeats any head-based
+  // reasoning (`cp big.html /dev/stdout`), so it can only make a segment
+  // costlier, never cheaper.
+  if (kind !== 'reader' && STDOUT_SINK.test(segment)) return 'reader';
+  return kind;
+}
+
+function baseClassify(segment) {
+  const { head, args, strippedAssignment, strippedWrapper, consumedWrapperFlag } = commandHead(segment);
+  // A segment that is nothing but assignments (`FILE=big.html`) hands the path
+  // to a later segment via `$FILE`, which this module cannot follow. Costly,
+  // and deliberately `reader` so backgrounding cannot free it. Same for a
+  // wrapper whose real command never materialised.
+  if (!head) return (strippedAssignment || strippedWrapper) ? 'reader' : 'passer';
+  if (READER_HEADS.has(head)) return 'reader';
+  if (INTERPRETER_HEADS.has(head)) {
+    return args.some(a => INLINE_CODE_FLAG.test(a)) ? 'reader' : 'unknown';
+  }
+  // git and gh are tools we KNOW can print file contents — that is why their
+  // subcommands are allowlisted at all. A form outside the allowlist is a
+  // recognised emitter in an unrecognised mode, so it is `reader`, not
+  // `unknown`: `git diff`, `git show`, `git add -p` and
+  // `gh api …/contents/<path>` must not become free by backgrounding them.
+  if (head === 'git') {
+    // Args are whitespace-split, so a `-p` inside a commit message counts too
+    // (`git commit -m "add -p support"`). Over-blocks only, and only when the
+    // same command also carries an expensive path — accepted.
+    if (args.some(a => GIT_PATCH_FLAG.test(a))) return 'reader';   // `git add -p`, `git stash show -p`
+    return GIT_SAFE_SUB.test(gitSubCommand(args)) ? 'passer' : 'reader';
+  }
+  if (head === 'gh') {
+    const { noun, verb } = ghNounVerb(args);
+    return noun && GH_SAFE_SUB[noun].test(verb) ? 'passer' : 'reader';
+  }
+  // Package managers are multiplexers that can run arbitrary code
+  // (`npm exec -- cat f`, `npm run <script>`), so they get the same treatment
+  // as git/gh: allowlisted form or `reader`, never `unknown`.
+  if (head === 'npm' || head === 'pnpm' || head === 'yarn') {
+    return subCommand(args) === 'publish' ? 'passer' : 'reader';
+  }
+  if (PASSER_HEADS.has(head)) return 'passer';
+  // A head we could not resolve because a wrapper FLAG took a separate value
+  // (`sudo -u root cat f` resolves to `root`) is a parse failure, not an
+  // unrecognised command — it must not inherit the background exemption. A
+  // wrapper stripped cleanly onto an unrecognised binary
+  // (`nohup ./server --html big.html`) is a genuine unknown and keeps it.
+  return consumedWrapperFlag ? 'reader' : 'unknown';
+}
+
+/**
+ * True when no segment of the command can pull anything into context.
+ * Deliberately ignores `run_in_background` so verbose-output detection
+ * downstream is never skipped for a backgrounded command.
+ */
+function isFreeOfContextCost(command) {
+  const segments = segmentize(command);
+  return segments.length > 0 && segments.every(s => classifySegment(s) === 'passer');
+}
+
+/** Compare paths on forward slashes so a Windows-style command still matches. */
+function normalizeSlashes(text) {
+  return String(text).replace(/\\/g, '/');
+}
+
+/**
+ * Which of the known expensive files does this command actually read?
+ *
+ * @param {string} command                 the Bash command text
+ * @param {Array<{path:string,estimatedTokens?:number}>} expensiveFiles
+ * @param {{runInBackground?:boolean}} [opts]
+ * @returns {Array<{path:string,tokens:number}>}
+ */
+function matchCostlyFiles(command, expensiveFiles, opts = {}) {
+  const runInBackground = !!opts.runInBackground;
+  const segments = segmentize(command);
+  const costly = segments
+    .filter(seg => {
+      const kind = classifySegment(seg);
+      if (kind === 'reader') return true;   // background does not save a reader
+      if (kind === 'passer') return false;
+      return !runInBackground;              // unknown: safe by default, free when detached
+    })
+    .map(normalizeSlashes);
+  // A reader can consume a path that lives in another segment —
+  // `echo big.html | xargs cat`, `find . -name x | cat`. Once anything reads,
+  // fall back to matching the whole command, exactly as the pre-0.9 substring
+  // check did. Strictly no wider than that check, so it adds no new
+  // false positives relative to the behaviour it replaces.
+  if (segments.some(seg => classifySegment(seg) === 'reader')) {
+    costly.push(normalizeSlashes(command));
+  }
+  const files = Array.isArray(expensiveFiles) ? expensiveFiles : [];
+  const matched = [];
+  for (const ef of files) {
+    if (!ef || !ef.path) continue;
+    const needle = normalizeSlashes(ef.path);
+    if (costly.some(seg => seg.includes(needle))) {
+      matched.push({ path: ef.path, tokens: ef.estimatedTokens || 20000 });
+    }
+  }
+  return matched;
+}
+
+module.exports = {
+  baseName,
+  segmentize,
+  commandHead,
+  classifySegment,
+  isFreeOfContextCost,
+  matchCostlyFiles,
+};

--- a/plugins/devops/hooks/lib/bash-context-cost.test.js
+++ b/plugins/devops/hooks/lib/bash-context-cost.test.js
@@ -1,0 +1,345 @@
+import { describe, test, expect } from "vitest";
+import {
+  segmentize,
+  commandHead,
+  classifySegment,
+  isFreeOfContextCost,
+  matchCostlyFiles,
+} from "./bash-context-cost.js";
+
+const BIG = [{ path: "docs/concepts/big.html", estimatedTokens: 49557 }];
+const hits = (cmd, opts) => matchCostlyFiles(cmd, BIG, opts).map(f => f.path);
+
+describe("segmentize", () => {
+  test("splits on &&, ;, |, || and newlines", () => {
+    expect(segmentize("a && b ; c | d || e\nf")).toEqual(["a", "b", "c", "d", "e", "f"]);
+  });
+
+  test("lifts command substitutions into their own segments", () => {
+    expect(segmentize('echo "$(cat big.html)"')).toContain("cat big.html");
+  });
+
+  test("lifts backtick substitutions too", () => {
+    expect(segmentize("echo `cat big.html`")).toContain("cat big.html");
+  });
+
+  test("handles nested substitutions", () => {
+    expect(segmentize('echo "$(head -1 $(ls big.html))"')).toEqual(
+      expect.arrayContaining(["ls big.html"])
+    );
+  });
+});
+
+describe("commandHead", () => {
+  test("strips a directory and a .exe suffix", () => {
+    expect(commandHead("/usr/bin/cat f").head).toBe("cat");
+    expect(commandHead("C:/Python/python.exe s.py").head).toBe("python");
+  });
+
+  test("skips leading env assignments", () => {
+    expect(commandHead("FOO=1 BAR=2 cat f").head).toBe("cat");
+  });
+
+  test("looks through wrappers and their flags", () => {
+    expect(commandHead("sudo cat f").head).toBe("cat");
+    expect(commandHead("timeout -k 2 30 cat f").head).toBe("cat");
+  });
+});
+
+describe("classifySegment", () => {
+  test.each(["cat f", "grep x f", "jq . f", "sed -n 1p f", "Get-Content f"])(
+    "%s → reader",
+    seg => expect(classifySegment(seg)).toBe("reader")
+  );
+
+  test.each(["ls -la f", "echo f", "mv a b", "touch f", "git add f", "gh pr create"])(
+    "%s → passer",
+    seg => expect(classifySegment(seg)).toBe("passer")
+  );
+
+  test.each(["python server.py --html f", "node dump.js f", "./mytool f"])(
+    "%s → unknown (fail safe)",
+    seg => expect(classifySegment(seg)).toBe("unknown")
+  );
+
+  test("an interpreter with inline code is a reader", () => {
+    expect(classifySegment(`python -c "print(open('f').read())"`)).toBe("reader");
+    expect(classifySegment("node -e \"console.log(require('fs').readFileSync('f'))\"")).toBe("reader");
+  });
+
+  // git and gh are known content emitters — that is why their subcommands are
+  // allowlisted. Anything outside the allowlist is `reader`, not `unknown`, so
+  // backgrounding cannot free it.
+  test("git subcommands that emit file content are readers", () => {
+    expect(classifySegment("git show HEAD:f")).toBe("reader");
+    expect(classifySegment("git diff f")).toBe("reader");
+    expect(classifySegment("git log")).toBe("reader");
+    expect(classifySegment("git add -p f")).toBe("reader");
+  });
+
+  test("an empty head after a wrapper is a parse failure, not an unknown command", () => {
+    expect(classifySegment("sudo")).toBe("reader");
+    expect(classifySegment("timeout 30")).toBe("reader");
+    expect(classifySegment("sudo -u root cat f")).toBe("reader");
+  });
+});
+
+describe("isFreeOfContextCost", () => {
+  test("all-passer commands are free", () => {
+    expect(isFreeOfContextCost("git add docs/concepts/big.html && git commit -m x")).toBe(true);
+    expect(isFreeOfContextCost("ls -la docs/concepts/big.html")).toBe(true);
+  });
+
+  test("one costly segment disqualifies the whole command", () => {
+    expect(isFreeOfContextCost("ls f && cat docs/concepts/big.html")).toBe(false);
+  });
+
+  test("does not use the background exemption (verbose detection must still run)", () => {
+    expect(isFreeOfContextCost("git log")).toBe(false);
+  });
+});
+
+describe("matchCostlyFiles", () => {
+  test("a reader consuming the path costs context", () => {
+    expect(hits("cat docs/concepts/big.html")).toEqual(["docs/concepts/big.html"]);
+  });
+
+  test("merely passing the path as an argument is free", () => {
+    expect(hits("ls -la docs/concepts/big.html")).toEqual([]);
+    expect(hits('echo "wrote docs/concepts/big.html"')).toEqual([]);
+    expect(hits("mv docs/concepts/big.html docs/concepts/old.html")).toEqual([]);
+  });
+
+  test("a detached non-reader (server start) is free — the reported bug", () => {
+    const cmd = "python scripts/concept-server.py 8883 . --html docs/concepts/big.html";
+    expect(hits(cmd, { runInBackground: true })).toEqual([]);
+    expect(hits(cmd)).toEqual(["docs/concepts/big.html"]); // foreground stays safe
+  });
+
+  test("backgrounding a READER does not buy an exemption", () => {
+    expect(hits("cat docs/concepts/big.html", { runInBackground: true }))
+      .toEqual(["docs/concepts/big.html"]);
+  });
+
+  test("a read hidden in a command substitution still counts", () => {
+    expect(hits('echo "$(cat docs/concepts/big.html)"')).toEqual(["docs/concepts/big.html"]);
+  });
+
+  test("a read behind a pipe still counts", () => {
+    expect(hits("cat docs/concepts/big.html | head -5")).toEqual(["docs/concepts/big.html"]);
+  });
+
+  test("an unknown foreground command head stays costly", () => {
+    expect(hits("./weird-tool docs/concepts/big.html")).toEqual(["docs/concepts/big.html"]);
+  });
+
+  test("unrelated commands match nothing", () => {
+    expect(hits("cat package.json")).toEqual([]);
+  });
+
+  test("a malformed expensiveFiles config does not throw", () => {
+    expect(matchCostlyFiles("cat x", null)).toEqual([]);
+    expect(matchCostlyFiles("cat x", "nope")).toEqual([]);
+    expect(matchCostlyFiles("cat x", [null, {}, { path: "" }])).toEqual([]);
+  });
+});
+
+// Every case below was raised by the red-team pass on this change. Each one is
+// a way the classifier could end up WEAKER than the substring match it
+// replaced — the invariant stated in the module header.
+describe("matchCostlyFiles — fail-safe invariant", () => {
+  test("a path parked in a variable is still costly (assignment-only segment)", () => {
+    expect(hits("FILE=docs/concepts/big.html && cat $FILE"))
+      .toEqual(["docs/concepts/big.html"]);
+  });
+
+  test("a literal paren inside quotes does not truncate the substitution", () => {
+    expect(hits(`echo "$(grep ')' docs/concepts/big.html)"`))
+      .toEqual(["docs/concepts/big.html"]);
+  });
+
+  test("a shell handed inline code is a reader, background or not", () => {
+    const cmd = `bash -c "cat docs/concepts/big.html"`;
+    expect(hits(cmd)).toEqual(["docs/concepts/big.html"]);
+    expect(hits(cmd, { runInBackground: true })).toEqual(["docs/concepts/big.html"]);
+    expect(hits(`cmd /c type docs/concepts/big.html`)).toEqual(["docs/concepts/big.html"]);
+  });
+
+  test("git patch mode emits content and is not a passer", () => {
+    expect(hits("git stash show -p docs/concepts/big.html")).toEqual(["docs/concepts/big.html"]);
+    expect(hits("git add -p docs/concepts/big.html")).toEqual(["docs/concepts/big.html"]);
+    expect(classifySegment("git show HEAD:docs/concepts/big.html")).toBe("reader");
+  });
+
+  test("gh is allowlisted per verb, and `gh api` never is", () => {
+    expect(hits("gh api repos/o/r/contents/docs/concepts/big.html"))
+      .toEqual(["docs/concepts/big.html"]);
+    expect(classifySegment("gh pr diff")).toBe("reader");
+    expect(classifySegment("gh run view --log")).toBe("reader");
+    expect(classifySegment("gh release view")).toBe("reader");
+    expect(classifySegment("gh pr create --title x")).toBe("passer");
+  });
+
+  test("writing to a stdout sink defeats the passer head", () => {
+    expect(hits("cp docs/concepts/big.html /dev/stdout")).toEqual(["docs/concepts/big.html"]);
+  });
+
+  test("a Windows-style path matches the forward-slash config entry", () => {
+    expect(hits("type docs\\concepts\\big.html")).toEqual(["docs/concepts/big.html"]);
+  });
+
+  test("a read hidden past the substitution cap is kept, not dropped", () => {
+    const noise = "$(true) ".repeat(2100);
+    expect(hits(`echo ${noise}$(cat docs/concepts/big.html)`))
+      .toEqual(["docs/concepts/big.html"]);
+  });
+
+  test("an apostrophe inside double quotes does not swallow later substitutions", () => {
+    // A ' inside "..." is literal. Treating it as an opening single quote hid
+    // every following $(...) and let the whole file through.
+    expect(hits(`gh pr create --title "Claude's fix" --body "$(cat docs/concepts/big.html)"`))
+      .toEqual(["docs/concepts/big.html"]);
+    expect(hits(`echo "it's done: $(cat docs/concepts/big.html)"`))
+      .toEqual(["docs/concepts/big.html"]);
+  });
+
+  test("a path piped from a passer into a reader still counts", () => {
+    expect(hits("echo docs/concepts/big.html | xargs cat"))
+      .toEqual(["docs/concepts/big.html"]);
+  });
+
+  test("the overflow sentinel really classifies as reader", () => {
+    expect(classifySegment("__unparsed__ cat docs/concepts/big.html")).toBe("reader");
+  });
+
+  test("a quoted stdout sink and stderr sinks are caught too", () => {
+    expect(hits(`cp docs/concepts/big.html "/dev/stdout"`)).toEqual(["docs/concepts/big.html"]);
+    expect(hits("cp docs/concepts/big.html /dev/stderr")).toEqual(["docs/concepts/big.html"]);
+  });
+
+  test("gh global flags before the noun do not break verb resolution", () => {
+    expect(classifySegment("gh --repo o/r pr create --fill")).toBe("passer");
+    expect(classifySegment("gh --repo o/r pr diff")).toBe("reader");
+  });
+
+  test("the whole-command fallback is deliberately over-inclusive", () => {
+    // Once anything reads, the whole command is the haystack, so a path only a
+    // PASSER touches is still counted. Pinned so the trade-off is a decision:
+    // it is a subset of the pre-0.9 behaviour, but wider than per-segment.
+    expect(hits("ls docs/concepts/big.html && cat other.txt"))
+      .toEqual(["docs/concepts/big.html"]);
+  });
+
+  test("the character budget trips independently of the pass budget", () => {
+    // One segment, one pass — only MAX_CHARS can end this.
+    const padding = "x".repeat(250_000);
+    expect(hits(`./tool ${padding} docs/concepts/big.html`))
+      .toEqual(["docs/concepts/big.html"]);
+  });
+});
+
+// `unknown` is the only verdict the background exemption may free. Every
+// fail-safe verdict must be `reader`, or backgrounding defeats it.
+describe("fail-safe verdicts survive run_in_background", () => {
+  const bg = { runInBackground: true };
+
+  test("assignment-only segment", () => {
+    expect(hits("FILE=docs/concepts/big.html && cat $FILE", bg))
+      .toEqual(["docs/concepts/big.html"]);
+  });
+
+  test("overflow tail", () => {
+    const noise = "$(true) ".repeat(2100);
+    expect(hits(`echo ${noise}$(cat docs/concepts/big.html)`, bg))
+      .toEqual(["docs/concepts/big.html"]);
+  });
+
+  test("stdout sink", () => {
+    expect(hits("cp docs/concepts/big.html /dev/stdout", bg))
+      .toEqual(["docs/concepts/big.html"]);
+  });
+
+  test("shell with inline code", () => {
+    expect(hits(`sh -c "cat docs/concepts/big.html"`, bg))
+      .toEqual(["docs/concepts/big.html"]);
+  });
+
+  test("git and gh forms outside their allowlists", () => {
+    expect(hits("git diff docs/concepts/big.html", bg)).toEqual(["docs/concepts/big.html"]);
+    expect(hits("git add -p docs/concepts/big.html", bg)).toEqual(["docs/concepts/big.html"]);
+    expect(hits("gh api repos/o/r/contents/docs/concepts/big.html", bg))
+      .toEqual(["docs/concepts/big.html"]);
+  });
+
+  test("a reader hidden behind a wrapper flag that takes a value", () => {
+    expect(hits("sudo -u root cat docs/concepts/big.html", bg))
+      .toEqual(["docs/concepts/big.html"]);
+  });
+
+  test("a package manager outside its allowlist", () => {
+    expect(hits("npm exec -- cat docs/concepts/big.html", bg))
+      .toEqual(["docs/concepts/big.html"]);
+    expect(classifySegment("npm publish")).toBe("passer");
+  });
+
+  test("but a genuinely unrecognised head is still freed — the accepted hole", () => {
+    expect(hits("python scripts/serve.py --html docs/concepts/big.html", bg)).toEqual([]);
+  });
+
+  test("…including a detached server behind a wrapper (only a FLAG derails a head)", () => {
+    expect(hits("nohup ./concept-server --html docs/concepts/big.html", bg)).toEqual([]);
+    expect(hits("timeout 3600 ./concept-server --html docs/concepts/big.html", bg)).toEqual([]);
+  });
+});
+
+describe("git head resolution", () => {
+  test("global flags that take a value do not hide the subcommand", () => {
+    expect(classifySegment("git -C docs status")).toBe("passer");
+    expect(classifySegment("git -c user.name=x commit -m y")).toBe("passer");
+    expect(classifySegment("git --no-pager status")).toBe("passer");
+  });
+
+  test("…and still resolve content-emitting subcommands correctly", () => {
+    expect(classifySegment("git -C docs diff")).toBe("reader");
+  });
+});
+
+// The v0.8 hook exempted these via `noTokenCostPattern`. Consumers rely on it,
+// so the classifier must not start blocking them.
+describe("parity with the removed noTokenCostPattern", () => {
+  const BIGP = "docs/concepts/big.html";
+  test.each([
+    "cd docs/concepts",
+    `rm ${BIGP}`,
+    "mkdir docs/new",
+    `cp ${BIGP} docs/copy.html`,
+    `mv ${BIGP} docs/old.html`,
+    "npm publish",
+    `git add ${BIGP}`,
+    'git commit -m "x"',
+    "git push origin main",
+    "git branch -d old",
+    "git checkout main",
+    "gh pr create --fill",
+    "gh issue close 1",
+  ])("%s stays exempt", cmd => {
+    expect(isFreeOfContextCost(cmd)).toBe(true);
+    expect(hits(cmd)).toEqual([]);
+  });
+
+  test("multi-segment combinations stay exempt", () => {
+    expect(isFreeOfContextCost(`git add ${BIGP} && git commit -m x && git push`)).toBe(true);
+  });
+
+  test("`gh api` is a DELIBERATE parity break — it can return file contents", () => {
+    expect(isFreeOfContextCost("gh api repos/o/r/pulls")).toBe(false);
+    // …but without an expensive path in it, the outcome for the user is unchanged.
+    expect(hits("gh api repos/o/r/pulls")).toEqual([]);
+  });
+
+  test("verbose-output commands must not be swallowed by the early exit", () => {
+    for (const cmd of ["git log", "npm ls", "find .", "docker logs web"]) {
+      expect(isFreeOfContextCost(cmd)).toBe(false);
+    }
+  });
+});

--- a/plugins/devops/hooks/pre-tool-use/pre.tokens.guard.bash.test.js
+++ b/plugins/devops/hooks/pre-tool-use/pre.tokens.guard.bash.test.js
@@ -1,0 +1,251 @@
+import { describe, test, expect } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const HOOK = path.join(__dirname, "pre.tokens.guard.js");
+
+const BIG = "docs/concepts/big.html";
+
+// Isolate ~/.claude from the machine running the tests (same idiom as
+// pre.tokens.guard.graphgate.test.js) so no global record can flip a verdict.
+const HOME_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "tokguard-home-"));
+fs.mkdirSync(path.join(HOME_DIR, ".claude"), { recursive: true });
+
+/** Temp project with one known expensive file, well above the 20K threshold. */
+function project() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tokguard-"));
+  fs.mkdirSync(path.join(dir, ".claude"), { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, ".claude", "settings.json"),
+    JSON.stringify({ enabledPlugins: { "devops@dotclaude": true } })
+  );
+  fs.writeFileSync(
+    path.join(dir, ".claude", "token-config.json"),
+    JSON.stringify({
+      plan: "max_20",
+      estimatedLimitTokens: 200000,
+      confirmThresholdPct: 0.1,
+      tokensPerByte: 0.25,
+      expensiveFiles: [{ path: BIG, estimatedTokens: 49557 }],
+    })
+  );
+  return dir;
+}
+
+function runBash(dir, sid, toolInput) {
+  // The full suite runs 50+ files in parallel; on a loaded machine spawnSync
+  // can fail to start the child at all (status null, res.error set). That is
+  // harness pressure, not a hook verdict, so retry it — but never retry a
+  // child that actually ran, or a real block would be masked.
+  for (let attempt = 0; ; attempt++) {
+    const res = spawnSync(process.execPath, [HOOK], {
+      cwd: dir,
+      input: JSON.stringify({ tool_name: "Bash", tool_input: toolInput, session_id: sid }),
+      encoding: "utf8",
+      env: { ...process.env, HOME: HOME_DIR, USERPROFILE: HOME_DIR },
+    });
+    if (res.status !== null || attempt >= 3) {
+      if (res.status === null) {
+        throw new Error(`hook never started after ${attempt + 1} attempts: ${res.error}`);
+      }
+      return { status: res.status, stderr: res.stderr || "" };
+    }
+  }
+}
+
+const blocked = r => r.status === 2 && /HIGH TOKEN COST/.test(r.stderr);
+const cleanup = dir => { try { fs.rmSync(dir, { recursive: true, force: true }); } catch {} };
+
+describe("pre.tokens.guard — Bash large-file matching (integration)", () => {
+  test("a command that READS the large file is blocked", () => {
+    const dir = project();
+    const r = runBash(dir, "s-read", { command: `cat ${BIG}` });
+    expect(blocked(r)).toBe(true);
+    expect(r.stderr).toContain("Large files referenced");
+    cleanup(dir);
+  });
+
+  test("merely passing the path as an argument is allowed", () => {
+    const dir = project();
+    expect(runBash(dir, "s-ls", { command: `ls -la ${BIG}` }).status).toBe(0);
+    expect(runBash(dir, "s-echo", { command: `echo "wrote ${BIG}"` }).status).toBe(0);
+    cleanup(dir);
+  });
+
+  test("a detached server start that only forwards the path is allowed (issue #277)", () => {
+    const dir = project();
+    const command = `python scripts/concept-server.py 8883 . --html ${BIG}`;
+    expect(runBash(dir, "s-server", { command, run_in_background: true }).status).toBe(0);
+    cleanup(dir);
+  });
+
+  test("backgrounding a reader does not buy an exemption", () => {
+    const dir = project();
+    const r = runBash(dir, "s-bgcat", { command: `cat ${BIG}`, run_in_background: true });
+    expect(blocked(r)).toBe(true);
+    cleanup(dir);
+  });
+
+  test("an unknown foreground command head still blocks (fail safe)", () => {
+    const dir = project();
+    expect(blocked(runBash(dir, "s-unknown", { command: `./weird-tool ${BIG}` }))).toBe(true);
+    cleanup(dir);
+  });
+
+  test("a detached shell that reads the file is still blocked", () => {
+    const dir = project();
+    const r = runBash(dir, "s-bgsh", { command: `bash -c "cat ${BIG}"`, run_in_background: true });
+    expect(blocked(r)).toBe(true);
+    cleanup(dir);
+  });
+
+  test("a path parked in a variable is still blocked", () => {
+    const dir = project();
+    expect(blocked(runBash(dir, "s-var", { command: `FILE=${BIG} && cat $FILE` }))).toBe(true);
+    cleanup(dir);
+  });
+
+  test("verbose-output detection still fires after the new early exit", () => {
+    const dir = project();
+    for (const command of ["git log", "npm ls", "find .", "docker logs web"]) {
+      const r = runBash(dir, `s-verbose-${command.replace(/\W/g, "")}`, { command });
+      expect(r.status, command).toBe(2);
+      expect(r.stderr, command).toContain("Unbounded output");
+    }
+    cleanup(dir);
+  });
+
+  test("commands the old noTokenCostPattern exempted are still exempt", () => {
+    const dir = project();
+    for (const command of [
+      `git add ${BIG}`, "git commit -m x", "git push origin main",
+      `rm ${BIG}`, `cp ${BIG} docs/copy.html`, `mv ${BIG} docs/old.html`,
+      "mkdir docs/new", "cd docs", "npm publish", "gh pr create --fill",
+    ]) {
+      expect(runBash(dir, "s-parity", { command }).status, command).toBe(0);
+    }
+    cleanup(dir);
+  });
+});
+
+describe("pre.tokens.guard — degraded inputs must not fail open", () => {
+  test.each([
+    ["expensiveFiles as an object", { expensiveFiles: { path: BIG } }],
+    ["expensiveFiles as a string", { expensiveFiles: "nope" }],
+    ["expensiveFiles missing", {}],
+    ["config is not JSON", "@@@not-json@@@"],
+  ])("%s → hook exits cleanly with no stack trace", (_label, cfg) => {
+    const dir = project();
+    fs.writeFileSync(
+      path.join(dir, ".claude", "token-config.json"),
+      typeof cfg === "string" ? cfg : JSON.stringify({ plan: "max_20", ...cfg })
+    );
+    const r = runBash(dir, "s-degraded", { command: `cat ${BIG}` });
+    expect(r.status).not.toBe(1);
+    expect(r.stderr).not.toContain("at Object.");   // no node stack trace
+    cleanup(dir);
+  });
+});
+
+describe("pre.tokens.guard — retry-to-proceed release (integration)", () => {
+  test("an identical retry releases", () => {
+    const dir = project();
+    const input = { command: `cat ${BIG}` };
+    expect(blocked(runBash(dir, "s-same", input))).toBe(true);
+    expect(runBash(dir, "s-same", input).status).toBe(0);
+    cleanup(dir);
+  });
+
+  test("a retry that adds run_in_background releases (issue #277)", () => {
+    const dir = project();
+    expect(blocked(runBash(dir, "s-bg", { command: `cat ${BIG}` }))).toBe(true);
+    expect(runBash(dir, "s-bg", { command: `cat ${BIG}`, run_in_background: true }).status).toBe(0);
+    cleanup(dir);
+  });
+
+  test("a retry with a reworded description releases (issue #277)", () => {
+    const dir = project();
+    expect(blocked(runBash(dir, "s-desc", { command: `cat ${BIG}`, description: "Read the concept page" }))).toBe(true);
+    expect(runBash(dir, "s-desc", { command: `cat ${BIG}`, description: "Show the concept page" }).status).toBe(0);
+    cleanup(dir);
+  });
+
+  test("a retry with reordered input keys releases", () => {
+    const dir = project();
+    expect(blocked(runBash(dir, "s-order", { description: "a", command: `cat ${BIG}` }))).toBe(true);
+    expect(runBash(dir, "s-order", { command: `cat ${BIG}`, timeout: 5000 }).status).toBe(0);
+    cleanup(dir);
+  });
+
+  test("a block in one project does not pre-authorise another", () => {
+    const a = project();
+    const b = project();
+    const input = { command: `cat ${BIG}` };
+    expect(blocked(runBash(a, "s-leak", input))).toBe(true);
+    expect(blocked(runBash(b, "s-leak", input))).toBe(true); // must still block in project B
+    cleanup(a);
+    cleanup(b);
+  });
+
+  // Deliberate trade-off, not an oversight: session_id is NOT part of the key.
+  // lib/session-id.js documents that Claude Code may deliver a different or
+  // missing session_id between hook invocations (issue #10), and this path has
+  // no escape hatch — keying on it could wedge the retry forever, which is the
+  // failure being fixed. A confirmation therefore survives into the project's
+  // next session; it still never crosses into another project.
+  test("a confirmation survives a session_id change (retry must never wedge)", () => {
+    const dir = project();
+    const input = { command: `cat ${BIG}` };
+    expect(blocked(runBash(dir, "s-one", input))).toBe(true);
+    expect(runBash(dir, "s-two", input).status).toBe(0);
+    cleanup(dir);
+  });
+
+  test("a confirmation survives a missing session_id entirely", () => {
+    const dir = project();
+    const input = { command: `cat ${BIG}` };
+    expect(blocked(runBash(dir, undefined, input))).toBe(true);
+    expect(runBash(dir, undefined, input).status).toBe(0);
+    cleanup(dir);
+  });
+
+  test("an expired confirmation blocks again instead of auto-approving", () => {
+    const dir = project();
+    const input = { command: `cat ${BIG}` };
+    const before = new Set(fs.readdirSync(os.tmpdir()).filter(f => f.startsWith("claude_confirm_")));
+    expect(blocked(runBash(dir, "s-ttl", input))).toBe(true);
+    const flag = fs.readdirSync(os.tmpdir())
+      .filter(f => f.startsWith("claude_confirm_") && !before.has(f))
+      .map(f => path.join(os.tmpdir(), f))[0];
+    expect(flag).toBeTruthy();
+    fs.writeFileSync(flag, String(Date.now() - 31 * 60 * 1000));  // older than the 30min TTL
+    expect(blocked(runBash(dir, "s-ttl", input))).toBe(true);
+    // …and the re-armed flag releases immediately on the next retry.
+    expect(runBash(dir, "s-ttl", input).status).toBe(0);
+    cleanup(dir);
+  });
+
+  test("an unreadable confirmation body counts as expired, not as approval", () => {
+    const dir = project();
+    const input = { command: `cat ${BIG}` };
+    const before = new Set(fs.readdirSync(os.tmpdir()).filter(f => f.startsWith("claude_confirm_")));
+    expect(blocked(runBash(dir, "s-garbage", input))).toBe(true);
+    const flag = fs.readdirSync(os.tmpdir())
+      .filter(f => f.startsWith("claude_confirm_") && !before.has(f))
+      .map(f => path.join(os.tmpdir(), f))[0];
+    fs.writeFileSync(flag, "");            // interrupted write / full disk
+    expect(blocked(runBash(dir, "s-garbage", input))).toBe(true);
+    cleanup(dir);
+  });
+
+  test("a different command is not released by an unrelated confirmation", () => {
+    const dir = project();
+    expect(blocked(runBash(dir, "s-x", { command: `cat ${BIG}` }))).toBe(true);
+    expect(blocked(runBash(dir, "s-x", { command: `grep foo ${BIG}` }))).toBe(true);
+    cleanup(dir);
+  });
+});

--- a/plugins/devops/hooks/pre-tool-use/pre.tokens.guard.js
+++ b/plugins/devops/hooks/pre-tool-use/pre.tokens.guard.js
@@ -1,13 +1,25 @@
 #!/usr/bin/env node
 /**
  * @hook pre.tokens.guard
- * @version 0.8.0
+ * @version 0.9.0
  * @event PreToolUse
  * @plugin devops
  * @description Block Read/Bash/Glob/Grep operations that would consume a
  *   significant percentage of the ~200K context window. Threshold scales
  *   with the user's Claude plan (pro/max_5/max_20). Uses a flag-file
  *   mechanism: first call blocks with warning, retry allows through.
+ *
+ *   For Bash, a large file only counts when a command actually READS it
+ *   (`hooks/lib/bash-context-cost`): passing the path as an argument — a
+ *   server start, `ls`, `mv`, `echo` — costs nothing. Unrecognised command
+ *   heads stay costly (fail safe); the one relaxation is a detached
+ *   `run_in_background` non-reader. Any failure in that classification
+ *   falls back to the pre-0.9 substring match rather than failing open.
+ *
+ *   The retry flag is keyed on the cost-determining fields plus cwd, so a
+ *   reworded `description` or a flipped `run_in_background` no longer
+ *   defeats "retry to proceed", and a block in one project no longer
+ *   pre-authorises another.
  *
  *   Session-start injection: on the FIRST broad Grep/Glob (no `path`) of a
  *   session, attaches orientation as additionalContext and ALLOWS the search,
@@ -20,7 +32,11 @@
  *   Fires if EITHER source is present.
  */
 
-require('../lib/plugin-guard');
+// Every sibling require here is guarded. A consumer's plugin cache can update
+// this hook before (or without) a lib landing; an unguarded throw would exit
+// non-2, which PreToolUse treats as non-blocking, so the guard would fail OPEN
+// on every tool call while printing a stack trace each time.
+try { require('../lib/plugin-guard'); } catch { process.exit(0); }
 
 const fs = require('fs');
 const path = require('path');
@@ -37,7 +53,37 @@ const CONFIG_PATH = path.join(CONFIG_DIR, 'token-config.json');
 // also records ok/fail to a sentinel file so a silent failure (Gap #5) can
 // be surfaced at the next SessionStart instead of vanishing.
 
-const PLAN_DEFAULTS = require('../lib/plan-defaults');
+let PLAN_DEFAULTS;
+try {
+  PLAN_DEFAULTS = require('../lib/plan-defaults');
+} catch {
+  PLAN_DEFAULTS = {
+    pro:    { estimatedLimitTokens: 200000, confirmThresholdPct: 0.05 },
+    max_5:  { estimatedLimitTokens: 200000, confirmThresholdPct: 0.08 },
+    max_20: { estimatedLimitTokens: 200000, confirmThresholdPct: 0.10 },
+  };
+}
+// Falls back to the pre-0.9 substring match rather than failing open.
+let bashCost = null;
+try { bashCost = require('../lib/bash-context-cost'); } catch { /* fallback below */ }
+
+// A confirmation is meant to cover the retry that follows seconds later, not
+// to pre-authorise the same command indefinitely. Without an expiry the flag
+// would silently approve a command the user abandoned weeks ago.
+// Accepted: a forward clock jump larger than this window costs one extra
+// retry. That is the harmless direction — the alternative is a stale approval.
+const CONFIRM_TTL_MS = 30 * 60 * 1000;
+
+/** Pre-0.9 behaviour: any expensive path mentioned anywhere counts. */
+function substringMatch(cmd, expensiveFiles) {
+  const matched = [];
+  for (const ef of expensiveFiles) {
+    if (ef && ef.path && cmd.includes(ef.path)) {
+      matched.push({ path: ef.path, tokens: ef.estimatedTokens || 20000 });
+    }
+  }
+  return matched;
+}
 
 function loadConfig() {
   try {
@@ -50,6 +96,8 @@ function loadConfig() {
       cfg.estimatedLimitTokens = defaults.estimatedLimitTokens;
       cfg.confirmThresholdPct = defaults.confirmThresholdPct;
     }
+    // A hand-edited config must never crash the guard downstream.
+    if (!Array.isArray(cfg.expensiveFiles)) cfg.expensiveFiles = [];
     return cfg;
   } catch {
     // No config yet — use most conservative defaults (pro)
@@ -61,6 +109,32 @@ function loadConfig() {
 function flagPath(key) {
   const hash = crypto.createHash('md5').update(key).digest('hex').slice(0, 12);
   return path.join(os.tmpdir(), `claude_confirm_${hash}.flag`);
+}
+
+/**
+ * The subset of a tool input that actually determines the token cost, in a
+ * fixed key order. Everything else (`description`, `run_in_background`,
+ * `timeout`) is noise that used to break the retry-to-proceed release.
+ */
+function costFields(toolName, toolInput) {
+  switch (toolName) {
+    case 'Read':
+      return { file_path: toolInput.file_path || '', limit: toolInput.limit || 0, offset: toolInput.offset || 0 };
+    case 'Bash':
+      return { command: toolInput.command || '' };
+    case 'Glob':
+      return { pattern: toolInput.pattern || '', path: toolInput.path || '' };
+    case 'Grep':
+      return {
+        pattern: toolInput.pattern || '',
+        path: toolInput.path || '',
+        glob: toolInput.glob || '',
+        type: toolInput.type || '',
+        output_mode: toolInput.output_mode || '',
+      };
+    default:
+      return { tool: toolName };
+  }
 }
 
 // Read hook input from stdin
@@ -80,6 +154,11 @@ process.stdin.on('end', () => {
 
   let estimatedTokens = 0;
   let description = '';
+  // Kept local — never written back onto toolInput. The retry flag key is
+  // derived from the tool input, so mutating it here used to change the key
+  // between the block and the retry and the confirmation never released.
+  let verboseSuggestion = '';
+  let matchedFilesOut = null;
 
   // Per-tool estimation
   if (toolName === 'Read') {
@@ -104,12 +183,13 @@ process.stdin.on('end', () => {
 
   else if (toolName === 'Bash') {
     const cmd = toolInput.command || '';
-    // Commands that don't produce output Claude needs to process — no token cost
-    const noTokenCostPattern = /^\s*(cd\s|git\s+(push|fetch|remote|prune|worktree|branch\s+-[dD]|checkout|switch|pull|merge|rebase|tag|stash|rm|add|commit)|gh\s+(pr|issue|project|api)|npm\s+publish|rm\s|mkdir\s|cp\s|mv\s)/;
-    const segments = cmd.split(/\s*(?:&&|;)\s*/);
-    if (segments.every(seg => noTokenCostPattern.test(seg))) {
-      process.exit(0);
-    }
+    // Commands that don't produce output Claude needs to process — no token
+    // cost. Per-segment command-head classification (bash-context-cost):
+    // a path handed to `ls`/`mv`/`echo`/`git add` never reaches context.
+    // Any failure here falls through to the conservative path below.
+    try {
+      if (bashCost && bashCost.isFreeOfContextCost(cmd)) process.exit(0);
+    } catch { /* classify conservatively */ }
 
     // --- Verbose command detection (output bloat guard) ---
     // Detect commands that produce unbounded output and suggest limited alternatives.
@@ -147,22 +227,27 @@ process.stdin.on('end', () => {
     if (verboseMatch) {
       estimatedTokens = THRESHOLD;
       description = 'Bash: unbounded output — may flood context';
-      toolInput._verboseSuggestion = verboseMatch.suggestion;
+      verboseSuggestion = verboseMatch.suggestion;
     }
 
-    // Check if command references known expensive files
+    // Check whether the command actually READS a known expensive file, rather
+    // than merely mentioning its path. A detached (`run_in_background`)
+    // non-reader — a server start — streams nothing into context; a
+    // backgrounded reader still does, so it stays blocked.
     if (!verboseMatch) {
-      const expensiveFiles = cfg.expensiveFiles || [];
-      const matchedFiles = [];
-      for (const ef of expensiveFiles) {
-        if (cmd.includes(ef.path)) {
-          matchedFiles.push({ path: ef.path, tokens: ef.estimatedTokens || 20000 });
-        }
+      const known = cfg.expensiveFiles;
+      let matchedFiles;
+      try {
+        matchedFiles = bashCost
+          ? bashCost.matchCostlyFiles(cmd, known, { runInBackground: !!toolInput.run_in_background })
+          : substringMatch(cmd, known);
+      } catch {
+        matchedFiles = substringMatch(cmd, known);   // never fail open on a parse bug
       }
       if (matchedFiles.length > 0) {
         estimatedTokens = matchedFiles.reduce((sum, f) => sum + f.tokens, 0);
         description = 'Bash referencing large file(s)';
-        toolInput._matchedFiles = matchedFiles;
+        matchedFilesOut = matchedFiles;
       } else {
         process.exit(0);
       }
@@ -239,7 +324,11 @@ process.stdin.on('end', () => {
             metrics.record('self_heal_kicked', { newerCount, truncated: info.truncated }, { cwd, sid });
           }
         } else if (!gstate.queryDone(sid, cwd)) {
-          const gflag = flagPath(`graphgate:${sid}:${cwd}:${toolName}:${JSON.stringify(toolInput)}`);
+          // Same keying discipline as the confirmation flag below: hashing the
+          // whole tool_input made a retry that merely added `-i` or
+          // `head_limit` look like a brand-new search, so the escape hatch
+          // never opened.
+          const gflag = flagPath(`graphgate:${sid}:${cwd}:${toolName}:${JSON.stringify(costFields(toolName, toolInput))}`);
           if (!fs.existsSync(gflag)) {
             try { fs.writeFileSync(gflag, Date.now().toString()); } catch {}
             // Within tolerance but still lagging by >0 files — enforce AND kick
@@ -284,9 +373,13 @@ process.stdin.on('end', () => {
     const sid = hook.session_id || hook.sessionId || 'nosid';
     const mapKey = crypto.createHash('md5').update(`${sid}:${cwd}`).digest('hex').slice(0, 12);
     const mapFlag = path.join(os.tmpdir(), `devops_mapinject_${mapKey}.flag`);
-    const graphNudge = require('../lib/graph-nudge');
+    // Guarded like every other sibling require — a missing lib must degrade to
+    // "no graph nudge", never crash the guard into failing open.
+    let graphNudge = null;
+    try { graphNudge = require('../lib/graph-nudge'); } catch { /* map-only */ }
     const hasMap = fs.existsSync(projectMap);
-    const hasGraph = graphNudge.hasGraph(cwd);
+    let hasGraph = false;
+    try { hasGraph = !!graphNudge && graphNudge.hasGraph(cwd); } catch { /* map-only */ }
     // Fire once per session if EITHER the project-map or a graphify graph exists.
     if ((hasMap || hasGraph) && !fs.existsSync(mapFlag)) {
       try {
@@ -323,12 +416,35 @@ process.stdin.on('end', () => {
   }
 
   const pct = ((estimatedTokens / LIMIT) * 100).toFixed(1);
-  const flagKey = `${toolName}:${JSON.stringify(toolInput)}`;
+  // Key the confirmation on the fields that determine the token cost — and
+  // nothing else. Hashing the whole tool_input made the flag miss whenever
+  // Claude reworded the model-authored `description`, flipped
+  // `run_in_background`, or the key order changed, so the documented
+  // "retry to proceed" never released.
+  //
+  // `cwd` scopes it, so a block in one project no longer pre-authorises
+  // another. `session_id` is deliberately NOT in the key: lib/session-id.js
+  // documents that Claude Code may deliver a different or missing session_id
+  // between hook invocations (issue #10), and this path has no escape hatch —
+  // an unstable id would wedge the retry forever, which is the very failure
+  // being fixed. The residual over-share is one project's own later session
+  // inheriting a confirmation; that is strictly narrower than the previous
+  // behaviour, which leaked across projects too.
+  const flagKey = `${toolName}:${cwd}:${JSON.stringify(costFields(toolName, toolInput))}`;
   const flag = flagPath(flagKey);
 
   if (fs.existsSync(flag)) {
+    // Unreadable or unparsable (interrupted write, full disk) counts as
+    // expired, not fresh — the flag is re-armed below, so the cost is one
+    // extra retry rather than an unearned approval.
+    let fresh = false;
+    try {
+      const written = parseInt(fs.readFileSync(flag, 'utf8'), 10);
+      if (Number.isFinite(written)) fresh = (Date.now() - written) < CONFIRM_TTL_MS;
+    } catch { /* stays expired */ }
     try { fs.unlinkSync(flag); } catch {}
-    process.exit(0); // User confirmed — allow
+    if (fresh) process.exit(0); // User confirmed — allow
+    // Expired: fall through and block again, re-arming the flag below.
   }
 
   // First time — block and warn
@@ -352,12 +468,12 @@ process.stdin.on('end', () => {
       console.error(`\nLarge file:`);
       console.error(`  ${path.relative(process.cwd(), absP).replace(/\\/g, '/')}  (${kb} KB → ~${estimatedTokens.toLocaleString()} tokens)`);
     } catch {}
-  } else if (toolInput._verboseSuggestion) {
+  } else if (verboseSuggestion) {
     console.error(`\nUnbounded output — command has no limit flag.`);
-    console.error(`Try instead:  ${toolInput._verboseSuggestion}`);
-  } else if (toolInput._matchedFiles) {
+    console.error(`Try instead:  ${verboseSuggestion}`);
+  } else if (matchedFilesOut) {
     console.error(`\nLarge files referenced:`);
-    for (const f of toolInput._matchedFiles) {
+    for (const f of matchedFilesOut) {
       console.error(`  ${f.path}  (~${f.tokens.toLocaleString()} tokens)`);
     }
   }

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.126.0",
+  "version": "0.126.1",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
Closes #277

## Summary

The token guard matched any known expensive-file path anywhere in a Bash command with a naked `cmd.includes()`. So starting the concept bridge with `--html <big>.html` was refused — and so were `ls -la <big>.html` and `echo "wrote <big>.html"`, none of which pull a byte into context. The documented escape hatch then failed too: "To proceed, retry the same operation" never released, because the confirmation flag hashed the **entire** tool input, and a reworded model-authored `description` or an added `run_in_background` produced a different key.

## Changes

- **New `hooks/lib/bash-context-cost`** — per-segment command classification. Splits on `&&`, `||`, `|`, `;`, `&` and newlines, lifts `$(…)` and backtick substitutions out quote-aware, resolves each segment's real command head through env assignments and wrappers (`sudo`, `timeout`, `xargs`), and classifies it:
  - `reader` — content demonstrably flows out, **or** the segment could not be reasoned about (assignments only, an unparsable tail, a `/dev/stdout` sink, a known multiplexer outside its allowlist: `git diff`, `gh api`, `npm exec`). Always costly.
  - `passer` — positively recognised as content-free.
  - `unknown` — a command we cannot reason about at all. Costly, **except** when detached via `run_in_background`.

  Only that last relaxation is deliberate, and it is what unblocks the reported server start. Fail-safe verdicts never route through `unknown`, so backgrounding can never defeat one — a backgrounded `cat` stays blocked.

- **Retry key** — derived from the cost-determining fields plus `cwd`, and the hook no longer mutates `tool_input` before computing it. `session_id` is deliberately excluded: `lib/session-id` documents that it may arrive changed or missing between hook invocations, and this path has no escape hatch, so keying on it could wedge the retry permanently. Confirmations now expire after 30 minutes. The graphify gate's escape-hatch flag had the identical defect and gets the identical fix.

- **Fail-safe, not fail-open** — any failure inside the classifier falls back to the previous substring match, and every sibling `require` is guarded, so a half-updated plugin cache can no longer disable the guard silently on every tool call.

## Verification

- `npm test` — 1084 green (88 new: a unit suite for the classifier, an integration suite driving the real hook)
- `npm run lint` — clean
- Pinned explicitly: the whole fail-safe set under `run_in_background`, and a parity sweep over every command the removed `noTokenCostPattern` used to exempt

## Review

Four adversarial review passes; three returned `rework`. They caught, among others: a regression introduced by an earlier round of this branch (an apostrophe inside double quotes opened single-quote state, so `gh pr create --title "Claude's fix" --body "$(cat <big>)"` went straight through), a dead overflow sentinel, and a stated safety invariant the test suite disproved. The Codex gate could not run — usage limit exhausted (`rc=1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)