### PR TITLE
fix(concept): pick up bridge submissions without a chat message

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.126.2"
+    "version": "0.126.3"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.126.2",
+      "version": "0.126.3",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.126.2",
+      "version": "0.126.3",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.126.3] — 2026-08-15
+
+### Fixed
+
+- **A decision submitted on a concept page is picked up on its own, without the user having to say anything in chat.** Clicking "Entscheidungen abschicken" and then typing nothing meant the submission sat unread: the page's connection indicator stayed green, so nothing looked wrong, and the user only found out by asking. The instructions told Claude to end the turn and wait for a message, while the same document claimed an indefinite autonomous poll and a third one forbade the very loop that would implement it. The mechanism was already written down and simply never referenced — a detached "pickup waker" that exits the moment a submission lands, which is what wakes Claude. It is now launched with the page, re-launched immediately after each round is processed rather than at the end of it, and re-armed after a Claude restart alongside the cron. The once-a-minute cron is a partial backup, not the primary path: it fires only while the session is idle, which is exactly when it is not needed. Every pickup check also moved from `/decisions` to `/pending` — only the latter acks a pickup, which is why the page's "Claude verarbeitet" step used to sit frozen while Claude was in fact working.
+
+- **The two watchers became a script instead of a shell loop pasted into three documents.** `scripts/concept-watch.js` replaces `while true; do … sleep 20; done` in both places that carried a copy. The loop shape was wrong in four independent ways, each of which silently reproduced the bug the watchers exist to prevent: it tested a *relative* state-file path against a working directory the docs say may differ; it was launched one step *before* the file it requires gets written; its port guard used `\b`, a GNU extension that never matches on BSD/macOS grep, so both watchers quit immediately there; and no honest `allowed-tools` prefix can cover a multi-line loop, so the only grant that did was a blanket one disguised as narrow. The script takes an absolute path, waits out a grace period, compares the port numerically, and runs as `node …`, which the existing grant already covers. A test pins the remaining copy byte-for-byte against the document.
+
+- **A resumed session's backup pickup path was dead on arrival.** The SessionStart recovery hook emitted its `python -c` snippet with escaped quotes, which reaches Python as a line continuation — a `SyntaxError` on every tick, in a path nobody watched because it only runs after a restart. Found by the byte-for-byte pin above.
+
+- **A duplicate wake can no longer run an `implement` round twice.** Two watchers on the same port both announce the same submission, and the second announcement arrives after the flag was already cleared — acting on it re-applied real code changes, which no version guard caught. Every wake is now re-confirmed before anything happens, and a matching version is read as "the previous reset never landed", not as a new submission.
+
 ## [0.126.2] — 2026-08-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.126.2**
+**Version: 0.126.3**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.126.2",
+  "version": "0.126.3",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/hooks/session-start/ss.concept.resume.docsync.test.js
+++ b/plugins/devops/hooks/session-start/ss.concept.resume.docsync.test.js
@@ -1,0 +1,90 @@
+import { describe, test, expect } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { buildCronBody, buildBackgroundTasks } from "./ss.concept.resume.js";
+
+// `bridge-server.md` § step 3 is the single source of truth for the cron body
+// and the two watchers. This hook necessarily carries a second copy — it has to
+// hand the text to a resumed session — and a second copy is exactly how the
+// concept skill drifted into issue #276 in the first place.
+//
+// So the copy is pinned against the source. This already caught one real
+// defect: the hook emitted `print(\'true\' ...)` where the doc has bare quotes,
+// which is a Python SyntaxError, so every resumed session's backup pickup path
+// was dead on arrival.
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SKILLDIR = path.join(__dirname, "..", "..", "skills", "concept");
+const BRIDGE = fs.readFileSync(path.join(SKILLDIR, "deep-knowledge", "bridge-server.md"), "utf8");
+
+const PORT = 8883;
+const STATE_PATH = "C:/proj/.claude/concept-active.json";
+
+describe("the hook's cron copy matches bridge-server.md", () => {
+  test("the /pending one-liner is byte-identical to the documented one", () => {
+    const documented = BRIDGE
+      .split("\n")
+      .find(l => l.includes("python -c") && l.includes("/pending") && l.includes("d.get"))
+      .replace(/\{port\}/g, String(PORT))
+      .trim();
+    expect(buildCronBody(PORT)).toContain(documented);
+  });
+
+  test("the emitted python snippet is valid python, not backslash-escaped", () => {
+    const snippet = buildCronBody(PORT).match(/python -c "([^"]*)"/)[1];
+    expect(snippet).not.toContain("\\'");
+    expect(snippet).toContain("print('true' if d.get('pending') else 'false')");
+  });
+});
+
+// The watchers used to be a `while true; do … sleep 20; done` loop pasted into
+// bridge-server.md AND re-emitted by this hook. Four independent defects lived
+// in that shape — a relative state path, a launch ordered before the file it
+// requires, a GNU-only `\b` in the port guard, and no honest allowed-tools
+// grant. They are one script now, so there is nothing left to drift.
+describe("the watchers are a script, not a duplicated shell loop", () => {
+  const { pulser, waker } = buildBackgroundTasks(PORT, STATE_PATH);
+
+  test("bridge-server.md documents concept-watch.js in both modes", () => {
+    expect(BRIDGE).toContain("concept-watch.js");
+    expect(BRIDGE).toContain("--mode pulse");
+    expect(BRIDGE).toContain("--mode watch");
+  });
+
+  test("the script the doc names actually exists", () => {
+    const script = path.join(__dirname, "..", "..", "scripts", "concept-watch.js");
+    expect(fs.existsSync(script)).toBe(true);
+  });
+
+  test("the hook emits the same invocation shape the doc documents", () => {
+    for (const [task, mode] of [[pulser, "pulse"], [waker, "watch"]]) {
+      expect(task).toMatch(/^node "/);
+      expect(task).toContain("concept-watch.js");
+      expect(task).toContain(`--mode ${mode}`);
+      expect(task).toContain(`--port ${PORT}`);
+      expect(task).toContain(`--state "${STATE_PATH}"`);
+    }
+  });
+
+  test("no inline loop survives in either place", () => {
+    for (const task of [pulser, waker]) {
+      expect(task).not.toContain("while true");
+      expect(task).not.toContain("sleep 20");
+    }
+    // The doc may still *discuss* the old loop in its rationale, but must not
+    // hand one back as an instruction.
+    expect(BRIDGE).not.toMatch(/```bash\n\s*fails=0\n\s*while true/);
+  });
+
+  test("bridge-server.md still names every exit reason the action table covers", () => {
+    for (const reason of ["PENDING_SUBMISSION", "SERVER_DEAD", "STATE_GONE", "PORT_CHANGED"]) {
+      expect(BRIDGE, reason).toContain(reason);
+    }
+  });
+
+  test("bridge-server.md no longer claims the cron covers the re-launch window", () => {
+    // It fires only while the REPL is idle, and the window is open precisely
+    // when the REPL is busy processing a round.
+    expect(BRIDGE).not.toMatch(/backup pickup path during the brief window/);
+  });
+});

--- a/plugins/devops/hooks/session-start/ss.concept.resume.js
+++ b/plugins/devops/hooks/session-start/ss.concept.resume.js
@@ -1,16 +1,19 @@
 #!/usr/bin/env node
 /**
  * @hook ss.concept.resume
- * @version 0.2.0
+ * @version 0.3.0
  * @event SessionStart
  * @plugin devops
  * @description Recover an open concept session after a Claude restart.
  *   Reads `.claude/concept-active.json` (written by /concept Step 3),
  *   probes the bridge server to confirm it is still running, and instructs
- *   Claude to re-arm the polling cron — and pick up any unprocessed
- *   submission immediately. Without this hook the polling cron (which is
- *   session-only) dies with the prior session and any pending submission
- *   silently rots in the bridge server until the user notices.
+ *   Claude to re-arm everything that watches it — the backup cron AND the two
+ *   detached background tasks (keepalive pulser, pickup waker) — plus pick up
+ *   any unprocessed submission immediately. All three are session-scoped and
+ *   die with the prior session; re-arming only the cron left the resumed
+ *   session watching on a path that fires just while the REPL is idle, so a
+ *   submission could rot in the bridge while the page still showed a green
+ *   indicator (issue #276).
  *
  *   Trust model: `.claude/concept-active.json` is treated as a per-project
  *   state file, NOT as authenticated control input. We accept that anyone
@@ -27,8 +30,6 @@
  *   the realistic case (one user, one active session per worktree) is
  *   the only one we optimize for.
  */
-
-require('../lib/plugin-guard');
 
 const fs = require('fs');
 const path = require('path');
@@ -136,89 +137,165 @@ function probe(port, pathname, timeoutMs = 1500) {
   });
 }
 
-(async () => {
-  const state = readState();
-  if (!state) process.exit(0);
-
-  // Consistency check: the concept HTML on disk is the source of truth for
-  // "is this session still real?" If the file is gone, the concept was
-  // discarded / moved / never persisted and any running bridge is an orphan.
-  // We do this BEFORE the heartbeat probe so a still-running ghost server
-  // gets shut down explicitly — relying on the watchdog alone would leave
-  // the server alive for up to 30 s after this hook returns, surfacing
-  // misleading "concept active" state in the meantime.
-  const htmlAbs = path.join(cwd, state.html_path);
-  if (!fs.existsSync(htmlAbs)) {
-    await postShutdown(state.port);
-    deleteState();
-    process.exit(0);
-  }
-
-  const heartbeat = await probe(state.port, '/heartbeat');
-  if (!heartbeat) {
-    // Server gone. If the file is also stale, prune it; otherwise leave it
-    // alone — the user might be restarting the server in another terminal.
-    if (isStale(state)) deleteState();
-    process.exit(0);
-  }
-
-  // Server is alive. Check whether a submission is sitting unprocessed.
-  // We must distinguish three states explicitly:
-  //   - probe ok, pending: false → safe to wait on cron schedule
-  //   - probe ok, pending: true  → process immediately
-  //   - probe failed              → AMBIGUOUS, do NOT pretend it's false.
-  //     Hiding "I don't know" as "no submission pending" is the worst
-  //     failure mode for a waiting user. Tell Claude to fetch /decisions
-  //     once now so the answer is resolved authoritatively.
-  const pending = await probe(state.port, '/pending');
-  let pendingState; // 'pending' | 'idle' | 'unknown'
-  if (pending && typeof pending.pending === 'boolean') {
-    pendingState = pending.pending ? 'pending' : 'idle';
-  } else {
-    pendingState = 'unknown';
-  }
-
-  const cronBody =
-    `Silently service the concept bridge on port ${state.port}. ` +
+/**
+ * The combined heartbeat + auto-poll cron body. Canonical definition lives in
+ * `skills/concept/deep-knowledge/bridge-server.md` § step 3; this mirrors it so
+ * a resumed session re-arms exactly what the original session had.
+ */
+function buildCronBody(port) {
+  return (
+    `Silently service the concept bridge on port ${port}. ` +
     `(0) Self-cleanup gate (FIRST step every tick): Read \`.claude/concept-active.json\`. ` +
-    `Cleanup triggers if the file is missing, OR state.port ≠ ${state.port}, OR state.html_path does not exist on disk. ` +
-    `On trigger: (a) Bash: curl -s -X POST http://localhost:${state.port}/shutdown > /dev/null 2>&1 || true; ` +
+    `Cleanup triggers if the file is missing, OR state.port ≠ ${port}, OR state.html_path does not exist on disk. ` +
+    `On trigger: (a) Bash: curl -s -X POST http://localhost:${port}/shutdown > /dev/null 2>&1 || true; ` +
     `(b) CronDelete the cron_id from the still-readable state file — or, if the state file is gone, ` +
-    `CronList and delete every cron whose prompt mentions \`port ${state.port}\`. ` +
+    `CronList and delete every cron whose prompt mentions \`port ${port}\`. ` +
     `Produce NO output and skip steps 1+2. ` +
-    `(1) Heartbeat POST: Bash: curl -s -X POST http://localhost:${state.port}/heartbeat > /dev/null. ` +
-    `(2) Pending check via /pending: Bash: curl -s http://localhost:${state.port}/pending | python -c "import sys,json; d=json.load(sys.stdin); print(\\'true\\' if d.get(\\'pending\\') else \\'false\\')". ` +
+    `(1) Heartbeat POST: Bash: curl -s -X POST http://localhost:${port}/heartbeat > /dev/null. ` +
+    // The quotes here must reach Python bare. Escaping them as \' emits a
+    // literal backslash — bash does not strip it inside double quotes, so
+    // Python got a line-continuation SyntaxError and the resumed session's
+    // backup pickup path was dead on arrival. Pinned by a byte-for-byte test
+    // against bridge-server.md.
+    `(2) Pending check via /pending: Bash: curl -s http://localhost:${port}/pending | python -c "import sys,json; d=json.load(sys.stdin); print('true' if d.get('pending') else 'false')". ` +
     `If exactly "false" → produce NO output (silent tick). ` +
-    `If exactly "true" → curl -s http://localhost:${state.port}/decisions, parse JSON, note _version, process per concept SKILL.md Step 5 (rewrite HTML, POST /reload, then conditionally POST /reset with the noted version). On 409 retry with the new version. Report the outcome to the user.`;
+    `If exactly "true" → curl -s http://localhost:${port}/decisions, parse JSON, note _version, process per concept SKILL.md Step 5 (rewrite HTML, POST /reload, then conditionally POST /reset with the noted version). On 409 retry with the new version. Report the outcome to the user.`
+  );
+}
 
+/**
+ * The two detached background tasks from `bridge-server.md` § step 3, now a
+ * single script in two modes rather than a shell loop duplicated across three
+ * documents.
+ *
+ * Background Bash tasks are session-scoped exactly like crons, so a restart
+ * kills them too — and this hook used to re-arm only the cron. That left a
+ * resumed session with the failure mode from issue #276: the cron is idle-only
+ * and lags by minutes, so a submission could sit unread while the page still
+ * showed a green indicator.
+ *
+ * The state path is passed ABSOLUTE. The shell version tested a relative
+ * `.claude/concept-active.json` against the task cwd, which is not always the
+ * project root the state file lives in — both watchers then exited STATE_GONE
+ * on their first iteration.
+ *
+ * @param {number} port
+ * @param {string} statePath absolute path to .claude/concept-active.json
+ */
+function buildBackgroundTasks(port, statePath) {
+  const script = path.join(__dirname, '..', '..', 'scripts', 'concept-watch.js');
+  const invoke = (mode) =>
+    `node "${script}" --mode ${mode} --port ${port} --state "${statePath}"`;
+  return { pulser: invoke('pulse'), waker: invoke('watch') };
+}
+
+
+/**
+ * The instruction text handed to the resumed Claude session.
+ * @param {{port:number, html_path:string, slug?:string}} state
+ * @param {'pending'|'idle'|'unknown'} pendingState
+ */
+function buildResumeInstructions(state, pendingState, statePath = STATE_PATH) {
+  const bg = buildBackgroundTasks(state.port, statePath);
   const lines = [];
+
   lines.push(
     `An open /concept session was found in this project ` +
     `(port ${state.port}, html_path ${state.html_path}, slug ${state.slug || '?'}). ` +
-    `The bridge server is alive but the polling cron from the previous Claude session is gone (crons are session-only). ` +
-    `Re-arm it now: call CronCreate with cron "* * * * *" (recurring: true) and prompt: '${cronBody}'.`
+    `The bridge server is alive, but everything that watched it is gone — background Bash tasks ` +
+    `are session-scoped just like crons. Re-arm all three now.`
+  );
+  lines.push(
+    `(a) BACKUP pickup path — CronCreate with cron "* * * * *" (recurring: true) and prompt: ` +
+    `'${buildCronBody(state.port)}'.`
+  );
+  lines.push(
+    `(b) Keepalive pulser — launch as a background Bash task (run_in_background: true). Without it ` +
+    `the page's connection indicator goes red within 90s: ${bg.pulser}`
+  );
+  lines.push(
+    `(c) PRIMARY pickup path, the pickup waker — launch as a background Bash task ` +
+    `(run_in_background: true). It exits the moment a submission lands and wakes you, with no user ` +
+    `chat message required, and MUST be re-launched after every processing round: ${bg.waker}`
   );
 
   if (pendingState === 'pending') {
     lines.push(
-      `IMMEDIATELY ALSO process the pending submission BEFORE waiting for the first cron tick: ` +
+      `IMMEDIATELY ALSO process the pending submission BEFORE waiting on any of the above: ` +
       `curl -s http://localhost:${state.port}/decisions, parse, then run concept SKILL.md Step 5 ` +
       `(rewrite HTML at ${state.html_path}, POST /reload, conditional /reset with the captured _version). ` +
-      `The user already submitted and is waiting — do not delay this on the cron schedule.`
+      `The user already submitted and is waiting — do not delay this on a schedule.`
     );
   } else if (pendingState === 'unknown') {
     lines.push(
       `The /pending probe was inconclusive (timeout, non-200, or malformed JSON). ` +
       `Do NOT assume idle. Fetch /decisions once now: curl -s http://localhost:${state.port}/decisions. ` +
       `If submitted=true, run Step 5 immediately (rewrite ${state.html_path}, /reload, conditional /reset). ` +
-      `If submitted=false, just continue with the cron — the next tick will catch any later submission.`
+      `If submitted=false, the waker from (c) catches any later submission.`
     );
   } else {
     lines.push(
-      `No submission is pending right now — just keeping the cron alive is enough. ` +
-      `When the user submits, the next cron tick (≤60s) will pick it up automatically.`
+      `No submission is pending right now. Once (b) and (c) are running the waker picks up the next ` +
+      `submission within ~20s on its own — the user does not have to announce it in chat.`
     );
   }
 
-  process.stdout.write(lines.join(' ') + '\n');
-})();
+  return lines.join(' ');
+}
+
+module.exports = {
+  isValidHtmlPath,
+  isStale,
+  buildCronBody,
+  buildBackgroundTasks,
+  buildResumeInstructions,
+};
+
+if (require.main === module) {
+  require('../lib/plugin-guard');
+
+  (async () => {
+    const state = readState();
+    if (!state) process.exit(0);
+
+    // Consistency check: the concept HTML on disk is the source of truth for
+    // "is this session still real?" If the file is gone, the concept was
+    // discarded / moved / never persisted and any running bridge is an orphan.
+    // We do this BEFORE the heartbeat probe so a still-running ghost server
+    // gets shut down explicitly — relying on the watchdog alone would leave
+    // the server alive for up to 30 s after this hook returns, surfacing
+    // misleading "concept active" state in the meantime.
+    const htmlAbs = path.join(cwd, state.html_path);
+    if (!fs.existsSync(htmlAbs)) {
+      await postShutdown(state.port);
+      deleteState();
+      process.exit(0);
+    }
+
+    const heartbeat = await probe(state.port, '/heartbeat');
+    if (!heartbeat) {
+      // Server gone. If the file is also stale, prune it; otherwise leave it
+      // alone — the user might be restarting the server in another terminal.
+      if (isStale(state)) deleteState();
+      process.exit(0);
+    }
+
+    // Server is alive. Check whether a submission is sitting unprocessed.
+    // We must distinguish three states explicitly:
+    //   - probe ok, pending: false → safe to leave to the waker
+    //   - probe ok, pending: true  → process immediately
+    //   - probe failed              → AMBIGUOUS, do NOT pretend it's false.
+    //     Hiding "I don't know" as "no submission pending" is the worst
+    //     failure mode for a waiting user. Tell Claude to fetch /decisions
+    //     once now so the answer is resolved authoritatively.
+    const pending = await probe(state.port, '/pending');
+    let pendingState; // 'pending' | 'idle' | 'unknown'
+    if (pending && typeof pending.pending === 'boolean') {
+      pendingState = pending.pending ? 'pending' : 'idle';
+    } else {
+      pendingState = 'unknown';
+    }
+
+    process.stdout.write(buildResumeInstructions(state, pendingState) + '\n');
+  })();
+}

--- a/plugins/devops/hooks/session-start/ss.concept.resume.test.js
+++ b/plugins/devops/hooks/session-start/ss.concept.resume.test.js
@@ -1,0 +1,138 @@
+import { describe, test, expect } from "vitest";
+import {
+  isValidHtmlPath,
+  isStale,
+  buildCronBody,
+  buildBackgroundTasks,
+  buildResumeInstructions,
+} from "./ss.concept.resume.js";
+
+const STATE = { port: 8883, html_path: "docs/concepts/2026-08-15-x.html", slug: "x" };
+
+describe("isValidHtmlPath — forged state files cannot steer Claude", () => {
+  test.each([
+    "docs/concepts/a.html",
+    "docs/concepts/nested/b.html",
+  ])("accepts %s", p => expect(isValidHtmlPath(p)).toBe(true));
+
+  test.each([
+    ["absolute posix", "/etc/passwd"],
+    ["windows drive", "C:\\Windows\\x.html"],
+    ["traversal", "docs/concepts/../../secrets.html"],
+    ["outside docs/concepts", "src/app.html"],
+    ["not html", "docs/concepts/a.md"],
+    ["empty", ""],
+    ["not a string", 42],
+  ])("rejects %s", (_label, p) => expect(isValidHtmlPath(p)).toBe(false));
+});
+
+describe("isStale", () => {
+  test("no started_at → never stale", () => {
+    expect(isStale({})).toBe(false);
+  });
+  test("fresh → not stale", () => {
+    expect(isStale({ started_at: new Date().toISOString() })).toBe(false);
+  });
+  test("older than 24h → stale", () => {
+    expect(isStale({ started_at: new Date(Date.now() - 25 * 3600_000).toISOString() })).toBe(true);
+  });
+});
+
+describe("buildCronBody", () => {
+  test("carries the port into every endpoint", () => {
+    const body = buildCronBody(8883);
+    expect(body).toContain("http://localhost:8883/heartbeat");
+    expect(body).toContain("http://localhost:8883/pending");
+    expect(body).toContain("http://localhost:8883/decisions");
+    expect(body).toContain("http://localhost:8883/shutdown");
+  });
+
+  test("checks /pending, not a substring match on /decisions", () => {
+    // A `contains "submitted":true` test silently misses every submission,
+    // because json.dumps emits a space after the colon.
+    expect(buildCronBody(8883)).not.toMatch(/"submitted":\s*true/);
+  });
+});
+
+// Issue #276: background Bash tasks are session-scoped exactly like crons, so a
+// restart kills them too. Re-arming only the cron left the resumed session on a
+// pickup path that fires solely while the REPL is idle.
+describe("buildBackgroundTasks — what a restart must bring back", () => {
+  const STATE_PATH = "C:/proj/.claude/concept-active.json";
+  const { pulser, waker } = buildBackgroundTasks(8883, STATE_PATH);
+
+  test("both invoke concept-watch.js, one per mode", () => {
+    expect(pulser).toContain("concept-watch.js");
+    expect(waker).toContain("concept-watch.js");
+    expect(pulser).toContain("--mode pulse");
+    expect(waker).toContain("--mode watch");
+  });
+
+  test("the state path is passed ABSOLUTE", () => {
+    // The shell version tested a relative path against the task cwd, which is
+    // not always the project root the state file lives in — both watchers then
+    // exited STATE_GONE on their first iteration.
+    for (const task of [pulser, waker]) {
+      expect(task).toContain(`--state "${STATE_PATH}"`);
+    }
+  });
+
+  test("both carry the port through", () => {
+    for (const task of [pulser, waker]) expect(task).toContain("--port 8883");
+  });
+
+  test("both start with `node ` — the prefix SKILL.md allowed-tools already grants", () => {
+    // A multi-line shell loop has no usable prefix; the only grant that covered
+    // it would have been a blanket one.
+    expect(pulser.startsWith('node "')).toBe(true);
+    expect(waker.startsWith('node "')).toBe(true);
+  });
+
+  test("no inline shell loop survives in the hook", () => {
+    for (const task of [pulser, waker]) {
+      expect(task).not.toContain("while true");
+      expect(task).not.toContain("grep -q");
+      expect(task).not.toContain("sleep 20");
+    }
+  });
+});
+
+describe("buildResumeInstructions", () => {
+  test("re-arms all three watchers, not just the cron", () => {
+    const out = buildResumeInstructions(STATE, "idle");
+    expect(out).toContain("CronCreate");
+    expect(out).toContain("Keepalive pulser");
+    expect(out).toContain("pickup waker");
+    expect(out).toMatch(/run_in_background: true/);
+  });
+
+  test("names the waker primary and the cron backup", () => {
+    const out = buildResumeInstructions(STATE, "idle");
+    expect(out).toMatch(/BACKUP pickup path[\s\S]*CronCreate/);
+    expect(out).toContain("PRIMARY pickup path");
+  });
+
+  test("the idle branch no longer promises the cron will pick it up", () => {
+    const out = buildResumeInstructions(STATE, "idle");
+    expect(out).toContain("the waker picks up the next submission within ~20s");
+    expect(out).not.toMatch(/next cron tick.*will pick it up/);
+  });
+
+  test("a pending submission is processed before anything is re-armed", () => {
+    const out = buildResumeInstructions(STATE, "pending");
+    expect(out).toContain("IMMEDIATELY ALSO process the pending submission");
+    expect(out).toContain(STATE.html_path);
+  });
+
+  test("an inconclusive probe is never reported as idle", () => {
+    const out = buildResumeInstructions(STATE, "unknown");
+    expect(out).toContain("Do NOT assume idle");
+    expect(out).toContain("/decisions");
+  });
+
+  test("a slug-less state file still produces usable instructions", () => {
+    const out = buildResumeInstructions({ port: 9001, html_path: "docs/concepts/y.html" }, "idle");
+    expect(out).toContain("slug ?");
+    expect(out).toContain("http://localhost:9001/pending");
+  });
+});

--- a/plugins/devops/scripts/concept-watch.js
+++ b/plugins/devops/scripts/concept-watch.js
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+/**
+ * @script concept-watch
+ * @version 0.1.0
+ * @plugin devops
+ * @description The concept bridge's two detached watchers, as a script instead
+ *   of a shell loop pasted into three documents.
+ *
+ *   `--mode pulse`  keepalive pulser — POSTs /heartbeat forever so the page's
+ *                   connection indicator stays green. Never exits on a pending
+ *                   submission, so `claude_ts` stays warm through a long
+ *                   `implement`.
+ *   `--mode watch`  pickup waker — polls /pending and exits the instant a
+ *                   submission lands. The exit IS the signal: a detached Bash
+ *                   task re-invokes Claude when it finishes, so the user never
+ *                   has to announce a submission in chat (issue #276).
+ *
+ *   Why a script and not the inline `while true; do … sleep 20; done` loops
+ *   this replaces:
+ *     - The loops' first statement tested a RELATIVE `.claude/concept-active.json`
+ *       while the docs mandate the state file at the project root, which is not
+ *       always the task's cwd. Both watchers then exited STATE_GONE on their
+ *       first iteration — the bug they exist to prevent. `--state` is absolute.
+ *     - They were launched BEFORE the step that writes that state file, so a
+ *       literal reading killed them at t=0. `--grace` waits for it instead.
+ *     - The port guard was `grep -qE '"port"…\b'`; `\b` is a GNU extension, so
+ *       on BSD/macOS grep it never matched and both watchers exited
+ *       PORT_CHANGED immediately. The comparison is numeric here.
+ *     - `allowed-tools` matches command prefixes, and a multi-line loop has no
+ *       usable prefix — the only grant that covered it was a blanket one. A
+ *       `node …` invocation is already covered.
+ *
+ *   Exit lines are unchanged (`PULSER_EXIT reason=…` / `WAKER_EXIT reason=…`)
+ *   so the reason→action table in the concept skill still applies verbatim,
+ *   plus `STATE_NEVER_APPEARED` for a launch that outran its setup.
+ *
+ *   Exit codes: 0 once it is running — the exit is a signal, not a failure, and
+ *   even an internal error is reported as a reason line. Only invalid arguments
+ *   exit 2, before any watching starts.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const http = require('http');
+
+const DEFAULTS = {
+  interval: 20,      // seconds — under the page's 90s HEARTBEAT_STALE_MS
+  grace: 60,         // seconds to wait for the state file before giving up
+  tolerate: 4,       // consecutive request failures before declaring the server dead
+  timeout: 8,        // seconds per request
+};
+
+function parseArgs(argv) {
+  const out = { mode: '', port: 0, state: '', ...DEFAULTS };
+  for (let i = 0; i < argv.length; i++) {
+    const key = argv[i].startsWith('--') ? argv[i].slice(2) : null;
+    if (!key) continue;
+    const raw = argv[i + 1];
+    if (raw === undefined || raw.startsWith('--')) continue;
+    i++;
+    if (key === 'mode' || key === 'state') out[key] = raw;
+    // hasOwn, not `in` — `in` walks the prototype chain, so `--toString 5`
+    // would set junk on the options object.
+    else if (Object.prototype.hasOwnProperty.call(DEFAULTS, key) || key === 'port') out[key] = Number(raw);
+  }
+  return out;
+}
+
+function validate(opts) {
+  if (opts.mode !== 'pulse' && opts.mode !== 'watch') return 'mode must be "pulse" or "watch"';
+  if (!Number.isInteger(opts.port) || opts.port < 1 || opts.port > 65535) return 'port must be 1-65535';
+  // Enforced, not merely described: a relative path resolved against the task's
+  // cwd is the exact defect this argument exists to prevent.
+  if (!opts.state || !path.isAbsolute(opts.state)) return 'state must be the ABSOLUTE path to concept-active.json';
+  if (!(opts.interval > 0) || !(opts.grace >= 0) || !(opts.tolerate > 0) || !(opts.timeout > 0)) {
+    return 'interval/grace/tolerate/timeout must be positive numbers';
+  }
+  return null;
+}
+
+/**
+ * Is this watcher still the right one for the concept on disk?
+ * @returns {'ok'|'gone'|'port-changed'}
+ */
+function checkState(statePath, port) {
+  let raw;
+  try {
+    raw = fs.readFileSync(statePath, 'utf8');
+  } catch (err) {
+    // Only "the file is not there" means the concept ended. A transient read
+    // error — EBUSY/EPERM during a state rewrite on Windows, EMFILE under load
+    // — must be tolerated exactly like the half-written JSON below, or the one
+    // terminal verdict fires on a live concept.
+    return err && err.code === 'ENOENT' ? 'gone' : 'ok';
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    // A half-written file during a state rewrite is not a dead concept.
+    return 'ok';
+  }
+  if (!parsed || typeof parsed.port !== 'number') return 'gone';
+  // Numeric, so no `"port": 8883` spacing dependency and no 8883-vs-88831 slip.
+  return parsed.port === port ? 'ok' : 'port-changed';
+}
+
+function request(port, path, method, timeoutSec) {
+  return new Promise((resolve) => {
+    const req = http.request(
+      { host: '127.0.0.1', port, path, method, timeout: timeoutSec * 1000 },
+      (res) => {
+        const chunks = [];
+        res.on('data', (c) => chunks.push(c));
+        res.on('end', () => resolve({ ok: res.statusCode === 200, body: Buffer.concat(chunks).toString('utf8') }));
+      }
+    );
+    req.on('timeout', () => { req.destroy(); resolve({ ok: false, body: '' }); });
+    req.on('error', () => resolve({ ok: false, body: '' }));
+    req.end();
+  });
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+function finish(tag, reason) {
+  // Synchronous write: the reason line IS the payload of the wake, and on
+  // POSIX a piped stdout is async — `process.exit` right after an async write
+  // can truncate it.
+  try { fs.writeSync(1, `${tag}_EXIT reason=${reason}\n`); }
+  catch { process.stdout.write(`${tag}_EXIT reason=${reason}\n`); }
+  process.exit(0);
+}
+
+async function run(opts, deps = {}) {
+  const io = { request, sleep, checkState, exists: (p) => fs.existsSync(p), ...deps };
+  const tag = opts.mode === 'pulse' ? 'PULSER' : 'WAKER';
+  const intervalMs = opts.interval * 1000;
+  const emit = deps.emit || ((reason) => finish(tag, reason));
+
+  // The launch step used to run before the state file was written, which made
+  // the very first check fatal. Wait it out instead.
+  // Distinct from STATE_GONE on purpose. "The file vanished" means the concept
+  // ended and nothing should be re-launched; "the file never showed up" means
+  // the launch outran its setup, and re-launching is exactly right. Collapsing
+  // the two would tell Claude to stand down on a live concept.
+  const deadline = opts.grace * 1000;
+  for (let waited = 0; !io.exists(opts.state); waited += intervalMs) {
+    if (waited >= deadline) return emit('STATE_NEVER_APPEARED');
+    await io.sleep(Math.min(intervalMs, deadline - waited));
+  }
+
+  let fails = 0;
+  for (;;) {
+    const state = io.checkState(opts.state, opts.port);
+    if (state === 'gone') return emit('STATE_GONE');
+    if (state === 'port-changed') return emit('PORT_CHANGED');
+
+    const res = opts.mode === 'pulse'
+      ? await io.request(opts.port, '/heartbeat', 'POST', opts.timeout)
+      : await io.request(opts.port, '/pending', 'GET', opts.timeout);
+
+    if (res.ok) {
+      fails = 0;
+      if (opts.mode === 'watch') {
+        let pending = false;
+        try { pending = !!JSON.parse(res.body).pending; } catch { /* treat as not pending */ }
+        if (pending) return emit('PENDING_SUBMISSION');
+      }
+    } else if (++fails >= opts.tolerate) {
+      // Tolerate transient blips — a single failed request (server busy, a
+      // competing request) must not tear the watcher down, or the page goes
+      // stale on every hiccup.
+      return emit('SERVER_DEAD');
+    }
+
+    await io.sleep(intervalMs);
+  }
+}
+
+module.exports = { parseArgs, validate, checkState, run, DEFAULTS };
+
+if (require.main === module) {
+  const opts = parseArgs(process.argv.slice(2));
+  const err = validate(opts);
+  if (err) {
+    process.stderr.write(`concept-watch: ${err}\n`);
+    process.stderr.write('usage: concept-watch.js --mode pulse|watch --port <n> --state <abs path> [--interval 20] [--grace 60]\n');
+    process.exit(2);
+  }
+  // A crash must still announce itself as a reason line, not as a stack trace:
+  // the exit IS the wake, and an unhandled rejection would exit 1 with nothing
+  // the reason → action table can key off.
+  run(opts).catch(() => finish(opts.mode === 'pulse' ? 'PULSER' : 'WAKER', 'SERVER_DEAD'));
+}

--- a/plugins/devops/scripts/concept-watch.test.js
+++ b/plugins/devops/scripts/concept-watch.test.js
@@ -1,0 +1,265 @@
+import { describe, test, expect } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { parseArgs, validate, checkState, run, DEFAULTS } from "./concept-watch.js";
+
+function stateFile(contents) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "concept-watch-"));
+  const p = path.join(dir, "concept-active.json");
+  if (contents !== undefined) {
+    fs.writeFileSync(p, typeof contents === "string" ? contents : JSON.stringify(contents));
+  }
+  return p;
+}
+
+/** Drive run() with fake IO so no sockets, timers, or process.exit are involved. */
+function harness({ mode = "watch", port = 8883, state, responses = [], exists = true, grace = 60, interval }) {
+  const calls = [];
+  let reason = null;
+  const opts = {
+    mode, port, state: state ?? "/fake/concept-active.json", ...DEFAULTS, grace,
+    ...(interval === undefined ? {} : { interval }),
+  };
+  const p = run(opts, {
+    exists: () => (typeof exists === "function" ? exists() : exists),
+    sleep: async (ms) => { calls.push({ sleep: ms }); },
+    // `state` here is the verdict checkState should return, not a path.
+    checkState: () => state,
+    request: async (_port, reqPath, method) => {
+      calls.push({ reqPath, method });
+      return responses.shift() ?? { ok: false, body: "" };
+    },
+    emit: (r) => { reason = r; return r; },
+  });
+  return { done: p.then(() => reason), calls };
+}
+
+describe("parseArgs / validate", () => {
+  test("parses the documented invocation", () => {
+    const o = parseArgs(["--mode", "watch", "--port", "8883", "--state", "C:/p/.claude/concept-active.json"]);
+    expect(o.mode).toBe("watch");
+    expect(o.port).toBe(8883);
+    expect(o.state).toBe("C:/p/.claude/concept-active.json");
+    expect(o.interval).toBe(20);   // under the page's 90s HEARTBEAT_STALE_MS
+  });
+
+  test.each([
+    ["bad mode", { mode: "poll", port: 8883, state: "/s" }],
+    ["port 0", { mode: "watch", port: 0, state: "/s" }],
+    ["port too high", { mode: "watch", port: 70000, state: "/s" }],
+    ["no state path", { mode: "watch", port: 8883, state: "" }],
+  ])("rejects %s", (_l, partial) => {
+    expect(validate({ ...DEFAULTS, ...partial })).toBeTruthy();
+  });
+
+  test("accepts a valid set", () => {
+    expect(validate({ ...DEFAULTS, mode: "pulse", port: 8883, state: "/s" })).toBeNull();
+  });
+});
+
+// The inline shell loops this replaces used `grep -qE '"port"…\b'`, which is
+// spacing-dependent, GNU-only, and could not tell 8883 from 88831.
+describe("checkState — the guard the shell version got wrong", () => {
+  test("matching port → ok, whatever the JSON spacing", () => {
+    expect(checkState(stateFile('{"port":8883}'), 8883)).toBe("ok");
+    expect(checkState(stateFile('{ "port" :   8883 }'), 8883)).toBe("ok");
+  });
+
+  test("a longer port is not a prefix match", () => {
+    expect(checkState(stateFile({ port: 88831 }), 8883)).toBe("port-changed");
+  });
+
+  test("a different port → port-changed", () => {
+    expect(checkState(stateFile({ port: 9001 }), 8883)).toBe("port-changed");
+  });
+
+  test("missing file → gone", () => {
+    expect(checkState(stateFile(undefined), 8883)).toBe("gone");
+  });
+
+  test("a half-written file is NOT a dead concept", () => {
+    // A state rewrite must not kill both watchers mid-flight.
+    expect(checkState(stateFile("{not json"), 8883)).toBe("ok");
+  });
+
+  test("valid JSON without a numeric port → gone", () => {
+    expect(checkState(stateFile({ slug: "x" }), 8883)).toBe("gone");
+  });
+});
+
+describe("run — waker", () => {
+  test("exits PENDING_SUBMISSION the moment a submission lands", async () => {
+    const h = harness({
+      state: "ok",
+      responses: [
+        { ok: true, body: '{"pending": false}' },
+        { ok: true, body: '{"pending": true, "version": 3}' },
+      ],
+    });
+    await expect(h.done).resolves.toBe("PENDING_SUBMISSION");
+    expect(h.calls.filter(c => c.reqPath === "/pending")).toHaveLength(2);
+  });
+
+  test("polls /pending, never /decisions — only /pending acks the pickup", async () => {
+    const h = harness({ state: "ok", responses: [{ ok: true, body: '{"pending": true}' }] });
+    await h.done;
+    expect(h.calls.every(c => !c.reqPath || c.reqPath === "/pending")).toBe(true);
+  });
+
+  test("tolerates 3 transient failures, gives up on the 4th", async () => {
+    const fail = { ok: false, body: "" };
+    const h = harness({ state: "ok", responses: [fail, fail, fail, fail] });
+    await expect(h.done).resolves.toBe("SERVER_DEAD");
+  });
+
+  test("a failure streak is reset by one success", async () => {
+    const fail = { ok: false, body: "" };
+    const ok = { ok: true, body: '{"pending": false}' };
+    const h = harness({ state: "ok", responses: [fail, fail, fail, ok, fail, { ok: true, body: '{"pending": true}' }] });
+    await expect(h.done).resolves.toBe("PENDING_SUBMISSION");
+  });
+
+  test("malformed /pending JSON is treated as not-pending, not as a crash", async () => {
+    const h = harness({
+      state: "ok",
+      responses: [{ ok: true, body: "<html>oops" }, { ok: true, body: '{"pending": true}' }],
+    });
+    await expect(h.done).resolves.toBe("PENDING_SUBMISSION");
+  });
+});
+
+describe("run — pulser", () => {
+  test("POSTs the heartbeat, never GETs anything", async () => {
+    const beat = { ok: true, body: "{}" };
+    const fail = { ok: false, body: "" };
+    const h = harness({ mode: "pulse", state: "ok", responses: [beat, beat, fail, fail, fail, fail] });
+    await expect(h.done).resolves.toBe("SERVER_DEAD");
+    const beats = h.calls.filter(c => c.reqPath);
+    expect(beats).toHaveLength(6);
+    expect(beats.every(c => c.reqPath === "/heartbeat" && c.method === "POST")).toBe(true);
+  });
+
+  test("keeps beating even while a submission IS pending", async () => {
+    // The pulser/waker split exists for exactly this: if the pulser exited on
+    // pending, nothing would keep `claude_ts` warm through a long `implement`
+    // and the indicator would go red precisely during implementation.
+    const pending = { ok: true, body: '{"pending": true}' };
+    const fail = { ok: false, body: "" };
+    const h = harness({
+      mode: "pulse",
+      state: "ok",
+      responses: [pending, pending, pending, fail, fail, fail, fail],
+    });
+    await expect(h.done).resolves.toBe("SERVER_DEAD");
+    expect(h.calls.filter(c => c.reqPath === "/heartbeat")).toHaveLength(7);
+  });
+});
+
+describe("run — lifecycle guards", () => {
+  test("a vanished concept exits STATE_GONE", async () => {
+    const h = harness({ state: "gone", responses: [{ ok: true, body: '{"pending": false}' }] });
+    await expect(h.done).resolves.toBe("STATE_GONE");
+  });
+
+  test("a superseded concept exits PORT_CHANGED", async () => {
+    const h = harness({ state: "port-changed", responses: [{ ok: true, body: '{"pending": false}' }] });
+    await expect(h.done).resolves.toBe("PORT_CHANGED");
+  });
+
+  test("a state file that does not exist YET is waited for, not fatal", async () => {
+    // bridge-server.md launches the watchers in step 3 and writes the state
+    // file in step 4. The shell version died on its first line.
+    let attempts = 0;
+    const h = harness({
+      state: "ok",
+      exists: () => ++attempts > 2,
+      responses: [{ ok: true, body: '{"pending": true}' }],
+    });
+    await expect(h.done).resolves.toBe("PENDING_SUBMISSION");
+    expect(attempts).toBeGreaterThan(2);
+  });
+
+  test("but a state file that never appears gives up — with its OWN reason", async () => {
+    // Distinct from STATE_GONE on purpose: the action table answers STATE_GONE
+    // with "do not re-launch, the session is over", which would be exactly
+    // wrong for a live concept whose launch merely outran its setup.
+    const h = harness({ state: "ok", exists: false, grace: 40, responses: [] });
+    await expect(h.done).resolves.toBe("STATE_NEVER_APPEARED");
+  });
+
+  test.each([[0, 20], [10, 60], [70, 20]])(
+    "the grace wait terminates for grace=%i interval=%i",
+    async (grace, interval) => {
+      // grace 0 must not hang, and interval > grace must not overshoot forever.
+      const h = harness({ state: "ok", exists: false, grace, interval, responses: [] });
+      await expect(h.done).resolves.toBe("STATE_NEVER_APPEARED");
+      const slept = h.calls.filter(c => c.sleep !== undefined).reduce((a, c) => a + c.sleep, 0);
+      expect(slept).toBeLessThanOrEqual(grace * 1000);
+    }
+  );
+
+  test("run() rejects on an internal throw — the CLI turns that into a reason line", async () => {
+    // The exit IS the wake, so an unhandled rejection would exit 1 with nothing
+    // the reason → action table can key off. The CLI wraps run() in .catch().
+    const boom = run(
+      { ...DEFAULTS, mode: "watch", port: 8883, state: "/s" },
+      {
+        exists: () => true,
+        checkState: () => { throw new Error("boom"); },
+        sleep: async () => {},
+        request: async () => ({ ok: true, body: "{}" }),
+        emit: (r) => r,
+      }
+    );
+    await expect(boom).rejects.toThrow("boom");
+  });
+});
+
+describe("validate — the guards the shell version could not express", () => {
+  test("a RELATIVE state path is rejected, not merely discouraged", () => {
+    expect(validate({ ...DEFAULTS, mode: "watch", port: 8883, state: ".claude/concept-active.json" }))
+      .toMatch(/ABSOLUTE/);
+  });
+
+  test("absolute paths in both shapes are accepted", () => {
+    for (const p of ["C:/proj/.claude/concept-active.json", "/home/u/proj/.claude/concept-active.json"]) {
+      expect(validate({ ...DEFAULTS, mode: "watch", port: 8883, state: p })).toBeNull();
+    }
+  });
+
+  test.each(["interval", "grace", "tolerate", "timeout"])("a non-numeric --%s is rejected", key => {
+    const opts = { ...DEFAULTS, mode: "watch", port: 8883, state: "/s", [key]: NaN };
+    expect(validate(opts)).toBeTruthy();
+  });
+
+  test("a zero timeout is rejected — it would disable the request deadline", () => {
+    expect(validate({ ...DEFAULTS, mode: "watch", port: 8883, state: "/s", timeout: 0 })).toBeTruthy();
+  });
+});
+
+describe("parseArgs — odd argv", () => {
+  test.each([
+    ["a trailing flag with no value", ["--mode", "watch", "--port", "8883", "--state"]],
+    ["a flag whose value is another flag", ["--mode", "watch", "--port", "8883", "--state", "--interval"]],
+  ])("%s leaves state empty and is rejected", (_l, argv) => {
+    const o = parseArgs(argv);
+    expect(o.state).toBe("");
+    expect(validate(o)).toBeTruthy();
+  });
+
+  test("a repeated --port takes the last value", () => {
+    expect(parseArgs(["--port", "1111", "--port", "2222"]).port).toBe(2222);
+  });
+
+  test.each([["-1"], ["8883.5"], ["abc"], ["99999"]])("--port %s is rejected", raw => {
+    const o = parseArgs(["--mode", "watch", "--state", "/s", "--port", raw]);
+    expect(validate(o)).toMatch(/port/);
+  });
+
+  test("prototype keys cannot be injected as options", () => {
+    const o = parseArgs(["--toString", "5", "--constructor", "7"]);
+    expect(Object.prototype.hasOwnProperty.call(o, "toString")).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(o, "constructor")).toBe(false);
+  });
+});

--- a/plugins/devops/skills/concept/SKILL.md
+++ b/plugins/devops/skills/concept/SKILL.md
@@ -12,7 +12,7 @@ description: >-
   Do NOT trigger for: simple code explanations, debugging
   (use /fix), or static documentation (use /setup-readme).
 argument-hint: "[topic, analysis result, plan, or concept to visualize]"
-allowed-tools: Read, Write, Glob, Grep, Bash(start *), Bash(cmd *), Bash(python *), Bash(curl *), Bash(kill *), AskUserQuestion, CronCreate, CronDelete, mcp__Claude_Preview__*, mcp__plugin_playwright_playwright__*, mcp__plugin_devops_dotclaude-completion__*
+allowed-tools: Read, Write, Glob, Grep, Bash(start *), Bash(cmd *), Bash(python *), Bash(curl *), Bash(kill *), Bash(node *), AskUserQuestion, CronCreate, CronDelete, mcp__Claude_Preview__*, mcp__plugin_playwright_playwright__*, mcp__plugin_devops_dotclaude-completion__*
 ---
 
 # Concept
@@ -502,6 +502,29 @@ the read-back is mandatory; a naked POST leaves a dead-bridge failure
 mode invisible until the user submits and gets no response), then open
 the page in the user's existing Edge window using the exact command above.
 
+**Then launch the two background tasks — the concept does not work without
+them.** Both are the same script in two modes, `scripts/concept-watch.js`,
+launched via the Bash tool with `run_in_background: true` (exact invocations in
+`deep-knowledge/bridge-server.md` § step 3):
+
+1. **Keepalive pulser** — POSTs `/heartbeat` every ~20 s for the whole session
+   and never exits on a pending submission, so the connection indicator stays
+   green even through a long `implement`.
+2. **Pickup waker** — polls `/pending` every ~20 s and exits the instant a
+   submission lands, which wakes Claude immediately.
+
+The cron alone is NOT sufficient for either job: it fires only while the REPL
+is idle and has multi-minute gaps in practice (observed: 638 s with the cron
+registered and the session idle). It stays armed as the backup pickup path,
+never as the primary one.
+
+Pass the state file's **absolute** path via `--state`. The watchers used to
+test a relative `.claude/concept-active.json` against their own cwd, which is
+not always the project root the state file lives in — both then exited
+`STATE_GONE` on their first iteration, which looks exactly like the bug they
+prevent. They also tolerate the state file not existing yet (60 s grace), so
+launching them here, before step 4 writes it, is safe.
+
 The state file (`port`, `html_path`, `slug`, `server_pid`, `cron_id`,
 `started_at`) is what makes the concept survivable across Claude restarts:
 the `ss.concept.resume` SessionStart hook reads it, verifies the bridge
@@ -531,37 +554,46 @@ Pick the wording that matches the `[ui-locale: ...]` hint injected by
 
 The bridge server handles all communication — no JS eval injection needed.
 
-**Heartbeat** is handled by the cron job set up in Step 3. Additionally,
-send a heartbeat POST on each manual poll cycle:
+**Heartbeat** is the keepalive pulser's job (Step 3, task 1), backed up by the
+cron. Send an extra POST on any manual poll cycle:
 
 ```bash
 curl -s -X POST http://localhost:$PORT/heartbeat
 ```
 
-**Polling for decisions** — check if the user has submitted:
+**Checking for a submission** — use `/pending`, not `/decisions`:
 
 ```bash
-curl -s http://localhost:$PORT/decisions
+curl -s http://localhost:$PORT/pending
 ```
 
-Parse the JSON response. If `submitted` is `true` → process decisions (Step 5).
-If `false` → wait and retry.
+`/pending` is the only endpoint that acks a pickup: it stamps `_picked_up_at`,
+which is what advances the "Claude verarbeitet" step in the page's submitted
+panel. A poll of `/decisions` reads the same data but acks nothing, so the user
+watches a progress list that never moves. Once `pending` is `true`, fetch the
+full payload from `/decisions` and process it (Step 5).
 
 **Polling schedule:**
-- **Primary mechanism**: the combined cron from Step 3 fires every minute and
-  handles heartbeat + decision pickup + reset automatically. No manual polling
-  needed from Claude between user turns.
-- **Initial wait**: 10 seconds after opening, then send one manual heartbeat +
-  decision check to close the 0–60 s gap before the first cron tick lands.
+- **Primary mechanism**: the **pickup waker** from Step 3. It exits the moment
+  a submission lands, which wakes Claude — no user chat message required.
+- **Backup**: the combined cron from Step 3, every minute — and only a partial
+  one. It covers the window between the waker exiting and being re-launched
+  ONLY while the REPL is idle, which is exactly when that window is not open:
+  during a processing round the REPL is busy and the cron cannot fire. That is
+  why 5c step 7 re-launches the waker immediately rather than leaving the gap
+  to the cron.
+- **Initial wait**: 10 seconds after opening, then one manual heartbeat +
+  `/pending` check to close the gap before the first waker cycle lands.
 - **No timeout** — monitoring runs indefinitely until the user ends it
   (says "fertig"/"done", closes the page, or closes Claude).
-- **On demand**: if the user asks "did my submission arrive?", do a manual
-  `curl http://localhost:$PORT/decisions` — do NOT wait for the next cron tick.
+- **On demand**: if the user asks "did my submission arrive?", poll
+  `/pending` manually — do NOT wait for the next tick.
 
-**Important:** While waiting, do NOT block the conversation. Inform the
-user that you're monitoring and they can continue chatting. If the user
-sends a message while monitoring, pause monitoring and respond normally.
-Resume monitoring after responding.
+**Important:** monitoring MUST NOT block the conversation, and it must not
+depend on one either. The waker runs detached, so an idle turn keeps watching
+on its own; a user who clicks submit and types nothing still gets picked up.
+If the user sends an unrelated message, respond normally — the waker keeps
+running and wakes you when the submission arrives.
 
 ## Step 5 — Live Feedback Loop
 
@@ -820,6 +852,13 @@ iteration must be live in the browser BEFORE the server signals "processed".
    it will only restore the panel state when a reload counter advance
    has been observed OR a long stale timeout elapses. See
    `deep-knowledge/templates.md` § Panel State Reset for the polling contract.
+7. **Immediately re-launch the pickup waker** (Step 5d) — right here, not
+   after the rest of the round. `/reset` clears the pending flag and
+   `/reload` has already handed the user a fresh panel, so from this moment
+   they can submit again. Every second between here and the re-launch is a
+   window with nothing watching, and the cron cannot cover it: it fires only
+   while the REPL is idle, and processing an `implement` keeps the REPL busy
+   for minutes.
 
 The tab bar is anchored at the top of the right-side decision panel —
 above the section TOC and the submit block. It must never appear inside
@@ -858,7 +897,11 @@ preservation) stays identical.
 5. Set `submitted: false` in `#concept-decisions`, remove `concept-submitted`
    from `<body>`. The submit-button reset is irrelevant because the
    final-report panel doesn't surface iterate/implement at all.
-6. /reload → /reset as steps 5–6 above.
+6. /reload → /reset → **re-launch the pickup waker**, as steps 5–7 above.
+   Step 7 is not optional here: the final-report panel still accepts `ship`,
+   `create-issues` and `dispose-concept` submissions, and `implement` is the
+   longest round there is — leaving it unwatched is the widest window in the
+   whole flow.
 
 **Verbatim copy directive (mandatory):**
 The final-report JS block — `updateCreateIssuesPanel`, `submitCreateIssues`,
@@ -892,7 +935,44 @@ the final report, they can start a new concept session — that's a clear
 new scope, not an additional iteration on a closed one.
 
 ### 5d. Resume Monitoring
-Return to Step 4 (monitor for next submission). The loop continues until:
+
+**Re-launch the pickup waker.** It exited to wake you for the submission you
+just processed, so nothing is watching `/pending` until you start it again —
+exactly as in Step 3 (`bridge-server.md` § step 3, task 2), with
+`run_in_background: true`. Do this at 5c step 7, the moment `/reset` lands; by
+the time you reach 5d it should already be running.
+
+**Before processing a wake, re-confirm.** Two wakers on the same port both exit
+`PENDING_SUBMISSION`, and the second wake arrives after `/reset` has already
+cleared the flag. Acting on it re-runs Step 5b — for `action: "implement"` that
+means writing real code changes a second time, which no version guard catches
+(`/reset`'s 409 only detects a *newer* submission). So on every wake, poll
+`/pending` once before doing anything: `false` means the wake is stale — just
+re-launch the waker and carry on. If it is `true`, compare `_version` against
+the one you last processed: **equal means the previous round's `/reset` never
+landed**, not that the user resubmitted. Retry the reset instead of running the
+same payload again.
+
+Skipping it is how a concept silently stops responding after iteration 1: the
+page still shows a green indicator (the pulser keeps `claude_ts` warm), the user
+submits again, and nothing picks it up until they ask in chat.
+
+**Act on the exit reason.** A background task announces why it stopped; each
+reason has exactly one correct response:
+
+| Exit line | What happened | Do this |
+|---|---|---|
+| `WAKER_EXIT reason=PENDING_SUBMISSION` | A submission landed | Re-confirm via `/pending`, then process it (Step 5a) and re-launch the waker. A `false` here is a stale wake — re-launch and carry on |
+| `WAKER_EXIT reason=SERVER_DEAD` / `PULSER_EXIT reason=SERVER_DEAD` | 4 consecutive failed polls — the bridge is gone | Restart the bridge server **on the same port** (do NOT pick a new one — the state file, the open tab and both watchers are all bound to it), then re-launch **both** tasks |
+| `*_EXIT reason=STATE_GONE` | `.claude/concept-active.json` is gone — the concept ended | Nothing. Do not re-launch; the session is over |
+| `*_EXIT reason=STATE_NEVER_APPEARED` | The launch outran the step that writes the state file | Write it, then re-launch. NOT the same as STATE_GONE — the concept is alive |
+| `*_EXIT reason=PORT_CHANGED` | A newer concept took over | Nothing. This task belongs to a superseded session |
+| No `*_EXIT` line at all | The task died without announcing why — bad arguments, a crash, `node` missing, killed | Do NOT assume the session ended. Verify the bridge with one `curl /heartbeat`, then re-launch both tasks |
+
+Re-launch the pulser only when you actually saw a `PULSER_EXIT` — normally it
+runs for the whole session and a second one on the same port is wasted work.
+
+Then return to Step 4 (monitor for next submission). The loop continues until:
 - The user closes the page
 - The user says "fertig" / "done" in chat
 - There are no more decisions to make (all items processed)

--- a/plugins/devops/skills/concept/deep-knowledge/bridge-server.md
+++ b/plugins/devops/skills/concept/deep-knowledge/bridge-server.md
@@ -8,7 +8,14 @@ AND provides HTTP endpoints for heartbeat and decision exchange.
 > is **milliseconds since the Unix epoch**, byte-compatible with JavaScript's
 > `Date.now()`. The browser compares them directly, with no conversion:
 > ```js
-> Date.now() - _lastHeartbeatTs < HEARTBEAT_STALE_MS   // both in ms
+> Date.now() - _lastHeartbeatTs < HEARTBEAT_STALE_MS   
+
+   **Verify both actually started.** They are the only launches in this document
+   whose failure is silent — the server has a heartbeat round-trip, the port has
+   a single-listener assert, the page has a 200-gate, and these had nothing.
+   Read each task's output once after launching: a `*_EXIT reason=` line within
+   seconds means it never got going. `STATE_NEVER_APPEARED` in particular means
+   the launch outran step 4 — write the state file, then re-launch.// both in ms
 > Date.now() - _lastServerTs    < SERVER_STALE_MS       // same unit contract
 > ```
 > `_lastServerTs` (cached from `server_ts`) is compared against `SERVER_STALE_MS`
@@ -256,24 +263,20 @@ AND provides HTTP endpoints for heartbeat and decision exchange.
    removes that coupling.
 
    Launch both as **detached background tasks** (Bash tool,
-   `run_in_background: true`, no trailing `&`, no `nohup`):
+   `run_in_background: true`, no trailing `&`, no `nohup`). Both are the same
+   script in two modes — `scripts/concept-watch.js`, resolved the same way as
+   the server in step 1.
+
+   **Resolve the path INSIDE each launch command.** Every Bash tool call is a
+   fresh shell (see § Troubleshooting), so a `WATCH=$(...)` assignment in one
+   call is empty in the next — `node "" --mode pulse` dies in under 100 ms and,
+   unlike every other launch in this document, does so silently.
 
    **(1) Keepalive pulser — pulses only, NEVER exits on pending.** Launched
    once at concept open; runs for the whole session so `claude_ts` stays warm
    even across a long `implement`. Exits only when the concept is truly gone:
    ```bash
-   fails=0
-   while true; do
-     [ -f .claude/concept-active.json ] || { echo "PULSER_EXIT reason=STATE_GONE"; exit 0; }
-     grep -q '"port": {port}' .claude/concept-active.json 2>/dev/null || { echo "PULSER_EXIT reason=PORT_CHANGED"; exit 0; }
-     if curl -s -X POST --max-time 8 http://localhost:{port}/heartbeat >/dev/null 2>&1; then
-       fails=0
-     else
-       fails=$((fails+1))
-       [ "$fails" -ge 4 ] && { echo "PULSER_EXIT reason=SERVER_DEAD"; exit 0; }
-     fi
-     sleep 20
-   done
+   node "$(ls -d ~/.claude/plugins/cache/dotclaude/devops/*/scripts/concept-watch.js 2>/dev/null | head -1)" --mode pulse --port {port} --state "{project-root}/.claude/concept-active.json"
    ```
 
    **(2) Pickup waker — wakes Claude the instant a submission lands.** Its
@@ -281,37 +284,57 @@ AND provides HTTP endpoints for heartbeat and decision exchange.
    the next cron tick. Re-launched after each processing round. It does NOT
    pulse the heartbeat (that is the pulser's job) — it only watches `/pending`:
    ```bash
-   fails=0
-   while true; do
-     [ -f .claude/concept-active.json ] || { echo "WAKER_EXIT reason=STATE_GONE"; exit 0; }
-     grep -q '"port": {port}' .claude/concept-active.json 2>/dev/null || { echo "WAKER_EXIT reason=PORT_CHANGED"; exit 0; }
-     if p=$(curl -s --max-time 8 http://localhost:{port}/pending | python -c "import sys,json;print('yes' if json.load(sys.stdin).get('pending') else 'no')" 2>/dev/null); then
-       fails=0
-       [ "$p" = "yes" ] && { echo "WAKER_EXIT reason=PENDING_SUBMISSION"; exit 0; }
-     else
-       fails=$((fails+1))
-       [ "$fails" -ge 4 ] && { echo "WAKER_EXIT reason=SERVER_DEAD"; exit 0; }
-     fi
-     sleep 20
-   done
+   node "$(ls -d ~/.claude/plugins/cache/dotclaude/devops/*/scripts/concept-watch.js 2>/dev/null | head -1)" --mode watch --port {port} --state "{project-root}/.claude/concept-active.json"
    ```
 
-   Both pulse/poll every ~20 s (well under the 90 s threshold). **Tolerate
-   transient blips:** declare `SERVER_DEAD` only after ≥4 consecutive failures
-   — a single failed `curl` (server busy, a competing request, a
-   duplicate-instance wedge per step 2) must NOT tear a task down, or the page
-   goes stale again on every hiccup. Both self-terminate when the state file
-   is gone, its port changed, or the server is truly unreachable, so neither
-   can become a ghost (the `--html` watchdog still backs them up).
+   **Verify both actually started.** They are the only launches in this document
+   whose failure would be silent — the server has a heartbeat round-trip, the
+   port has a single-listener assert, the page has a 200-gate, and these had
+   nothing. Read each task's output once after launching: a `*_EXIT reason=`
+   line within seconds means it never got going. `STATE_NEVER_APPEARED` in
+   particular means the launch outran step 4 — write the state file, then
+   re-launch.
+
+   **Why a script and not an inline `while true; do … sleep 20; done`.** The
+   loop shape is easy to write and was wrong in four independent ways, each of
+   which silently reproduced the bug the watchers exist to prevent:
+   - it tested a **relative** `.claude/concept-active.json`, but this document
+     mandates the state file at the project root, which is not always the
+     task's cwd — both watchers then exited `STATE_GONE` on iteration 1;
+   - it was launched here, in step 3, **before** step 4 writes that file, so a
+     literal reading killed both at t=0. `--state` is absolute and `--grace`
+     (60 s) waits for the file instead of treating its absence as terminal, so
+     the step 3 → step 4 order is safe as written;
+   - its port guard `grep -qE '"port"…\b'` depended on JSON spacing and on
+     `\b`, a GNU extension — on BSD/macOS grep it never matched, so both
+     watchers exited `PORT_CHANGED` immediately. The script compares the port
+     numerically;
+   - `allowed-tools` matches command *prefixes*, and a multi-line loop has no
+     usable prefix, so the only grant that covered it was a blanket one. A
+     `node …` invocation is already covered by `Bash(node *)`.
+
+   Behaviour is otherwise unchanged: both poll every ~20 s (well under the 90 s
+   threshold), and **tolerate transient blips** — `SERVER_DEAD` only after ≥4
+   consecutive failures, because a single failed request (server busy, a
+   competing request, a duplicate-instance wedge per step 2) must NOT tear a
+   task down, or the page goes stale on every hiccup. Both self-terminate when
+   the state file is gone, its port changed, or the server is truly
+   unreachable, so neither can become a ghost (the `--html` watchdog still
+   backs them up). The exit lines (`PULSER_EXIT reason=…` / `WAKER_EXIT
+   reason=…`) are unchanged, so the reason → action table in SKILL.md Step 5d
+   applies verbatim.
 
    **Lifecycle:** launch BOTH at concept open. On `PENDING_SUBMISSION` the
-   waker exits and wakes Claude; Claude processes the payload, then
-   **re-launches only the waker** for the next round — the pulser is still
-   running and must not be duplicated (a second pulser on the same port is
-   harmless but wasteful; if unsure, the pulser's `STATE_GONE`/`PORT_CHANGED`
-   guards make a stale one exit on its own). Keep the cron too: it is the
-   backup pickup path during the brief window between the waker exiting and
-   being re-launched.
+   waker exits and wakes Claude; Claude processes the payload and
+   **re-launches only the waker** — immediately after `/reset` (SKILL.md 5c
+   step 7), not at the end of the round. The pulser is still running and must
+   not be duplicated (a second pulser on the same port is harmless but
+   wasteful; if unsure, the pulser's `STATE_GONE`/`PORT_CHANGED` guards make a
+   stale one exit on its own). Keep the cron too — but as a **partial** backup
+   only: it fires solely while the REPL is idle, so it cannot cover the window
+   between the waker exiting and being re-launched, because during a
+   processing round the REPL is busy. That window is closed by re-launching
+   early, not by the cron.
 
 4. **Persist active-concept state.** Write `.claude/concept-active.json` in
    the project root with the metadata the SessionStart resume hook

--- a/plugins/devops/skills/concept/deep-knowledge/monitoring.md
+++ b/plugins/devops/skills/concept/deep-knowledge/monitoring.md
@@ -30,7 +30,8 @@ The loop continues until the user is done (closes page or says "fertig").
 
 ### Primary: HTTP Bridge (preferred)
 
-Claude's cron polls the bridge server for the deterministic pending flag:
+The pickup waker polls the bridge server for the deterministic pending flag
+(the backup cron does the same, once a minute):
 
 ```bash
 curl -s http://localhost:$PORT/pending
@@ -41,9 +42,9 @@ curl -s http://localhost:$PORT/pending
 of substring-matching `/decisions`. The `/decisions` JSON response is
 formatted via `json.dumps` which emits `"submitted": true` **with** a space
 after the colon, so a literal `contains "submitted":true` check silently
-misses every real submission. The cron in SKILL.md Step 3 pipes `/pending`
-through `python -c` and only falls back to `/decisions` when pending is
-true, eliminating that class of bug.
+misses every real submission. Both the waker and the backup cron (bridge-server.md § step 3) pipe
+`/pending` through `python -c` and only fall back to `/decisions` once
+pending is true, eliminating that class of bug.
 
 Once pending is true, Claude fetches the full payload:
 
@@ -100,15 +101,19 @@ curl -s http://localhost:$PORT/heartbeat
 If this returns `{"ts": ...}` → bridge is running. If it fails → the server
 didn't start; debug before proceeding.
 
-### 2. Start heartbeat cron
+### 2. Arm the cron and the two background tasks
 
-Set up a recurring heartbeat so the page knows Claude is monitoring:
+**Single source of truth: `bridge-server.md` § step 3.** Do not redefine any of
+them here. That section carries the combined heartbeat **+ auto-poll** cron
+body, and the two detached background tasks — the keepalive pulser and the
+pickup waker — that do the actual work.
 
-```
-CronCreate(cron: "* * * * *", prompt: "Run silently: curl -s -X POST http://localhost:{port}/heartbeat > /dev/null. Output nothing.")
-```
+A heartbeat-only cron is NOT enough and is actively misleading: it advances
+`_claude_ts`, which is the only thing the page's connection indicator gates on,
+so the indicator turns green while nothing is watching for submissions. That
+combination is precisely how a submitted decision goes unnoticed.
 
-Also send the first heartbeat immediately:
+Send the first heartbeat immediately and verify it round-trips:
 
 ```bash
 curl -s -X POST http://localhost:$PORT/heartbeat
@@ -122,7 +127,8 @@ Store the cron job ID as `$HEARTBEAT_CRON_ID` for cleanup.
 ```bash
 curl -s -X POST http://localhost:$PORT/heartbeat
 ```
-Sent by the cron job every ~60s, and additionally on each manual poll cycle.
+Sent by the keepalive pulser every ~20s — the cron every ~60s is only a
+backup, and fires solely while the REPL is idle.
 
 The bridge server self-pulses `_server_ts` (NOT the heartbeat) every 30s
 from a daemon thread. That proves the *server process* is alive — it does
@@ -139,13 +145,20 @@ keepalive — it pulses every ~20s for the whole session and, crucially, does
 NOT exit when a submission is pending, so `claude_ts` stays warm even during
 a long `implement`.
 
-**Check submission** (poll for user decisions):
+**Check submission** — poll `/pending`, never `/decisions`:
 ```bash
-curl -s http://localhost:$PORT/decisions
+curl -s http://localhost:$PORT/pending
 ```
-Returns JSON. Check the `submitted` field:
-- `true` → user has submitted, read the decisions from the same response
-- `false` → not yet submitted, wait and retry
+Returns a strict `{"pending": true|false, "version": N}`.
+- `true` → fetch the full payload from `GET /decisions` and process it
+- `false` → not yet submitted, keep watching
+
+`/pending` is the **only** endpoint that acks a pickup — it stamps
+`_picked_up_at`, which is what advances the "Claude verarbeitet" step in the
+submitted panel. Polling `/decisions` returns the same data but acks nothing,
+so the user sees a progress list frozen at step 1 even though Claude is
+working. A `submitted: true` alongside an empty `_picked_up_at` is therefore
+proof that no `/pending` call ever ran while that submission was current.
 
 **Read decisions** — they're in the same JSON response from `GET /decisions`:
 ```json
@@ -218,28 +231,58 @@ console.log(document.getElementById('concept-decisions').textContent)
 ## Polling Strategy
 
 ### Timing
+
+Three tiers, and only one of them is primary:
+
 - **Initial wait**: 10 seconds after opening (give the page time to load and
-  the user time to orient)
-- **Poll interval**: 15 seconds
+  the user time to orient), then one manual heartbeat + `/pending` check.
+- **Pickup waker — 20 s, primary.** The detached background task from
+  `bridge-server.md` § step 3, task 2. 20 s is not arbitrary: it sits well
+  under the 90 s `HEARTBEAT_STALE_MS` the page uses to decide the indicator.
+- **Cron — 60 s, backup only, and only a partial one.** Session-only crons fire
+  only while the REPL is idle, so it cannot cover the window it looks like it
+  covers: during a processing round the REPL is busy. Re-launch the waker at
+  SKILL.md 5c step 7 instead of leaving that gap to the cron.
 - **Timeout**: NONE — monitoring runs indefinitely until the user explicitly
-  ends it (says "fertig"/"done", closes the page, or closes Claude). The
-  heartbeat cron keeps the connection alive. Never impose artificial timeouts.
+  ends it (says "fertig"/"done", closes the page, or closes Claude). Never
+  impose artificial timeouts.
 
 ### Non-Blocking Behavior
 
-Monitoring MUST NOT block the conversation:
+Monitoring must not block the conversation — and must not depend on one
+either. **The bridge page IS the submission channel.** A user who clicks
+"Entscheidungen abschicken" has no reason to also type "fertig" in chat, and
+expects Claude to react to the click itself.
 
-1. After opening the page, inform the user and **wait for their next message**
-2. If the user sends a message → respond normally, then resume monitoring
-3. If the user says "fertig" / "done" / "abgeschickt" → immediately read decisions
-4. If the user asks for something unrelated → pause monitoring, handle request
+1. After opening the page, confirm that the **pickup waker is running** (Step 3,
+   task 2). It watches `/pending` detached and exits the instant a submission
+   lands, which wakes Claude with no user message involved. This is step 1 —
+   not "wait for their next message".
+2. Re-launch the waker after **every** processing round (SKILL.md Step 5d). It
+   exited to wake you; until it is restarted, nothing is watching.
+3. If the user sends a message → respond normally. The waker keeps running; it
+   is a separate process, not a turn.
+4. If the user says "fertig" / "done" / "abgeschickt" → read decisions
+   immediately rather than waiting for the next waker cycle. This is a
+   shortcut, never the trigger.
+
+Ending the turn with nothing watching is the failure this section exists to
+prevent: the pulser keeps the indicator green, so the page looks connected
+while the submission sits unread.
+
+**Do not poll in the foreground.** A `sleep` loop inside a normal Bash call
+blocks the turn and the conversation with it. The pulser and the waker are the
+sanctioned form: the same loop, launched **detached** with
+`run_in_background: true`, so it watches without occupying a turn. See
+`bridge-server.md` § step 3 for both bodies.
 
 ### Per-Poll Validation
 
 On each poll cycle:
 
 1. **Send heartbeat**: `curl -s -X POST http://localhost:$PORT/heartbeat`
-2. **Check decisions**: `curl -s http://localhost:$PORT/decisions`
+2. **Check pending**: `curl -s http://localhost:$PORT/pending` — then fetch
+   `/decisions` only once `pending` is `true`
 3. If curl fails → bridge server may have crashed → attempt restart
 
 **Tab-alive check** (via HTTP):
@@ -252,30 +295,25 @@ On each poll cycle:
 
 A page reload (F5) is **not a problem** with the HTTP bridge:
 - The bridge server keeps running independently of the page
-- Heartbeat cron keeps posting → page reconnects automatically after reload
+- The keepalive pulser keeps posting → page reconnects automatically after reload
 - `localStorage` preserves user selections (see `templates.md` § State Persistence)
 - The `concept-submitted` class resets (correct — user can re-submit)
 - Decisions in the bridge server persist across reloads
 
 **No special recovery needed** — the HTTP bridge makes page reloads transparent.
 
-**Do NOT use sleep loops.** Instead, check the page state:
-- When the user sends a message that could indicate completion
-- When the user explicitly says they're done
-- Periodically if the conversation is idle (via cron or tool-based check)
-
 ### No Timeout Policy
 
 There is **no timeout**. The user decides when to submit — whether that takes
-2 minutes or 2 hours. Claude keeps the heartbeat cron alive and responds
-whenever the user submits or sends a chat message.
+2 minutes or 2 hours. The pulser and the waker keep running, so Claude
+responds to the submission itself — no chat message required.
 
 The monitoring loop ends ONLY when:
 - The user says "fertig" / "done" / "abbrechen" in chat
 - The user closes the browser tab (detected when bridge server stays alive
   but no submissions arrive and the user confirms in chat)
 - The user closes Claude Desktop
-- The heartbeat cron expires after 7 days (platform limit, effectively infinite)
+- The backup cron expires after 7 days (platform limit, effectively infinite)
 
 ## Decision Processing
 
@@ -398,8 +436,9 @@ Each round appends to the same file (array of rounds), preserving full history:
 | Error | Symptom | Recovery |
 |-------|---------|----------|
 | Bridge server not responding | `curl /heartbeat` fails or times out | Check if server process is alive, restart if needed |
-| Bridge server crashed | Connection refused on all endpoints | Re-run `python concept-server.py $PORT "$DIR" &` |
-| Heartbeat cron stopped | Page shows "nicht verbunden" despite server running | Send manual `curl -s -X POST /heartbeat`, re-create cron |
+| Bridge server crashed | Connection refused on all endpoints | Relaunch per `bridge-server.md` § step 2 — same port, `run_in_background: true`, `--html` set. Never the `&` form: a child backgrounded inside one Bash call is reaped when that call ends. Then re-launch both watchers |
+| Keepalive pulser stopped (`PULSER_EXIT`) | Page shows "nicht verbunden" despite server running | Send a manual `curl -s -X POST /heartbeat`, then re-launch the pulser (bridge-server.md § step 3, task 1) |
+| Pickup waker stopped without a submission (`WAKER_EXIT reason=SERVER_DEAD`) | Submissions go unnoticed while the indicator may still be green | Restart the bridge server ON THE SAME PORT (a new one orphans the state file, the open tab, and makes fresh watchers exit PORT_CHANGED), then re-launch BOTH background tasks |
 | Decisions JSON parse error | `curl /decisions` returns malformed JSON | Show raw content to user, ask to verify |
 | Empty decisions array | Parsed but `decisions.length === 0` | Ask if intentional (all defaults accepted) |
 | Tab closed by user | Bridge server alive but no activity | Ask user via AskUserQuestion when they send a chat message |
@@ -410,7 +449,11 @@ Each round appends to the same file (array of rounds), preserving full history:
 
 ### Retry Protocol
 
-1. **Bridge server failure**: Restart the server, re-create heartbeat cron
+1. **Bridge server failure**: restart the server on the SAME port, re-arm the
+   backup cron, and re-launch BOTH background tasks (pulser + waker). A new
+   port orphans the state file and the user's open tab; restarting the server
+   alone leaves nothing watching `/pending`, so the page goes green again while
+   submissions rot.
 2. **Browser tool failure** (for page updates): Inform user, continue monitoring via HTTP
 3. **Both fail**: Manual fallback (AskUserQuestion + console.log)
 4. **NEVER silently stop monitoring** — always inform the user why monitoring ended

--- a/plugins/devops/skills/concept/deep-knowledge/templates.md
+++ b/plugins/devops/skills/concept/deep-knowledge/templates.md
@@ -223,7 +223,7 @@ the `[ui-locale: ...]` hint produced.
                               OR bootstrap (claude_ts==0 while server_ts fresh).
                               Pulsing accent dot + animated ellipsis.
                connected    — claude_ts fresh. Steady green dot.
-               disconnected — claude_ts stale (dead cron) OR server_ts stale /
+               disconnected — claude_ts stale (nothing pulsing) OR server_ts stale /
                               fetch failing (bridge down). Pulsing amber dot.
              It NEVER overlays or disables the submit buttons and has NO
              acknowledge button. A disconnected submit is cached and
@@ -3886,7 +3886,7 @@ list tracks:
 | Step | Trigger | Visible? |
 |---|---|---|
 | 1 · Übermittelt | The user just clicked submit (POST /decisions succeeded) | Always |
-| 2 · Claude verarbeitet | First `/pending=true` response on the server (Claude's cron picked up the submission) — surfaces via `_picked_up_at` in `/decisions` | Always |
+| 2 · Claude verarbeitet | First `/pending=true` response on the server (the pickup waker, or the backup cron, picked up the submission) — surfaces via `_picked_up_at` in `/decisions` | Always |
 | 3 · Implementierung abgeschlossen | Claude POSTs `/status {phase: "implemented"}` after the implement branch finishes — surfaces via `_phase === "implemented"` in `/decisions` | Only for `action: "implement"` submissions |
 
 The browser only writes step state in `submitWithAction` (reset to baseline)
@@ -3992,7 +3992,7 @@ self-pulse refreshed every 30s, so the page showed "Claude verbunden"
 indefinitely no matter what Claude was actually doing.
 
 ```javascript
-const HEARTBEAT_STALE_MS = 90000;  // claude_ts older than this → dead cron
+const HEARTBEAT_STALE_MS = 90000;  // claude_ts older than this → nothing is pulsing
 const SERVER_STALE_MS    = 90000;  // server_ts older than this → bridge process down
 // HEARTBEAT_GRACE_MS / _pageLoadedAt removed — the bootstrap window is now
 // keyed on claude_ts==0 && fresh server_ts (mirrors the concept-server
@@ -4089,7 +4089,7 @@ function checkClaudeConnection() {
   const now = Date.now();
 
   // Connected: Claude has pinged AND that ping is recent. (gate unchanged —
-  // never gates on server_ts, or a dead cron would read green forever.)
+  // never gates on server_ts, or a dead pulser would read green forever.)
   const isConnected = _lastHeartbeatTs && (now - _lastHeartbeatTs) < HEARTBEAT_STALE_MS;
 
   // Server liveness via the daemon self-pulse. Mirrors the concept-server
@@ -4103,7 +4103,7 @@ function checkClaudeConnection() {
   //       ~1 network RTT after load). Calling this disconnected IS the
   //       fresh-page connect→disconnect→connect flash; it is "connecting".
   //   (b) claude_ts==0 while server_ts is fresh — Claude has never pinged but
-  //       the bridge is alive; the first cron tick (<=60s) or the setup-time
+  //       the bridge is alive; the pickup waker (~20s), the backup cron tick (<=60s), or the setup-time
   //       POST flips us to connected.
   const bootstrapping = !_everPolled || ((_lastHeartbeatTs === 0) && serverAlive);
 

--- a/plugins/devops/skills/concept/monitoring-contract.test.js
+++ b/plugins/devops/skills/concept/monitoring-contract.test.js
@@ -1,0 +1,191 @@
+import { describe, test, expect } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Issue #276: the concept skill dropped a bridge submission whenever the user
+// clicked "submit" and then typed nothing. The cause was documentation, not
+// code — monitoring.md told Claude to "wait for their next message" while its
+// own Polling Strategy claimed an indefinite autonomous poll, and SKILL.md
+// never once mentioned the background task that actually does the polling.
+//
+// Nothing enforces prose, so these tests pin the load-bearing sentences the way
+// templates-reference.test.js pins the template's script blocks: a future edit
+// that reintroduces the drift fails the suite instead of shipping silently.
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const read = f => fs.readFileSync(path.join(__dirname, f), "utf8");
+
+const SKILL = read("SKILL.md");
+const MONITORING = read("deep-knowledge/monitoring.md");
+const BRIDGE = read("deep-knowledge/bridge-server.md");
+
+describe("bridge-server.md stays the single source of truth", () => {
+  test("it still defines both background tasks", () => {
+    expect(BRIDGE).toContain("Keepalive pulser");
+    expect(BRIDGE).toContain("Pickup waker");
+    expect(BRIDGE).toContain("concept-watch.js");
+  });
+
+  test("the exit vocabulary lives in the script the doc points at", () => {
+    // The reason strings used to be inline in the doc's shell loop. They are
+    // emitted by concept-watch.js now — that is the source of truth for them,
+    // and SKILL.md Step 5d's action table keys off the same words.
+    const script = fs.readFileSync(
+      path.join(__dirname, "..", "..", "scripts", "concept-watch.js"),
+      "utf8"
+    );
+    expect(script).toContain("PULSER");
+    expect(script).toContain("WAKER");
+    for (const reason of ["PENDING_SUBMISSION", "SERVER_DEAD", "STATE_GONE", "PORT_CHANGED"]) {
+      expect(script, reason).toContain(reason);
+      expect(BRIDGE, reason).toContain(reason);
+    }
+  });
+
+  test("monitoring.md points at it instead of redefining the cron", () => {
+    expect(MONITORING).toContain("bridge-server.md");
+    // The heartbeat-ONLY cron is what made the indicator green while nothing
+    // watched for submissions. It must not come back.
+    expect(MONITORING).not.toContain(
+      'CronCreate(cron: "* * * * *", prompt: "Run silently: curl -s -X POST http://localhost:{port}/heartbeat'
+    );
+  });
+});
+
+describe("monitoring.md — the idle default is autonomous polling", () => {
+  test("step 1 is not 'wait for their next message'", () => {
+    expect(MONITORING).not.toMatch(/1\.\s*After opening the page, inform the user and \*\*wait for their next message\*\*/);
+  });
+
+  test("it states that the page IS the submission channel", () => {
+    expect(MONITORING).toMatch(/bridge page IS the submission channel/i);
+  });
+
+  test("the waker is named as what keeps watching", () => {
+    expect(MONITORING).toMatch(/pickup waker/i);
+  });
+
+  test("a user chat message is a shortcut, never the trigger", () => {
+    expect(MONITORING).toMatch(/shortcut, never the trigger/i);
+  });
+
+  test("sleep loops are forbidden only in the FOREGROUND", () => {
+    // The old blanket "Do NOT use sleep loops" contradicted bridge-server.md,
+    // which mandates exactly that loop — detached.
+    expect(MONITORING).not.toMatch(/\*\*Do NOT use sleep loops\.\*\*/);
+    expect(MONITORING).toMatch(/Do not poll in the foreground/i);
+  });
+});
+
+describe("one interval, stated once", () => {
+  test("monitoring.md no longer advertises a 15s poll no code path implements", () => {
+    expect(MONITORING).not.toMatch(/\*\*Poll interval\*\*:\s*15 seconds/);
+  });
+
+  test("it names 20s primary and 60s backup", () => {
+    // Anchored deliberately: a `.*` across newlines would pass on almost any
+    // text and pin nothing.
+    expect(MONITORING).toMatch(/20 s, primary/);
+    expect(MONITORING).toMatch(/60 s, backup only/);
+  });
+
+  test("the documented interval matches the loops in bridge-server.md", () => {
+    expect(BRIDGE).toContain("sleep 20");
+  });
+});
+
+describe("pickup acks via /pending, never /decisions", () => {
+  test("monitoring.md polls /pending", () => {
+    expect(MONITORING).toMatch(/curl -s http:\/\/localhost:\$PORT\/pending/);
+  });
+
+  test("monitoring.md explains that /decisions acks nothing", () => {
+    expect(MONITORING).toMatch(/_picked_up_at/);
+    expect(MONITORING).toMatch(/only.*endpoint that acks/i);
+  });
+
+  test("SKILL.md Step 4 polls /pending too", () => {
+    expect(SKILL).toMatch(/curl -s http:\/\/localhost:\$PORT\/pending/);
+  });
+});
+
+describe("SKILL.md wires the tasks into the step list", () => {
+  test("Step 3 launches both background tasks", () => {
+    expect(SKILL).toContain("Keepalive pulser");
+    expect(SKILL).toContain("Pickup waker");
+    expect(SKILL).toMatch(/run_in_background: true/);
+  });
+
+  test("Step 5d re-launches the waker — the gap that broke iteration 2", () => {
+    expect(SKILL).toMatch(/Re-launch the pickup waker/);
+  });
+
+  test("the re-launch happens at 5c step 7, not after the whole round", () => {
+    // The unwatched window spans the entire processing round, which for an
+    // `implement` is minutes — and the cron cannot cover it, because it fires
+    // only while the REPL is idle and the REPL is busy processing.
+    expect(SKILL).toMatch(/\*\*Immediately re-launch the pickup waker\*\*/);
+    expect(SKILL).toMatch(/5c step 7/);
+  });
+
+  test("the pulser is only re-launched when it actually exited", () => {
+    // It does exit — on SERVER_DEAD and PORT_CHANGED. Claiming otherwise
+    // hard-codes a false invariant.
+    expect(SKILL).not.toMatch(/it never exited/);
+    expect(SKILL).toMatch(/Re-launch the pulser only when you actually saw a `PULSER_EXIT`/);
+  });
+
+  test("every background-task exit reason has a documented response", () => {
+    for (const reason of ["PENDING_SUBMISSION", "SERVER_DEAD", "STATE_GONE", "PORT_CHANGED"]) {
+      expect(SKILL, reason).toContain(reason);
+    }
+    expect(SKILL).toMatch(/re-launch \*\*both\*\* tasks/i);
+  });
+
+  test("Step 4 no longer calls the cron the primary mechanism", () => {
+    expect(SKILL).not.toMatch(/\*\*Primary mechanism\*\*: the combined cron/);
+    expect(SKILL).toMatch(/\*\*Primary mechanism\*\*: the \*\*pickup waker\*\*/);
+  });
+
+  test("allowed-tools grants the watchers honestly, with no fake-narrow prefix", () => {
+    const frontmatter = SKILL.slice(0, SKILL.indexOf("\n---", 4));
+    // The watchers are `node …` invocations, so the existing grant covers them.
+    // `Bash(fails=0*)` would have granted ANY command starting with `fails=0`
+    // — a blanket grant dressed up as a narrow one.
+    expect(frontmatter).toContain("Bash(node *)");
+    expect(frontmatter).not.toContain("fails=0");
+  });
+
+  test("the state path is passed absolute", () => {
+    expect(SKILL).toMatch(/\*\*absolute\*\* path via `--state`/);
+  });
+
+  test("a wake is re-confirmed before it is acted on", () => {
+    // Two wakers both exit PENDING_SUBMISSION; the second wake arrives after
+    // /reset cleared the flag, and acting on it re-runs `implement`.
+    expect(SKILL).toMatch(/Before processing a wake, re-confirm/);
+    expect(SKILL).not.toMatch(/Re-launching twice is harmless/);
+  });
+
+  test("SERVER_DEAD recovery reuses the port instead of picking a new one", () => {
+    expect(SKILL).toMatch(/Restart the bridge server \*\*on the same port\*\*/);
+  });
+
+  test("the final-report branch reaches the re-launch too", () => {
+    // It is the longest round and the one most exposed by an unwatched window.
+    expect(SKILL).toMatch(/as steps 5–7 above/);
+  });
+});
+
+describe("monitoring.md's recovery matches the launch contract", () => {
+  test("it no longer prescribes the forbidden `&` restart", () => {
+    // bridge-server.md is explicit that a child backgrounded inside one Bash
+    // call is reaped when that call ends.
+    expect(MONITORING).not.toMatch(/python concept-server\.py \$PORT "\$DIR" &/);
+    expect(MONITORING).toMatch(/Never the `&` form/);
+  });
+
+  test("recovery re-launches the watchers, not just the server", () => {
+    expect(MONITORING).toMatch(/re-launch both watchers/i);
+  });
+});

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.126.2",
+  "version": "0.126.3",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
Closes #276

## Summary

A decision submitted on the concept page went unnoticed whenever the user clicked "submit" and then typed nothing. `GET /decisions` showed `submitted: true` with an empty `_picked_up_at` — proof that no `GET /pending` ever ran, since that is the only endpoint which acks a pickup. The heartbeat cron kept the page's connection indicator green, so the flow looked alive while nothing was watching.

## Two corrections to the issue

- **`GET /status` does not exist.** The payload in the report is `GET /decisions`. An implementer following the issue literally would have added an endpoint that exists under another name.
- **The proposed `ScheduleWakeup` loop was rejected.** Zero usage anywhere in this repo, not in the skill's `allowed-tools`, and a 60s minimum against a documented 15s — strictly worse than the 20s pickup waker `bridge-server.md` already specified. Also rejected: making `/decisions` stamp `_picked_up_at`; it does not fix the bug and destroys the guarantee that the field means *Claude* pickup, since the page polls `/decisions` itself every 5s.

## The actual defect was wiring, not capability

The waker existed, fully specified. `grep -n "waker" SKILL.md` returned nothing. Step 4 called the once-a-minute cron the "primary mechanism" — it fires only while the REPL is idle (observed: a 638s gap) — and Step 5d never re-launched the waker after a round, which is why the report came from iteration 2.

## Changes

- **New `scripts/concept-watch.js`**, one implementation in two modes, replacing a shell loop duplicated across two files and wrong in four independent ways: a *relative* state path tested against a cwd the docs say may differ; a launch ordered one step *before* the file it requires; a port guard using `\b`, a GNU extension that silently never matches on BSD/macOS grep; and no honest `allowed-tools` prefix for a multi-line loop. Absolute `--state`, a 60s grace, numeric port comparison, and a `node …` invocation the existing grant covers.
- **SKILL.md** launches both watchers in Step 3, polls `/pending`, demotes the cron to a partial backup, re-launches the waker at 5c step 7 (immediately after `/reset` — the cron cannot cover that window, because it is open precisely while the REPL is busy), and gains a reason→action table for every way a watcher can exit.
- **monitoring.md** starts from "the waker is running" instead of "wait for their next message", states one interval instead of three, and stops prescribing a restart form `bridge-server.md` forbids.
- **`ss.concept.resume.js`** re-arms the pulser and waker after a restart, not just the cron — background tasks are session-scoped exactly like crons. Refactored into exported builders so it is testable at all; it had none.
- A wake is re-confirmed before it is acted on, and `_version` compared against the last processed one, so a duplicate wake cannot run an `implement` round twice.

Also fixed, found by the new byte-for-byte pin: the resume hook emitted `print(\'true\' …)` in its cron body — a Python `SyntaxError`, so every resumed session's backup pickup path was dead on arrival.

## Verification

- `npm test` — 1516 green (105 new)
- `npm run lint` — clean
- The load-bearing assumption ("a detached task's exit re-invokes Claude") was verified empirically, not argued: a background task that slept 25s and exited delivered a notification that started a turn.

## Review

Three adversarial passes, all returning `rework`. Beyond the four loop defects above, they caught a claim that re-launching twice is harmless (two wakers mean an `implement` round can write code twice) and — on the final pass — that my own launch snippet resolved the script through a shell variable across two separate tool calls, which the same document states cannot work. It would have died in under 100ms, silently. The Codex gate could not run: usage limit exhausted (`rc=1`), confirmed twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)