### PR TITLE
fix(git-sync): replace 10-min cron with detached background sync

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.128.0"
+    "version": "0.129.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.128.0",
+      "version": "0.129.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.128.0",
+      "version": "0.129.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.129.0] — 2026-08-16
+
+### Changed
+
+- **The git sync no longer costs a Claude turn every ten minutes.** It ran as a recurring cron that re-entered Claude with a prompt of roughly 1600 characters, so every tick rendered as a full turn — the Bash call inline, a model reply after it, and completion/stop hooks to suppress afterwards — for a `fetch` + `merge` that has nothing to say in almost every tick. Claude Code renders a cron's entire prompt as its card in the background-tasks panel, which meant this one card filled the panel and hid every other task behind it. A mechanical fetch and merge needs no model in the loop; only a genuinely ambiguous conflict does. The sync now runs as a detached child process, started once per worktree at session start and again at turn end on a 30-minute throttle shared across every session on that worktree — turn end rather than an arbitrary instant, because a merge landing mid-tool-call could otherwise move a file out from under the work in progress. The child writes its result atomically to a per-worktree file and the next user prompt picks it up, so a conflict now surfaces inside a turn the user is already in instead of waking Claude up in one of its own.
+
+  What reaches the chat is what happened: commits merged gets one informational line, an ambiguous conflict gets the full resolution procedure, a failure gets reported. A sync that found nothing — the overwhelming majority — is silent, as is the `✓ skipped (throttled, last sync 4m ago)` line the prompt hook used to print about not having done anything. The user-facing sync frequency drops from every 10 minutes plus every 15 minutes of prompting to a single sync per 30-minute window per worktree.
+
+### Fixed
+
+- **Plugins that ship only skills, or only hooks, are no longer "repaired" on every single session start.** The cache completeness check demanded both a `skills/` and a `hooks/` directory from every installed plugin, but plugins legitimately ship one without the other — so those could never satisfy the check. The rebuild reported failure, the registry commit SHA was therefore never advanced, and the next session found the same apparent damage and rebuilt again, printing the same `1.0.0 → 1.0.0 [cache repair]` block at the top of every session forever. The check now asserts only what the source plugin actually ships, the same per-plugin rule the MCP-file check already used for exactly this reason. A successful same-version cache repair is also no longer reported at all: it is housekeeping the user cannot act on and no restart follows from it. Version changes and real failures still surface.
+
 ## [0.128.0] — 2026-08-16
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ For the full extension guide with examples per skill, see `deep-knowledge/skill-
 
 ## Features
 
-- **<!--devops:count:hooks-->40<!--/devops:count:hooks--> Hooks** — automated guards and triggers across the full session lifecycle
+- **<!--devops:count:hooks-->41<!--/devops:count:hooks--> Hooks** — automated guards and triggers across the full session lifecycle
 - **<!--devops:count:skills-->21<!--/devops:count:skills--> Skills** — ship, promote, commit, fix, setup-issue, setup-project, setup-readme, auto-usage, claude-extend-skill, setup-cleanup, auto-update, concept, run-agents, run-autonomous, run-burn, run-backlog, claude-learn, tune-harden, tune-polish, tune-rethink, auto-graph
 - **<!--devops:count:agents-->12<!--/devops:count:agents--> Agents** — AI, Core, Designer, Feature, Frontend, Gamer, PO, QA, Redteam, Research, Windows
 - **Completion Flow** — mandatory card after every task (8 variants), visual verification, ship recommendation
@@ -178,7 +178,7 @@ For the full extension guide with examples per skill, see `deep-knowledge/skill-
 
 ### Hooks (automatic, no user action needed)
 
-<!--devops:count:hooks-->40<!--/devops:count:hooks--> hooks fire automatically across the session lifecycle — no user action needed.
+<!--devops:count:hooks-->41<!--/devops:count:hooks--> hooks fire automatically across the session lifecycle — no user action needed.
 
 <details>
 <summary><strong>By session lifecycle</strong> — when does it fire?</summary>
@@ -200,7 +200,7 @@ SessionStart  ──>  UserPromptSubmit  ──>  PreToolUse  ──>  PostToolU
 - `ss.mcp.reap` — Reclaim orphaned Claude Desktop MCP server processes leaked by previously-closed sess…
 - `ss.tokens.scan` — Scan project for expensive files and update config for the pre.tokens.guard hook.
 - `ss.git.check` — Check for stale changes AND workspace setup issues at session start.
-- `ss.git.sync` — Registers a recurring git sync cron job (every 10 minutes).
+- `ss.git.sync` — Starts ONE detached background git sync for this worktree.
 - `ss.graphify` — graphify enforcement — install-check + auto-build wiring for the auto-graph feature.
 - `ss.ship.verify` — Surface results from the post-merge watcher (post-ship CI + optional deploy verify).
 - `ss.concept.resume` — Recover an open concept session after a Claude restart.
@@ -210,7 +210,7 @@ SessionStart  ──>  UserPromptSubmit  ──>  PreToolUse  ──>  PostToolU
 
 - `prompt.flow.silent-turn` — Detects background/cron-injected prompts and marks the turn as "silent" so post.flow.…
 - `prompt.knowledge.dispatch` — On-demand deep-knowledge injection based on prompt keywords.
-- `prompt.git.sync` — Throttled git sync on user prompt — delegates to scripts/git-sync.js.
+- `prompt.git.sync` — Delivers the result of a background git sync — nothing else.
 - `prompt.issue.detect` — Detect issue references in user messages.
 - `prompt.plugin.scope` — Inject the scope-routing rule when a consumer project's session starts talking about…
 - `prompt.skill.enforce` — Detects inline skill commands (e.g.
@@ -238,6 +238,7 @@ SessionStart  ──>  UserPromptSubmit  ──>  PreToolUse  ──>  PostToolU
 
 #### Stop — runs when Claude finishes responding
 
+- `stop.git.sync` — Throttled background git sync at turn end.
 - `stop.flow.browsertest` — Light-verification enforcement gate (the "V" of the V&V gate).
 - `stop.flow.guard` — Per-turn completion card + validation enforcement (the validation half of the V&V gate).
 - `stop.flow.selfcalibration` — Run self-calibration when Claude finishes a response turn.
@@ -257,8 +258,9 @@ SessionStart  ──>  UserPromptSubmit  ──>  PreToolUse  ──>  PostToolU
 #### git — keep the working tree in sync
 
 - `ss.git.check` — Check for uncommitted/unpushed changes *(SessionStart)*
-- `ss.git.sync` — Register recurring git-sync cron, every 10 min *(SessionStart)*
-- `prompt.git.sync` — Throttled pull/merge main, every 15 min *(UserPromptSubmit)*
+- `ss.git.sync` — Start one detached background sync per worktree *(SessionStart)*
+- `stop.git.sync` — Same, throttled to 30 min, at turn end *(Stop)*
+- `prompt.git.sync` — Deliver a background sync's result, if any *(UserPromptSubmit)*
 
 #### ship — enforce the shipping pipeline
 
@@ -690,7 +692,7 @@ Wk  ━━──╏─────────   15% +1%   · 4d 22h left
 devops/
 ├── .claude-plugin/plugin.json     ← Plugin manifest
 ├── CONVENTIONS.md                 ← Naming, versioning, extension rules
-├── hooks/                         ← <!--devops:count:hooks-->40<!--/devops:count:hooks--> hooks (JS) registered in hooks.json
+├── hooks/                         ← <!--devops:count:hooks-->41<!--/devops:count:hooks--> hooks (JS) registered in hooks.json
 ├── skills/                        ← <!--devops:count:skills-->21<!--/devops:count:skills--> skill definitions (SKILL.md)
 ├── agents/                        ← <!--devops:count:agents-->12<!--/devops:count:agents--> agent definitions
 ├── deep-knowledge/                ← Cross-cutting reference docs

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.128.0**
+**Version: 0.129.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.128.0",
+  "version": "0.129.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/deep-knowledge/git-hygiene.md
+++ b/plugins/devops/deep-knowledge/git-hygiene.md
@@ -33,7 +33,7 @@ Cross-cutting git rules referenced by `/commit`, `/ship`, and hooks.
 
 - **Never** use `--ours`, `--theirs`, or any strategy that silently picks one side.
 - Conflict resolution follows `deep-knowledge/merge-safety.md`.
-- The `git-sync` cron detects conflicts and defers resolution to Claude.
+- The background `git-sync` detects conflicts and defers resolution to Claude.
 - Complementary changes (both additions, non-overlapping edits) → AI resolves automatically.
 - Mutually exclusive design decisions (user-facing choices) → user decides via `AskUserQuestion`.
 - After resolving conflicts, verify the merged code is semantically correct (not just textually).

--- a/plugins/devops/deep-knowledge/merge-safety.md
+++ b/plugins/devops/deep-knowledge/merge-safety.md
@@ -103,7 +103,7 @@ unsupported or unparseable files.
 
 ## When This Applies
 
-- `git-sync` cron merging parent branches into the current working branch
+- background `git-sync` merging parent branches into the current working branch
 - Feature agent merging sub-agent branches at integration
 - `/ship` when base branch has diverged
 - Any `git merge` or `git rebase` during collaborative work
@@ -177,9 +177,9 @@ After all textual conflicts are resolved (or after a clean merge):
    directions (e.g. "all elements get hotkeys" must cover an element the
    other branch added, and a convention introduced on the shipping branch is
    retro-applied to existing artifacts).
-   See `skills/ship/deep-knowledge/purpose-alignment.md`. The git-sync
-   cron resolves code-level conflicts only — purpose alignment runs at ship
-   time.
+   See `skills/ship/deep-knowledge/purpose-alignment.md`. The background
+   git-sync resolves code-level conflicts only — purpose alignment runs at
+   ship time.
 
 ### Step 6 — Complete the merge
 
@@ -200,7 +200,11 @@ As of v0.3.0, `git-sync.js` resolves conflicts in two tiers:
 2. **Ambiguous conflicts** — merge is aborted, warning printed:
    - Both sides changed the same code in different ways
    - No trivial resolution determinable from the diff alone
-   - Claude resolves semantically via the cron callback (Steps 2–6 above)
+   - Claude resolves semantically (Steps 2–6 above) on the next user turn:
+     the sync runs detached from `ss.git.sync` / `stop.git.sync` and leaves a
+     result file that `prompt.git.sync` injects as turn context. Conflicts
+     therefore surface inside a turn the user is already in — there is no
+     cron waking Claude up in a turn of its own.
 
 ## How ship_release Prevents Overwrites
 
@@ -262,7 +266,7 @@ belt-and-suspenders for history readability.
 The `git push --force-with-lease` only ever targets the **feature branch**,
 never `base` — so it cannot clobber base commits. It uses an **explicit lease**
 pinned to the last-known remote sha (`--force-with-lease=<branch>:<sha>`) rather
-than the bare form, so an implicit background fetch (the git-sync cron) cannot
+than the bare form, so an implicit background fetch (the background git-sync) cannot
 widen the lease and let a concurrent push to the same branch slip through
 unseen. Brand-new branches (no remote-tracking ref) push without a lease.
 

--- a/plugins/devops/docs/architecture.html
+++ b/plugins/devops/docs/architecture.html
@@ -169,7 +169,7 @@
 <section id="overview">
 <h1>Architecture Documentation <small>devops v0.87.0</small></h1>
 <p class="lead">
-  A comprehensive DevOps automation plugin for Claude Code &mdash; <!--devops:count:hooks-->40<!--/devops:count:hooks--> hooks, <!--devops:count:skills-->21<!--/devops:count:skills--> skills, <!--devops:count:agents-->12<!--/devops:count:agents--> agents,
+  A comprehensive DevOps automation plugin for Claude Code &mdash; <!--devops:count:hooks-->41<!--/devops:count:hooks--> hooks, <!--devops:count:skills-->21<!--/devops:count:skills--> skills, <!--devops:count:agents-->12<!--/devops:count:agents--> agents,
   2 MCP servers, a deterministic completion card engine, and a 3-layer extension system.
 </p>
 <div role="note" style="margin:.4rem 0 1.4rem;padding:.6rem .9rem;background:var(--bg2);border-left:3px solid var(--warn);border-radius:4px;color:var(--text2);font-size:.85rem;">
@@ -180,13 +180,13 @@
 
 <div class="card-grid">
   <div class="card">
-    <h4><!--devops:count:hooks-->40<!--/devops:count:hooks--> Hooks</h4>
+    <h4><!--devops:count:hooks-->41<!--/devops:count:hooks--> Hooks</h4>
     <p style="color:var(--text2);font-size:.85rem">Lifecycle guards across SessionStart, UserPromptSubmit, PreToolUse, PostToolUse, Stop</p>
     <span class="badge b-hook">SessionStart &times;<!--devops:count:hooks:ss-->15<!--/devops:count:hooks:ss--></span>
     <span class="badge b-hook">Prompt &times;<!--devops:count:hooks:prompt-->9<!--/devops:count:hooks:prompt--></span>
     <span class="badge b-hook">Pre &times;<!--devops:count:hooks:pre-->7<!--/devops:count:hooks:pre--></span>
     <span class="badge b-hook">Post &times;<!--devops:count:hooks:post-->5<!--/devops:count:hooks:post--></span>
-    <span class="badge b-hook">Stop &times;<!--devops:count:hooks:stop-->4<!--/devops:count:hooks:stop--></span>
+    <span class="badge b-hook">Stop &times;<!--devops:count:hooks:stop-->5<!--/devops:count:hooks:stop--></span>
   </div>
   <div class="card">
     <h4><!--devops:count:skills-->21<!--/devops:count:skills--> Skills</h4>
@@ -221,7 +221,7 @@
 │   ├── user-prompt-submit/    <span style="color:var(--purple)"># <!--devops:count:hooks:prompt-->9<!--/devops:count:hooks:prompt--> hooks (prompt.*)</span>
 │   ├── pre-tool-use/          <span style="color:var(--purple)"># <!--devops:count:hooks:pre-->7<!--/devops:count:hooks:pre--> hooks (pre.*)</span>
 │   ├── post-tool-use/         <span style="color:var(--purple)"># <!--devops:count:hooks:post-->5<!--/devops:count:hooks:post--> hooks (post.*)</span>
-│   └── stop/                  <span style="color:var(--purple)"># <!--devops:count:hooks:stop-->4<!--/devops:count:hooks:stop--> hooks (stop.*)</span>
+│   └── stop/                  <span style="color:var(--purple)"># <!--devops:count:hooks:stop-->5<!--/devops:count:hooks:stop--> hooks (stop.*)</span>
 ├── mcp-server/
 │   ├── index.js               <span style="color:var(--orange)"># dotclaude-completion MCP</span>
 │   └── ship/

--- a/plugins/devops/hooks/hooks.json
+++ b/plugins/devops/hooks/hooks.json
@@ -81,6 +81,7 @@
     "Stop": [
       {
         "hooks": [
+          { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/stop/stop.git.sync.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/stop/stop.flow.browsertest.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/stop/stop.flow.guard.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/stop/stop.flow.selfcalibration.js" },

--- a/plugins/devops/hooks/lib/git-sync-bg.js
+++ b/plugins/devops/hooks/lib/git-sync-bg.js
@@ -1,0 +1,201 @@
+/**
+ * @module git-sync-bg
+ * @version 0.1.0
+ * @description Fire-and-forget background git sync — shared by ss.git.sync
+ *   (SessionStart) and stop.git.sync (Stop), consumed by prompt.git.sync
+ *   (UserPromptSubmit).
+ *
+ *   WHY THIS EXISTS (issue: git-sync UI noise)
+ *   The sync used to run as a recurring ten-minute cron that re-entered
+ *   Claude with a "Silently run via Bash: node git-sync.js" prompt. A cron tick
+ *   is a full turn: the Bash call renders inline, the model answers, and the
+ *   stop/completion hooks have to be suppressed after the fact. Every ten
+ *   minutes the transcript grew a turn that said nothing — the sync itself has
+ *   no output unless a merge actually happened.
+ *
+ *   A mechanical `git fetch` + `git merge` needs no model in the loop. Only the
+ *   rare ambiguous conflict does. So the sync is spawned DETACHED from a hook
+ *   (no turn, no tool call, no card) and its result is written to a per-worktree
+ *   file. The next UserPromptSubmit picks the file up and injects it as context
+ *   — so the user sees something in chat exactly when there IS something:
+ *   commits merged, or a conflict that needs semantic resolution.
+ *
+ *   Throttle + result files are keyed by WORKTREE, not by session: two Claude
+ *   sessions on the same worktree must share one sync cadence, and a sync
+ *   started by session A is equally relevant to session B.
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const crypto = require('crypto');
+
+/** Default gap between two background syncs for the same worktree. */
+const THROTTLE_MS = 30 * 60 * 1000;
+
+const PREFIX = 'dotclaude-devops-git-sync';
+
+/** Stable short key for a worktree path (case-insensitive — Windows). */
+function keyFor(cwd) {
+  return crypto.createHash('sha1').update(String(cwd).toLowerCase()).digest('hex').slice(0, 12);
+}
+
+function throttleFile(cwd, tmpdir = os.tmpdir()) {
+  return path.join(tmpdir, `${PREFIX}-throttle-${keyFor(cwd)}`);
+}
+
+function resultFile(cwd, tmpdir = os.tmpdir()) {
+  return path.join(tmpdir, `${PREFIX}-result-${keyFor(cwd)}`);
+}
+
+/**
+ * True when the last background sync for this worktree is older than the
+ * throttle window. Touches the marker on success, so callers that get `true`
+ * own the slot — two hooks firing back to back cannot double-spawn.
+ *
+ * `peek: true` answers the same question WITHOUT claiming. stop.git.sync runs
+ * on every single turn end, so it peeks first and only pays for the three git
+ * probes when the window is actually open — and only claims once those probes
+ * confirm there is something to sync. Claiming before the probes would burn the
+ * slot on a repo that is on main or has no remote, silencing the sync for the
+ * next 30 minutes after a branch switch.
+ *
+ * @param {string} cwd
+ * @param {{throttleMs?: number, tmpdir?: string, now?: number, peek?: boolean}} [opts]
+ */
+function claimSyncSlot(cwd, opts = {}) {
+  const { throttleMs = THROTTLE_MS, tmpdir = os.tmpdir(), now = Date.now(), peek = false } = opts;
+  const file = throttleFile(cwd, tmpdir);
+  try {
+    const stat = fs.statSync(file);
+    if (now - stat.mtimeMs < throttleMs) return false;
+  } catch {
+    // No marker yet — first sync for this worktree.
+  }
+  if (peek) return true;
+  try {
+    fs.writeFileSync(file, String(now));
+  } catch {
+    return false; // cannot claim → do not spawn
+  }
+  return true;
+}
+
+/**
+ * Classify raw git-sync output into something worth surfacing, or null.
+ *
+ * git-sync.js is already silent when nothing happened, so ANY output means a
+ * merge landed (✓), needs semantic resolution (⚠), or failed (✗).
+ *
+ * @param {string|null|undefined} output
+ * @returns {{kind: 'conflict'|'error'|'synced', text: string}|null}
+ */
+function classify(output) {
+  if (typeof output !== 'string') return null;
+  const text = output.trim();
+  if (!text) return null;
+  if (text.includes('⚠')) return { kind: 'conflict', text };
+  if (text.includes('✗')) return { kind: 'error', text };
+  if (text.includes('✓')) return { kind: 'synced', text };
+  return null;
+}
+
+/**
+ * The resolution procedure that used to live in the cron prompt. Only rendered
+ * for the conflict case — a clean sync gets one line and nothing else.
+ */
+const CONFLICT_PROCEDURE = [
+  'A background git sync hit conflicts it could not resolve mechanically. Resolve them now — do not just report them:',
+  '(1) Extract the source branch from the ⚠ line (format: "⚠ <source> → <target>: …").',
+  '(2) Re-run the merge: `git merge <source> --no-edit`.',
+  '(3) For each conflicted file read the markers plus both sides: `git diff :1:<file> :2:<file>` (ours) and `git diff :1:<file> :3:<file>` (theirs).',
+  '(4) Classify every hunk per `deep-knowledge/merge-safety.md` Step 3 (complementary, redundant, superseding, technical, design, delete-vs-modify).',
+  '(5) Edit each file to the semantically correct merged result — keep both sides when complementary, pick the better option for technical choices.',
+  '(6) Ask the user (AskUserQuestion) ONLY for mutually exclusive design decisions.',
+  '(7) `git add <file>` each resolved file, then `git commit --no-edit`.',
+  '(8) Verify the merged files for logical consistency (e.g. changed signatures with stale callers).',
+];
+
+/**
+ * Render the context lines injected into the next user turn.
+ * Deliberately asymmetric: a clean sync is one informational line the assistant
+ * may mention in passing; a conflict is an instruction it must act on.
+ *
+ * @param {{kind: string, text: string}} result
+ * @returns {string[]}
+ */
+function renderContext(result) {
+  if (!result) return [];
+  if (result.kind === 'conflict') {
+    return [result.text, '', ...CONFLICT_PROCEDURE];
+  }
+  if (result.kind === 'error') {
+    return [result.text, '', 'The background git sync failed. Tell the user what failed; do not retry silently.'];
+  }
+  return [result.text, '', 'Background git sync — informational only. Do not act on it, do not open a section for it, mention it in one clause at most.'];
+}
+
+/**
+ * Read and consume the pending result for this worktree.
+ * Returns null when there is nothing pending.
+ *
+ * @param {string} cwd
+ * @param {{tmpdir?: string}} [opts]
+ */
+function takeResult(cwd, opts = {}) {
+  const file = resultFile(cwd, opts.tmpdir);
+  let raw;
+  try {
+    raw = fs.readFileSync(file, 'utf8');
+  } catch {
+    return null;
+  }
+  try { fs.unlinkSync(file); } catch { /* consumed anyway */ }
+  return classify(raw);
+}
+
+/**
+ * Spawn scripts/git-sync.js detached. Returns true when the spawn was issued.
+ *
+ * The child writes its own result file (DEVOPS_GIT_SYNC_RESULT_FILE) atomically
+ * and only when it has something to report — so a half-finished sync can never
+ * be read as a finished one, and a silent sync leaves no file behind.
+ *
+ * @param {string} cwd
+ * @param {{tmpdir?: string, spawn?: Function, scriptPath?: string}} [opts]
+ */
+function spawnSync_(cwd, opts = {}) {
+  const spawn = opts.spawn || require('child_process').spawn;
+  const script = opts.scriptPath || path.resolve(__dirname, '../../scripts/git-sync.js');
+  const out = resultFile(cwd, opts.tmpdir);
+
+  // Drop a stale result from an earlier run — the fresh sync is authoritative.
+  try { fs.unlinkSync(out); } catch { /* nothing to clear */ }
+
+  try {
+    const child = spawn(process.execPath, [script], {
+      cwd,
+      detached: true,
+      stdio: 'ignore',
+      windowsHide: true,
+      env: { ...process.env, DEVOPS_GIT_SYNC_RESULT_FILE: out },
+    });
+    child.unref();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+module.exports = {
+  THROTTLE_MS,
+  CONFLICT_PROCEDURE,
+  keyFor,
+  throttleFile,
+  resultFile,
+  claimSyncSlot,
+  classify,
+  renderContext,
+  takeResult,
+  startBackgroundSync: spawnSync_,
+};

--- a/plugins/devops/hooks/lib/git-sync-bg.test.js
+++ b/plugins/devops/hooks/lib/git-sync-bg.test.js
@@ -1,0 +1,204 @@
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import {
+  keyFor,
+  throttleFile,
+  resultFile,
+  claimSyncSlot,
+  classify,
+  renderContext,
+  takeResult,
+  startBackgroundSync,
+} from "./git-sync-bg.js";
+
+let tmpdir;
+
+beforeEach(() => {
+  tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), "git-sync-bg-test-"));
+});
+
+afterEach(() => {
+  try { fs.rmSync(tmpdir, { recursive: true, force: true }); } catch { /* best effort */ }
+});
+
+describe("keyFor — worktree-scoped, not session-scoped", () => {
+  test("same path → same key", () => {
+    expect(keyFor("C:/repo/wt")).toBe(keyFor("C:/repo/wt"));
+  });
+
+  test("different worktrees → different keys", () => {
+    expect(keyFor("C:/repo/a")).not.toBe(keyFor("C:/repo/b"));
+  });
+
+  test("case-insensitive — Windows hands the same path in both casings", () => {
+    expect(keyFor("C:/Repo/WT")).toBe(keyFor("c:/repo/wt"));
+  });
+
+  test("throttle and result files are distinct for the same worktree", () => {
+    expect(throttleFile("C:/repo", tmpdir)).not.toBe(resultFile("C:/repo", tmpdir));
+  });
+});
+
+describe("claimSyncSlot — one sync per worktree per window", () => {
+  test("first call claims", () => {
+    expect(claimSyncSlot("C:/repo", { tmpdir })).toBe(true);
+  });
+
+  test("second call inside the window is refused", () => {
+    claimSyncSlot("C:/repo", { tmpdir });
+    expect(claimSyncSlot("C:/repo", { tmpdir })).toBe(false);
+  });
+
+  test("a second session on the SAME worktree does not double-sync", () => {
+    // SessionStart of session A, then SessionStart of session B moments later.
+    expect(claimSyncSlot("C:/repo", { tmpdir })).toBe(true);
+    expect(claimSyncSlot("C:/repo", { tmpdir })).toBe(false);
+  });
+
+  test("a different worktree has its own slot", () => {
+    claimSyncSlot("C:/repo/a", { tmpdir });
+    expect(claimSyncSlot("C:/repo/b", { tmpdir })).toBe(true);
+  });
+
+  // The marker's mtime is real wall-clock (writeFileSync), so these drive the
+  // comparison by moving `now` forward from the actual write time.
+  test("claims again once the window has passed", () => {
+    claimSyncSlot("C:/repo", { tmpdir });
+    const later = Date.now() + 31 * 60 * 1000;
+    expect(claimSyncSlot("C:/repo", { tmpdir, now: later })).toBe(true);
+  });
+
+  test("still refused one minute before the window closes", () => {
+    claimSyncSlot("C:/repo", { tmpdir });
+    const almost = Date.now() + 29 * 60 * 1000;
+    expect(claimSyncSlot("C:/repo", { tmpdir, now: almost })).toBe(false);
+  });
+
+  test("a shorter throttle can be requested explicitly", () => {
+    claimSyncSlot("C:/repo", { tmpdir });
+    const soon = Date.now() + 2 * 60 * 1000;
+    expect(claimSyncSlot("C:/repo", { tmpdir, now: soon, throttleMs: 60 * 1000 })).toBe(true);
+  });
+
+  test("peek reports the window without consuming the slot", () => {
+    expect(claimSyncSlot("C:/repo", { tmpdir, peek: true })).toBe(true);
+    // Peeking must not have written a marker — a real claim still succeeds.
+    expect(claimSyncSlot("C:/repo", { tmpdir })).toBe(true);
+  });
+
+  test("peek reports a closed window as closed", () => {
+    claimSyncSlot("C:/repo", { tmpdir });
+    expect(claimSyncSlot("C:/repo", { tmpdir, peek: true })).toBe(false);
+  });
+});
+
+describe("classify — silence is the default", () => {
+  test("empty output → nothing to surface", () => {
+    expect(classify("")).toBeNull();
+    expect(classify("   \n ")).toBeNull();
+    expect(classify(null)).toBeNull();
+    expect(classify(undefined)).toBeNull();
+  });
+
+  test("✓ line → synced", () => {
+    const r = classify("[git-sync] ✓ main → feat/x: 3 commit(s)\n");
+    expect(r.kind).toBe("synced");
+    expect(r.text).toContain("3 commit(s)");
+  });
+
+  test("⚠ line → conflict", () => {
+    const r = classify("[git-sync] ⚠ main → feat/x: 2 file(s) with ambiguous conflicts");
+    expect(r.kind).toBe("conflict");
+  });
+
+  test("✗ line → error", () => {
+    expect(classify("[git-sync] ✗ main → feat/x: merge failed").kind).toBe("error");
+  });
+
+  test("conflict wins over a clean merge in the same run", () => {
+    // git-sync joins per-parent messages with ' | ' — a ⚠ anywhere must dominate.
+    const r = classify("[git-sync] ✓ main → feat: 1 commit(s) | ⚠ feat → feat/x: 1 file(s)");
+    expect(r.kind).toBe("conflict");
+  });
+
+  test("unrecognised output is not surfaced", () => {
+    expect(classify("some unrelated stdout noise")).toBeNull();
+  });
+});
+
+describe("renderContext — asymmetric by severity", () => {
+  test("a clean sync is informational and explicitly non-actionable", () => {
+    const out = renderContext(classify("[git-sync] ✓ main → feat/x: 3 commit(s)")).join("\n");
+    expect(out).toContain("3 commit(s)");
+    expect(out).toContain("informational only");
+    expect(out).not.toContain("Resolve them now");
+  });
+
+  test("a conflict carries the full resolution procedure", () => {
+    const out = renderContext(classify("[git-sync] ⚠ main → feat/x: 2 file(s)")).join("\n");
+    expect(out).toContain("Resolve them now");
+    expect(out).toContain("merge-safety.md");
+    expect(out).toContain("git commit --no-edit");
+    expect(out).toContain("AskUserQuestion");
+  });
+
+  test("an error is reported, not silently retried", () => {
+    const out = renderContext(classify("[git-sync] ✗ merge failed")).join("\n");
+    expect(out).toContain("do not retry silently");
+  });
+
+  test("null result renders nothing", () => {
+    expect(renderContext(null)).toEqual([]);
+  });
+});
+
+describe("takeResult — one-shot delivery", () => {
+  test("no result file → null", () => {
+    expect(takeResult("C:/repo", { tmpdir })).toBeNull();
+  });
+
+  test("reads and consumes the file", () => {
+    fs.writeFileSync(resultFile("C:/repo", tmpdir), "[git-sync] ✓ main → feat: 2 commit(s)\n");
+    expect(takeResult("C:/repo", { tmpdir }).kind).toBe("synced");
+    // Consumed — the same result must never be delivered twice.
+    expect(takeResult("C:/repo", { tmpdir })).toBeNull();
+  });
+
+  test("a result for another worktree is not picked up", () => {
+    fs.writeFileSync(resultFile("C:/repo/a", tmpdir), "[git-sync] ✓ main → feat: 1 commit(s)\n");
+    expect(takeResult("C:/repo/b", { tmpdir })).toBeNull();
+  });
+});
+
+describe("startBackgroundSync — detached, never blocking", () => {
+  test("spawns detached with the result file in the env and unrefs the child", () => {
+    let seen = null;
+    let unreffed = false;
+    const fakeSpawn = (cmd, args, opts) => {
+      seen = { cmd, args, opts };
+      return { unref: () => { unreffed = true; } };
+    };
+
+    expect(startBackgroundSync("C:/repo", { tmpdir, spawn: fakeSpawn, scriptPath: "/x/git-sync.js" })).toBe(true);
+    expect(seen.opts.detached).toBe(true);
+    expect(seen.opts.stdio).toBe("ignore");
+    expect(seen.opts.cwd).toBe("C:/repo");
+    expect(seen.args).toEqual(["/x/git-sync.js"]);
+    expect(seen.opts.env.DEVOPS_GIT_SYNC_RESULT_FILE).toBe(resultFile("C:/repo", tmpdir));
+    expect(unreffed).toBe(true);
+  });
+
+  test("clears a stale result before spawning — the fresh sync is authoritative", () => {
+    const stale = resultFile("C:/repo", tmpdir);
+    fs.writeFileSync(stale, "[git-sync] ✓ old run\n");
+    startBackgroundSync("C:/repo", { tmpdir, spawn: () => ({ unref() {} }), scriptPath: "/x.js" });
+    expect(fs.existsSync(stale)).toBe(false);
+  });
+
+  test("a spawn failure is swallowed — a hook must never break on it", () => {
+    const boom = () => { throw new Error("ENOENT"); };
+    expect(startBackgroundSync("C:/repo", { tmpdir, spawn: boom, scriptPath: "/x.js" })).toBe(false);
+  });
+});

--- a/plugins/devops/hooks/lib/graphify-state.js
+++ b/plugins/devops/hooks/lib/graphify-state.js
@@ -24,7 +24,8 @@
  *   default 2) so the TOTAL live builds across all cwds is bounded. The
  *   SessionStart (10-min) and PreToolUse (2-min) throttles only DEBOUNCE bursts;
  *   on a large repo a single build outlasts its throttle window while a trigger
- *   recurs (e.g. a 10-min git-sync cron), so time-based throttling alone let
+ *   recurs (historically the 10-min git-sync cron, since removed — but any
+ *   recurring session trigger does it), so time-based throttling alone let
  *   builds stack without bound — measured at 12 concurrent runs / ~29 GB commit,
  *   exhausting RAM. The per-project lock alone still let N worktrees each run a
  *   heavy build (RAM + disk saturation), which the global cap prevents.
@@ -230,8 +231,9 @@ const BG_RUN_FLAG = '--bg-run';
 //   1. PER-PROJECT lock (updateInFlight): a single `graphify update .` on a large
 //      repo can outlast the SessionStart (10-min) and PreToolUse (2-min) spawn
 //      throttles, which only DEBOUNCE bursts. When a trigger recurs at least as
-//      often as the build takes (e.g. a 10-min git-sync cron opening a fresh
-//      session), time-based throttling alone let builds stack without bound
+//      often as the build takes (historically the 10-min git-sync cron opening a
+//      fresh session; that cron is gone, the hazard is not), time-based
+//      throttling alone let builds stack without bound
 //      (measured: 12 concurrent runs, ~29 GB commit, RAM exhausted). The PID lock
 //      caps concurrency at ONE build PER PROJECT across every trigger.
 //   2. MACHINE-WIDE cap (globalUpdatesInFlight + updateGlobalCap): the per-project

--- a/plugins/devops/hooks/session-start/ss.git.sync.js
+++ b/plugins/devops/hooks/session-start/ss.git.sync.js
@@ -1,19 +1,27 @@
 #!/usr/bin/env node
 /**
  * @hook ss.git.sync
- * @version 0.2.0
+ * @version 1.0.0
  * @event SessionStart
  * @plugin devops
- * @description Registers a recurring git sync cron job (every 10 minutes).
- *   The cron runs scripts/git-sync.js to fetch remote main and merge
- *   the parent chain into the current worktree branch.
- *   One-time registration — the cron persists for the session lifetime.
+ * @description Starts ONE detached background git sync for this worktree.
+ *   Produces no output — ever. Whatever the sync finds is picked up by
+ *   prompt.git.sync on the next user turn.
+ *
+ *   BREAKING (v1.0.0): no longer registers a ten-minute CronCreate job.
+ *   A cron tick is a full Claude turn — inline Bash call, a model reply, and
+ *   completion/stop hooks to suppress afterwards — fired every ten minutes for
+ *   a fetch+merge that is silent in the overwhelming majority of ticks. The
+ *   sync needs no model unless a conflict is genuinely ambiguous, so it now
+ *   runs as a detached child process (see hooks/lib/git-sync-bg.js) and only
+ *   surfaces in chat when it actually merged something or hit a conflict.
+ *   In-session recurrence is covered by stop.git.sync (throttled, per Stop).
  */
 
 require('../lib/plugin-guard');
 
 const { execSync } = require('child_process');
-const path = require('path');
+const { claimSyncSlot, startBackgroundSync } = require('../lib/git-sync-bg');
 
 const cwd = process.cwd();
 
@@ -30,46 +38,16 @@ function git(cmd) {
   }
 }
 
-// Only register in a git repo on a non-main branch with a remote
+// Only sync in a git repo on a non-main branch with a remote
 if (git('rev-parse --is-inside-work-tree') !== 'true') process.exit(0);
 if (!git('remote')) process.exit(0);
 
 const branch = git('rev-parse --abbrev-ref HEAD');
 if (!branch || branch === 'main') process.exit(0);
 
-// Resolve absolute path to the shared sync script (forward slashes for bash)
-const scriptPath = path.resolve(__dirname, '../../scripts/git-sync.js').replace(/\\/g, '/');
+// Throttle is worktree-scoped, so reopening Claude five times in ten minutes
+// (or running two sessions on the same worktree) still yields one sync.
+if (!claimSyncSlot(cwd)) process.exit(0);
 
-// The cron prompt must NOT bake in a version-specific path. An in-session ship
-// rebuilds the plugin cache under a fresh version dir and removes the old one
-// (ss.plugin.update.rebuildCache), so an embedded `.../devops/<version>/...`
-// path dangles and the cron then fails MODULE_NOT_FOUND every interval.
-// In the versioned cache layout (.../devops/<version>/hooks/session-start),
-// emit a command that resolves the script from the current version dir at
-// cron-run time — the rebuild leaves exactly one version dir, so a glob +
-// head -1 is unambiguous; fall back to the literal path if the glob is empty.
-// In a dev/marketplace checkout there is no version dir → use the literal path.
-const versionDir = path.resolve(__dirname, '../..');
-const isCacheLayout = /^\d+\.\d+\.\d+/.test(path.basename(versionDir));
-const versionsParent = path.dirname(versionDir).replace(/\\/g, '/');
-const runScript = isCacheLayout
-  ? `f="$(ls -d "${versionsParent}"/*/scripts/git-sync.js 2>/dev/null | head -1)"; [ -z "$f" ] && f="${scriptPath}"; node "$f"`
-  : `node "${scriptPath}"`;
-
-process.stdout.write(
-  `Register a recurring git-sync cron job for this session. ` +
-  `Call CronCreate with cron "*/10 * * * *" (recurring: true) ` +
-  `and prompt: 'Silently run via Bash: ${runScript}. ` +
-  `If output contains ⚠ (merge conflicts detected), YOU MUST resolve the conflicts — do not just report them. ` +
-  `Follow this procedure: ` +
-  `(1) Extract the source branch from the ⚠ line (format: "⚠ <source> → <target>: ..."). ` +
-  `(2) Re-run the merge: git merge <extracted-source> --no-edit. ` +
-  `(3) For each conflicted file: read the file with conflict markers, read both sides via git diff :1:<file> :2:<file> (ours) and git diff :1:<file> :3:<file> (theirs). ` +
-  `(4) Classify each conflict hunk per deep-knowledge/merge-safety.md Step 3 (complementary, redundant, superseding, technical, design, delete-vs-modify). ` +
-  `(5) Edit each conflicted file to contain the semantically correct merged result — keep both sides when complementary, pick the better option for technical choices. ` +
-  `(6) Only ask the user (via AskUserQuestion) for mutually exclusive design decisions (e.g. both sides changed the same value to different things). ` +
-  `(7) Stage resolved files: git add <file>. Complete the merge: git commit --no-edit. ` +
-  `(8) Verify: read the merged files and check for logical consistency (e.g. changed function signatures with stale callers). ` +
-  `If output contains ✗ (unresolvable errors), inform the user. ` +
-  `If no conflict markers (only ✓), produce no output.'\n`
-);
+startBackgroundSync(cwd);
+process.exit(0);

--- a/plugins/devops/hooks/session-start/ss.plugin.update.completeness.test.js
+++ b/plugins/devops/hooks/session-start/ss.plugin.update.completeness.test.js
@@ -119,3 +119,60 @@ describe("ss.plugin.update missingMcpFiles — per-plugin completeness", () => {
     expect(missingMcpFiles(dst, src)).toEqual([".mcp.json"]);
   });
 });
+
+/**
+ * Same class of bug, one layer up: rebuildCache's skills/hooks completeness
+ * check required BOTH directories from every plugin. Third-party plugins ship
+ * one or the other — claude-code-setup has skills/ but no hooks/,
+ * code-simplifier has hooks/ but no skills/. Neither can ever satisfy an
+ * unconditional check, so rebuildCache returned ok:false, the registry SHA was
+ * never advanced, and the next SessionStart rebuilt them again — printing the
+ * same "⚠ …\hooks [cache repair]" block in chat every single session.
+ *
+ * Mirror of the post-fix loop (the hook's module body self-executes on import,
+ * so the function cannot be imported directly — same constraint as above).
+ */
+function missingPluginDirs(targetRoot, sourceRoot) {
+  const missing = [];
+  for (const dirName of ["skills", "hooks"]) {
+    if (!fs.existsSync(path.join(sourceRoot, dirName))) continue;
+    if (!fs.existsSync(path.join(targetRoot, dirName))) missing.push(dirName);
+  }
+  return missing;
+}
+
+describe("ss.plugin.update rebuildCache — per-plugin skills/hooks completeness", () => {
+  test("source with skills/ but no hooks/, cache mirrors it → NOT flagged", () => {
+    // claude-code-setup shape. The regression: reported …\hooks as missing forever.
+    write(src, path.join("skills", "x", "SKILL.md"), "# x");
+    write(dst, path.join("skills", "x", "SKILL.md"), "# x");
+    expect(missingPluginDirs(dst, src)).toEqual([]);
+  });
+
+  test("source with hooks/ but no skills/, cache mirrors it → NOT flagged", () => {
+    // code-simplifier shape.
+    write(src, path.join("hooks", "h.js"), "// h");
+    write(dst, path.join("hooks", "h.js"), "// h");
+    expect(missingPluginDirs(dst, src)).toEqual([]);
+  });
+
+  test("source with both, cache mirrors both → NOT flagged", () => {
+    write(src, path.join("skills", "x", "SKILL.md"), "# x");
+    write(src, path.join("hooks", "h.js"), "// h");
+    write(dst, path.join("skills", "x", "SKILL.md"), "# x");
+    write(dst, path.join("hooks", "h.js"), "// h");
+    expect(missingPluginDirs(dst, src)).toEqual([]);
+  });
+
+  test("source with both, cache dropped hooks/ → still flagged (real incomplete copy)", () => {
+    write(src, path.join("skills", "x", "SKILL.md"), "# x");
+    write(src, path.join("hooks", "h.js"), "// h");
+    write(dst, path.join("skills", "x", "SKILL.md"), "# x");
+    expect(missingPluginDirs(dst, src)).toEqual(["hooks"]);
+  });
+
+  test("source with neither (docs-only plugin) → asserts nothing", () => {
+    write(src, "README.md", "# docs only");
+    expect(missingPluginDirs(dst, src)).toEqual([]);
+  });
+});

--- a/plugins/devops/hooks/session-start/ss.plugin.update.js
+++ b/plugins/devops/hooks/session-start/ss.plugin.update.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * @hook ss.plugin.update
- * @version 0.10.0
+ * @version 0.11.0
  * @event SessionStart
  * @plugin devops
  * @description Auto-update plugin marketplace clones, rebuild cache, and update registry.
@@ -30,6 +30,10 @@
  *   identity and de-registers the plugin's skills/slash-commands from Claude
  *   Code's already-loaded registry for the rest of the session (issue #219) —
  *   an in-place overwrite keeps the dir so /devops-* stays registered.
+ *
+ *   OUTPUT POLICY: only version changes and failures are printed. A successful
+ *   same-version cache repair is housekeeping the user cannot act on, so it is
+ *   done silently — see the `reportable` filter at the bottom.
  */
 
 require('../lib/plugin-guard');
@@ -241,14 +245,18 @@ function rebuildCache(marketplace, pluginName, pluginDir, version, sha, { versio
     return { ok: false, missing: 'copy failed — .claude-plugin/plugin.json not found after copy' };
   }
 
-  // Verify cache completeness
-  const checks = [
-    path.join(newCache, 'skills'),
-    path.join(newCache, 'hooks'),
-  ];
-  for (const check of checks) {
-    if (!fs.existsSync(check)) {
-      return { ok: false, missing: check };
+  // Verify cache completeness — asserted PER-PLUGIN against what the SOURCE
+  // actually ships, exactly like missingMcpFiles(). Requiring both `skills/`
+  // and `hooks/` unconditionally fails every plugin that ships only one of
+  // them (claude-code-setup has no hooks/, code-simplifier no skills/). Such a
+  // plugin can never satisfy the check, so rebuildCache returns ok:false, the
+  // registry SHA is never advanced, and the next SessionStart rebuilds it
+  // again — a permanent loop that reprinted the same "⚠ …/skills [cache
+  // repair]" block in chat every single session.
+  for (const dirName of ['skills', 'hooks']) {
+    if (!fs.existsSync(path.join(pluginDir, dirName))) continue;
+    if (!fs.existsSync(path.join(newCache, dirName))) {
+      return { ok: false, missing: path.join(newCache, dirName) };
     }
   }
 
@@ -492,11 +500,17 @@ if (mcpAffected.length > 0) {
   try { fs.unlinkSync(sentinelFile); } catch { /* ignore */ }
 }
 
-if (updated.length === 0) process.exit(0);
+// Report only what the user can act on. A SUCCESSFUL same-version cache repair
+// is pure housekeeping — the plugin was already at the right version, nothing
+// changed for the user, and no restart is needed — yet it used to print a
+// three-line block at the top of every session ("1.0.0 → 1.0.0 [cache repair]").
+// Version changes and failures still surface: those are real.
+const reportable = updated.filter(u => !u.verified || u.from !== u.to);
+if (reportable.length === 0) process.exit(0);
 
 const lines = [t('header', lang, DICT)];
 lines.push('');
-for (const u of updated) {
+for (const u of reportable) {
   const status = u.verified ? '✓ cache rebuilt' : `⚠ ${u.error}`;
   const repair = u.cacheRepair ? ' [cache repair]' : '';
   lines.push(`- **${u.name}**: ${u.from} → ${u.to} (${status}${repair})`);

--- a/plugins/devops/hooks/stop/stop.git.sync.js
+++ b/plugins/devops/hooks/stop/stop.git.sync.js
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+/**
+ * @hook stop.git.sync
+ * @version 0.1.0
+ * @event Stop
+ * @plugin devops
+ * @description Throttled background git sync at turn end. Replaces the former
+ *   ten-minute git-sync cron as the in-session recurrence mechanism.
+ *
+ *   Stop is the right moment: the turn is over, so a merge cannot land under a
+ *   file the assistant is mid-edit on — the cron could fire at any instant,
+ *   including inside a tool call. The child is detached and this hook returns
+ *   immediately, so turn end is never delayed by a fetch.
+ *
+ *   Always exits 0 with no output. A sync that finds something writes a result
+ *   file; prompt.git.sync delivers it on the next user turn. Never blocks the
+ *   stop (exit 2), never prints — this hook is invisible by construction.
+ */
+
+require('../lib/plugin-guard');
+
+const { execSync } = require('child_process');
+const { claimSyncSlot, startBackgroundSync } = require('../lib/git-sync-bg');
+
+const cwd = process.cwd();
+
+function git(cmd) {
+  try {
+    return execSync(`git ${cmd}`, {
+      cwd,
+      encoding: 'utf8',
+      timeout: 5000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function maybeSync() {
+  // Cheap gate first: this hook fires on EVERY turn end, and the throttle is a
+  // single statSync — the git probes below cost ~100ms each on Windows and are
+  // pure waste while the window is closed.
+  if (!claimSyncSlot(cwd, { peek: true })) return;
+
+  if (git('rev-parse --is-inside-work-tree') !== 'true') return;
+  if (!git('remote')) return;
+
+  const branch = git('rev-parse --abbrev-ref HEAD');
+  if (!branch || branch === 'main') return;
+
+  // Claim only now that a sync will actually happen.
+  if (!claimSyncSlot(cwd)) return;
+
+  startBackgroundSync(cwd);
+}
+
+// Drain stdin before working, like every other Stop hook here: Claude Code
+// writes the hook payload to this process, and exiting before it is consumed
+// gives the writer an EPIPE.
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', () => {});
+process.stdin.on('end', () => {
+  try { maybeSync(); } catch { /* a background sync must never break turn end */ }
+  process.exit(0);
+});

--- a/plugins/devops/hooks/user-prompt-submit/prompt.flow.silent-turn.js
+++ b/plugins/devops/hooks/user-prompt-submit/prompt.flow.silent-turn.js
@@ -8,7 +8,8 @@
  *   as "silent" so post.flow.completion skips the completion-card reminder
  *   and stop.flow.guard skips enforcement.
  *
- *   Why: cron jobs (git-sync, concept bridge poll) and autonomous loops
+ *   Why: cron jobs (concept bridge poll — git-sync no longer uses one, it runs
+ *   detached from ss.git.sync/stop.git.sync) and autonomous loops
  *   re-enter Claude with a prompt that ALWAYS begins with a silence marker
  *   ("Silently run", "Run silently") or with a loop sentinel
  *   (`<<autonomous-loop>>`). Without this flag, every silent tick is

--- a/plugins/devops/hooks/user-prompt-submit/prompt.git.sync.js
+++ b/plugins/devops/hooks/user-prompt-submit/prompt.git.sync.js
@@ -1,76 +1,31 @@
 #!/usr/bin/env node
 /**
  * @hook prompt.git.sync
- * @version 0.3.0
+ * @version 1.0.0
  * @event UserPromptSubmit
  * @plugin devops
- * @description Throttled git sync on user prompt — delegates to scripts/git-sync.js.
- *   Complements the session-start cron (ss.git.sync) with immediate sync
- *   on user interaction. Throttled to 15 minutes to avoid overlap with cron.
+ * @description Delivers the result of a background git sync — nothing else.
+ *
+ *   BREAKING (v1.0.0): no longer RUNS the sync. It used to shell out to
+ *   git-sync.js synchronously (30s timeout) on the user's prompt, and printed
+ *   a `✓ skipped (throttled, last sync 4m ago)` line on every other prompt —
+ *   noise about not having done anything. Both are gone: syncing is started
+ *   detached by ss.git.sync / stop.git.sync, and this hook only picks up what
+ *   the child left behind.
+ *
+ *   Silent unless the sync merged commits (✓), hit ambiguous conflicts (⚠) or
+ *   failed (✗). stdout on UserPromptSubmit becomes turn context, which is
+ *   exactly the right channel for the ⚠ case — the assistant resolves the
+ *   conflict inside the turn the user is already in, instead of a cron waking
+ *   it up in a turn of its own.
  */
 
 require('../lib/plugin-guard');
 
-const { execSync, execFileSync } = require('child_process');
-const fs = require('fs');
-const path = require('path');
-const os = require('os');
+const { takeResult, renderContext } = require('../lib/git-sync-bg');
 
-/**
- * Returns true if cwd is inside a git work tree.
- * @param {string} cwd
- * @returns {boolean}
- */
-function isGitRepo(cwd) {
-  try {
-    execFileSync('git', ['rev-parse', '--is-inside-work-tree'], {
-      cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'],
-    });
-    return true;
-  } catch {
-    return false;
-  }
-}
+const result = takeResult(process.cwd());
+if (!result) process.exit(0);
 
-const THROTTLE_FILE = path.join(os.tmpdir(), `dotclaude-devops-git-sync-${process.ppid}`);
-const THROTTLE_MS = 15 * 60 * 1000; // 15 minutes
-
-// Throttle — skip if last sync was recent
-try {
-  if (fs.existsSync(THROTTLE_FILE)) {
-    const lastSync = parseInt(fs.readFileSync(THROTTLE_FILE, 'utf8'), 10);
-    const ageMs = Date.now() - lastSync;
-    if (ageMs < THROTTLE_MS) {
-      const ageMin = Math.round(ageMs / 60000);
-      const remainMin = Math.ceil((THROTTLE_MS - ageMs) / 60000);
-      process.stderr.write(`[prompt.git.sync] ✓ skipped (throttled, last sync ${ageMin}m ago, retry in ${remainMin}m)\n`);
-      process.exit(0);
-    }
-  }
-} catch {}
-
-// Update throttle timestamp immediately
-try { fs.writeFileSync(THROTTLE_FILE, Date.now().toString()); } catch {}
-
-// Guard: skip in non-git directories
-if (!isGitRepo(process.cwd())) {
-  process.exit(0);
-}
-
-// Delegate to shared sync script
-const scriptPath = path.resolve(__dirname, '../../scripts/git-sync.js');
-try {
-  const output = execSync(`node "${scriptPath}"`, {
-    cwd: process.cwd(),
-    encoding: 'utf8',
-    timeout: 30000,
-    stdio: ['pipe', 'pipe', 'pipe'],
-  });
-  if (output.trim()) {
-    process.stderr.write(output);
-  }
-} catch (err) {
-  if (err.stdout && err.stdout.trim()) {
-    process.stderr.write(err.stdout);
-  }
-}
+process.stdout.write(renderContext(result).join('\n'));
+process.exit(0);

--- a/plugins/devops/scripts/git-sync.js
+++ b/plugins/devops/scripts/git-sync.js
@@ -296,5 +296,24 @@ for (const parent of parents) {
 }
 
 if (messages.length) {
-  process.stdout.write(`[git-sync] ${messages.join(' | ')}\n`);
+  const line = `[git-sync] ${messages.join(' | ')}\n`;
+
+  // Background mode (hooks/lib/git-sync-bg.js): the caller detached this process
+  // and is not reading stdout — it polls a result file on the next user turn.
+  // Write it atomically (tmp + rename) so a mid-sync read can never see a
+  // partial line, and write it ONLY when there is something to report: the
+  // absence of the file is what "nothing happened, stay silent" means.
+  const resultFile = process.env.DEVOPS_GIT_SYNC_RESULT_FILE;
+  if (resultFile) {
+    try {
+      const tmp = `${resultFile}.tmp`;
+      writeFileSync(tmp, line, 'utf8');
+      require('fs').renameSync(tmp, resultFile);
+    } catch {
+      // Result file unwritable — fall through to stdout so the output is not lost
+      process.stdout.write(line);
+    }
+  } else {
+    process.stdout.write(line);
+  }
 }

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.128.0",
+  "version": "0.129.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

The git-sync cron re-entered Claude every ten minutes with a ~1600-character prompt, producing a full turn — inline Bash call plus a model reply — for a `fetch` + `merge` that is silent in almost every tick. Claude Code renders a cron's whole prompt as its card in the background-tasks panel, so this one card filled the panel and hid every other task.

A mechanical fetch+merge needs no model in the loop; only an ambiguous conflict does.

## What changed

- **`ss.git.sync` (1.0.0)** — no longer registers a `CronCreate` job. Starts one detached sync per worktree, produces no output.
- **`stop.git.sync` (new, Stop)** — takes over in-session recurrence, throttled to 30 min per worktree. Turn end rather than an arbitrary instant: a cron tick could land a merge inside a tool call.
- **`prompt.git.sync` (1.0.0)** — no longer runs the sync (it used to shell out synchronously with a 30s timeout on the user's prompt). Now only delivers a pending result as turn context, so a conflict lands in a turn the user is already in.
- **`hooks/lib/git-sync-bg.js` (new)** — throttle claim/peek, result classification, context rendering. Keys are per-worktree, not per-session, so two sessions on one worktree share a cadence.
- **`scripts/git-sync.js`** — writes its result atomically (tmp + rename) when `DEVOPS_GIT_SYNC_RESULT_FILE` is set, and only when it has something to report. The absence of the file *is* "nothing happened".

Output policy: ✓ merged → one informational line · ⚠ conflict → full resolution procedure · ✗ failure → reported · nothing → silent.

## Also fixed

`ss.plugin.update`'s cache completeness check demanded both `skills/` and `hooks/` from every plugin. Plugins shipping only one could never satisfy it → `rebuildCache` returned `ok:false` → the registry SHA was never advanced → every session reprinted the same `1.0.0 → 1.0.0 [cache repair]` block. Now asserted per-plugin against what the source actually ships (the pattern `missingMcpFiles` already used). Successful same-version repairs are no longer reported.

## Tests

- 1629/1629 green, lint clean.
- 29 new tests for `git-sync-bg` (throttle windows, peek without claim, per-worktree isolation, one-shot delivery, detached spawn contract, conflict-beats-clean classification).
- 5 new tests for the per-plugin `skills`/`hooks` check.
- Integration-verified in a real repo (bare origin + main + feat/x): stdout stays empty, the detached child merges and writes the result file, the next pickup delivers and consumes it exactly once.

## Note

The concept-bridge cron has the same panel-filling shape (3185-char prompt) but drives a live per-minute interaction — deliberately not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)