### PR TITLE
fix(graphify): deterministic sentinel tests, atomic sentinel write

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.126.3"
+    "version": "0.126.4"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.126.3",
+      "version": "0.126.4",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.126.3",
+      "version": "0.126.4",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.126.4] — 2026-08-15
+
+### Fixed
+
+- **Two background-build tests no longer pass or fail depending on what else the machine happens to be doing.** They failed in a full suite run and passed when run alone, which reads as a timing problem and is not one. `bgWithSentinel` refuses to start a `graphify update` once two builds are already live anywhere on the machine, and it counts them by scanning lock files in the shared temp directory. The two tests asserting that it *does* start one were the only ones of their kind without an isolated lock directory, so a real graphify build in another worktree — or a leftover lock from a runner killed before it cleaned up, which Windows can resurrect by recycling the PID — pushed the count to the cap and turned the expected spawn into a skip. The two neighbouring test blocks already isolated their lock directory for exactly this reason; these now do too, and the block that writes live-PID locks was isolated as well, so the suite stops seeding that contamination into the shared pool for later runs. What the tests actually assert is unchanged.
+
+- **A finished background build is no longer reported as an unknown outcome.** The runner recorded its ok/fail result by truncating the file and then writing it, so anything reading in the gap between the two — including the next session start, the surface whose whole job is to reveal a build that failed silently — saw an empty file and reported "unknown" instead of the real result. The result is now staged beside the target and renamed into place, which is atomic on both Windows and POSIX.
+
 ## [0.126.3] — 2026-08-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.126.3**
+**Version: 0.126.4**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.126.3",
+  "version": "0.126.4",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/hooks/lib/graphify-state.js
+++ b/plugins/devops/hooks/lib/graphify-state.js
@@ -1,7 +1,7 @@
 'use strict';
 /**
  * @lib graphify-state
- * @version 0.7.0
+ * @version 0.7.1
  * @plugin devops
  * @description Consent + session-state helpers for the graphify enforcement
  *   layer (auto-graph). Default-on / opt-out model: graphify enforcement is
@@ -601,7 +601,21 @@ if (require.main === module && process.argv[2] === BG_RUN_FLAG) {
   const runArgs = process.argv.slice(7);
   const writeSentinel = (text) => {
     if (sentinelArg === NO_SENTINEL) return;
-    try { fs.writeFileSync(sentinelArg, text); } catch { /* tmp unwritable — nothing to surface to */ }
+    // Publish ATOMICALLY: writeFileSync opens with O_TRUNC, so a concurrent
+    // reader landing between the truncate and the write sees a zero-byte file
+    // and readSentinel parses '' as {status:'unknown'} — a real outcome silently
+    // downgraded to garbage. Stage beside the target, then rename; both paths sit
+    // in the same directory, so the rename is atomic on POSIX and on win32
+    // (MoveFileEx + MOVEFILE_REPLACE_EXISTING). Matters for every poller: the
+    // SessionStart surface in ss.graphify.js as much as the tests.
+    const stage = `${sentinelArg}.${process.pid}.tmp`;
+    try {
+      fs.writeFileSync(stage, text);
+      fs.renameSync(stage, sentinelArg);
+    } catch {
+      // tmp unwritable — nothing to surface to; never leave the stage file behind
+      try { fs.unlinkSync(stage); } catch { /* nothing staged */ }
+    }
   };
   const clearLock = () => {
     if (lockArg === NO_SENTINEL) return;

--- a/plugins/devops/hooks/lib/graphify-state.test.js
+++ b/plugins/devops/hooks/lib/graphify-state.test.js
@@ -314,24 +314,64 @@ describe("background-build sentinel — read/clear", () => {
 // sentinel from Node's `exit` event, so both ok and non-zero exits are reported
 // on every platform. Detached spawn → poll.
 describe("background-build sentinel — bgWithSentinel end-to-end", () => {
-  const waitForSentinel = async (cwd, timeoutMs = 5000) => {
+  // Poll for the sentinel on a generous budget with a short interval — never a
+  // fixed wait. A healthy run settles in well under a second and returns
+  // immediately; a full-suite run (56 files, many parallel workers) starves the
+  // detached runner's node boot + child spawn far more than an isolated run
+  // does, and a tight budget turns that starvation into a false failure.
+  const SETTLE_MS = 30000;
+  const POLL_MS = 25;
+  const waitForSentinel = async (cwd, timeoutMs = SETTLE_MS) => {
     const start = Date.now();
     for (;;) {
       const s = readSentinel(cwd);
       if (s !== null) return s;
       if (Date.now() - start > timeoutMs) return null;
-      await new Promise((r) => setTimeout(r, 100));
+      await new Promise((r) => setTimeout(r, POLL_MS));
     }
   };
+  const waitForGone = async (p, timeoutMs = 10000) => {
+    const start = Date.now();
+    while (fs.existsSync(p)) {
+      if (Date.now() - start > timeoutMs) return false;
+      await new Promise((r) => setTimeout(r, POLL_MS));
+    }
+    return true;
+  };
+
+  // Isolate the lock dir — the actual cause of this pair going flaky. Both tests
+  // assert that bgWithSentinel SPAWNS, but its machine-wide cap counts every live
+  // `dotclaude-graphupdate-*.lock` in the SHARED os.tmpdir(): real graphify builds
+  // on the machine, other worktrees, and leftovers from a runner killed before it
+  // cleared its own lock (win32 recycles PIDs, so a stale lock can read as live).
+  // With the default cap of 2, two such foreign locks flip the expected spawn into
+  // a skip and bgWithSentinel returns false — reproduced exactly, as this pair
+  // failing under a loaded full-suite run and passing in isolation. An isolated
+  // lock dir makes the count start at 0 every test, so the spawn precondition no
+  // longer depends on machine state. Same isolation the two describes below use.
+  let origLockDir, isoDir;
+  beforeEach(() => {
+    origLockDir = process.env.DOTCLAUDE_GRAPHLOCK_DIR;
+    isoDir = fs.mkdtempSync(path.join(os.tmpdir(), "gstate-e2e-lockiso-"));
+    process.env.DOTCLAUDE_GRAPHLOCK_DIR = isoDir;
+  });
+  afterEach(() => {
+    try { fs.rmSync(isoDir, { recursive: true, force: true }); } catch {}
+    if (origLockDir === undefined) delete process.env.DOTCLAUDE_GRAPHLOCK_DIR;
+    else process.env.DOTCLAUDE_GRAPHLOCK_DIR = origLockDir;
+  });
 
   test("successful command → 'ok' sentinel", async () => {
     const dir = tmp();
     const okCmd = process.platform === "win32" ? "ver" : "true";
     expect(bgWithSentinel(okCmd, [], dir)).toBe(true);
     expect(await waitForSentinel(dir)).toEqual({ status: "ok" });
+    // Let the runner release its lock before teardown removes the iso dir, so
+    // this test never leaves a live-PID lock behind for a later run to trip on.
+    await waitForGone(updateLockPath(dir));
     clearSentinel(dir);
     try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
-  }, 10000);
+  }, 45000);
 
   test("failing command → parseable 'fail' sentinel (not 'unknown')", async () => {
     const dir = tmp();
@@ -341,9 +381,10 @@ describe("background-build sentinel — bgWithSentinel end-to-end", () => {
     const s = await waitForSentinel(dir);
     expect(s).not.toBeNull();
     expect(s.status).toBe("fail"); // the regression this guards against
+    await waitForGone(updateLockPath(dir));
     clearSentinel(dir);
     try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
-  }, 10000);
+  }, 45000);
 });
 
 // Direct-call tests for the runner's child-spawn logic — the shell-less default
@@ -399,10 +440,24 @@ describe("runBgEntrypointChild — shell-less default + shim fallback", () => {
 // as often, runs stacked without bound (measured: 12 concurrent, ~29 GB commit).
 // bgWithSentinel now takes a PID lock so at most ONE build runs per project.
 describe("updateInFlight / updateLockPath — graphify-update concurrency mutex", () => {
-  let dir;
-  beforeEach(() => { dir = tmp(); });
+  // Isolate the lock dir here too. These tests write locks holding a LIVE pid
+  // (this very process), and unisolated they land in the shared os.tmpdir() —
+  // the same pool bgWithSentinel's machine-wide cap counts. An interrupted run
+  // leaks one, and win32 PID reuse can later make it read as live, so the suite
+  // would seed exactly the foreign-lock contamination that made the end-to-end
+  // pair flaky. Keep this file's locks out of the shared pool.
+  let dir, origLockDir, isoDir;
+  beforeEach(() => {
+    origLockDir = process.env.DOTCLAUDE_GRAPHLOCK_DIR;
+    isoDir = fs.mkdtempSync(path.join(os.tmpdir(), "gstate-mutex-lockiso-"));
+    process.env.DOTCLAUDE_GRAPHLOCK_DIR = isoDir;
+    dir = tmp();
+  });
   afterEach(() => {
     clearUpdateLock(dir);
+    try { fs.rmSync(isoDir, { recursive: true, force: true }); } catch {}
+    if (origLockDir === undefined) delete process.env.DOTCLAUDE_GRAPHLOCK_DIR;
+    else process.env.DOTCLAUDE_GRAPHLOCK_DIR = origLockDir;
     try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
   });
 

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.126.3",
+  "version": "0.126.4",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

Two `bgWithSentinel` end-to-end tests in `plugins/devops/hooks/lib/graphify-state.test.js` failed during a full `npm test` run and passed when the file ran in isolation. The reported hypothesis was a fixed sleep or a too-short poll budget. It was neither — both tests failed at `expect(bgWithSentinel(...)).toBe(true)`, before the sentinel wait ever ran.

## Root cause

`bgWithSentinel` enforces a machine-wide cap: it skips the spawn when `globalUpdatesInFlight() >= 2`, and that counts every live `dotclaude-graphupdate-*.lock` in the **shared** `os.tmpdir()`. The end-to-end describe was the only `bgWithSentinel` block in the file without `DOTCLAUDE_GRAPHLOCK_DIR` isolation — the two blocks below it already have it, with a comment naming this exact risk. Two foreign locks reach the cap, `bgWithSentinel` returns `false`, and the spawn never issues.

Foreign locks come from a real `graphify update` on the machine, another worktree, or a runner killed before clearing its own lock — win32 recycles PIDs, so a dead lock can later read as live.

Measured on the machine that reported the flake: `globalUpdatesInFlight()` already stood at **1** of the cap of **2**, from a leftover lock belonging to no current checkout. One lock away from breaking.

## Changes

- isolate `DOTCLAUDE_GRAPHLOCK_DIR` per test in the end-to-end describe, so the count starts at 0 and the spawn precondition no longer depends on machine state
- isolate the concurrency-mutex describe too, so the suite stops seeding live-PID locks into the shared tmpdir for later runs to trip on
- publish the sentinel atomically (stage + rename). `writeFileSync` opens with `O_TRUNC`, so a reader landing in the gap sees a zero-byte file and `readSentinel` parses `''` as `{status:'unknown'}` — the exact regression the second test guards against, and a real hazard for the SessionStart reader in `ss.graphify.js`
- poll at 25ms over a 30s budget instead of 100ms/5s, so a runner starved under full-suite load is not a false failure

## Assertions unchanged

`toEqual({ status: 'ok' })` and `expect(s.status).toBe('fail')` are untouched — only the spawn precondition and the wait budget changed. A genuinely garbage sentinel still surfaces as `unknown` and still fails the test.

## Verification

- deterministic reproduction: with two seeded live foreign locks, exactly the two named tests failed; after the fix they pass at `globalUpdatesInFlight() = 6`, three times the cap
- full suite 6x consecutively green, including one run under seeded lock contamination
- `ship_build` on the rebased tree: lint clean, 63 files / 1516 tests passed

## Note

The Codex review gate returned a usage-limit error (rc=1, not a timeout) and was skipped per the skill's documented failure-tolerance rule.