### PR TITLE
feat(concept): durable bridge submissions + image attachments

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.126.4"
+    "version": "0.127.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.126.4",
+      "version": "0.127.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.126.4",
+      "version": "0.127.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ node_modules/
 .claude/.ship-in-progress
 .claude/.ship-watcher/
 .claude/concept-active.json
+# Durable concept-bridge stores: submissions, progress journals and pasted
+# screenshots. Never committed — disposed of by /concept Step 6a.
+.claude/concepts/
 .claude/session-opened-files.json
 # Plugin-managed runtime dirs
 .claude/.plugin-version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [0.127.0] — 2026-08-16
+
+### Added
+
+- **Concept comments take images — paste, drop, or click the paperclip.** A screenshot is usually the fastest way to say what is wrong with a concept, and describing it in prose instead is work nobody should have to do twice. Every comment field now accepts `Ctrl`/`Cmd`+`V`, drag & drop, and a 📎 button. The image uploads the moment it is attached rather than when the form is submitted, so it is on disk seconds after being pasted — long before the decision to submit is made, and therefore outside the window where anything could be lost. A comment consisting of nothing but an image now counts as a comment; it used to be dropped for having no text. Images are content-addressed, so pasting the same one twice costs nothing and a retry can never duplicate it. Only real image formats are accepted, and a thumbnail marked with ⟳ means that one is still only on this machine.
+
+### Fixed
+
+- **A concept submission can no longer be lost, whatever happens to Claude or the machine.** Submissions lived in the bridge server's memory and nowhere else, so anything that ended that process took the user's work with it — and said nothing. Afterwards the bridge reported "nothing pending", which is indistinguishable from never having submitted, so the user waited for an iteration that was never coming and eventually had to redo the whole round. Three routes led there: restarting the PC, a crash, and — the common one — Claude hitting its usage limit, because the heartbeat that keeps the bridge alive dies with the turn and the watchdog then reaps the bridge half an hour later, holding the unread submission. Every submission is now written to disk and confirmed there *before* the page is told it went through, and the bridge reloads it on startup. The watchdog still shuts a stale bridge down, but shutting down no longer destroys anything.
+
+- **Work interrupted halfway through is now resumed from where it actually got to.** A submission that asks Claude to implement or ship can be cut off mid-flight, leaving a branch, a commit, or an open PR behind. Claude now records each of those as it happens, and a later session reads that record to find out how far the previous run got — then checks each item against reality before continuing, so nothing gets created twice and a merged PR is never merged again.
+
+- **The page no longer claims a submission went through when it did not.** It treated any answer from the bridge as success, including the one that means "I could not save this". The result was a confident "übermittelt" panel sitting on top of work that no longer existed anywhere. It now waits for confirmation that the submission reached disk, and says plainly when it did not — distinguishing a bridge that is merely unreachable, which resolves itself on reconnect, from one that cannot save, which needs attention.
+
+- **Discarding a concept now clears its attachments too**, and never silently deletes a submission Claude has not yet processed — that case is reported instead. Concept stores left behind by a wiped worktree or an interrupted session are swept after a week.
+
+- **Two hook test files no longer fail depending on what else the suite is doing.** Both passed alone and failed at random in a full run. The token-guard tests located their confirmation flag by looking for new files in the machine-wide temp directory and taking the first one, which under parallel execution could be a different test's flag — expiring that one left the test's own confirmation valid, so the expected block never came. The completion-card test read a hook's output without checking the hook had started at all, so a child process that failed to launch under load looked exactly like a hook that emitted nothing. Each test now gets a private temp directory, and the launch failure is retried while a process that genuinely ran is not, so a real defect still fails.
+
 ## [0.126.4] — 2026-08-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.126.4**
+**Version: 0.127.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.126.4",
+  "version": "0.127.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/hooks/post-tool-use/post.flow.completion.test.js
+++ b/plugins/devops/hooks/post-tool-use/post.flow.completion.test.js
@@ -17,21 +17,41 @@ function project() {
     path.join(dir, ".claude", "settings.json"),
     JSON.stringify({ enabledPlugins: { "devops@dotclaude": true } })
   );
+  // Private tmpdir: the hook keeps once-per-session state as a flag file in
+  // `os.tmpdir()`, which honours TMPDIR/TEMP/TMP. Sharing the system tmpdir
+  // with every other hook test lets a foreign flag suppress this hook's
+  // output. Same isolation as pre.tokens.guard.bash.test.js.
+  fs.mkdirSync(path.join(dir, ".tmp"), { recursive: true });
   return dir;
 }
 
 function runHook(dir, sid, toolName = "Read") {
-  const res = spawnSync(process.execPath, [HOOK], {
-    cwd: dir,
-    input: JSON.stringify({
-      tool_name: toolName,
-      tool_input: { file_path: path.join(dir, "a.js") },
-      session_id: sid,
+  // The full suite runs 60+ files in parallel; on a loaded machine spawnSync
+  // can fail to start the child at all (status null, res.error set), and the
+  // hook's stdout then comes back empty — which reads as "the hook emitted no
+  // instruction" and fails the assertion for a reason that has nothing to do
+  // with the hook. Retry only that case; never retry a child that actually
+  // ran, or a genuinely missing instruction would be masked.
+  const tmp = path.join(dir, ".tmp");
+  for (let attempt = 0; ; attempt++) {
+    const res = spawnSync(process.execPath, [HOOK], {
       cwd: dir,
-    }),
-    encoding: "utf8",
-  });
-  return res.stdout || "";
+      input: JSON.stringify({
+        tool_name: toolName,
+        tool_input: { file_path: path.join(dir, "a.js") },
+        session_id: sid,
+        cwd: dir,
+      }),
+      encoding: "utf8",
+      env: { ...process.env, TMPDIR: tmp, TEMP: tmp, TMP: tmp },
+    });
+    if (res.status !== null || attempt >= 3) {
+      if (res.status === null) {
+        throw new Error(`hook never started after ${attempt + 1} attempts: ${res.error}`);
+      }
+      return res.stdout || "";
+    }
+  }
 }
 
 function cleanup(dir) {

--- a/plugins/devops/hooks/pre-tool-use/pre.tokens.guard.bash.test.js
+++ b/plugins/devops/hooks/pre-tool-use/pre.tokens.guard.bash.test.js
@@ -19,6 +19,14 @@ fs.mkdirSync(path.join(HOME_DIR, ".claude"), { recursive: true });
 function project() {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tokguard-"));
   fs.mkdirSync(path.join(dir, ".claude"), { recursive: true });
+  // Private tmpdir for THIS project's confirmation flags. The hook writes them
+  // to `os.tmpdir()`, which honours TMPDIR/TEMP/TMP, so pointing those at a
+  // per-project directory keeps each test's flags to itself. Without it every
+  // test in the suite drops `claude_confirm_*` into the one shared system
+  // tmpdir, and the flag-lookup tests below — which pick the first file that
+  // appeared since a `before` snapshot — could grab a PARALLEL test's flag,
+  // expire that one, and then see their own confirmation still valid.
+  fs.mkdirSync(path.join(dir, ".tmp"), { recursive: true });
   fs.writeFileSync(
     path.join(dir, ".claude", "settings.json"),
     JSON.stringify({ enabledPlugins: { "devops@dotclaude": true } })
@@ -42,11 +50,16 @@ function runBash(dir, sid, toolInput) {
   // harness pressure, not a hook verdict, so retry it — but never retry a
   // child that actually ran, or a real block would be masked.
   for (let attempt = 0; ; attempt++) {
+    const tmp = path.join(dir, ".tmp");
     const res = spawnSync(process.execPath, [HOOK], {
       cwd: dir,
       input: JSON.stringify({ tool_name: "Bash", tool_input: toolInput, session_id: sid }),
       encoding: "utf8",
-      env: { ...process.env, HOME: HOME_DIR, USERPROFILE: HOME_DIR },
+      env: {
+        ...process.env,
+        HOME: HOME_DIR, USERPROFILE: HOME_DIR,
+        TMPDIR: tmp, TEMP: tmp, TMP: tmp,
+      },
     });
     if (res.status !== null || attempt >= 3) {
       if (res.status === null) {
@@ -58,6 +71,18 @@ function runBash(dir, sid, toolInput) {
 }
 
 const blocked = r => r.status === 2 && /HIGH TOKEN COST/.test(r.stderr);
+
+/**
+ * Confirmation flags this project wrote. Reads the project's PRIVATE tmpdir,
+ * so the result cannot contain another test's flag no matter how many run in
+ * parallel — which a `before`/`after` diff of the shared system tmpdir could.
+ */
+const confirmFlags = dir => {
+  const tmp = path.join(dir, ".tmp");
+  return fs.readdirSync(tmp)
+    .filter(f => f.startsWith("claude_confirm_"))
+    .map(f => path.join(tmp, f));
+};
 const cleanup = dir => { try { fs.rmSync(dir, { recursive: true, force: true }); } catch {} };
 
 describe("pre.tokens.guard — Bash large-file matching (integration)", () => {
@@ -117,7 +142,7 @@ describe("pre.tokens.guard — Bash large-file matching (integration)", () => {
       expect(r.stderr, command).toContain("Unbounded output");
     }
     cleanup(dir);
-  });
+  }, 30_000);
 
   test("commands the old noTokenCostPattern exempted are still exempt", () => {
     const dir = project();
@@ -129,7 +154,9 @@ describe("pre.tokens.guard — Bash large-file matching (integration)", () => {
       expect(runBash(dir, "s-parity", { command }).status, command).toBe(0);
     }
     cleanup(dir);
-  });
+    // Ten node spawns. Vitest's 5s default is not a budget this can meet while
+    // 60+ other test files compete for the machine.
+  }, 30_000);
 });
 
 describe("pre.tokens.guard — degraded inputs must not fail open", () => {
@@ -216,31 +243,26 @@ describe("pre.tokens.guard — retry-to-proceed release (integration)", () => {
   test("an expired confirmation blocks again instead of auto-approving", () => {
     const dir = project();
     const input = { command: `cat ${BIG}` };
-    const before = new Set(fs.readdirSync(os.tmpdir()).filter(f => f.startsWith("claude_confirm_")));
     expect(blocked(runBash(dir, "s-ttl", input))).toBe(true);
-    const flag = fs.readdirSync(os.tmpdir())
-      .filter(f => f.startsWith("claude_confirm_") && !before.has(f))
-      .map(f => path.join(os.tmpdir(), f))[0];
+    const flag = confirmFlags(dir)[0];
     expect(flag).toBeTruthy();
     fs.writeFileSync(flag, String(Date.now() - 31 * 60 * 1000));  // older than the 30min TTL
     expect(blocked(runBash(dir, "s-ttl", input))).toBe(true);
     // …and the re-armed flag releases immediately on the next retry.
     expect(runBash(dir, "s-ttl", input).status).toBe(0);
     cleanup(dir);
-  });
+  }, 30_000);
 
   test("an unreadable confirmation body counts as expired, not as approval", () => {
     const dir = project();
     const input = { command: `cat ${BIG}` };
-    const before = new Set(fs.readdirSync(os.tmpdir()).filter(f => f.startsWith("claude_confirm_")));
     expect(blocked(runBash(dir, "s-garbage", input))).toBe(true);
-    const flag = fs.readdirSync(os.tmpdir())
-      .filter(f => f.startsWith("claude_confirm_") && !before.has(f))
-      .map(f => path.join(os.tmpdir(), f))[0];
+    const flag = confirmFlags(dir)[0];
+    expect(flag).toBeTruthy();
     fs.writeFileSync(flag, "");            // interrupted write / full disk
     expect(blocked(runBash(dir, "s-garbage", input))).toBe(true);
     cleanup(dir);
-  });
+  }, 30_000);
 
   test("a different command is not released by an unrelated confirmation", () => {
     const dir = project();

--- a/plugins/devops/hooks/session-start/ss.concept.resume.js
+++ b/plugins/devops/hooks/session-start/ss.concept.resume.js
@@ -83,6 +83,126 @@ function deleteState() {
 }
 
 /**
+ * Directory of the durable store for a concept (#284). Must mirror the
+ * server's own derivation in `concept-server.py` __main__ — the HTML basename
+ * without its extension, under `.claude/concepts/` in the project root.
+ */
+function storeDirFor(htmlPath) {
+  const base = path.basename(String(htmlPath || '')).replace(/\.html$/i, '');
+  return path.join(cwd, '.claude', 'concepts', base);
+}
+
+/**
+ * Read whatever the bridge managed to persist, WITHOUT needing it to be alive.
+ *
+ * This is the half that did not exist before. The hook used to probe
+ * `/heartbeat` and give up when it failed, because there was nothing on disk
+ * to fall back to — which is precisely why a submission lost to a usage-limit
+ * watchdog reap was unrecoverable and, worse, invisible.
+ *
+ * @returns {{unprocessed:boolean, version:number|null, marker:object|null,
+ *            lastCheckpoint:object|null, progress:object[], attachments:number,
+ *            storeDir:string, present:boolean}}
+ */
+function readStore(storeDir) {
+  const empty = {
+    unprocessed: false, version: null, marker: null, lastCheckpoint: null,
+    progress: [], attachments: 0, storeDir, present: false,
+  };
+  let state = null;
+  try {
+    state = JSON.parse(fs.readFileSync(path.join(storeDir, 'state.json'), 'utf8'));
+  } catch {
+    return empty;
+  }
+  if (!state || typeof state !== 'object') return empty;
+
+  // `submitted: true` in the persisted payload is the authoritative signal.
+  // The marker file is corroborating evidence of HOW the process died
+  // (watchdog reap / crash vs. a clean exit), not the source of truth — a
+  // marker write can fail on a full disk while the fsynced payload is fine.
+  let unprocessed = false;
+  try {
+    const payload = JSON.parse(state.decisions);
+    unprocessed = payload && payload.submitted === true;
+  } catch { /* unparseable payload — treat as nothing pending */ }
+
+  let marker = null;
+  try {
+    marker = JSON.parse(fs.readFileSync(path.join(storeDir, 'UNPROCESSED'), 'utf8'));
+  } catch { /* absent = clean teardown */ }
+
+  const progress = [];
+  try {
+    const raw = fs.readFileSync(path.join(storeDir, 'journal.jsonl'), 'utf8');
+    for (const line of raw.split('\n')) {
+      if (!line.trim()) continue;
+      try {
+        const rec = JSON.parse(line);
+        if (rec && rec.type === 'progress') progress.push(rec);
+      } catch { /* skip a torn final line */ }
+    }
+  } catch { /* no journal yet */ }
+
+  let attachments = 0;
+  try {
+    attachments = fs.readdirSync(path.join(storeDir, 'attachments')).length;
+  } catch { /* none */ }
+
+  return {
+    unprocessed,
+    version: typeof state.version === 'number' ? state.version : null,
+    marker,
+    lastCheckpoint: progress.length ? progress[progress.length - 1] : null,
+    progress,
+    attachments,
+    storeDir,
+    present: true,
+  };
+}
+
+/**
+ * The verification mandate. The user's rule is auto-resume, but auto-resume
+ * that trusts a checkpoint is how you double-ship: the checkpoint records what
+ * a previous run *believed* it had done, and it died precisely because
+ * something went wrong. So the checkpoint is only ever a place to LOOK.
+ * Reality — git, gh — decides what actually happened, and the resumed run
+ * continues from the observed state.
+ */
+function buildVerificationMandate(store) {
+  const cp = store.lastCheckpoint;
+  const lines = [
+    `RECOVERY (concept bridge, store ${store.storeDir}): an unprocessed submission ` +
+    `(version ${store.version}) survived a teardown` +
+    (store.marker && store.marker.reason ? ` — cause: ${store.marker.reason}` : '') +
+    `. The user's work was preserved on disk; do NOT ask them to redo it.`,
+  ];
+  if (cp) {
+    lines.push(
+      `A previous run got as far as: action=${cp.action || '?'}, step=${cp.step || '?'}, ` +
+      `status=${cp.status || '?'}, artifacts=${JSON.stringify(cp.artifacts || {})}.`
+    );
+  } else {
+    lines.push(`No progress checkpoint was written — the previous run died before it started processing.`);
+  }
+  lines.push(
+    `VERIFY BEFORE YOU ACT — the checkpoint says where to look, never what to trust. ` +
+    `Establish the real state first: for a branch, \`git rev-parse --verify <branch>\` and \`git log\`; ` +
+    `for a PR, \`gh pr view <n> --json state,mergedAt\`; for issues, \`gh issue view <n>\`; ` +
+    `for code changes, read the files. THEN resume from what you observed, not from the checkpoint: ` +
+    `never re-create a branch/PR/issue that exists, never re-merge a merged PR, never re-run a ` +
+    `completed step. Checkpoint each further step via POST /progress as you go.`
+  );
+  if (store.attachments > 0) {
+    lines.push(
+      `${store.attachments} attachment(s) are in ${path.join(store.storeDir, 'attachments')} — ` +
+      `read the referenced images with the Read tool when processing the comments.`
+    );
+  }
+  return lines.join(' ');
+}
+
+/**
  * Fire-and-forget POST /shutdown. We don't wait for the response — even on
  * Windows with PID recycling, the server's listening socket is on the port
  * we know, and the watchdog already handles the no-response case. Best-effort
@@ -195,7 +315,7 @@ function buildBackgroundTasks(port, statePath) {
  * @param {{port:number, html_path:string, slug?:string}} state
  * @param {'pending'|'idle'|'unknown'} pendingState
  */
-function buildResumeInstructions(state, pendingState, statePath = STATE_PATH) {
+function buildResumeInstructions(state, pendingState, statePath = STATE_PATH, store = null) {
   const bg = buildBackgroundTasks(state.port, statePath);
   const lines = [];
 
@@ -226,6 +346,13 @@ function buildResumeInstructions(state, pendingState, statePath = STATE_PATH) {
       `(rewrite HTML at ${state.html_path}, POST /reload, conditional /reset with the captured _version). ` +
       `The user already submitted and is waiting — do not delay this on a schedule.`
     );
+    // A checkpoint means a PREVIOUS run already started processing this very
+    // submission and died partway. Re-running it blind is how a half-finished
+    // ship becomes a double ship, so the verification mandate applies here
+    // just as it does to a dead-bridge recovery.
+    if (store && store.lastCheckpoint) {
+      lines.push(buildVerificationMandate(store));
+    }
   } else if (pendingState === 'unknown') {
     lines.push(
       `The /pending probe was inconclusive (timeout, non-200, or malformed JSON). ` +
@@ -243,12 +370,39 @@ function buildResumeInstructions(state, pendingState, statePath = STATE_PATH) {
   return lines.join(' ');
 }
 
+/**
+ * Instructions for the case the hook could not handle at all before: the
+ * bridge process is GONE, but the user's submission is on disk.
+ *
+ * The old code path exited 0 here. That silence is the bug the user actually
+ * hit — Claude ran out of budget, the watchdog reaped the bridge 30 min later,
+ * and the next session had no idea anything had ever been submitted.
+ */
+function buildDeadBridgeRecovery(state, store) {
+  const server = path.join(__dirname, '..', '..', 'scripts', 'concept-server.py');
+  const bg = buildBackgroundTasks(state.port, STATE_PATH);
+  return [
+    buildVerificationMandate(store),
+    `The bridge process itself is gone. Relaunch it on the SAME port so the open tab and the ` +
+    `state file stay valid — it restores the pending submission from the store automatically: ` +
+    `\`python "${server}" ${state.port} "${cwd}" --html "${state.html_path}"\` ` +
+    `(Bash tool, run_in_background: true — no trailing &, no nohup).`,
+    `Then confirm the recovery with \`curl -s http://localhost:${state.port}/recovery\`, ` +
+    `re-arm the keepalive pulser (${bg.pulser}) and the pickup waker (${bg.waker}), ` +
+    `and process the recovered submission.`,
+  ].join(' ');
+}
+
 module.exports = {
   isValidHtmlPath,
   isStale,
   buildCronBody,
   buildBackgroundTasks,
   buildResumeInstructions,
+  storeDirFor,
+  readStore,
+  buildVerificationMandate,
+  buildDeadBridgeRecovery,
 };
 
 if (require.main === module) {
@@ -265,17 +419,41 @@ if (require.main === module) {
     // gets shut down explicitly — relying on the watchdog alone would leave
     // the server alive for up to 30 s after this hook returns, surfacing
     // misleading "concept active" state in the meantime.
+    // Read the durable store FIRST. Every branch below needs to know whether
+    // the user has unprocessed work sitting on disk, and none of them may
+    // throw that away just because a process or a file went missing.
+    const store = readStore(storeDirFor(state.html_path));
+
     const htmlAbs = path.join(cwd, state.html_path);
     if (!fs.existsSync(htmlAbs)) {
       await postShutdown(state.port);
       deleteState();
+      // The concept HTML is gone, so there is no page left to iterate on —
+      // but an unprocessed submission must not disappear with it. Surface it
+      // and leave the store alone; deleting it is the user's call, made
+      // through the disposition flow, not a side effect of a missing file.
+      if (store.unprocessed) {
+        process.stdout.write(
+          buildVerificationMandate(store) +
+          ` NOTE: the concept HTML (${state.html_path}) no longer exists, so there is no page to ` +
+          `iterate on. Report the recovered submission to the user and ask how they want to use it ` +
+          `BEFORE removing anything under ${store.storeDir}.\n`
+        );
+      }
       process.exit(0);
     }
 
     const heartbeat = await probe(state.port, '/heartbeat');
     if (!heartbeat) {
-      // Server gone. If the file is also stale, prune it; otherwise leave it
-      // alone — the user might be restarting the server in another terminal.
+      // The bridge process is dead. This branch used to exit silently, which
+      // is exactly how a usage-limit watchdog reap turned into an invisible
+      // loss. Now the store answers the question the dead server cannot.
+      if (store.unprocessed) {
+        process.stdout.write(buildDeadBridgeRecovery(state, store) + '\n');
+        process.exit(0);
+      }
+      // Nothing pending. If the state file is also stale, prune it; otherwise
+      // leave it — the user might be restarting the server in another terminal.
       if (isStale(state)) deleteState();
       process.exit(0);
     }
@@ -296,6 +474,6 @@ if (require.main === module) {
       pendingState = 'unknown';
     }
 
-    process.stdout.write(buildResumeInstructions(state, pendingState) + '\n');
+    process.stdout.write(buildResumeInstructions(state, pendingState, STATE_PATH, store) + '\n');
   })();
 }

--- a/plugins/devops/hooks/session-start/ss.concept.resume.recovery.test.js
+++ b/plugins/devops/hooks/session-start/ss.concept.resume.recovery.test.js
@@ -1,0 +1,191 @@
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  storeDirFor,
+  readStore,
+  buildVerificationMandate,
+  buildDeadBridgeRecovery,
+  buildResumeInstructions,
+} from "./ss.concept.resume.js";
+
+// The hook's job in a recovery is to answer one question the dead bridge
+// cannot: "did the user lose work?". Before #284 it exited 0 here, so a
+// submission reaped by the watchdog (which is what happens when Claude hits a
+// usage limit and the session-scoped pulser dies) vanished without a trace.
+
+let dir;
+
+function writeStore({ submitted = true, version = 3, marker = true, progress = [], attachments = [] } = {}) {
+  fs.mkdirSync(path.join(dir, "attachments"), { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, "state.json"),
+    JSON.stringify({
+      decisions: JSON.stringify({ submitted, action: "implement", comments: [{ id: "a", text: "hart erarbeitet" }] }),
+      version,
+      processed_at: "",
+      picked_up_at: "2026-08-16T07:00:00.000Z",
+      phase: "",
+    })
+  );
+  if (marker) {
+    fs.writeFileSync(
+      path.join(dir, "UNPROCESSED"),
+      JSON.stringify({ version, reason: "watchdog:heartbeat_stale", at: "2026-08-16T07:30:00.000Z" })
+    );
+  }
+  const lines = [
+    JSON.stringify({ type: "submission", seq: 1, version }),
+    ...progress.map((p, i) => JSON.stringify({ type: "progress", seq: i + 2, ...p })),
+  ];
+  fs.writeFileSync(path.join(dir, "journal.jsonl"), lines.join("\n") + "\n");
+  for (const a of attachments) fs.writeFileSync(path.join(dir, "attachments", a), "x");
+}
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "concept-store-"));
+});
+afterEach(() => {
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe("storeDirFor mirrors the server's own derivation", () => {
+  test("uses the HTML basename without its extension", () => {
+    const d = storeDirFor("docs/concepts/2026-08-16-auth-redesign.html");
+    expect(path.basename(d)).toBe("2026-08-16-auth-redesign");
+    expect(d).toContain(path.join(".claude", "concepts"));
+  });
+
+  test("a drifting derivation would silently read an empty store", () => {
+    // Guard against someone "simplifying" this to state.slug, which is the
+    // topic slug WITHOUT the date and would point at a directory the server
+    // never writes — recovery would then always report nothing pending.
+    expect(path.basename(storeDirFor("docs/concepts/2026-01-02-x.html"))).not.toBe("x");
+  });
+});
+
+describe("readStore works with no live server", () => {
+  test("a missing store reports absent, not pending", () => {
+    const s = readStore(path.join(dir, "nope"));
+    expect(s.present).toBe(false);
+    expect(s.unprocessed).toBe(false);
+  });
+
+  test("an unprocessed submission is detected from disk alone", () => {
+    writeStore({ version: 7 });
+    const s = readStore(dir);
+    expect(s.present).toBe(true);
+    expect(s.unprocessed).toBe(true);
+    expect(s.version).toBe(7);
+    expect(s.marker.reason).toBe("watchdog:heartbeat_stale");
+  });
+
+  test("an already-processed submission is not resurrected", () => {
+    writeStore({ submitted: false, marker: false });
+    expect(readStore(dir).unprocessed).toBe(false);
+  });
+
+  test("the payload decides, not the marker", () => {
+    // A marker write can fail on a full disk while the fsynced payload is
+    // fine. Trusting the marker over the payload would under-report a loss.
+    writeStore({ submitted: true, marker: false });
+    expect(readStore(dir).unprocessed).toBe(true);
+    expect(readStore(dir).marker).toBeNull();
+  });
+
+  test("progress checkpoints and attachments are surfaced", () => {
+    writeStore({
+      progress: [
+        { action: "implement", step: "branch-created", artifacts: { branch: "feat/x" } },
+        { action: "implement", step: "pr-opened", artifacts: { pr: 42 } },
+      ],
+      attachments: ["aa.png", "bb.png"],
+    });
+    const s = readStore(dir);
+    expect(s.progress).toHaveLength(2);
+    expect(s.lastCheckpoint.step).toBe("pr-opened");
+    expect(s.attachments).toBe(2);
+  });
+
+  test("a torn final journal line does not lose the earlier records", () => {
+    // A hard kill mid-append can leave a partial last line. Losing the whole
+    // journal to one bad line would defeat the point of an append-only log.
+    writeStore({ progress: [{ action: "ship", step: "preflight" }] });
+    fs.appendFileSync(path.join(dir, "journal.jsonl"), '{"type":"progress","step":"tor');
+    expect(readStore(dir).progress).toHaveLength(1);
+  });
+});
+
+describe("the verification mandate keeps auto-resume from double-shipping", () => {
+  test("it names the artifacts to verify and forbids trusting them", () => {
+    writeStore({ progress: [{ action: "ship", step: "pr-opened", artifacts: { pr: 42, branch: "feat/x" } }] });
+    const text = buildVerificationMandate(readStore(dir));
+    expect(text).toContain("VERIFY BEFORE YOU ACT");
+    expect(text).toContain("gh pr view");
+    expect(text).toContain("git rev-parse");
+    expect(text).toMatch(/never re-merge a merged PR/i);
+    expect(text).toContain('"pr":42');
+  });
+
+  test("it tells Claude the work was preserved, so the user is not asked to redo it", () => {
+    writeStore();
+    expect(buildVerificationMandate(readStore(dir))).toMatch(/do NOT ask them to redo it/i);
+  });
+
+  test("it says so explicitly when no checkpoint was ever written", () => {
+    writeStore({ progress: [] });
+    expect(buildVerificationMandate(readStore(dir))).toMatch(/died before it started processing/i);
+  });
+
+  test("attachments are pointed at so comments referencing images stay readable", () => {
+    writeStore({ attachments: ["aa.png"] });
+    const text = buildVerificationMandate(readStore(dir));
+    expect(text).toContain("attachment");
+    expect(text).toContain("Read tool");
+  });
+});
+
+describe("a dead bridge is relaunched, not written off", () => {
+  test("the relaunch pins the SAME port so the open tab stays valid", () => {
+    writeStore();
+    const text = buildDeadBridgeRecovery(
+      { port: 8748, html_path: "docs/concepts/2026-08-16-x.html" },
+      readStore(dir)
+    );
+    expect(text).toContain("concept-server.py");
+    expect(text).toContain("8748");
+    expect(text).toContain("/recovery");
+    expect(text).toMatch(/SAME port/i);
+  });
+
+  test("both watchers are re-armed — a restored server nobody watches is the #276 trap", () => {
+    writeStore();
+    const text = buildDeadBridgeRecovery(
+      { port: 8748, html_path: "docs/concepts/2026-08-16-x.html" },
+      readStore(dir)
+    );
+    expect(text).toContain("--mode pulse");
+    expect(text).toContain("--mode watch");
+  });
+});
+
+describe("a live bridge with a half-finished run also verifies first", () => {
+  const state = { port: 8700, html_path: "docs/concepts/2026-08-16-x.html", slug: "x" };
+
+  test("a checkpoint pulls the mandate into the normal resume path", () => {
+    writeStore({ progress: [{ action: "implement", step: "pr-opened", artifacts: { pr: 9 } }] });
+    const text = buildResumeInstructions(state, "pending", "C:/p/.claude/concept-active.json", readStore(dir));
+    expect(text).toContain("VERIFY BEFORE YOU ACT");
+  });
+
+  test("a fresh submission with no checkpoint is processed without the ceremony", () => {
+    writeStore({ progress: [] });
+    const text = buildResumeInstructions(state, "pending", "C:/p/.claude/concept-active.json", readStore(dir));
+    expect(text).not.toContain("VERIFY BEFORE YOU ACT");
+  });
+
+  test("omitting the store keeps the legacy signature working", () => {
+    expect(() => buildResumeInstructions(state, "idle")).not.toThrow();
+  });
+});

--- a/plugins/devops/scripts/concept-server.py
+++ b/plugins/devops/scripts/concept-server.py
@@ -37,6 +37,26 @@ Replaces `python -m http.server` with a custom server that adds:
   path in /concept Step 6 and by the watchdog when state files
   vanish. PID-based kill is unreliable on Windows after process
   recycling — an HTTP endpoint targets the live process by port.
+- POST /attachments — Persist one pasted/dropped image, content-addressed by
+  sha256. Uploaded at ATTACH time, not at submit time, so an image is durable
+  seconds after the user pastes it. Raster only (png/jpeg/gif/webp); SVG is
+  rejected because attachments are served back same-origin.
+- GET /attachments/<sha256>.<ext> — Read a blob back. The identifier is shape-
+  validated before it touches the filesystem and the Content-Type comes from
+  the server's own extension map, with nosniff.
+- POST /progress — Claude checkpoints its processing (action, step, status and
+  real-world artifacts: branch, commit, PR, created issues) into the journal.
+- GET /recovery — "Where did we stand?" for a resumed session: whether a
+  submission is unprocessed, its version, the teardown marker, and every
+  progress checkpoint the previous run managed to write.
+
+DURABILITY (#284). Submissions used to live in RAM only, so a PC restart, a
+crash, or the watchdog reaping a server whose heartbeat went stale (which is
+what happens when Claude hits a usage limit) destroyed them silently — the
+restarted bridge answered `pending: false`, indistinguishable from "never
+submitted". Now every submission is fsynced to a per-concept store BEFORE the
+browser is acked, the state is restored on boot, and teardown paths leave an
+UNPROCESSED marker. See § Durable store below for the on-disk layout.
 
 A background **watchdog daemon** terminates the process when:
 - `--html <path>` was passed and the file disappeared for > 10 s
@@ -80,6 +100,8 @@ Example:
 """
 
 import argparse
+import base64
+import hashlib
 import http.server
 import json
 import os
@@ -138,6 +160,282 @@ _lock = threading.Lock()
 
 def _iso_now():
     return datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z'
+
+
+# ---------------------------------------------------------------------------
+# Durable store (#284)
+# ---------------------------------------------------------------------------
+# Every global above this line lives in RAM only, and that was the whole bug.
+# A submission existed exclusively as `_decisions`, so a bridge that died for
+# ANY reason took the user's work with it — silently. The three real paths:
+#
+#   * the PC is restarted mid-review;
+#   * the process crashes;
+#   * Claude hits a usage limit, the session-scoped heartbeat pulser dies with
+#     the turn, and 30 min later the watchdog reaps a server that was still
+#     holding an unprocessed submission.
+#
+# In all three, `GET /pending` afterwards answers `false` — indistinguishable
+# from "the user never submitted". The store closes that hole from two sides:
+# the submission is durable BEFORE the browser is told the POST succeeded, and
+# processing progress is journalled AS IT HAPPENS, so a resumed session can
+# establish where it stood instead of guessing.
+#
+#   <store>/journal.jsonl   append-only, fsynced, NEVER truncated — the full
+#                           history of submissions, pickups, progress
+#                           checkpoints, attachments and resets.
+#   <store>/state.json      atomically replaced snapshot of the live globals,
+#                           so a restart restores in O(1) without replaying.
+#   <store>/attachments/    content-addressed image blobs (sha256).
+#   <store>/UNPROCESSED     written when the process is torn down while a
+#                           submission is unprocessed; read by the
+#                           `ss.concept.resume` SessionStart hook.
+#
+# The store lives under the PROJECT ROOT (`.claude/concepts/<slug>/`) rather
+# than beside the concept HTML in `docs/concepts/`. It survives worktree wipes
+# for the same reason `.claude/concept-active.json` does, it stays out of the
+# tracked content tree so a pasted screenshot cannot be committed by accident,
+# and it is one directory to remove when the user discards the concept.
+
+_store_dir = None
+_journal_path = None
+_state_path = None
+_attach_dir = None
+_marker_path = None
+_journal_seq = 0
+_store_ok = False  # stays False until the store is initialised AND writable
+_store_lock = threading.Lock()
+
+# Lock ordering is always `_lock` -> `_store_lock`, never the reverse. Request
+# handlers take `_lock`; store helpers take only `_store_lock`. Holding `_lock`
+# across an fsync costs a few ms on the other endpoints, which is the right
+# trade: a heartbeat that waits is harmless, an unpersisted submission is not.
+
+MAX_DECISIONS_BYTES = 32 * 1024 * 1024
+MAX_ATTACHMENT_BYTES = 10 * 1024 * 1024
+MAX_ATTACHMENT_TOTAL_BYTES = 200 * 1024 * 1024
+_attach_total_bytes = 0
+
+# Raster only, and SVG is deliberately absent. The bridge serves attachments
+# back to the page from the SAME origin, so an inline <script> in an uploaded
+# SVG would execute against the bridge origin and could drive every endpoint
+# on it. There is no use case for a pasted vector screenshot that justifies it.
+ATTACH_EXT_BY_MIME = {
+    'image/png': '.png',
+    'image/jpeg': '.jpg',
+    'image/gif': '.gif',
+    'image/webp': '.webp',
+}
+# Reverse map for serving. Deriving the response Content-Type from OUR map
+# rather than from the stored upload means a blob can only ever be served as
+# one of the four raster types we accepted in the first place.
+ATTACH_MIME_BY_EXT = {v: k for k, v in ATTACH_EXT_BY_MIME.items()}
+_SHA256_RE = None  # compiled in _store_init to keep the import list tight
+
+
+def _durable_write(path, data_bytes):
+    """Atomically replace `path`, fsyncing the payload before the rename.
+
+    tmp-write + fsync + os.replace is the only sequence that cannot leave a
+    half-written state.json behind: os.replace is atomic on both POSIX and
+    Windows (same volume), and the fsync guarantees the bytes are on the
+    platter before the rename publishes them.
+    """
+    tmp = path + '.tmp'
+    with open(tmp, 'wb') as f:
+        f.write(data_bytes)
+        f.flush()
+        os.fsync(f.fileno())
+    os.replace(tmp, path)
+
+
+def _store_init(store_dir):
+    """Create the store and prove it is writable. Returns True on success.
+
+    A store we cannot write to must fail LOUDLY at startup rather than at the
+    moment the user submits — the launcher checks the exit code, so a bad
+    path surfaces before the browser tab is ever opened.
+    """
+    global _store_dir, _journal_path, _state_path, _attach_dir, _marker_path
+    global _store_ok, _journal_seq, _attach_total_bytes, _SHA256_RE
+    import re
+    _SHA256_RE = re.compile(r'^[0-9a-f]{64}$')
+    try:
+        os.makedirs(store_dir, exist_ok=True)
+        _attach_dir = os.path.join(store_dir, 'attachments')
+        os.makedirs(_attach_dir, exist_ok=True)
+        _store_dir = store_dir
+        _journal_path = os.path.join(store_dir, 'journal.jsonl')
+        _state_path = os.path.join(store_dir, 'state.json')
+        _marker_path = os.path.join(store_dir, 'UNPROCESSED')
+        # Journal line count is authoritative for the sequence: records may
+        # have been appended after the last state.json snapshot was written.
+        if os.path.exists(_journal_path):
+            with open(_journal_path, 'r', encoding='utf-8') as f:
+                _journal_seq = sum(1 for line in f if line.strip())
+        _attach_total_bytes = sum(
+            os.path.getsize(os.path.join(_attach_dir, n))
+            for n in os.listdir(_attach_dir)
+            if os.path.isfile(os.path.join(_attach_dir, n))
+        )
+        _store_ok = True
+        return True
+    except OSError as exc:
+        sys.stderr.write(f"[concept-server] store unusable at {store_dir}: {exc}\n")
+        _store_ok = False
+        return False
+
+
+def _journal_append(record):
+    """Append one fsynced record. Raises OSError so callers that must not
+    silently succeed (POST /decisions, POST /attachments) can refuse to ack."""
+    global _journal_seq
+    if not _store_ok:
+        return None
+    with _store_lock:
+        _journal_seq += 1
+        rec = dict(record)
+        rec['seq'] = _journal_seq
+        rec['ts'] = _iso_now()
+        with open(_journal_path, 'a', encoding='utf-8') as f:
+            f.write(json.dumps(rec, ensure_ascii=False) + '\n')
+            f.flush()
+            os.fsync(f.fileno())
+        return _journal_seq
+
+
+def _state_write(snapshot):
+    """Persist a caller-built snapshot. The caller assembles it while holding
+    `_lock` so the on-disk state is a consistent view, never a torn read."""
+    if not _store_ok:
+        return
+    _durable_write(_state_path, json.dumps(snapshot, ensure_ascii=False).encode('utf-8'))
+
+
+def _snapshot(decisions, version, processed_at, picked_up_at, phase):
+    return {
+        'decisions': decisions,
+        'version': version,
+        'processed_at': processed_at,
+        'picked_up_at': picked_up_at,
+        'phase': phase,
+        'journal_seq': _journal_seq,
+        'saved_at': _iso_now(),
+    }
+
+
+def _is_submitted(raw):
+    try:
+        obj = json.loads(raw)
+        return bool(isinstance(obj, dict) and obj.get('submitted') is True)
+    except (ValueError, TypeError):
+        return False
+
+
+def _set_unprocessed_marker(version, reason=''):
+    """Flag that a submission exists which nobody has processed yet.
+
+    Written on submit and removed on reset, so its mere presence after a
+    teardown is the signal `ss.concept.resume` needs — no journal replay
+    required to answer "did we lose something?".
+    """
+    if not _store_ok:
+        return
+    try:
+        _durable_write(_marker_path, json.dumps({
+            'version': version,
+            'reason': reason,
+            'at': _iso_now(),
+        }).encode('utf-8'))
+    except OSError:
+        pass
+
+
+def _clear_unprocessed_marker():
+    if not _store_ok:
+        return
+    try:
+        os.remove(_marker_path)
+    except OSError:
+        pass
+
+
+def _store_restore():
+    """Reload state.json at boot so a restarted bridge serves the SAME pending
+    submission and version it held before it died. This single function is
+    what turns #284's "version: 0, indistinguishable from never submitted"
+    into a faithful resume."""
+    global _decisions, _version, _processed_at, _picked_up_at, _phase
+    if not _store_ok or not os.path.exists(_state_path):
+        return None
+    try:
+        with open(_state_path, 'r', encoding='utf-8') as f:
+            snap = json.load(f)
+    except (OSError, ValueError):
+        sys.stderr.write("[concept-server] state.json unreadable — starting clean\n")
+        return None
+    if not isinstance(snap, dict):
+        return None
+    decisions = snap.get('decisions')
+    version = snap.get('version')
+    if not isinstance(decisions, str) or not isinstance(version, int) or version < 0:
+        return None
+    try:
+        parsed = json.loads(decisions)
+        if not isinstance(parsed, dict):
+            return None
+    except (ValueError, TypeError):
+        return None
+    _decisions = decisions
+    _version = version
+    _processed_at = snap.get('processed_at') if isinstance(snap.get('processed_at'), str) else ''
+    _picked_up_at = snap.get('picked_up_at') if isinstance(snap.get('picked_up_at'), str) else ''
+    _phase = snap.get('phase') if isinstance(snap.get('phase'), str) else ''
+    return snap
+
+
+def _read_progress():
+    """Replay the journal's progress checkpoints for GET /recovery.
+
+    This is the "where did we stand" half of the contract. Checkpoints are the
+    ONLY evidence a resumed session has about how far a previous run got, and
+    they are advisory: the resume flow verifies each claimed artifact against
+    reality (does the branch exist, is the PR merged, were the issues created)
+    before continuing. A checkpoint says where to look, never what to trust.
+    """
+    if not _store_ok or not os.path.exists(_journal_path):
+        return []
+    out = []
+    try:
+        with open(_journal_path, 'r', encoding='utf-8') as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                except ValueError:
+                    continue
+                if isinstance(rec, dict) and rec.get('type') == 'progress':
+                    out.append(rec)
+    except OSError:
+        return out
+    return out
+
+
+def _attachment_meta():
+    """List persisted attachments so a reloaded page can rebuild thumbnails."""
+    if not _store_ok or not _attach_dir or not os.path.isdir(_attach_dir):
+        return []
+    out = []
+    try:
+        for name in sorted(os.listdir(_attach_dir)):
+            p = os.path.join(_attach_dir, name)
+            if os.path.isfile(p):
+                out.append({'id': name, 'size': os.path.getsize(p)})
+    except OSError:
+        pass
+    return out
 
 
 class ConceptBridgeHandler(http.server.SimpleHTTPRequestHandler):
@@ -228,6 +526,55 @@ class ConceptBridgeHandler(http.server.SimpleHTTPRequestHandler):
             with _lock:
                 counter = _reload_counter
             self._json_response({"counter": counter})
+        elif self.path == '/recovery':
+            # "Where did we stand?" — the endpoint a resumed session asks
+            # before doing anything else. Reports whether a submission is
+            # unprocessed, which version it is, and every progress checkpoint
+            # a previous run managed to journal.
+            #
+            # `unprocessed` is computed from the LIVE payload, not from the
+            # marker file, so it stays correct even if a marker write failed.
+            # The marker is reported separately as corroborating evidence of
+            # a hard teardown (watchdog reap, crash) rather than a clean exit.
+            with _lock:
+                data = _decisions
+                version = _version
+                processed_at = _processed_at
+                picked_up_at = _picked_up_at
+                phase = _phase
+            marker = None
+            if _store_ok and _marker_path and os.path.exists(_marker_path):
+                try:
+                    with open(_marker_path, 'r', encoding='utf-8') as f:
+                        marker = json.load(f)
+                except (OSError, ValueError):
+                    marker = {'unreadable': True}
+            progress = _read_progress()
+            self._json_response({
+                "durable": _store_ok,
+                "store_dir": _store_dir or '',
+                "unprocessed": _is_submitted(data),
+                "version": version,
+                "processed_at": processed_at,
+                "picked_up_at": picked_up_at,
+                "phase": phase,
+                "marker": marker,
+                "progress": progress,
+                "last_checkpoint": progress[-1] if progress else None,
+                "attachments": _attachment_meta(),
+                "journal_seq": _journal_seq,
+            })
+        elif self.path.startswith('/attachments/'):
+            # Content-addressed read-back so a reloaded page can rebuild its
+            # thumbnails from the server instead of trusting only IndexedDB.
+            #
+            # The id is matched against a strict sha256+known-extension shape
+            # BEFORE it touches the filesystem, so a user-supplied filename can
+            # never traverse out of the attachments directory. Content-Type
+            # comes from our own extension map (never from the upload) and
+            # nosniff blocks the browser from re-interpreting a raster blob as
+            # something executable.
+            self._serve_attachment(self.path[len('/attachments/'):])
         else:
             super().do_GET()
 
@@ -244,18 +591,102 @@ class ConceptBridgeHandler(http.server.SimpleHTTPRequestHandler):
             self._json_response({"ok": True, "ts": ts, "claude_ts": ts})
         elif self.path == '/decisions':
             length = int(self.headers.get('Content-Length', 0))
+            if length > MAX_DECISIONS_BYTES:
+                self.send_error(413, "decisions payload too large")
+                return
             body = self.rfile.read(length).decode()
+            # ---- DURABILITY GATE (#284) --------------------------------
+            # The browser is told "ok" only after the payload is on disk.
+            # Accepting in RAM and acking optimistically is exactly what
+            # made submissions vanish: the page cleared its local copy on
+            # a success it had no right to trust. If the disk write fails
+            # we answer 507 and the page KEEPS its IndexedDB copy and
+            # surfaces the failure, instead of painting a success panel
+            # over work that no longer exists anywhere.
+            err = None
+            seq = None
+            version = None
             with _lock:
-                _decisions = body
-                _version += 1
-                version = _version
-                # New submission supersedes any prior pickup/phase state.
-                # If we kept _picked_up_at across submissions, the progress
-                # list on the new submission would already show "Claude
-                # verarbeitet" before Claude's cron actually noticed.
-                _picked_up_at = ''
-                _phase = ''
-            self._json_response({"ok": True, "version": version})
+                next_version = _version + 1
+                try:
+                    seq = _journal_append({
+                        'type': 'submission',
+                        'version': next_version,
+                        'payload': body,
+                    })
+                    _state_write(_snapshot(body, next_version, _processed_at, '', ''))
+                    if _is_submitted(body):
+                        _set_unprocessed_marker(next_version, 'submitted')
+                except OSError as exc:
+                    err = str(exc)
+                if err is None:
+                    _decisions = body
+                    _version = next_version
+                    version = next_version
+                    # A new submission supersedes any prior pickup/phase
+                    # state. Keeping _picked_up_at would make the new
+                    # submission's progress list show "Claude verarbeitet"
+                    # before Claude's cron had actually noticed it.
+                    _picked_up_at = ''
+                    _phase = ''
+            if err is not None:
+                self._error_response(507, {
+                    "ok": False,
+                    "durable": False,
+                    "reason": "store_write_failed",
+                    "detail": err,
+                })
+                return
+            self._json_response({
+                "ok": True,
+                "version": version,
+                "durable": _store_ok,
+                "seq": seq,
+            })
+        elif self.path == '/attachments':
+            self._handle_attachment_upload()
+        elif self.path == '/progress':
+            # Claude checkpoints its own processing here: which action it is
+            # running, which step it reached, and the real-world artifacts it
+            # produced (branch, commit, PR number, created issue numbers).
+            #
+            # This is what makes auto-resume safe. Without checkpoints a
+            # recovered `implement` or `ship` could only be re-run blind;
+            # with them the resume flow knows where to LOOK, verifies each
+            # artifact against reality, and continues from the observed
+            # state. Checkpoints are evidence to check, never truth to trust.
+            length = int(self.headers.get('Content-Length', 0))
+            payload = {}
+            if length > 0:
+                try:
+                    raw = self.rfile.read(length).decode()
+                    payload = json.loads(raw) if raw else {}
+                except (ValueError, UnicodeDecodeError):
+                    payload = {}
+            if not isinstance(payload, dict):
+                payload = {}
+            with _lock:
+                current_version = _version
+            try:
+                seq = _journal_append({
+                    'type': 'progress',
+                    'version': payload.get('version', current_version),
+                    'action': str(payload.get('action') or ''),
+                    'step': str(payload.get('step') or ''),
+                    'status': str(payload.get('status') or ''),
+                    'artifacts': payload.get('artifacts')
+                    if isinstance(payload.get('artifacts'), dict) else {},
+                    'note': str(payload.get('note') or ''),
+                })
+            except OSError as exc:
+                self._error_response(507, {
+                    "ok": False,
+                    "durable": False,
+                    "reason": "store_write_failed",
+                    "detail": str(exc),
+                })
+                return
+            self._json_response({"ok": True, "seq": seq, "durable": _store_ok})
         elif self.path == '/status':
             # Free-form phase channel: Claude POSTs {"phase": "implemented",
             # "version": N} after the implement branch finished its code
@@ -333,6 +764,25 @@ class ConceptBridgeHandler(http.server.SimpleHTTPRequestHandler):
                     self.send_error(403, "forbidden origin")
                     return
             self._json_response({"ok": True, "shutting_down": True})
+            # Final durable snapshot before we go. A graceful /shutdown is
+            # normally the cleanup path (concept disposed), but it is also how
+            # `ss.concept.resume` reaps an orphan — so an unprocessed
+            # submission must survive this exit exactly as it survives a
+            # watchdog reap.
+            with _lock:
+                _snap = _snapshot(_decisions, _version, _processed_at, _picked_up_at, _phase)
+                _unprocessed = _is_submitted(_decisions)
+            try:
+                _journal_append({
+                    'type': 'shutdown',
+                    'version': _snap['version'],
+                    'unprocessed': _unprocessed,
+                })
+                _state_write(_snap)
+            except OSError:
+                pass
+            if _unprocessed:
+                _set_unprocessed_marker(_snap['version'], 'shutdown')
             _remove_registry()  # drop our port-registry entry (os._exit skips atexit)
             # Flush the response, then exit on a short delay so the wfile
             # has time to drain before the socket closes. os._exit skips
@@ -365,6 +815,25 @@ class ConceptBridgeHandler(http.server.SimpleHTTPRequestHandler):
                     # state so the next submission starts from a clean panel.
                     _picked_up_at = ''
                     _phase = ''
+                    # Durable side of the reset. The journal is append-only,
+                    # so the processed submission stays recoverable forever;
+                    # only the LIVE payload is cleared. Dropping the marker
+                    # here is what tells a later resume "nothing was lost".
+                    # Best-effort: a reset that cannot reach disk must still
+                    # succeed in RAM, or a full disk would wedge the loop with
+                    # a submission Claude has already acted on.
+                    try:
+                        _journal_append({
+                            'type': 'processed',
+                            'version': _version,
+                            'processed_at': _processed_at,
+                        })
+                        _state_write(_snapshot(
+                            _decisions, _version, _processed_at, '', ''))
+                    except OSError as exc:
+                        sys.stderr.write(
+                            f"[concept-server] reset persisted in memory only: {exc}\n")
+                    _clear_unprocessed_marker()
                     self._json_response({"ok": True, "version": _version, "processed_at": _processed_at})
                 else:
                     # Mismatch — newer submission landed after Claude read
@@ -397,6 +866,168 @@ class ConceptBridgeHandler(http.server.SimpleHTTPRequestHandler):
         self._cors_headers()
         self.end_headers()
         self.wfile.write(body)
+
+    def _error_response(self, code, data):
+        """Structured non-200 with a machine-readable reason.
+
+        The page distinguishes "rejected, keep your local copy and tell the
+        user" (507 store_write_failed) from a transport error, so the body
+        matters — a bare send_error would give it only an HTML page.
+        """
+        body = json.dumps(data).encode()
+        self.send_response(code)
+        self.send_header('Content-Type', 'application/json')
+        self._cors_headers()
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _same_origin_ok(self):
+        """True for curl (no Origin) or a fetch from the served page itself."""
+        origin = self.headers.get('Origin')
+        if origin is None:
+            return True
+        host = self.headers.get('Host', '')
+        port_part = host.split(':')[-1] if ':' in host else ''
+        return origin in {
+            f'http://{host}',
+            f'http://localhost:{port_part}',
+            f'http://127.0.0.1:{port_part}',
+        }
+
+    def _serve_attachment(self, ident):
+        """Serve one content-addressed blob.
+
+        `ident` is validated against a strict `<sha256>.<known-ext>` shape
+        before it is joined to a path, so nothing a user can type reaches the
+        filesystem as a traversal. Content-Type comes from our own extension
+        map — never from the upload — and nosniff stops the browser from
+        re-interpreting the bytes as anything executable.
+        """
+        if not _store_ok or not _attach_dir:
+            self.send_error(404)
+            return
+        base, _, ext = ident.rpartition('.')
+        mime = ATTACH_MIME_BY_EXT.get('.' + ext) if ext else None
+        if not mime or not _SHA256_RE or not _SHA256_RE.match(base):
+            self.send_error(404)
+            return
+        path = os.path.join(_attach_dir, ident)
+        try:
+            with open(path, 'rb') as f:
+                blob = f.read()
+        except OSError:
+            self.send_error(404)
+            return
+        self.send_response(200)
+        self.send_header('Content-Type', mime)
+        self.send_header('Content-Length', str(len(blob)))
+        self.send_header('X-Content-Type-Options', 'nosniff')
+        self.send_header('Content-Disposition', 'inline')
+        self._cors_headers()
+        self.end_headers()
+        self.wfile.write(blob)
+
+    def _handle_attachment_upload(self):
+        """Persist one pasted/dropped image, content-addressed by sha256.
+
+        Uploaded at ATTACH time, not at submit time — that is the whole point.
+        An image the user pasted is on disk seconds later, long before they
+        decide to submit, so even a hard teardown mid-review cannot lose it.
+
+        Content addressing makes the write idempotent for free: the same image
+        pasted twice (or re-sent by the client's retry queue) resolves to the
+        same file, so a retry can never duplicate a blob or corrupt one.
+        """
+        global _attach_total_bytes
+        if not self._same_origin_ok():
+            self.send_error(403, "forbidden origin")
+            return
+        if not _store_ok:
+            self._error_response(507, {
+                "ok": False, "durable": False, "reason": "store_unavailable",
+            })
+            return
+        length = int(self.headers.get('Content-Length', 0))
+        # base64 inflates by ~4/3; cap the wire size before reading it in.
+        if length > MAX_ATTACHMENT_BYTES * 2:
+            self._error_response(413, {
+                "ok": False, "reason": "too_large",
+                "max_bytes": MAX_ATTACHMENT_BYTES,
+            })
+            return
+        try:
+            payload = json.loads(self.rfile.read(length).decode())
+        except (ValueError, UnicodeDecodeError):
+            self._error_response(400, {"ok": False, "reason": "bad_json"})
+            return
+        if not isinstance(payload, dict):
+            self._error_response(400, {"ok": False, "reason": "bad_json"})
+            return
+        mime = str(payload.get('mime') or '').lower()
+        ext = ATTACH_EXT_BY_MIME.get(mime)
+        if not ext:
+            # SVG lands here on purpose — see ATTACH_EXT_BY_MIME.
+            self._error_response(415, {
+                "ok": False, "reason": "unsupported_type", "mime": mime,
+                "allowed": sorted(ATTACH_EXT_BY_MIME),
+            })
+            return
+        try:
+            blob = base64.b64decode(str(payload.get('data') or ''), validate=True)
+        except (ValueError, TypeError):
+            self._error_response(400, {"ok": False, "reason": "bad_base64"})
+            return
+        if not blob:
+            self._error_response(400, {"ok": False, "reason": "empty"})
+            return
+        if len(blob) > MAX_ATTACHMENT_BYTES:
+            self._error_response(413, {
+                "ok": False, "reason": "too_large",
+                "size": len(blob), "max_bytes": MAX_ATTACHMENT_BYTES,
+            })
+            return
+
+        digest = hashlib.sha256(blob).hexdigest()
+        ident = digest + ext
+        path = os.path.join(_attach_dir, ident)
+        already = os.path.exists(path)
+        if not already and (_attach_total_bytes + len(blob)) > MAX_ATTACHMENT_TOTAL_BYTES:
+            self._error_response(507, {
+                "ok": False, "reason": "quota_exceeded",
+                "total_bytes": _attach_total_bytes,
+                "max_total_bytes": MAX_ATTACHMENT_TOTAL_BYTES,
+            })
+            return
+        if not already:
+            try:
+                _durable_write(path, blob)
+                _attach_total_bytes += len(blob)
+                _journal_append({
+                    'type': 'attachment',
+                    'id': ident,
+                    'sha256': digest,
+                    'mime': mime,
+                    'size': len(blob),
+                    # Display name only. It never touches a filesystem path —
+                    # the stored filename is derived purely from the digest.
+                    'name': str(payload.get('name') or '')[:200],
+                })
+            except OSError as exc:
+                self._error_response(507, {
+                    "ok": False, "durable": False,
+                    "reason": "store_write_failed", "detail": str(exc),
+                })
+                return
+        self._json_response({
+            "ok": True,
+            "durable": True,
+            "id": ident,
+            "sha256": digest,
+            "mime": mime,
+            "size": len(blob),
+            "url": f"/attachments/{ident}",
+            "deduplicated": already,
+        })
 
     def _send_raw_json(self, raw):
         self.send_response(200)
@@ -463,6 +1094,7 @@ def _watchdog(html_path, heartbeat_timeout_ms, interval_s=30, html_grace_s=10):
                         f"[watchdog] html_path gone for > {html_grace_s}s: "
                         f"{html_path} — shutting down\n"
                     )
+                    _watchdog_teardown('html_gone')
                     _remove_registry()
                     os._exit(0)
             else:
@@ -475,8 +1107,49 @@ def _watchdog(html_path, heartbeat_timeout_ms, interval_s=30, html_grace_s=10):
                 f"[watchdog] claude_ts stale by {now_ms - claude_ts}ms "
                 f"(threshold {heartbeat_timeout_ms}ms) — shutting down\n"
             )
+            _watchdog_teardown('heartbeat_stale')
             _remove_registry()
             os._exit(0)
+
+
+def _watchdog_teardown(reason):
+    """Last rites before `os._exit(0)`.
+
+    The watchdog used to be a silent data shredder: the `heartbeat_stale`
+    branch fires exactly when Claude has hit a usage limit (the session-scoped
+    pulser died with the turn, nothing else POSTs /heartbeat), so after the
+    default 30 min it reaped a server that was still holding the user's
+    unprocessed submission — with the payload only ever in RAM.
+
+    Killing the process is still correct; it is what keeps a ghost bridge from
+    outliving its session. What changes is that the kill is no longer
+    destructive. The submission is already on disk from the /decisions
+    durability gate, and this records HOW the process died plus a marker so
+    the next SessionStart reports a recoverable loss instead of silence.
+    """
+    with _lock:
+        data = _decisions
+        version = _version
+        processed_at = _processed_at
+        picked_up_at = _picked_up_at
+        phase = _phase
+    unprocessed = _is_submitted(data)
+    try:
+        _journal_append({
+            'type': 'watchdog_exit',
+            'reason': reason,
+            'version': version,
+            'unprocessed': unprocessed,
+        })
+        _state_write(_snapshot(data, version, processed_at, picked_up_at, phase))
+    except OSError:
+        pass  # we are exiting either way; the submission was fsynced at POST
+    if unprocessed:
+        _set_unprocessed_marker(version, f'watchdog:{reason}')
+        sys.stderr.write(
+            f"[watchdog] UNPROCESSED submission v{version} preserved in "
+            f"{_store_dir} — the next session will recover it\n"
+        )
 
 
 class ConceptBridgeServer(http.server.ThreadingHTTPServer):
@@ -574,6 +1247,12 @@ if __name__ == '__main__':
                              'Default 1800000 (30 min). Calibrated for concept-review '
                              'flows with long user-idle phases. Pass a lower value '
                              '(e.g. 300000) for active coding sessions.')
+    parser.add_argument('--store', default=None,
+                        help='Durable store directory for submissions, progress '
+                             'checkpoints and attachments. Defaults to '
+                             '.claude/concepts/<html-basename>/ inside <directory>. '
+                             'Without a usable store the bridge refuses to start — '
+                             'a bridge that cannot persist is the bug (#284).')
     args = parser.parse_args()
 
     port = int(args.port)
@@ -585,6 +1264,42 @@ if __name__ == '__main__':
     # cwd-change (unlikely, but cheap to be defensive) cannot misdirect the
     # existence check.
     html_path = os.path.abspath(args.html) if args.html else None
+
+    # ---- Durable store (#284) --------------------------------------------
+    # Derived from the concept filename so each concept gets its own directory
+    # and `discard` is a single recursive delete. Anchored at the project root
+    # (cwd after the chdir above), never inside a worktree.
+    if args.store:
+        store_dir = os.path.abspath(args.store)
+    elif args.html:
+        slug = os.path.splitext(os.path.basename(args.html))[0]
+        store_dir = os.path.abspath(os.path.join('.claude', 'concepts', slug))
+    else:
+        store_dir = os.path.abspath(os.path.join('.claude', 'concepts', f'port-{port}'))
+
+    if not _store_init(store_dir):
+        # Refusing to start is the point. A bridge that silently runs without
+        # durability is precisely the failure this whole change removes — it
+        # would look healthy right up until it ate a submission.
+        sys.stderr.write(
+            f"[concept-server] refusing to start without a writable store.\n"
+            f"[concept-server] tried: {store_dir}\n"
+        )
+        sys.exit(1)
+
+    restored = _store_restore()
+    if restored:
+        _resume_note = (
+            f"[concept-server] restored state v{_version} from {store_dir}"
+        )
+        if _is_submitted(_decisions):
+            _resume_note += "  ** UNPROCESSED SUBMISSION — pending stays true **"
+        print(_resume_note)
+        _journal_append({
+            'type': 'restore',
+            'version': _version,
+            'unprocessed': _is_submitted(_decisions),
+        })
 
     # Prime + self-pulse: the browser checks the heartbeat within 5s of page
     # load, so set `_server_ts` once before serving and then refresh every 30s

--- a/plugins/devops/scripts/concept-server.py
+++ b/plugins/devops/scripts/concept-server.py
@@ -215,6 +215,9 @@ MAX_DECISIONS_BYTES = 32 * 1024 * 1024
 MAX_ATTACHMENT_BYTES = 10 * 1024 * 1024
 MAX_ATTACHMENT_TOTAL_BYTES = 200 * 1024 * 1024
 _attach_total_bytes = 0
+# Guards the quota-check → write → accounting sequence as one critical section.
+# Separate from `_store_lock` so a large blob write never blocks a heartbeat.
+_attachment_quota_lock = threading.Lock()
 
 # Raster only, and SVG is deliberately absent. The bridge serves attachments
 # back to the page from the SAME origin, so an inline <script> in an uploaded
@@ -990,18 +993,42 @@ class ConceptBridgeHandler(http.server.SimpleHTTPRequestHandler):
         digest = hashlib.sha256(blob).hexdigest()
         ident = digest + ext
         path = os.path.join(_attach_dir, ident)
-        already = os.path.exists(path)
-        if not already and (_attach_total_bytes + len(blob)) > MAX_ATTACHMENT_TOTAL_BYTES:
+
+        # Quota check, write and accounting must be ONE critical section. This
+        # is a ThreadingHTTPServer, so `_attach_total_bytes += n` is a
+        # read-modify-write that two concurrent uploads can interleave: both
+        # pass the check against a stale total, and one increment is lost, so
+        # the cap drifts upward permanently. `_attachment_quota_lock` is taken
+        # WITHOUT holding `_lock`, keeping the global `_lock -> _store_lock`
+        # ordering intact (_journal_append takes _store_lock below).
+        already = False
+        err = None
+        quota_exceeded = False
+        with _attachment_quota_lock:
+            already = os.path.exists(path)
+            if not already and (_attach_total_bytes + len(blob)) > MAX_ATTACHMENT_TOTAL_BYTES:
+                quota_exceeded = True
+            elif not already:
+                try:
+                    _durable_write(path, blob)
+                    _attach_total_bytes += len(blob)
+                except OSError as exc:
+                    err = str(exc)
+        if quota_exceeded:
             self._error_response(507, {
                 "ok": False, "reason": "quota_exceeded",
                 "total_bytes": _attach_total_bytes,
                 "max_total_bytes": MAX_ATTACHMENT_TOTAL_BYTES,
             })
             return
+        if err is not None:
+            self._error_response(507, {
+                "ok": False, "durable": False,
+                "reason": "store_write_failed", "detail": err,
+            })
+            return
         if not already:
             try:
-                _durable_write(path, blob)
-                _attach_total_bytes += len(blob)
                 _journal_append({
                     'type': 'attachment',
                     'id': ident,
@@ -1012,12 +1039,10 @@ class ConceptBridgeHandler(http.server.SimpleHTTPRequestHandler):
                     # the stored filename is derived purely from the digest.
                     'name': str(payload.get('name') or '')[:200],
                 })
-            except OSError as exc:
-                self._error_response(507, {
-                    "ok": False, "durable": False,
-                    "reason": "store_write_failed", "detail": str(exc),
-                })
-                return
+            except OSError:
+                # The blob itself is already fsynced, which is what matters for
+                # recovery; a missing journal line only costs an audit entry.
+                pass
         self._json_response({
             "ok": True,
             "durable": True,

--- a/plugins/devops/skills/concept/SKILL.md
+++ b/plugins/devops/skills/concept/SKILL.md
@@ -606,6 +606,14 @@ User submits → Claude reads → Claude processes → Claude updates page → U
 ### 5a. Read & Parse
 1. Read the JSON from `#concept-decisions`
 2. Parse into structured decisions and comments
+3. **Open any attached images.** A comment may carry
+   `attachments: [{id, name, mime, size, path}]` — pasted or dropped
+   screenshots, already persisted by the bridge at
+   `.claude/concepts/{date}-{slug}/attachments/<id>`. Read every one with the
+   Read tool before acting on that comment. A comment can also be
+   image-ONLY with an empty `text`; that is a complete remark, not an empty
+   one, and skipping it because the text is blank silently discards the
+   user's point.
 
 **Coverage check:** before processing decisions, verify every named form
 field that exists in the just-frozen iteration HTML appears in the
@@ -619,6 +627,31 @@ Collection for the required pattern.
 
 The submit payload carries an `action` field (`"iterate"` or `"implement"`).
 Branch on it:
+
+**Checkpoint duty (all branches except `iterate`).** `implement`,
+`create-issues` and `ship` create real, externally-visible artifacts, and any
+of them can be cut short mid-flight — a usage limit, a crash, a PC restart.
+POST a checkpoint to the bridge as each artifact comes into existence:
+
+```bash
+curl -s -X POST -H "Content-Type: application/json" \
+  -d '{"action":"ship","step":"pr-opened","status":"done","version":<captured _version>,"artifacts":{"branch":"feat/x","pr":42}}' \
+  http://localhost:$PORT/progress
+```
+
+Use `step` values that name what now exists in the world — `branch-created`,
+`code-written`, `committed`, `pr-opened`, `merged`, `issues-created` (with the
+numbers in `artifacts`) — not internal phases. A resumed session replays these
+to learn how far the dead run got.
+
+**And on the receiving end: verify, never trust.** When you resume a run that
+has checkpoints (`ss.concept.resume` hands you the mandate, or `GET /recovery`
+shows them), establish the real state before acting — `git rev-parse --verify`
+for a branch, `gh pr view <n> --json state,mergedAt` for a PR, `gh issue view`
+for issues, and read the files for code changes. Then continue from what you
+observed. Never re-create an artifact that exists, never re-merge a merged PR,
+never re-run a completed step. The checkpoint records what the previous run
+*believed* it had done, and it died for a reason.
 
 **`action: "iterate"` (default — "Zur nächsten Iteration" button):**
 1. **Summarize** what was selected/rejected/commented
@@ -1054,6 +1087,54 @@ NOT match.
 | `gitignore` | null | Files stay at original path. Append `docs/concepts/{date}-{slug}.*` to `.gitignore` if not already covered. Run `git rm --cached -- "<html>" "<decisions.json>"` to untrack them if they were already added. |
 | `gitignore` | set | `mkdir -p -- "<moveTo>"` then `mv -- "<html>" "<moveTo>/"`; same for the decisions JSON. Append `<moveTo>/{date}-{slug}.*` to `.gitignore` if not already covered. Run `git rm --cached -- "<original-html>" "<original-decisions.json>"` on the original tracked entries. |
 
+**Also dispose of the durable store.** The bridge keeps every submission,
+progress checkpoint and pasted image under
+`.claude/concepts/{date}-{slug}/` (§ Durable store in `concept-server.py`).
+It is deliberately gitignored and invisible, which is exactly why it needs an
+explicit disposition step — otherwise pasted screenshots silt up forever in a
+directory nobody looks at.
+
+| `mode` | Store action |
+|---|---|
+| `discard` | `rm -rf -- ".claude/concepts/{date}-{slug}"` — journal and attachments go with the concept. Subject to the UNPROCESSED guard below. |
+| `keep` | Keep the store. If it holds attachments, copy them to `docs/concepts/{date}-{slug}-attachments/` and `git add` them, so the kept record is self-contained instead of pointing into an ignored directory. Skip when there are none. |
+| `gitignore` | Leave the store in place — it is already outside git. No extra `.gitignore` entry is needed beyond the blanket `.claude/concepts/` rule. |
+
+**UNPROCESSED guard — never discard unseen work.** Before any `rm -rf` of a
+store, check for `.claude/concepts/{date}-{slug}/UNPROCESSED`. Its presence
+means a submission was made that Claude never finished processing, so the user
+has not yet seen a result for it. Deleting that is the very loss this whole
+mechanism exists to prevent, and a default-`discard` disposition (§ above:
+`discard` is what an aborted session falls back to) would otherwise do it
+silently.
+
+```bash
+store=".claude/concepts/{date}-{slug}"
+if [ -e "$store/UNPROCESSED" ]; then
+  echo "UNPROCESSED submission in $store — not deleting"
+else
+  rm -rf -- "$store"
+fi
+```
+
+When the guard trips: keep the store, and report it as a `⏸ Rückfrage`-style
+line in the completion card naming the directory, so the user can decide.
+Never resolve it by deleting.
+
+**Orphan sweep.** A store whose concept HTML no longer exists — the file was
+deleted manually, a worktree was wiped, an older session never ran cleanup —
+is an orphan. Sweep those whose `state.json` is older than 7 days, applying
+the same UNPROCESSED guard to each:
+
+```bash
+for d in .claude/concepts/*/; do
+  slug="$(basename "$d")"
+  [ -e "docs/concepts/$slug.html" ] && continue          # live concept
+  [ -e "$d/UNPROCESSED" ] && continue                    # unseen work — keep
+  [ -n "$(find "$d/state.json" -mtime +7 2>/dev/null)" ] && rm -rf -- "$d"
+done
+```
+
 **Safety rules:**
 
 - `moveTo` is treated as a project-relative path. Resolve it relative to
@@ -1074,6 +1155,11 @@ NOT match.
   `docs/concepts/{date}-{slug}.*` pattern for THIS session's slug.
   Other concept HTML files in `docs/concepts/` belong to other
   sessions and MUST be preserved.
+- The same applies to the store: `rm -rf` exactly
+  `.claude/concepts/{date}-{slug}` and nothing else. A parallel concept
+  session in another worktree has its own directory next to it, and a
+  glob that catches it destroys a live bridge's state. Never
+  `rm -rf .claude/concepts/*` outside the guarded orphan sweep above.
 - `.gitignore` edits are append-only. Before appending, grep for an
   existing exact match (the full `docs/concepts/{date}-{slug}.*` line)
   — if it already exists, skip the append. Never rewrite or reorder

--- a/plugins/devops/skills/concept/bridge-durability.test.js
+++ b/plugins/devops/skills/concept/bridge-durability.test.js
@@ -1,0 +1,239 @@
+import { describe, test, expect, beforeAll, afterAll } from "vitest";
+import { spawn, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Integration proof for #284. The unit under test is the bridge's promise
+// that a submission survives the process dying — so this test actually kills
+// the process, which is the only way to test it honestly. A mocked server
+// would re-assert the assumption that broke.
+//
+// The scenario is the reported one: Claude hits a usage limit, the
+// session-scoped heartbeat pulser dies with the turn, and 30 min later the
+// watchdog reaps a bridge still holding the user's unprocessed submission.
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SERVER = path.join(__dirname, "..", "..", "scripts", "concept-server.py");
+const PNG_1PX =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+
+function pythonBin() {
+  for (const bin of ["python", "python3", "py"]) {
+    const r = spawnSync(bin, ["--version"], { encoding: "utf8" });
+    if (r.status === 0) return bin;
+  }
+  return null;
+}
+const PY = pythonBin();
+
+function freePort() {
+  return new Promise((resolve, reject) => {
+    const s = net.createServer();
+    s.listen(0, "127.0.0.1", () => {
+      const p = s.address().port;
+      s.close(() => resolve(p));
+    });
+    s.on("error", reject);
+  });
+}
+
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+async function call(port, p, method = "GET", body) {
+  const res = await fetch(`http://127.0.0.1:${port}${p}`, {
+    method,
+    headers: { "Content-Type": "application/json" },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  const buf = Buffer.from(await res.arrayBuffer());
+  let json = null;
+  try { json = JSON.parse(buf.toString("utf8")); } catch { /* binary */ }
+  return { status: res.status, json, buf };
+}
+
+async function boot(port, root, htmlRel) {
+  const proc = spawn(PY, [SERVER, String(port), root, "--html", htmlRel], { stdio: "pipe" });
+  for (let i = 0; i < 100; i++) {
+    await sleep(100);
+    try {
+      const r = await call(port, "/heartbeat");
+      if (r.status === 200) return proc;
+    } catch { /* not up yet */ }
+  }
+  proc.kill("SIGKILL");
+  throw new Error("bridge never came up");
+}
+
+const SLUG = "2026-08-16-durability";
+const results = {};
+let root, store, port, proc;
+
+beforeAll(async () => {
+  if (!PY) return;
+  root = fs.mkdtempSync(path.join(os.tmpdir(), "concept-dur-"));
+  fs.mkdirSync(path.join(root, "docs", "concepts"), { recursive: true });
+  const htmlRel = `docs/concepts/${SLUG}.html`;
+  fs.writeFileSync(path.join(root, htmlRel), "<html><body>c</body></html>");
+  store = path.join(root, ".claude", "concepts", SLUG);
+  port = await freePort();
+
+  // --- round 1: the user works ---
+  proc = await boot(port, root, htmlRel);
+  results.storeCreated = fs.existsSync(store);
+
+  results.submit = (await call(port, "/decisions", "POST", {
+    submitted: true, round: 1, action: "ship",
+    comments: [{ id: "f1", text: "alles was ich erarbeiten musste", attachments: [] }],
+  })).json;
+
+  results.upload = (await call(port, "/attachments", "POST", {
+    name: "shot.png", mime: "image/png", data: PNG_1PX,
+  })).json;
+
+  results.svgStatus = (await call(port, "/attachments", "POST", {
+    name: "x.svg", mime: "image/svg+xml",
+    data: Buffer.from("<svg onload=alert(1)/>").toString("base64"),
+  })).status;
+
+  await call(port, "/progress", "POST", {
+    action: "ship", step: "pr-opened", status: "done",
+    version: results.submit.version, artifacts: { branch: "feat/x", pr: 42 },
+  });
+
+  results.pendingBefore = (await call(port, "/pending")).json;
+
+  // --- the kill: SIGKILL, no atexit, no graceful shutdown ---
+  proc.kill("SIGKILL");
+  await sleep(700);
+  results.markerAfterKill = fs.existsSync(path.join(store, "UNPROCESSED"));
+
+  // --- round 2: a new session finds it ---
+  proc = await boot(port, root, htmlRel);
+  results.pendingAfter = (await call(port, "/pending")).json;
+  results.decisionsAfter = (await call(port, "/decisions")).json;
+  results.recovery = (await call(port, "/recovery")).json;
+  results.blob = await call(port, `/attachments/${results.upload.id}`);
+  results.traversalStatus = (await call(port, "/attachments/../../../../state.json")).status;
+
+  // --- processing completes ---
+  results.resetStatus = (await call(port, "/reset", "POST", { version: results.submit.version })).status;
+  results.markerAfterReset = fs.existsSync(path.join(store, "UNPROCESSED"));
+
+  proc.kill("SIGKILL");
+  await sleep(500);
+  proc = await boot(port, root, htmlRel);
+  results.pendingAfterReset = (await call(port, "/pending")).json;
+
+  results.journal = fs
+    .readFileSync(path.join(store, "journal.jsonl"), "utf8")
+    .split("\n").filter(Boolean).map(JSON.parse);
+}, 120_000);
+
+afterAll(async () => {
+  // Wait for the killed interpreter to actually go away before removing the
+  // tree. On Windows its file handles outlive the SIGKILL by a moment, and
+  // rmSync then fails EPERM — a teardown race that would fail the suite while
+  // every assertion passed.
+  if (proc && proc.exitCode === null && proc.signalCode === null) {
+    await new Promise(resolve => {
+      proc.once("exit", resolve);
+      try { proc.kill("SIGKILL"); } catch { resolve(); }
+      setTimeout(resolve, 3000);
+    });
+  }
+  await sleep(400);
+  if (root) {
+    fs.rmSync(root, { recursive: true, force: true, maxRetries: 12, retryDelay: 250 });
+  }
+}, 30_000);
+
+const it = PY ? test : test.skip;
+
+describe("a submission survives the bridge being killed", () => {
+  it("the bridge creates its durable store on startup", () => {
+    expect(results.storeCreated).toBe(true);
+  });
+
+  it("POST /decisions only acks once the payload is on disk", () => {
+    // `durable: true` is the contract the page relies on before it clears its
+    // own copy. A bare 200 is not that promise.
+    expect(results.submit.durable).toBe(true);
+  });
+
+  it("pending is true before the kill", () => {
+    expect(results.pendingBefore.pending).toBe(true);
+  });
+
+  it("an UNPROCESSED marker outlives a SIGKILL", () => {
+    expect(results.markerAfterKill).toBe(true);
+  });
+
+  it("pending is STILL true after the restart — this is the #284 regression", () => {
+    // Before the fix this was {pending: false, version: 0}, which a resumed
+    // session could not tell apart from "the user never submitted".
+    expect(results.pendingAfter.pending).toBe(true);
+    expect(results.pendingAfter.version).toBe(results.submit.version);
+  });
+
+  it("the payload itself is intact, not just the pending flag", () => {
+    expect(results.decisionsAfter.comments[0].text).toBe("alles was ich erarbeiten musste");
+  });
+});
+
+describe("/recovery tells a resumed session where it stood", () => {
+  it("reports the submission as unprocessed", () => {
+    expect(results.recovery.unprocessed).toBe(true);
+  });
+
+  it("surfaces the teardown marker as evidence of a hard exit", () => {
+    expect(results.recovery.marker).toBeTruthy();
+  });
+
+  it("replays the progress checkpoint with its real-world artifacts", () => {
+    expect(results.recovery.last_checkpoint.step).toBe("pr-opened");
+    expect(results.recovery.last_checkpoint.artifacts).toEqual({ branch: "feat/x", pr: 42 });
+  });
+});
+
+describe("attachments are durable and safe to serve", () => {
+  it("an image uploaded on attach is content-addressed by sha256", () => {
+    expect(results.upload.ok).toBe(true);
+    expect(results.upload.id).toMatch(/^[0-9a-f]{64}\.png$/);
+  });
+
+  it("it reads back byte-identical after the restart", () => {
+    expect(results.blob.status).toBe(200);
+    expect(results.blob.buf.equals(Buffer.from(PNG_1PX, "base64"))).toBe(true);
+  });
+
+  it("SVG is rejected — it would run script on the bridge origin", () => {
+    expect(results.svgStatus).toBe(415);
+  });
+
+  it("a traversal attempt on the attachment route is refused", () => {
+    expect(results.traversalStatus).toBe(404);
+  });
+});
+
+describe("a processed submission stays processed", () => {
+  it("reset clears the marker", () => {
+    expect(results.resetStatus).toBe(200);
+    expect(results.markerAfterReset).toBe(false);
+  });
+
+  it("it does not come back as pending after another restart", () => {
+    // The mirror image of the bug: recovery must not resurrect work Claude
+    // already acted on, or every restart would re-run the last submission.
+    expect(results.pendingAfterReset.pending).toBe(false);
+  });
+
+  it("the journal keeps the whole history append-only across all three runs", () => {
+    const types = results.journal.map(r => r.type);
+    expect(types.filter(t => t === "submission")).toHaveLength(1);
+    expect(types).toContain("processed");
+    expect(types.filter(t => t === "restore").length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/plugins/devops/skills/concept/deep-knowledge/bridge-server.md
+++ b/plugins/devops/skills/concept/deep-knowledge/bridge-server.md
@@ -370,6 +370,62 @@ AND provides HTTP endpoints for heartbeat and decision exchange.
    (add `concept-active.json` to `.gitignore` if not already covered by
    `.claude/`).
 
+4b. **The durable store — nothing to launch, but know it exists (#284).**
+   The server creates `.claude/concepts/<html-basename>/` on startup, derived
+   from `--html`, and **refuses to start (exit 1) if it cannot write there**.
+   That is deliberate: a bridge without durability looks perfectly healthy
+   right up until it eats a submission, so the failure belongs at launch time
+   where the 200-gate and the single-listener assert already catch problems.
+   Override the location with `--store <path>` only if you have a reason to.
+
+   ```
+   .claude/concepts/{date}-{slug}/
+     journal.jsonl    append-only, fsynced: submissions, pickups, progress
+                      checkpoints, attachments, resets, teardowns
+     state.json       atomically-replaced snapshot; restored on boot
+     attachments/     <sha256>.<png|jpg|gif|webp> — pasted/dropped images
+     UNPROCESSED      present iff a submission has not been processed yet
+   ```
+
+   What this buys, concretely: `POST /decisions` fsyncs the payload BEFORE it
+   acks the browser, and the server reloads `state.json` on boot. A bridge
+   that dies for any reason — PC restart, crash, or the watchdog reaping it
+   because Claude hit a usage limit and the session-scoped pulser stopped
+   heartbeating — comes back serving the SAME `pending: true` and the same
+   `_version`. Before this, `GET /pending` answered `false` afterwards, which
+   is indistinguishable from "the user never submitted".
+
+   **Restart on the same port, always.** The store is keyed to the concept,
+   not the port, but the open tab and `concept-active.json` both point at the
+   old port. A new port orphans them and makes fresh watchers exit
+   `PORT_CHANGED`.
+
+   **Ask the server where you stand** before processing anything on a resumed
+   session:
+   ```bash
+   curl -s http://localhost:{port}/recovery
+   ```
+   It returns `{unprocessed, version, marker, progress[], last_checkpoint,
+   attachments[]}`. A non-null `marker` means the previous process was torn
+   down hard rather than exiting cleanly.
+
+   **Checkpoint as you process.** For `implement` / `create-issues` / `ship`,
+   POST each real artifact as it comes into existence:
+   ```bash
+   curl -s -X POST -H "Content-Type: application/json" \
+     -d '{"action":"ship","step":"pr-opened","status":"done","version":<v>,"artifacts":{"branch":"feat/x","pr":42}}' \
+     http://localhost:{port}/progress
+   ```
+   A recovered run reads these to find out how far the dead run got — and
+   then **verifies each artifact against reality** (`git rev-parse`,
+   `gh pr view`, `gh issue view`) before continuing, because the checkpoint
+   records what the previous run believed, and it died for a reason. The
+   checkpoint says where to look; git and gh say what is true.
+
+   The store is disposed of by SKILL.md § Step 6a alongside the concept HTML —
+   `discard` removes the whole directory, guarded so an `UNPROCESSED` marker
+   is never deleted silently.
+
 5. **Verified heartbeat round-trip.** A naked `POST /heartbeat` with no
    read-back is not enough — if the server failed to bind, never started,
    or crashed on the first request, the POST exits 0 and the next step

--- a/plugins/devops/skills/concept/deep-knowledge/monitoring.md
+++ b/plugins/devops/skills/concept/deep-knowledge/monitoring.md
@@ -415,10 +415,23 @@ lands.
 
 ### Persistence
 
-Write processed decisions to:
-`docs/concepts/{same-timestamp}-{same-slug}-v{same-version}-decisions.json`
+Two layers, and it matters which one is load-bearing.
 
-Each round appends to the same file (array of rounds), preserving full history:
+**1. The bridge's durable store — automatic, Claude-independent (#284).**
+`.claude/concepts/{date}-{slug}/` is written by the SERVER, not by Claude:
+`POST /decisions` fsyncs the payload before it acks the browser, `/progress`
+journals each processing checkpoint, `/attachments` persists pasted images on
+attach. This is the layer that survives the failures that matter — a PC
+restart, a crash, or the watchdog reaping the bridge because Claude hit a
+usage limit and stopped heartbeating. Nothing Claude does or fails to do can
+lose a submission any more.
+
+Read the store when resuming: `GET /recovery` on a live bridge, or the files
+directly when the bridge is gone (which is what `ss.concept.resume` does).
+
+**2. The readable round history — written by Claude after processing.**
+`docs/concepts/{same-timestamp}-{same-slug}-v{same-version}-decisions.json`,
+appending one entry per round:
 
 ```json
 {
@@ -429,6 +442,28 @@ Each round appends to the same file (array of rounds), preserving full history:
 }
 ```
 
+This is a human-readable artefact for the repo, subject to the Step 6a
+disposition rules — **not** a safety net. It is written only after a round
+completes, so it covers none of the window where work is actually at risk.
+Treating it as the persistence layer is what left that window open in the
+first place.
+
+### Checkpointing while processing
+
+For anything longer than an `iterate` — `implement`, `create-issues`, `ship` —
+POST a checkpoint as each real-world artifact comes into existence:
+
+```bash
+curl -s -X POST -H "Content-Type: application/json" \
+  -d '{"action":"ship","step":"pr-opened","status":"done","version":<v>,"artifacts":{"branch":"feat/x","pr":42}}' \
+  http://localhost:$PORT/progress
+```
+
+A resumed session replays these to find out where the previous run stopped.
+Without them, recovering a half-finished `ship` means either re-running it
+blind or giving up — which is why the checkpoint is not optional for the
+non-`iterate` branches. See SKILL.md Step 5b.
+
 ## Error Handling
 
 ### Error Recovery Matrix
@@ -436,7 +471,9 @@ Each round appends to the same file (array of rounds), preserving full history:
 | Error | Symptom | Recovery |
 |-------|---------|----------|
 | Bridge server not responding | `curl /heartbeat` fails or times out | Check if server process is alive, restart if needed |
-| Bridge server crashed | Connection refused on all endpoints | Relaunch per `bridge-server.md` § step 2 — same port, `run_in_background: true`, `--html` set. Never the `&` form: a child backgrounded inside one Bash call is reaped when that call ends. Then re-launch both watchers |
+| Bridge server crashed | Connection refused on all endpoints | Relaunch per `bridge-server.md` § step 2 — same port, `run_in_background: true`, `--html` set. Never the `&` form: a child backgrounded inside one Bash call is reaped when that call ends. Then re-launch both watchers. The restarted server restores its state from the store, so a submission made before the crash is served again as `pending: true` |
+| Bridge reaped while a submission was unprocessed | New session, `.claude/concepts/<slug>/UNPROCESSED` exists | The usage-limit path: the pulser died with the turn and the watchdog reaped the bridge 30 min later. Nothing is lost — relaunch on the same port, `GET /recovery`, verify the last checkpoint against reality, resume. `ss.concept.resume` emits these instructions automatically |
+| Submission rejected as not durable | Page shows the durability warning strip, HTTP 507 | The bridge could not write its store (disk full, store directory removed). The payload is still in the page's localStorage and the panel is back in ready state — fix the disk/path, then re-submit. Do NOT tell the user to retype anything |
 | Keepalive pulser stopped (`PULSER_EXIT`) | Page shows "nicht verbunden" despite server running | Send a manual `curl -s -X POST /heartbeat`, then re-launch the pulser (bridge-server.md § step 3, task 1) |
 | Pickup waker stopped without a submission (`WAKER_EXIT reason=SERVER_DEAD`) | Submissions go unnoticed while the indicator may still be green | Restart the bridge server ON THE SAME PORT (a new one orphans the state file, the open tab, and makes fresh watchers exit PORT_CHANGED), then re-launch BOTH background tasks |
 | Decisions JSON parse error | `curl /decisions` returns malformed JSON | Show raw content to user, ask to verify |

--- a/plugins/devops/skills/concept/deep-knowledge/templates.md
+++ b/plugins/devops/skills/concept/deep-knowledge/templates.md
@@ -3284,6 +3284,8 @@ function ensureCommentSlots() {
 
     row.appendChild(label);
     row.appendChild(ta);
+    // Image attachments for this comment — see § Comment Attachments.
+    row.appendChild(buildAttachmentBar(commentKey));
 
     // Insert right after the bi-state group when both share the same parent;
     // otherwise append to the card so the override is visually attached.
@@ -3293,6 +3295,9 @@ function ensureCommentSlots() {
       card.appendChild(row);
     }
   });
+  // Wire paste / drop / button on every comment textarea, including the ones
+  // emitted inline by the generator rather than injected above.
+  initCommentAttachments();
 }
 ```
 
@@ -3306,6 +3311,326 @@ function ensureCommentSlots() {
   section is inserted; the `DOMContentLoaded` hook only fires on full
   reloads. Either trigger it manually or rely on the next `/reload` POST
   which forces a `location.reload()`.
+
+## Comment Attachments (images)
+
+Every comment slot accepts images: a 📎 button, **Ctrl/Cmd+V paste** into the
+focused textarea, and drag & drop onto it. A screenshot is very often the
+fastest way to say what is wrong with a concept, and re-describing it in prose
+is exactly the work users should not have to redo.
+
+**The durability rule: upload on ATTACH, never on submit.** The image is
+`POST`ed to the bridge the moment it is pasted and is fsynced to
+`.claude/concepts/<slug>/attachments/<sha256>.<ext>` seconds later — long
+before the user decides to submit. A teardown mid-review therefore cannot lose
+it. Deferring the upload to submit time would put every pasted image back
+inside the exact window that made submissions disappear (#284).
+
+Two independent copies exist until the submission is processed:
+
+| Copy | Written when | Survives |
+|------|-------------|----------|
+| IndexedDB (`concept-attachments`) | immediately, before the network call | server down, bridge reaped, offline |
+| `attachments/<sha256>.<ext>` on disk | on the `POST /attachments` ack | browser cache wipe, tab close, PC restart |
+
+The local copy is kept — not deleted on a successful upload — until the whole
+submission has been processed. An upload that fails leaves the attachment
+marked `synced: false` with a visible retry badge, and it is retried on the
+next reconnect alongside `retryPendingSubmission()`.
+
+Content addressing by sha256 makes all of this idempotent: pasting the same
+image twice, or a retry re-sending one, resolves to the same file. A retry can
+never duplicate a blob.
+
+**Only raster images are accepted** (`png`, `jpeg`, `gif`, `webp`). SVG is
+rejected by the server (HTTP 415) because attachments are served back from the
+bridge origin, where a script inside an uploaded SVG would run against every
+bridge endpoint.
+
+### HTML
+
+The bar is injected per comment slot by `ensureCommentSlots()`; generated
+pages may also emit it inline:
+
+```html
+<div class="attach-bar" data-attach-for="variant-a-note">
+  <button type="button" class="attach-btn" title="{{attach.button_title}}">📎</button>
+  <span class="attach-hint">{{attach.hint}}</span>
+  <input type="file" accept="image/png,image/jpeg,image/gif,image/webp" multiple hidden>
+  <div class="attach-thumbs"></div>
+</div>
+```
+
+`{{attach.button_title}}` → e.g. "Bild anhängen (oder Strg+V / hierher ziehen)",
+`{{attach.hint}}` → e.g. "Strg+V oder ablegen". Resolve both at generation time
+per § UI Locale.
+
+### CSS
+
+```css
+.attach-bar { display: flex; align-items: center; gap: .5rem; flex-wrap: wrap; margin-top: .4rem; }
+.attach-btn {
+  background: var(--surface-2); border: 1px solid var(--border-color);
+  color: var(--text-secondary); border-radius: 6px; cursor: pointer;
+  padding: .15rem .45rem; font-size: .95rem; line-height: 1.4;
+}
+.attach-btn:hover { border-color: var(--accent-color); color: var(--text-primary); }
+.attach-hint { font-size: .72rem; color: var(--text-tertiary); }
+.attach-thumbs { display: flex; gap: .4rem; flex-wrap: wrap; width: 100%; }
+.attach-thumb { position: relative; width: 64px; height: 64px; border-radius: 6px;
+                overflow: hidden; border: 1px solid var(--border-color); }
+.attach-thumb img { width: 100%; height: 100%; object-fit: cover; display: block; }
+.attach-thumb .attach-remove {
+  position: absolute; top: 1px; right: 1px; width: 16px; height: 16px;
+  border: none; border-radius: 50%; cursor: pointer; font-size: .7rem; line-height: 1;
+  background: rgba(0,0,0,.65); color: #fff;
+}
+/* Unsynced = on this machine only. Must be visible: it is the difference
+   between "safe everywhere" and "safe until this browser forgets". */
+.attach-thumb[data-synced="false"] { border-color: var(--warning-color, #d08c30); }
+.attach-thumb[data-synced="false"]::after {
+  content: "⟳"; position: absolute; bottom: 1px; left: 3px;
+  font-size: .7rem; color: var(--warning-color, #d08c30);
+}
+/* Drop affordance on the textarea itself. */
+textarea[data-comment].attach-dragover { outline: 2px dashed var(--accent-color); outline-offset: 2px; }
+```
+
+### JS
+
+```javascript
+// --- IndexedDB mirror: the copy that survives the bridge being gone ---
+const ATTACH_DB_NAME = 'concept-attachments';
+const ATTACH_STORE = 'blobs';
+
+function attachDB() {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(ATTACH_DB_NAME, 1);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(ATTACH_STORE)) {
+        const os = db.createObjectStore(ATTACH_STORE, { keyPath: 'key' });
+        os.createIndex('bySlot', 'slot', { unique: false });
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+async function attachDBPut(rec) {
+  const db = await attachDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(ATTACH_STORE, 'readwrite');
+    tx.objectStore(ATTACH_STORE).put(rec);
+    tx.oncomplete = resolve;
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+async function attachDBAll() {
+  const db = await attachDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(ATTACH_STORE, 'readonly');
+    const req = tx.objectStore(ATTACH_STORE).getAll();
+    req.onsuccess = () => resolve(req.result || []);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+async function attachDBDelete(key) {
+  const db = await attachDB();
+  return new Promise((resolve) => {
+    const tx = db.transaction(ATTACH_STORE, 'readwrite');
+    tx.objectStore(ATTACH_STORE).delete(key);
+    tx.oncomplete = resolve;
+    tx.onerror = resolve;
+  });
+}
+
+// Slot key -> [{key, slot, id, name, mime, size, synced, blob}]
+const _attachments = new Map();
+
+function buildAttachmentBar(slotKey) {
+  const bar = document.createElement('div');
+  bar.className = 'attach-bar';
+  bar.dataset.attachFor = slotKey;
+  bar.innerHTML =
+    '<button type="button" class="attach-btn" title="{{attach.button_title}}">📎</button>' +
+    '<span class="attach-hint">{{attach.hint}}</span>' +
+    '<input type="file" accept="image/png,image/jpeg,image/gif,image/webp" multiple hidden>' +
+    '<div class="attach-thumbs"></div>';
+  return bar;
+}
+
+function _slotKeyOf(ta) { return ta.dataset.comment || ta.id || ''; }
+
+function _barFor(slotKey) {
+  return document.querySelector('.attach-bar[data-attach-for="' + CSS.escape(slotKey) + '"]');
+}
+
+function initCommentAttachments() {
+  document.querySelectorAll('textarea[data-comment]').forEach(ta => {
+    if (ta.dataset.attachWired) return;      // idempotent, like ensureCommentSlots
+    ta.dataset.attachWired = '1';
+    const slotKey = _slotKeyOf(ta);
+    if (!slotKey) return;
+
+    // A page whose textarea was emitted inline has no bar yet.
+    if (!_barFor(slotKey) && ta.parentElement) {
+      ta.parentElement.appendChild(buildAttachmentBar(slotKey));
+    }
+    const bar = _barFor(slotKey);
+    if (!bar) return;
+
+    const fileInput = bar.querySelector('input[type="file"]');
+    bar.querySelector('.attach-btn').addEventListener('click', () => fileInput.click());
+    fileInput.addEventListener('change', () => {
+      addAttachments(slotKey, Array.from(fileInput.files || []));
+      fileInput.value = '';
+    });
+
+    // Hotkey: plain Ctrl/Cmd+V into the textarea. The clipboard carries the
+    // image as a file item, so nothing extra needs pressing.
+    ta.addEventListener('paste', ev => {
+      const items = Array.from((ev.clipboardData || {}).items || []);
+      const files = items.filter(i => i.kind === 'file' && i.type.startsWith('image/'))
+                         .map(i => i.getAsFile())
+                         .filter(Boolean);
+      if (!files.length) return;             // plain text paste — leave it alone
+      ev.preventDefault();
+      addAttachments(slotKey, files);
+    });
+
+    ['dragenter', 'dragover'].forEach(evt =>
+      ta.addEventListener(evt, e => { e.preventDefault(); ta.classList.add('attach-dragover'); }));
+    ['dragleave', 'drop'].forEach(evt =>
+      ta.addEventListener(evt, () => ta.classList.remove('attach-dragover')));
+    ta.addEventListener('drop', e => {
+      const files = Array.from(e.dataTransfer?.files || []).filter(f => f.type.startsWith('image/'));
+      if (!files.length) return;
+      e.preventDefault();
+      addAttachments(slotKey, files);
+    });
+  });
+}
+
+async function addAttachments(slotKey, files) {
+  for (const file of files) {
+    const key = slotKey + ':' + Date.now() + ':' + Math.random().toString(36).slice(2, 8);
+    const rec = {
+      key, slot: slotKey, id: null, name: file.name || 'pasted-image',
+      mime: file.type, size: file.size, synced: false, blob: file,
+    };
+    // LOCAL FIRST — before the network call, so a failure at any point after
+    // this leaves the image recoverable on this machine.
+    try { await attachDBPut(rec); } catch { /* private mode: server copy still applies */ }
+    const list = _attachments.get(slotKey) || [];
+    list.push(rec);
+    _attachments.set(slotKey, list);
+    renderAttachments(slotKey);
+    uploadAttachment(rec).then(() => renderAttachments(slotKey));
+    if (typeof _markUserInteracted === 'function') _markUserInteracted();
+  }
+}
+
+async function uploadAttachment(rec) {
+  try {
+    const data = await new Promise((resolve, reject) => {
+      const fr = new FileReader();
+      fr.onload = () => resolve(String(fr.result).split(',')[1] || '');
+      fr.onerror = () => reject(fr.error);
+      fr.readAsDataURL(rec.blob);
+    });
+    const res = await fetch('/attachments', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: rec.name, mime: rec.mime, data })
+    });
+    if (!res.ok) return false;               // 415/413/507 — keep it local, badge stays
+    const meta = await res.json();
+    rec.id = meta.id;
+    rec.synced = true;
+    try { await attachDBPut(rec); } catch { /* ignore */ }
+    return true;
+  } catch {
+    return false;                            // offline — the reconnect path retries
+  }
+}
+
+function renderAttachments(slotKey) {
+  const bar = _barFor(slotKey);
+  if (!bar) return;
+  const thumbs = bar.querySelector('.attach-thumbs');
+  thumbs.innerHTML = '';
+  for (const rec of _attachments.get(slotKey) || []) {
+    const wrap = document.createElement('div');
+    wrap.className = 'attach-thumb';
+    wrap.dataset.synced = String(!!rec.synced);
+    wrap.title = rec.name + (rec.synced ? '' : ' — {{attach.not_synced}}');
+    const img = document.createElement('img');
+    // Prefer the server copy once it exists: it proves the durable write
+    // landed, and it survives an IndexedDB eviction.
+    img.src = rec.synced && rec.id ? '/attachments/' + rec.id : URL.createObjectURL(rec.blob);
+    img.alt = rec.name;
+    const rm = document.createElement('button');
+    rm.type = 'button';
+    rm.className = 'attach-remove';
+    rm.textContent = '×';
+    rm.addEventListener('click', () => removeAttachment(slotKey, rec.key));
+    wrap.appendChild(img);
+    wrap.appendChild(rm);
+    thumbs.appendChild(wrap);
+  }
+}
+
+async function removeAttachment(slotKey, key) {
+  // Drops the LOCAL reference only. The server blob is content-addressed and
+  // may be referenced by another slot or an earlier round; the store is
+  // cleaned as a whole by the disposition step, never piecemeal from the UI.
+  _attachments.set(slotKey, (_attachments.get(slotKey) || []).filter(r => r.key !== key));
+  await attachDBDelete(key);
+  renderAttachments(slotKey);
+}
+
+async function restoreAttachments() {
+  let all = [];
+  try { all = await attachDBAll(); } catch { return; }
+  for (const rec of all) {
+    const list = _attachments.get(rec.slot) || [];
+    list.push(rec);
+    _attachments.set(rec.slot, list);
+  }
+  // Anything that never reached the bridge gets another chance now.
+  for (const rec of all.filter(r => !r.synced)) await uploadAttachment(rec);
+  for (const slot of _attachments.keys()) renderAttachments(slot);
+}
+
+// Called from collectDecisionDecisions — only synced attachments are named in
+// the payload, because Claude reads them from disk by id. An unsynced one is
+// still on this machine and is retried, but it must not be advertised as a
+// path that does not exist.
+function attachmentsFor(slotKey) {
+  return (_attachments.get(slotKey) || [])
+    .filter(r => r.synced && r.id)
+    .map(r => ({ id: r.id, name: r.name, mime: r.mime, size: r.size,
+                 path: '.claude/concepts/{{slug}}/attachments/' + r.id }));
+}
+
+function unsyncedAttachmentCount() {
+  let n = 0;
+  for (const list of _attachments.values()) n += list.filter(r => !r.synced).length;
+  return n;
+}
+```
+
+Wire `restoreAttachments()` into `DOMContentLoaded` **after** `ensureCommentSlots()`
+(the bars must exist before thumbnails render), and call `initCommentAttachments()`
+again after any iteration append, exactly like `ensureCommentSlots()`.
+
+`{{slug}}` is the concept's date-slug, substituted at generation time — it is
+the store directory name, so Claude can open the referenced file directly with
+the Read tool.
 
 ## collectDecisions (dispatcher)
 
@@ -3381,11 +3706,14 @@ function collectDecisionDecisions() {
   });
 
   document.querySelectorAll('[data-comment]').forEach(el => {
-    if (el.value.trim()) {
-      comments.push({
-        id: el.dataset.comment,
-        text: el.value.trim()
-      });
+    const text = el.value.trim();
+    const attachments = (typeof attachmentsFor === 'function')
+      ? attachmentsFor(el.dataset.comment) : [];
+    // An image with no prose is a complete comment — a screenshot often says
+    // it better than a sentence. Gating on `text` alone (as this did before
+    // attachments existed) would silently drop an image-only remark.
+    if (text || attachments.length) {
+      comments.push({ id: el.dataset.comment, text, attachments });
     }
   });
 
@@ -3466,6 +3794,22 @@ deliberately to reach the implement button.
 }
 .implement-btn .warn-icon { font-size: 1rem; }
 .hint-warn { color: var(--warning-color, #d29922); }
+
+/* Durability warning strip — shown when a submission or an attachment did
+   not reach the bridge's durable store. Deliberately loud: a silent failure
+   here is the exact bug the store exists to remove. */
+.submit-warning {
+  display: none;
+  margin: 0 0 .75rem;
+  padding: .5rem .7rem;
+  border: 1px solid var(--warning-color, #d29922);
+  border-left-width: 3px;
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--warning-color, #d29922) 12%, transparent);
+  color: var(--text-primary);
+  font-size: .8rem;
+  line-height: 1.4;
+}
 ```
 
 ### JS
@@ -3549,21 +3893,88 @@ async function submitWithAction(action) {
   document.getElementById('panel-ready').style.display = 'none';
   document.getElementById('panel-submitted').style.display = 'block';
 
+  // The submitted panel is already on screen, and it is a promise that the
+  // payload is safe. That promise must be backed by a DURABLE ack, not by
+  // "the request did not throw". `fetch` rejects only on a transport failure,
+  // so a 507 (bridge could not persist) resolved like any other response and
+  // the old code counted it as success — then cleared the local copy. That is
+  // the client-side half of #284.
+  let durable = false;
+  let transportFailed = false;
   try {
-    await fetch('/decisions', {
+    const res = await fetch('/decisions', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(data)
     });
+    const body = res.ok ? await res.json().catch(() => ({})) : {};
+    durable = res.ok && body.durable !== false;
   } catch (e) {
-    localStorage.setItem(STORAGE_KEY + '-pending', JSON.stringify(data));
+    transportFailed = true;
   }
+
+  if (!durable) {
+    // Keep a local copy first, whatever went wrong.
+    localStorage.setItem(STORAGE_KEY + '-pending', JSON.stringify(data));
+    if (transportFailed) {
+      // Offline / bridge down. This case self-heals — retryPendingSubmission()
+      // fires on reconnect — so the submitted panel stays up and we only
+      // explain the delay.
+      showSubmitWarning('{{panel.submit_queued_offline}}');
+    } else {
+      // The bridge answered but could not persist (disk full, store gone).
+      // Nothing retries this on its own, so do NOT leave a "sent" panel
+      // standing over it: hand control back and say why.
+      restorePanelToReady();
+      showSubmitWarning('{{panel.submit_not_durable}}');
+    }
+  }
+
+  const unsynced = (typeof unsyncedAttachmentCount === 'function')
+    ? unsyncedAttachmentCount() : 0;
+  if (unsynced > 0) showSubmitWarning('{{panel.attachments_not_synced}}');
+
   saveState();
   _submitInFlight = false;
 }
 
 wireSubmit('submit-iterate-btn', 'iterate');
 wireSubmit('submit-implement-btn', 'implement');
+
+// --- Submit warnings ---
+// A submission that did not reach disk must SAY SO on the page. The whole
+// failure mode this guards against is a confident "übermittelt" panel sitting
+// on top of work that no longer exists anywhere, which is what sends the user
+// away believing Claude will pick it up.
+//
+// Locale strings, resolved at generation time per § UI Locale:
+//   {{panel.submit_queued_offline}}   — "Bridge nicht erreichbar — wird bei
+//                                        Reconnect automatisch nachgeholt.
+//                                        Deine Eingaben sind lokal gesichert."
+//   {{panel.submit_not_durable}}      — "Die Bridge konnte die Übermittlung
+//                                        nicht sichern (Speicherproblem).
+//                                        Nichts ist verloren — deine Eingaben
+//                                        liegen lokal. Bitte erneut absenden."
+//   {{panel.attachments_not_synced}}  — "Ein Bild liegt noch nur lokal vor und
+//                                        wird automatisch nachgereicht."
+function showSubmitWarning(msg) {
+  const host = document.getElementById('panel-submitted')
+            || document.getElementById('panel-ready');
+  if (!host) return;
+  let strip = host.querySelector('.submit-warning');
+  if (!strip) {
+    strip = document.createElement('div');
+    strip.className = 'submit-warning';
+    strip.setAttribute('role', 'alert');
+    host.insertBefore(strip, host.firstChild);
+  }
+  strip.textContent = msg;
+  strip.style.display = 'block';
+}
+
+function clearSubmitWarning() {
+  document.querySelectorAll('.submit-warning').forEach(el => el.remove());
+}
 
 // --- Content dimmer (focus shifter after submit) ---
 // After a submit the user's attention belongs on the decision panel / FAB,
@@ -3832,8 +4243,13 @@ async function retryPendingSubmission() {
       headers: { 'Content-Type': 'application/json' },
       body: pending
     });
-    if (res.ok) localStorage.removeItem(pendingKey);
+    const body = res.ok ? await res.json().catch(() => ({})) : {};
+    // Drop the local copy ONLY once the bridge confirms it reached disk.
+    // `res.ok` alone is not that confirmation — see submitWithAction.
+    if (res.ok && body.durable !== false) localStorage.removeItem(pendingKey);
   } catch (e) { /* still offline */ }
+  // Images that never made it up get another attempt on the same trigger.
+  if (typeof restoreAttachments === 'function') restoreAttachments();
 }
 ```
 

--- a/plugins/devops/skills/setup-project/SKILL.md
+++ b/plugins/devops/skills/setup-project/SKILL.md
@@ -80,6 +80,7 @@ See `deep-knowledge/claude-directory-structure.md` for the canonical `.claude/` 
 .claude/*.log
 .claude/token-config.json
 .claude/concept-active.json
+.claude/concepts/
 .claude/session-opened-files.json
 ```
 

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.126.4",
+  "version": "0.127.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
Closes #284

## Summary

Concept submissions lived in the bridge server's RAM and nowhere else. Anything that ended that process took the user's work with it, silently — the restarted bridge answered `pending: false`, which is indistinguishable from "the user never submitted".

The issue describes a session restart. There is a third path it does not cover, and it is the common one: the watchdog reaps the bridge on a stale heartbeat (30 min default), and the heartbeat pulser is a session-scoped background task that dies with the turn. **Claude hitting a usage limit therefore destroyed any unprocessed submission half an hour later, deterministically.**

## What changed

**Durability spine.** A per-concept store at `.claude/concepts/<slug>/` — append-only fsynced `journal.jsonl`, atomically replaced `state.json`, `attachments/`, and an `UNPROCESSED` marker. Project-root anchored, so it survives worktree wipes; outside the tracked tree, so pasted screenshots cannot be committed by accident.

- `POST /decisions` fsyncs **before** it acks the browser. A failed write returns 507 instead of a silent success.
- State is restored on boot, so a restarted bridge serves the same pending submission and version.
- The watchdog and `/shutdown` journal their teardown and leave the marker behind. The anti-ghost guarantee is unchanged — exiting is simply no longer destructive.
- The server refuses to start without a writable store. A bridge that cannot persist looks perfectly healthy right up until it eats a submission.

**Auto-resume, verified against reality.** New `POST /progress` records checkpoints as real artifacts appear (branch, commit, PR, created issues); `GET /recovery` reports the unprocessed state, the teardown marker and every checkpoint. `ss.concept.resume` no longer gives up when the heartbeat probe fails — it reads the store directly and instructs a same-port relaunch. Recovery then verifies each claimed artifact against `git`/`gh` before continuing, so a half-finished ship resumes rather than double-ships. A checkpoint says where to look, never what to trust.

**Image attachments.** Paperclip button, `Ctrl`/`Cmd`+`V` paste and drag & drop on every comment slot. Uploaded on attach rather than on submit, so an image is durable seconds after it is pasted — before the submit decision, and therefore outside the vulnerable window entirely. Content-addressed by sha256, which makes retries idempotent for free. An IndexedDB mirror is held until the server confirms `durable: true`. Raster only; SVG is rejected because attachments are served back same-origin, where a script inside one would run against every bridge endpoint. An image-only comment with empty text is now submitted instead of dropped.

**Client-side half of the same bug.** `submitWithAction` treated any non-throwing `fetch` as success — but `fetch` rejects only on transport failure, so a 507 rendered a confident "übermittelt" panel over lost work. It now requires a durable ack and distinguishes offline (self-heals on reconnect, panel stays) from unpersistable (panel returns to ready with a visible warning).

**Cleanup.** Step 6a disposes of the store alongside the concept: `discard` removes it wholesale, guarded so an `UNPROCESSED` marker is never deleted silently. Plus an orphan sweep and a `.claude/concepts/` gitignore entry, here and in the setup-project template.

## Also in this PR

Two hook test files failed non-deterministically under `npm test` while passing in isolation, which blocked this branch's build gate and predates it (same behavior on pristine `main`). Both came from tests sharing machine-global state: the token-guard tests located their confirmation flag by diffing the shared system tmpdir and could grab a parallel test's flag; `post.flow.completion.test.js` read `res.stdout` with no retry, so a child that failed to launch under load looked like a hook that emitted nothing. Each test now gets a private tmpdir, and only a genuinely-unstarted child is retried.

## Verification

- 16 integration assertions that actually `SIGKILL` the bridge and assert recovery, including the exact #284 regression, attachment round-trip, SVG rejection and path traversal.
- 17 unit tests for the resume hook's disk-recovery path.
- Four consecutive full-suite runs: 1549/1549 each.
- Codex review gate hit its own usage limit and was skipped per the failure-tolerance rule; the upload endpoint was reviewed manually instead, which found and fixed an unlocked read-modify-write on the attachment quota counter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)