### PR TITLE
refactor(concept): move the bridge cron body into a tick script

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.129.0"
+    "version": "0.130.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.129.0",
+      "version": "0.130.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.129.0",
+      "version": "0.130.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.130.0] — 2026-08-16
+
+### Changed
+
+- **The concept bridge's cron no longer fills the background-tasks panel either.** The previous release fixed this for the git sync; the concept bridge had the same shape and was left standing. Its cron prompt spelled out the whole per-tick procedure inline — the self-cleanup gate, the heartbeat POST, a `curl | python -c` probe of `/pending`, and the entire pending-branch procedure with its five action branches — 1128 characters that Claude Code renders verbatim as the cron's card, so one card covered the panel and the user could not see their other background tasks at a glance. Unlike the git sync this cron cannot simply be deleted: it drives a live interaction, keeping the page's connection indicator green and picking up submissions once a minute.
+
+  So nothing was dropped — the procedure moved into `scripts/concept-tick.js`, which performs all three steps and prints an instruction only on the ticks that need one: the cleanup tick, which still needs Claude because `CronDelete` is a tool, and the tick a submission lands on, which receives the pending-branch procedure verbatim. An idle tick — the overwhelmingly common case — prints nothing at all, so it now costs no tokens instead of restating the procedure every minute, and the single Bash call replaces the two `curl` calls the old body already made. The remaining prompt is 375 characters, most of it the script path.
+
+  Two phrasings in that prompt are load-bearing and documented as such, because both read like noise and both are one "cleanup" away from a silent regression. It opens with `Silently run` because `prompt.flow.silent-turn` flags a tick as silent only when the prompt *opens* with a marker — put a `Concept bridge, port N — ` lead-in in front and every tick becomes a real user turn, firing the completion-card reminder once a minute for the whole session. And it names `port N` in prose because the orphan sweep deletes crons whose prompt mentions exactly that, which is the only way to reap this cron once the state file, and with it `cron_id`, is gone. The prompt also resolves the script through a glob rather than a baked-in versioned path: a cron outlives a plugin rebuild, so an in-session `/ship` would otherwise leave it failing `MODULE_NOT_FOUND` every minute.
+
+  The doc-sync pin against `bridge-server.md` got stricter rather than weaker in the process. It used to compare a single line of a 1128-character prompt; the prompt now fits in one byte-for-byte comparison, the displaced procedure is pinned against the script that inherited it, and a length ceiling guards the card against the procedure creeping back one helpful sentence at a time.
+
+### Fixed
+
+- **A merge artifact in the concept bridge documentation.** A paragraph from step 3 had been spliced into the middle of the timestamp-convention code block in the file's preamble, breaking that block's markdown and leaving the unit contract — the single most expensive silent-failure mode the document warns about — sitting behind mangled formatting.
+
 ## [0.129.0] — 2026-08-16
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.129.0**
+**Version: 0.130.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.129.0",
+  "version": "0.130.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/hooks/session-start/ss.concept.resume.docsync.test.js
+++ b/plugins/devops/hooks/session-start/ss.concept.resume.docsync.test.js
@@ -3,9 +3,10 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { buildCronBody, buildBackgroundTasks } from "./ss.concept.resume.js";
+import { pendingInstruction, cleanupInstruction } from "../../scripts/concept-tick.js";
 
-// `bridge-server.md` § step 3 is the single source of truth for the cron body
-// and the two watchers. This hook necessarily carries a second copy — it has to
+// `bridge-server.md` § step 3 is the single source of truth for the cron and
+// the two watchers. This hook necessarily carries a second copy — it has to
 // hand the text to a resumed session — and a second copy is exactly how the
 // concept skill drifted into issue #276 in the first place.
 //
@@ -13,6 +14,12 @@ import { buildCronBody, buildBackgroundTasks } from "./ss.concept.resume.js";
 // defect: the hook emitted `print(\'true\' ...)` where the doc has bare quotes,
 // which is a Python SyntaxError, so every resumed session's backup pickup path
 // was dead on arrival.
+//
+// The cron body is no longer a paraphrase of a procedure — the procedure moved
+// into `scripts/concept-tick.js` so the cron's card stops filling the whole
+// background tasks panel. That makes the pin STRICTER, not looser: the prompt
+// is now short enough to compare byte-for-byte in full, and the procedure it
+// used to inline is pinned against the script that inherited it.
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const SKILLDIR = path.join(__dirname, "..", "..", "skills", "concept");
 const BRIDGE = fs.readFileSync(path.join(SKILLDIR, "deep-knowledge", "bridge-server.md"), "utf8");
@@ -20,20 +27,114 @@ const BRIDGE = fs.readFileSync(path.join(SKILLDIR, "deep-knowledge", "bridge-ser
 const PORT = 8883;
 const STATE_PATH = "C:/proj/.claude/concept-active.json";
 
+/** The hook's prompt, normalised back to the doc's placeholder form. */
+const emittedCron = () =>
+  buildCronBody(PORT, STATE_PATH)
+    .replace(/\\/g, "/")
+    .replace(/"[^"]*\/scripts\/concept-tick\.js"/, '"{plugin-root}/scripts/concept-tick.js"')
+    .replace(/"[^"]*\/\.claude\/concept-active\.json"/, '"{project-root}/.claude/concept-active.json"')
+    .replace(new RegExp(String(PORT), "g"), "{port}");
+
+const documentedCron = () =>
+  BRIDGE.split("\n")
+    .find(l => l.includes("concept-tick.js") && l.includes("Silently run via Bash"))
+    .trim();
+
+/** Source with comments removed — prose about a pattern is not a use of it. */
+const codeOnly = file =>
+  fs.readFileSync(path.join(__dirname, "..", "..", "scripts", file), "utf8")
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/^\s*\/\/.*$/gm, "");
+
 describe("the hook's cron copy matches bridge-server.md", () => {
-  test("the /pending one-liner is byte-identical to the documented one", () => {
-    const documented = BRIDGE
-      .split("\n")
-      .find(l => l.includes("python -c") && l.includes("/pending") && l.includes("d.get"))
-      .replace(/\{port\}/g, String(PORT))
-      .trim();
-    expect(buildCronBody(PORT)).toContain(documented);
+  test("the whole prompt is byte-identical to the documented one", () => {
+    // Not `toContain` on one line any more — the entire prompt fits in one
+    // comparison now, so any drift at all fails here.
+    expect(emittedCron()).toBe(documentedCron());
   });
 
-  test("the emitted python snippet is valid python, not backslash-escaped", () => {
-    const snippet = buildCronBody(PORT).match(/python -c "([^"]*)"/)[1];
-    expect(snippet).not.toContain("\\'");
-    expect(snippet).toContain("print('true' if d.get('pending') else 'false')");
+  test("the script the doc names actually exists", () => {
+    expect(fs.existsSync(path.join(__dirname, "..", "..", "scripts", "concept-tick.js"))).toBe(true);
+  });
+
+  test("the prompt stays small enough to be one card among many", () => {
+    // The whole point: Claude Code renders a cron's full prompt as its card in
+    // the background tasks panel. The old body was 1128 characters and filled
+    // the panel on its own. A ceiling is the only thing that stops the
+    // procedure from creeping back in one helpful sentence at a time.
+    expect(buildCronBody(PORT, STATE_PATH).length).toBeLessThan(400);
+  });
+
+  test("the procedure is NOT inlined in the prompt any more", () => {
+    const body = buildCronBody(PORT, STATE_PATH);
+    for (const leak of ["python -c", "/decisions", "/heartbeat", "CronDelete", "Step 5"]) {
+      expect(body, leak).not.toContain(leak);
+    }
+  });
+
+  test("the literal `port {port}` the orphan sweep keys off survives", () => {
+    // Step (0) sweeps orphaned crons via CronList "every cron whose prompt
+    // mentions `port {port}`" when the state file — and with it cron_id — is
+    // gone. `--port 8883` alone does not match that phrasing.
+    expect(buildCronBody(PORT, STATE_PATH)).toContain(`port ${PORT}`);
+    expect(BRIDGE).toContain("mentions `port {port}`");
+    expect(cleanupInstruction(PORT, "state file is gone", null)).toContain(`mentions \`port ${PORT}\``);
+  });
+
+  test("the doc still warns that the prompt must OPEN with the silence marker", () => {
+    expect(BRIDGE).toContain("MUST **start** with `Silently run`");
+  });
+
+  test("the state path is passed ABSOLUTE, as the doc mandates", () => {
+    expect(buildCronBody(PORT, STATE_PATH)).toContain(`--state "${STATE_PATH}"`);
+    expect(BRIDGE).toContain("**`--state` must be ABSOLUTE**");
+  });
+});
+
+// Everything the prompt used to spell out is now emitted by the script — on the
+// ticks that need it, and only then. The doc still documents all of it, so the
+// same drift test applies, just against the new owner of the text.
+describe("concept-tick.js carries the procedure the prompt gave up", () => {
+  test("the pending branch still names every action the doc lists", () => {
+    const out = pendingInstruction(PORT, 7);
+    for (const action of ["iterate", "implement", "create-issues", "ship", "dispose-concept"]) {
+      expect(out, action).toContain(`"${action}"`);
+      expect(BRIDGE, action).toContain(`"${action}"`);
+    }
+  });
+
+  test("the pending branch keeps the ordering and concurrency rules", () => {
+    const out = pendingInstruction(PORT, 7);
+    expect(out).toContain("/reload");
+    expect(out).toContain("/reset");
+    expect(out).toMatch(/\/reload[\s\S]*BEFORE the reset/);
+    expect(out).toContain("409");
+    expect(out).toContain("Zero-prompt invariant");
+    expect(out).toContain("Step 5b");
+    // Issue #276's actual lesson: the waker must come back before the report.
+    expect(out).toMatch(/Re-launch the pickup waker[\s\S]*report the outcome/);
+    expect(BRIDGE).toContain("Re-launch the pickup waker immediately after `/reset`");
+  });
+
+  test("pending is decided on /pending, never a substring match on /decisions", () => {
+    // json.dumps emits `"submitted": true` WITH a space, so a substring test
+    // silently misses every submission. Comments are stripped first — the file
+    // explains that trap, and explaining it is not falling into it.
+    const script = codeOnly("concept-tick.js");
+    expect(script).toContain("'/pending'");
+    // No quoted `"submitted"` JSON key anywhere — that is the substring test.
+    // (The word itself is fine: the 409 branch tells Claude "the user submitted
+    // again while you worked".)
+    expect(script).not.toMatch(/["']"submitted"/);
+    // The verdict comes from parsed JSON and is strict-equal to true, so a
+    // stringly "true" or a truthy 1 cannot wake Claude for nothing.
+    expect(script).toContain("body.pending !== true");
+    expect(BRIDGE).toContain("never** a substring match on `/decisions`");
+  });
+
+  test("the cleanup gate offers both the cron_id and the by-port sweep", () => {
+    expect(cleanupInstruction(PORT, "concept HTML is gone", "ab12cd34")).toContain("CronDelete the cron with id ab12cd34");
+    expect(cleanupInstruction(PORT, "state file is gone", null)).toContain("CronList");
   });
 });
 

--- a/plugins/devops/hooks/session-start/ss.concept.resume.js
+++ b/plugins/devops/hooks/session-start/ss.concept.resume.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * @hook ss.concept.resume
- * @version 0.3.0
+ * @version 0.4.0
  * @event SessionStart
  * @plugin devops
  * @description Recover an open concept session after a Claude restart.
@@ -258,28 +258,57 @@ function probe(port, pathname, timeoutMs = 1500) {
 }
 
 /**
+ * A `node "<script>"` prefix that still resolves after an in-session `/ship`.
+ *
+ * A cron outlives a plugin rebuild. `ss.plugin.update.rebuildCache` writes the
+ * new version under a fresh `.../devops/<version>/` directory and removes the
+ * old one, so an absolute path baked into a cron prompt dangles from that
+ * moment on and every tick fails MODULE_NOT_FOUND — once a minute, silently,
+ * for the rest of the session. Same reasoning and same shape as
+ * `ss.git.sync`: in the versioned cache layout, resolve from the current
+ * version directory at run time (the rebuild leaves exactly one, so the glob
+ * is unambiguous) and fall back to the literal path if the glob comes up
+ * empty. A dev/marketplace checkout has no version directory, so it just uses
+ * the literal path.
+ */
+function resolveScript(name, baseDir = __dirname) {
+  const literal = path.resolve(baseDir, '..', '..', 'scripts', name);
+  const versionDir = path.resolve(baseDir, '..', '..');
+  if (!/^\d+\.\d+\.\d+/.test(path.basename(versionDir))) return `node "${literal}"`;
+  const parent = path.dirname(versionDir).replace(/\\/g, '/');
+  return `f="$(ls -d "${parent}"/*/scripts/${name} 2>/dev/null | head -1)"; node "\${f:-${literal.replace(/\\/g, '/')}}"`;
+}
+
+/**
  * The combined heartbeat + auto-poll cron body. Canonical definition lives in
  * `skills/concept/deep-knowledge/bridge-server.md` § step 3; this mirrors it so
  * a resumed session re-arms exactly what the original session had.
+ *
+ * The body used to spell out all three steps inline — 1128 characters of gate,
+ * heartbeat, `curl | python -c` probe and pending-branch procedure. Claude Code
+ * renders a cron's whole prompt as its card in the background tasks panel, so
+ * that one card filled the panel and hid every other task. The procedure did
+ * not shrink; it moved into `scripts/concept-tick.js`, which prints an
+ * instruction only on the ticks that need one and stays silent otherwise.
+ *
+ * Two phrasings here are load-bearing and must not be "tidied up":
+ *   - It has to START with `Silently run`. `prompt.flow.silent-turn` classifies
+ *     a cron tick as a silent turn only when the prompt OPENS with a silence
+ *     marker; anything in front of it (a `Concept bridge, port N — ` lead-in,
+ *     say) makes every tick look like a real user turn, and the completion-card
+ *     reminder plus the stop-hook enforcement fire once a minute.
+ *   - It has to contain the literal `port ${port}`. The cleanup path sweeps
+ *     orphaned crons via CronList "every cron whose prompt mentions
+ *     `port {port}`" once the state file — and with it `cron_id` — is gone.
+ *     `--port ${port}` alone does not match that phrasing.
  */
-function buildCronBody(port) {
+function buildCronBody(port, statePath = STATE_PATH) {
   return (
-    `Silently service the concept bridge on port ${port}. ` +
-    `(0) Self-cleanup gate (FIRST step every tick): Read \`.claude/concept-active.json\`. ` +
-    `Cleanup triggers if the file is missing, OR state.port ≠ ${port}, OR state.html_path does not exist on disk. ` +
-    `On trigger: (a) Bash: curl -s -X POST http://localhost:${port}/shutdown > /dev/null 2>&1 || true; ` +
-    `(b) CronDelete the cron_id from the still-readable state file — or, if the state file is gone, ` +
-    `CronList and delete every cron whose prompt mentions \`port ${port}\`. ` +
-    `Produce NO output and skip steps 1+2. ` +
-    `(1) Heartbeat POST: Bash: curl -s -X POST http://localhost:${port}/heartbeat > /dev/null. ` +
-    // The quotes here must reach Python bare. Escaping them as \' emits a
-    // literal backslash — bash does not strip it inside double quotes, so
-    // Python got a line-continuation SyntaxError and the resumed session's
-    // backup pickup path was dead on arrival. Pinned by a byte-for-byte test
-    // against bridge-server.md.
-    `(2) Pending check via /pending: Bash: curl -s http://localhost:${port}/pending | python -c "import sys,json; d=json.load(sys.stdin); print('true' if d.get('pending') else 'false')". ` +
-    `If exactly "false" → produce NO output (silent tick). ` +
-    `If exactly "true" → curl -s http://localhost:${port}/decisions, parse JSON, note _version, process per concept SKILL.md Step 5 (rewrite HTML, POST /reload, then conditionally POST /reset with the noted version). On 409 retry with the new version. Report the outcome to the user.`
+    `Silently run via Bash: ${resolveScript('concept-tick.js')} ` +
+    `--port ${port} --state "${statePath}" ` +
+    `— this services the concept bridge on port ${port}. ` +
+    `No output → produce NO output (silent tick). ` +
+    `Any output IS your instruction for this tick: follow it exactly.`
   );
 }
 
@@ -327,7 +356,7 @@ function buildResumeInstructions(state, pendingState, statePath = STATE_PATH, st
   );
   lines.push(
     `(a) BACKUP pickup path — CronCreate with cron "* * * * *" (recurring: true) and prompt: ` +
-    `'${buildCronBody(state.port)}'.`
+    `'${buildCronBody(state.port, statePath)}'.`
   );
   lines.push(
     `(b) Keepalive pulser — launch as a background Bash task (run_in_background: true). Without it ` +
@@ -396,6 +425,7 @@ function buildDeadBridgeRecovery(state, store) {
 module.exports = {
   isValidHtmlPath,
   isStale,
+  resolveScript,
   buildCronBody,
   buildBackgroundTasks,
   buildResumeInstructions,

--- a/plugins/devops/hooks/session-start/ss.concept.resume.test.js
+++ b/plugins/devops/hooks/session-start/ss.concept.resume.test.js
@@ -1,11 +1,14 @@
 import { describe, test, expect } from "vitest";
+import path from "node:path";
 import {
   isValidHtmlPath,
   isStale,
+  resolveScript,
   buildCronBody,
   buildBackgroundTasks,
   buildResumeInstructions,
 } from "./ss.concept.resume.js";
+import { isSilent as isSilentTurn } from "../user-prompt-submit/prompt.flow.silent-turn.js";
 
 const STATE = { port: 8883, html_path: "docs/concepts/2026-08-15-x.html", slug: "x" };
 
@@ -38,19 +41,70 @@ describe("isStale", () => {
   });
 });
 
+// The cron prompt IS its card in the background tasks panel, so the procedure
+// it used to spell out inline (1128 characters of gate + heartbeat + probe +
+// pending branch) now lives in scripts/concept-tick.js. What is left has to
+// stay small — and has to keep two phrasings that are easy to "tidy up" into
+// a regression.
 describe("buildCronBody", () => {
-  test("carries the port into every endpoint", () => {
-    const body = buildCronBody(8883);
-    expect(body).toContain("http://localhost:8883/heartbeat");
-    expect(body).toContain("http://localhost:8883/pending");
-    expect(body).toContain("http://localhost:8883/decisions");
-    expect(body).toContain("http://localhost:8883/shutdown");
+  const STATE_PATH = "C:/proj/.claude/concept-active.json";
+
+  test("delegates the whole tick to concept-tick.js", () => {
+    const body = buildCronBody(8883, STATE_PATH);
+    expect(body).toContain("concept-tick.js");
+    expect(body).toContain("--port 8883");
+    expect(body).toContain(`--state "${STATE_PATH}"`);
   });
 
-  test("checks /pending, not a substring match on /decisions", () => {
-    // A `contains "submitted":true` test silently misses every submission,
-    // because json.dumps emits a space after the colon.
-    expect(buildCronBody(8883)).not.toMatch(/"submitted":\s*true/);
+  test("passes the state path ABSOLUTE", () => {
+    // A relative `.claude/concept-active.json` resolves against the cron task's
+    // cwd, which is not always the project root — the exact defect the watchers
+    // already had to fix.
+    expect(buildCronBody(8883)).toMatch(/--state "(?:[a-zA-Z]:[\\/]|\/)/);
+  });
+
+  test("carries no endpoint or procedure text any more", () => {
+    const body = buildCronBody(8883, STATE_PATH);
+    for (const leak of ["/heartbeat", "/pending", "/decisions", "/shutdown", "python -c", "CronDelete"]) {
+      expect(body, leak).not.toContain(leak);
+    }
+  });
+
+  test("stays short enough to be one card among many", () => {
+    expect(buildCronBody(8883, STATE_PATH).length).toBeLessThan(400);
+  });
+
+  test("OPENS with the silence marker prompt.flow.silent-turn keys off", () => {
+    // Not cosmetic. That hook flags a tick as silent only when the prompt
+    // *opens* with the marker; a lead-in in front of it makes every tick look
+    // like a real user turn, so the completion-card reminder and the stop-hook
+    // enforcement fire once a minute for the whole session.
+    expect(isSilentTurn(buildCronBody(8883, STATE_PATH))).toBe(true);
+  });
+
+  test("resolves the script at run time in the versioned cache layout", () => {
+    // A cron outlives a plugin rebuild: an in-session /ship writes the new
+    // version under a fresh .../devops/<version>/ and deletes the old one, so
+    // a baked-in absolute path fails MODULE_NOT_FOUND once a minute after it.
+    const cache = path.join("C:", "cache", "dotclaude", "devops", "0.128.0", "hooks", "session-start");
+    const out = resolveScript("concept-tick.js", cache);
+    expect(out).toContain("ls -d");
+    expect(out).toContain("/*/scripts/concept-tick.js");
+    expect(out).toContain("head -1");
+    // …and still runs SOMETHING if the glob comes up empty.
+    expect(out).toMatch(/node "\$\{f:-[^}]*concept-tick\.js\}"/);
+  });
+
+  test("a dev checkout has no version dir, so it uses the literal path", () => {
+    const dev = path.join("C:", "repo", "plugins", "devops", "hooks", "session-start");
+    expect(resolveScript("concept-tick.js", dev)).not.toContain("ls -d");
+    expect(resolveScript("concept-tick.js", dev)).toContain("concept-tick.js");
+  });
+
+  test("still mentions `port N` literally, for the orphan sweep", () => {
+    // Cleanup lists crons and deletes "every cron whose prompt mentions
+    // `port {port}`" when the state file, and with it cron_id, is gone.
+    expect(buildCronBody(8883, STATE_PATH)).toContain("port 8883");
   });
 });
 
@@ -133,6 +187,7 @@ describe("buildResumeInstructions", () => {
   test("a slug-less state file still produces usable instructions", () => {
     const out = buildResumeInstructions({ port: 9001, html_path: "docs/concepts/y.html" }, "idle");
     expect(out).toContain("slug ?");
-    expect(out).toContain("http://localhost:9001/pending");
+    // The port has to reach all three re-armed watchers, slug or no slug.
+    expect(out.match(/--port 9001/g)).toHaveLength(3);
   });
 });

--- a/plugins/devops/scripts/concept-tick.js
+++ b/plugins/devops/scripts/concept-tick.js
@@ -1,0 +1,250 @@
+#!/usr/bin/env node
+/**
+ * @script concept-tick
+ * @version 0.1.0
+ * @plugin devops
+ * @description One tick of the concept bridge's backup cron, as a script instead
+ *   of a 1128-character prompt.
+ *
+ *   Claude Code renders a cron's full prompt text as its card in the background
+ *   tasks panel, so the old inline body — self-cleanup gate, heartbeat POST,
+ *   `/pending` probe via `curl | python -c`, and the whole pending-branch
+ *   procedure — made a single card fill the entire panel and hid every other
+ *   background task. The cron prompt is now two sentences; everything it used to
+ *   spell out inline happens here.
+ *
+ *   Nothing was dropped, only moved. The steps map 1:1 onto the numbered steps
+ *   of `skills/concept/deep-knowledge/bridge-server.md` § step 3:
+ *     (0) self-cleanup gate — state file missing / foreign port / concept HTML
+ *         gone ⇒ POST /shutdown and tell Claude which cron to delete
+ *     (1) heartbeat POST — keeps the page's connection indicator green
+ *     (2) pending check via the deterministic `/pending` endpoint (never a
+ *         substring match on `/decisions`: `json.dumps` emits `"submitted": true`
+ *         WITH a space, so a substring test misses every submission)
+ *
+ *   Output contract — this is what makes the cron prompt short. stdout is
+ *   Claude's instruction, and there is stdout ONLY when Claude must actually do
+ *   something:
+ *     - idle tick        → NOTHING on stdout. The cron tick costs no tokens.
+ *     - cleanup needed   → the CronDelete instruction (only Claude has the tool)
+ *     - submission ready → the full pending-branch procedure
+ *
+ *   Why not have the cron read a file per tick instead: a Read call every 60 s
+ *   costs tokens on every idle tick, which is the common case by far. A Bash
+ *   call that prints nothing costs nothing, and it replaces the TWO curl calls
+ *   the old body already made — so this is strictly cheaper than what it
+ *   replaces, not a new per-tick cost.
+ *
+ *   Exit code is 0 for every tick outcome, including an unreachable bridge:
+ *   a non-zero exit would surface as a failed Bash call in the transcript on
+ *   every tick of a dying bridge. Bridge liveness is owned by the pulser and
+ *   the server-side `--html` watchdog, not by this script. Only invalid
+ *   arguments exit 2.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const http = require('http');
+
+const DEFAULTS = {
+  timeout: 8, // seconds per request
+};
+
+function parseArgs(argv) {
+  const out = { port: 0, state: '', ...DEFAULTS };
+  for (let i = 0; i < argv.length; i++) {
+    const key = argv[i].startsWith('--') ? argv[i].slice(2) : null;
+    if (!key) continue;
+    const raw = argv[i + 1];
+    if (raw === undefined || raw.startsWith('--')) continue;
+    i++;
+    if (key === 'state') out[key] = raw;
+    // hasOwn, not `in` — `in` walks the prototype chain, so `--toString 5`
+    // would set junk on the options object.
+    else if (Object.prototype.hasOwnProperty.call(DEFAULTS, key) || key === 'port') out[key] = Number(raw);
+  }
+  return out;
+}
+
+function validate(opts) {
+  if (!Number.isInteger(opts.port) || opts.port < 1 || opts.port > 65535) return 'port must be 1-65535';
+  // Enforced, not merely described: a relative path resolved against the cron
+  // task's cwd is the exact defect `concept-watch.js` already had to fix.
+  if (!opts.state || !path.isAbsolute(opts.state)) return 'state must be the ABSOLUTE path to concept-active.json';
+  if (!(opts.timeout > 0)) return 'timeout must be a positive number';
+  return null;
+}
+
+/**
+ * Step (0), the read half. Does the concept on disk still belong to this cron?
+ *
+ * A transient read error is NOT a dead concept — EBUSY/EPERM during a state
+ * rewrite on Windows or EMFILE under load would otherwise make one tick tear
+ * down a live session. Only ENOENT and a parsed-but-wrong state file are
+ * terminal, matching `concept-watch.js` § checkState.
+ *
+ * @returns {{cleanup:boolean, reason?:string, cronId?:string|null, stateReadable:boolean}}
+ */
+function inspectState(statePath, port, exists = fs.existsSync) {
+  let raw;
+  try {
+    raw = fs.readFileSync(statePath, 'utf8');
+  } catch (err) {
+    if (err && err.code === 'ENOENT') {
+      return { cleanup: true, reason: 'state file is gone', cronId: null, stateReadable: false };
+    }
+    return { cleanup: false, stateReadable: false };
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    // A half-written file during a state rewrite is not a dead concept.
+    return { cleanup: false, stateReadable: false };
+  }
+  if (!parsed || typeof parsed !== 'object') return { cleanup: false, stateReadable: false };
+
+  const cronId = typeof parsed.cron_id === 'string' ? parsed.cron_id : null;
+
+  // Numeric, so no `"port": 8883` spacing dependency and no 8883-vs-88831 slip.
+  if (parsed.port !== port) {
+    return { cleanup: true, reason: `state file now owns port ${parsed.port}, not ${port}`, cronId, stateReadable: true };
+  }
+
+  // The concept HTML is the source of truth for "is this session still real?".
+  // `html_path` is relative to the project root, which is the state file's
+  // grandparent (`<root>/.claude/concept-active.json`).
+  const root = path.dirname(path.dirname(statePath));
+  const html = typeof parsed.html_path === 'string' ? parsed.html_path : '';
+  if (!html || !exists(path.join(root, html))) {
+    return { cleanup: true, reason: `concept HTML ${html || '(unset)'} no longer exists`, cronId, stateReadable: true };
+  }
+
+  return { cleanup: false, stateReadable: true };
+}
+
+function request(port, pathname, method, timeoutSec) {
+  return new Promise((resolve) => {
+    const req = http.request(
+      { host: '127.0.0.1', port, path: pathname, method, timeout: timeoutSec * 1000 },
+      (res) => {
+        const chunks = [];
+        res.on('data', (c) => chunks.push(c));
+        res.on('end', () => resolve({ ok: res.statusCode === 200, body: Buffer.concat(chunks).toString('utf8') }));
+      }
+    );
+    req.on('timeout', () => { req.destroy(); resolve({ ok: false, body: '' }); });
+    req.on('error', () => resolve({ ok: false, body: '' }));
+    req.end();
+  });
+}
+
+/**
+ * The cleanup instruction. CronDelete is a tool, so this one step cannot move
+ * into the script — but the *text* can, and it only ever reaches Claude on the
+ * single tick that actually needs it.
+ */
+function cleanupInstruction(port, reason, cronId) {
+  return (
+    `Concept bridge on port ${port} is over (${reason}); its server has been shut down. ` +
+    (cronId
+      ? `CronDelete the cron with id ${cronId}. `
+      : `The state file no longer names a cron id, so CronList and delete every cron whose prompt mentions \`port ${port}\`. `) +
+    `Then produce NO further output.`
+  );
+}
+
+/**
+ * The pending-branch procedure, verbatim from `bridge-server.md` § step 3 (2).
+ * It reaches Claude once per submission instead of once per minute.
+ */
+function pendingInstruction(port, version) {
+  return (
+    `A concept submission is waiting on the bridge at port ${port}` +
+    (version === null ? '' : ` (version ${version})`) + `. ` +
+    `Fetch it: curl -s http://localhost:${port}/decisions. Parse the JSON, note \`_version\`, and strip ` +
+    `\`_version\` and \`_processed_at\` before treating the rest as decision data. Read \`action\` — it is one ` +
+    `of "iterate", "implement", "create-issues", "ship" or "dispose-concept", each with its own branch in ` +
+    `concept SKILL.md Step 5b. Process per Step 5 (Live Feedback Loop). ` +
+    `Zero-prompt invariant: create-issues, ship and dispose-concept MUST complete without asking the user ` +
+    `anything — the button click was the sign-off, and the payload is self-sufficient (a ship-pipeline hard ` +
+    `gate failure is the one exception, and a force-push to main still needs confirmation). ` +
+    `Step 5c writes the new iteration to the HTML file and POSTs /reload BEFORE the reset. ` +
+    `Reset LAST and conditionally, passing the noted version: curl -s -o /dev/null -w "%{http_code}" ` +
+    `-X POST -H "Content-Type: application/json" -d '{"version": <noted>}' http://localhost:${port}/reset. ` +
+    `On HTTP 409 the user submitted again while you worked — re-fetch /decisions, process the new payload ` +
+    `(it supersedes what you just finished), then retry the conditional reset with the new \`_version\`. ` +
+    `Re-launch the pickup waker immediately after /reset, then report the outcome to the user.`
+  );
+}
+
+/**
+ * @returns {Promise<{stdout:string, stderr:string}>} — `stdout` empty means a
+ *   silent tick. Returned rather than written so the tests can assert on it.
+ */
+async function tick(opts, deps = {}) {
+  const io = { request, inspectState, exists: fs.existsSync, ...deps };
+
+  // (0) Self-cleanup gate — FIRST step every tick, before any bridge traffic.
+  const state = io.inspectState(opts.state, opts.port, io.exists);
+  if (state.cleanup) {
+    await io.request(opts.port, '/shutdown', 'POST', opts.timeout);
+    return { stdout: cleanupInstruction(opts.port, state.reason, state.cronId), stderr: '' };
+  }
+
+  // (1) Heartbeat POST — what keeps the page's indicator green when the pulser
+  // is gone. Its failure is not reported: the pulser and the server-side
+  // watchdog own bridge liveness, and a per-tick complaint about a dying
+  // bridge would spam the transcript once a minute.
+  const beat = await io.request(opts.port, '/heartbeat', 'POST', opts.timeout);
+  if (!beat.ok) {
+    return { stdout: '', stderr: `concept-tick: bridge on port ${opts.port} did not answer /heartbeat\n` };
+  }
+
+  // (2) Pending check via /pending — a strict `{"pending": bool, "version": N}`,
+  // never a substring match on /decisions.
+  const res = await io.request(opts.port, '/pending', 'GET', opts.timeout);
+  if (!res.ok) {
+    return { stdout: '', stderr: `concept-tick: bridge on port ${opts.port} did not answer /pending\n` };
+  }
+
+  let body;
+  try {
+    body = JSON.parse(res.body);
+  } catch {
+    return { stdout: '', stderr: `concept-tick: /pending returned unparseable JSON\n` };
+  }
+  if (!body || body.pending !== true) return { stdout: '', stderr: '' };
+
+  const version = typeof body.version === 'number' ? body.version : null;
+  return { stdout: pendingInstruction(opts.port, version), stderr: '' };
+}
+
+module.exports = {
+  parseArgs,
+  validate,
+  inspectState,
+  cleanupInstruction,
+  pendingInstruction,
+  tick,
+  DEFAULTS,
+};
+
+if (require.main === module) {
+  const opts = parseArgs(process.argv.slice(2));
+  const err = validate(opts);
+  if (err) {
+    process.stderr.write(`concept-tick: ${err}\n`);
+    process.stderr.write('usage: concept-tick.js --port <n> --state <abs path> [--timeout 8]\n');
+    process.exit(2);
+  }
+  tick(opts)
+    .then(({ stdout, stderr }) => {
+      if (stderr) process.stderr.write(stderr);
+      if (stdout) process.stdout.write(`${stdout}\n`);
+    })
+    // An internal error must stay a silent tick, not a failed Bash call every
+    // minute — and never a stack trace Claude would try to act on.
+    .catch((e) => process.stderr.write(`concept-tick: ${e && e.message}\n`));
+}

--- a/plugins/devops/scripts/concept-tick.test.js
+++ b/plugins/devops/scripts/concept-tick.test.js
@@ -1,0 +1,244 @@
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  parseArgs,
+  validate,
+  inspectState,
+  cleanupInstruction,
+  pendingInstruction,
+  tick,
+} from "./concept-tick.js";
+
+const PORT = 8883;
+
+// A real temp project tree — inspectState reads the state file and stats the
+// concept HTML relative to it, and faking fs for that would test the fake.
+let root;
+let statePath;
+
+function writeState(obj) {
+  fs.mkdirSync(path.dirname(statePath), { recursive: true });
+  fs.writeFileSync(statePath, typeof obj === "string" ? obj : JSON.stringify(obj));
+}
+
+function writeHtml(rel) {
+  const abs = path.join(root, rel);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, "<html></html>");
+}
+
+const LIVE = {
+  port: PORT,
+  html_path: "docs/concepts/2026-08-16-x.html",
+  slug: "x",
+  cron_id: "ab12cd34",
+};
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), "concept-tick-"));
+  statePath = path.join(root, ".claude", "concept-active.json");
+});
+
+afterEach(() => {
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe("parseArgs / validate", () => {
+  test("reads port, state and the timeout default", () => {
+    const opts = parseArgs(["--port", "8883", "--state", "C:/p/.claude/concept-active.json"]);
+    expect(opts.port).toBe(8883);
+    expect(opts.state).toBe("C:/p/.claude/concept-active.json");
+    expect(opts.timeout).toBe(8);
+  });
+
+  test("does not walk the prototype chain", () => {
+    // `key in DEFAULTS` would let `--toString 5` set junk on the options object.
+    const opts = parseArgs(["--toString", "5"]);
+    expect(typeof opts.toString).toBe("function");
+  });
+
+  test("rejects a relative state path", () => {
+    // The defect this argument exists to prevent: resolved against the cron
+    // task's cwd, which is not always the project root.
+    expect(validate({ port: PORT, state: ".claude/concept-active.json", timeout: 8 }))
+      .toMatch(/ABSOLUTE/);
+  });
+
+  test.each([0, -1, 70000, 1.5, NaN])("rejects port %s", p => {
+    expect(validate({ port: p, state: "C:/p/x.json", timeout: 8 })).toMatch(/port/);
+  });
+
+  test("accepts a valid pair", () => {
+    expect(validate({ port: PORT, state: path.resolve("/p/x.json"), timeout: 8 })).toBeNull();
+  });
+});
+
+// Step (0) of bridge-server.md § step 3 — the gate that keeps a stale cron
+// from servicing a concept that is over.
+describe("inspectState — the self-cleanup gate", () => {
+  test("a live concept is not a cleanup trigger", () => {
+    writeState(LIVE);
+    writeHtml(LIVE.html_path);
+    expect(inspectState(statePath, PORT).cleanup).toBe(false);
+  });
+
+  test("a missing state file triggers cleanup, with no cron id to delete", () => {
+    const res = inspectState(statePath, PORT);
+    expect(res.cleanup).toBe(true);
+    expect(res.cronId).toBeNull();
+  });
+
+  test("a state file owning a different port triggers cleanup and keeps the id", () => {
+    writeState({ ...LIVE, port: 9001 });
+    writeHtml(LIVE.html_path);
+    const res = inspectState(statePath, PORT);
+    expect(res.cleanup).toBe(true);
+    expect(res.cronId).toBe("ab12cd34");
+    expect(res.reason).toContain("9001");
+  });
+
+  test("the port comparison is numeric, not a JSON-spacing substring match", () => {
+    // `"port": 8883` vs `"port":8883` used to decide this, and 88831 used to
+    // match 8883.
+    writeState(`{"port":${PORT},"html_path":"${LIVE.html_path}","cron_id":"ab12cd34"}`);
+    writeHtml(LIVE.html_path);
+    expect(inspectState(statePath, PORT).cleanup).toBe(false);
+
+    writeState({ ...LIVE, port: 88831 });
+    expect(inspectState(statePath, PORT).cleanup).toBe(true);
+  });
+
+  test("a vanished concept HTML triggers cleanup", () => {
+    writeState(LIVE);
+    const res = inspectState(statePath, PORT);
+    expect(res.cleanup).toBe(true);
+    expect(res.reason).toContain(LIVE.html_path);
+  });
+
+  test("html_path resolves against the project root, not the cwd", () => {
+    writeState(LIVE);
+    writeHtml(LIVE.html_path);
+    // Proof it is the state file's grandparent that is used: the same relative
+    // path under the process cwd must NOT satisfy the check.
+    const seen = [];
+    inspectState(statePath, PORT, p => { seen.push(p); return true; });
+    expect(seen[0]).toBe(path.join(root, LIVE.html_path));
+  });
+
+  test("a half-written state file is NOT a dead concept", () => {
+    writeState('{"port": 88');
+    expect(inspectState(statePath, PORT).cleanup).toBe(false);
+  });
+
+  test("a state file that is a directory (EISDIR/EPERM) is NOT a dead concept", () => {
+    // Stands in for the EBUSY/EPERM window during a state rewrite on Windows:
+    // any read error that is not ENOENT must be tolerated, or one unlucky tick
+    // tears down a live concept.
+    fs.mkdirSync(statePath, { recursive: true });
+    expect(inspectState(statePath, PORT).cleanup).toBe(false);
+  });
+});
+
+describe("the instructions the script emits", () => {
+  test("cleanup names the cron id when the state file still has one", () => {
+    const out = cleanupInstruction(PORT, "concept HTML is gone", "ab12cd34");
+    expect(out).toContain("CronDelete the cron with id ab12cd34");
+    expect(out).not.toContain("CronList");
+  });
+
+  test("cleanup falls back to the by-port sweep when the id is lost", () => {
+    const out = cleanupInstruction(PORT, "state file is gone", null);
+    expect(out).toContain("CronList");
+    expect(out).toContain(`mentions \`port ${PORT}\``);
+  });
+
+  test("the pending instruction carries the version it was handed", () => {
+    expect(pendingInstruction(PORT, 7)).toContain("(version 7)");
+    // A version-less /pending response must not invent one — Claude still
+    // reads the authoritative `_version` out of /decisions either way.
+    expect(pendingInstruction(PORT, null)).not.toMatch(/\(version /);
+    expect(pendingInstruction(PORT, null)).toContain("`_version`");
+  });
+});
+
+describe("tick", () => {
+  const ok = body => ({ ok: true, body });
+
+  function spyRequest(routes) {
+    const calls = [];
+    return {
+      calls,
+      request: async (port, pathname) => {
+        calls.push(pathname);
+        return routes[pathname] || { ok: false, body: "" };
+      },
+    };
+  }
+
+  test("an idle tick prints absolutely nothing", async () => {
+    writeState(LIVE);
+    writeHtml(LIVE.html_path);
+    const spy = spyRequest({
+      "/heartbeat": ok(""),
+      "/pending": ok(JSON.stringify({ pending: false, version: 3 })),
+    });
+    const res = await tick({ port: PORT, state: statePath, timeout: 8 }, { request: spy.request });
+    expect(res).toEqual({ stdout: "", stderr: "" });
+  });
+
+  test("a pending submission returns the processing instruction", async () => {
+    writeState(LIVE);
+    writeHtml(LIVE.html_path);
+    const spy = spyRequest({
+      "/heartbeat": ok(""),
+      "/pending": ok(JSON.stringify({ pending: true, version: 4 })),
+    });
+    const res = await tick({ port: PORT, state: statePath, timeout: 8 }, { request: spy.request });
+    expect(res.stdout).toContain("version 4");
+    expect(res.stdout).toContain("/decisions");
+    expect(res.stdout).toContain("409");
+  });
+
+  test("the gate runs FIRST — no bridge traffic beyond /shutdown", async () => {
+    // No state file at all.
+    const spy = spyRequest({ "/shutdown": ok("") });
+    const res = await tick({ port: PORT, state: statePath, timeout: 8 }, { request: spy.request });
+    expect(spy.calls).toEqual(["/shutdown"]);
+    expect(res.stdout).toContain("CronList");
+  });
+
+  test("a heartbeat failure is stderr only, never an instruction", async () => {
+    writeState(LIVE);
+    writeHtml(LIVE.html_path);
+    const spy = spyRequest({});
+    const res = await tick({ port: PORT, state: statePath, timeout: 8 }, { request: spy.request });
+    expect(res.stdout).toBe("");
+    expect(res.stderr).toContain("/heartbeat");
+    // It must not go on to probe a bridge that just failed to answer.
+    expect(spy.calls).toEqual(["/heartbeat"]);
+  });
+
+  test("unparseable /pending JSON is a silent tick, not a guess", async () => {
+    writeState(LIVE);
+    writeHtml(LIVE.html_path);
+    const spy = spyRequest({ "/heartbeat": ok(""), "/pending": ok("<html>not json") });
+    const res = await tick({ port: PORT, state: statePath, timeout: 8 }, { request: spy.request });
+    expect(res.stdout).toBe("");
+    expect(res.stderr).toContain("unparseable");
+  });
+
+  test("`pending` must be exactly true — no truthiness", async () => {
+    writeState(LIVE);
+    writeHtml(LIVE.html_path);
+    for (const value of ["true", 1, {}, null]) {
+      const spy = spyRequest({
+        "/heartbeat": ok(""),
+        "/pending": ok(JSON.stringify({ pending: value })),
+      });
+      const res = await tick({ port: PORT, state: statePath, timeout: 8 }, { request: spy.request });
+      expect(res.stdout, String(value)).toBe("");
+    }
+  });
+});

--- a/plugins/devops/skills/concept/deep-knowledge/bridge-server.md
+++ b/plugins/devops/skills/concept/deep-knowledge/bridge-server.md
@@ -8,14 +8,7 @@ AND provides HTTP endpoints for heartbeat and decision exchange.
 > is **milliseconds since the Unix epoch**, byte-compatible with JavaScript's
 > `Date.now()`. The browser compares them directly, with no conversion:
 > ```js
-> Date.now() - _lastHeartbeatTs < HEARTBEAT_STALE_MS   
-
-   **Verify both actually started.** They are the only launches in this document
-   whose failure is silent — the server has a heartbeat round-trip, the port has
-   a single-listener assert, the page has a 200-gate, and these had nothing.
-   Read each task's output once after launching: a `*_EXIT reason=` line within
-   seconds means it never got going. `STATE_NEVER_APPEARED` in particular means
-   the launch outran step 4 — write the state file, then re-launch.// both in ms
+> Date.now() - _lastHeartbeatTs < HEARTBEAT_STALE_MS   // both in ms
 > Date.now() - _lastServerTs    < SERVER_STALE_MS       // same unit contract
 > ```
 > `_lastServerTs` (cached from `server_ts`) is compared against `SERVER_STALE_MS`
@@ -144,43 +137,89 @@ AND provides HTTP endpoints for heartbeat and decision exchange.
    the connection indicator green AND automatically picks up user submissions
    — no manual trigger needed from the user.
 
+   **The prompt is two sentences — the procedure is a script.** Claude Code
+   renders a cron's *entire* prompt text as its card in the background tasks
+   panel, so the old inline body (gate + heartbeat + `curl | python -c` probe +
+   the whole pending-branch procedure, 1128 characters) made one card fill the
+   panel and hid every other background task from the user. Nothing was
+   dropped: `scripts/concept-tick.js` performs every one of those steps and
+   prints an instruction only on the ticks that need one, so an ordinary idle
+   tick now costs zero tokens instead of re-reading the procedure every minute.
+
+   **Resolve the script at run time, never bake in a versioned path.** A cron
+   outlives a plugin rebuild: an in-session `/ship` writes the new version under
+   a fresh `.../devops/<version>/` directory and deletes the old one, so an
+   absolute path baked into the prompt dangles from that moment and every tick
+   fails MODULE_NOT_FOUND — once a minute, silently, for the rest of the
+   session. In the versioned cache layout emit the same `ls -d … | head -1`
+   prefix `ss.git.sync` uses (the rebuild leaves exactly one version directory,
+   so the glob is unambiguous), with the literal path as the fallback:
+   `f="$(ls -d "{cache-root}/devops"/*/scripts/concept-tick.js 2>/dev/null | head -1)"; node "${f:-{literal}}"`.
+   A dev/marketplace checkout has no version directory and just uses the
+   literal path, which is the form shown below.
+
    ```
    CronCreate(cron: "* * * * *", recurring: true, prompt: <<EOF
-   Silently service the concept bridge on port {port}.
+   Silently run via Bash: node "{plugin-root}/scripts/concept-tick.js" --port {port} --state "{project-root}/.claude/concept-active.json" — this services the concept bridge on port {port}. No output → produce NO output (silent tick). Any output IS your instruction for this tick: follow it exactly.
+   EOF)
+   ```
 
-   (0) Self-cleanup gate (FIRST step every tick).
-       Read `.claude/concept-active.json` from the project root. Cleanup
-       triggers when ANY of these is true:
+   **Two phrasings in that prompt are load-bearing — do not tidy them up.**
+   - It MUST **start** with `Silently run`. The `prompt.flow.silent-turn` hook
+     marks a cron tick as a silent turn only when the prompt *opens* with a
+     silence marker. Put anything in front of it — a `Concept bridge, port N — `
+     lead-in reads nicely and is exactly the trap — and every tick is treated as
+     a real user turn: the completion-card reminder fires and the stop hook
+     blocks the turn to force a card, once a minute, for the whole session.
+   - It MUST contain the literal `port {port}`. Step (0)'s orphan sweep deletes
+     "every cron whose prompt mentions `port {port}`" when the state file, and
+     with it `cron_id`, is gone. `--port {port}` alone does not match that
+     phrasing, so the trailing clause is what keeps the sweep able to find this
+     cron.
+
+   **`--state` must be ABSOLUTE**, for the same reason it is absolute for the
+   watchers below: a relative `.claude/concept-active.json` is resolved against
+   the cron task's cwd, which is not always the project root the state file
+   lives in.
+
+   **What `concept-tick.js` does on each tick** — the same three steps, in the
+   same order, with the same triggers:
+
+   (0) **Self-cleanup gate (FIRST step every tick).** It reads the state file
+       at `--state`. Cleanup triggers when ANY of these is true:
          - The state file is missing.
-         - State.port ≠ {port} (this cron is for a stale session — a
-           newer concept overwrote the state file with a different port).
-         - State.html_path does not exist on disk.
-       On trigger:
-         - Bash: curl -s -X POST http://localhost:{port}/shutdown > /dev/null 2>&1 || true
-         - Then call CronDelete with the id from the (still-readable)
-           state file's `cron_id` field — OR, if the state file is gone
-           entirely, list crons via CronList and delete every cron whose
-           prompt mentions `port {port}` (a missing state file proves
-           the session is unrecoverable; sweeping by-port catches the
-           orphan even when the id is lost).
-       Produce NO user-visible output. Skip steps 1 and 2.
+         - `state.port` ≠ `{port}` (this cron is for a stale session — a newer
+           concept overwrote the state file with a different port).
+         - `state.html_path` does not exist on disk (resolved against the
+           state file's grandparent, i.e. the project root).
+       A state file that is present but *unreadable* (EBUSY/EPERM during a
+       rewrite on Windows, EMFILE under load) or half-written is explicitly
+       NOT a trigger — one unlucky tick must not tear down a live concept.
+       On trigger the script POSTs `/shutdown` itself, then prints the one
+       instruction it cannot execute, because `CronDelete` is a tool:
+       delete `cron_id` from the still-readable state file — or, if the state
+       file is gone entirely, `CronList` and delete every cron whose prompt
+       mentions `port {port}` (a missing state file proves the session is
+       unrecoverable; sweeping by-port catches the orphan even when the id is
+       lost). Steps 1 and 2 are skipped.
 
-   (1) Heartbeat POST:
-       Bash: curl -s -X POST http://localhost:{port}/heartbeat > /dev/null
+   (1) **Heartbeat POST** to `/heartbeat`. A failure here is reported on
+       stderr only, never as an instruction: bridge liveness is owned by the
+       keepalive pulser and the server-side `--html` watchdog, and a per-tick
+       complaint about a dying bridge would spam the transcript once a minute.
 
-   (2) Pending check — use the deterministic /pending endpoint, NOT a
-       substring match on /decisions. The response is a strict JSON object
-       `{"pending": true|false, "version": N}` with no free-form content.
-       Bash (produces ONLY the literal string "true" or "false"):
-         curl -s http://localhost:{port}/pending | python -c "import sys,json; d=json.load(sys.stdin); print('true' if d.get('pending') else 'false')"
+   (2) **Pending check** against the deterministic `/pending` endpoint — a
+       strict `{"pending": true|false, "version": N}` with no free-form
+       content, **never** a substring match on `/decisions`. Not pending →
+       the script prints nothing at all and the tick is silent.
 
-       If the output is exactly "false" → produce NO user-visible output. Silent tick.
-
-       If the output is exactly "true" → fetch the full payload and process:
-         Bash: curl -s http://localhost:{port}/decisions
-         • Parse the JSON. Note `_version`. Strip `_version` and `_processed_at`
-           before treating the rest as decision data. Read `action` — it is
-           one of FIVE values, each with its own SKILL.md Step 5b branch:
+       Pending → it prints the processing instruction, carrying the version
+       from `/pending`. That instruction is the branch procedure that used to
+       sit in the cron prompt, and it is unchanged:
+         • Fetch `curl -s http://localhost:{port}/decisions`. Parse the JSON.
+           Note `_version`. Strip `_version` and `_processed_at` before
+           treating the rest as decision data. Read `action` — it is one of
+           FIVE values, each with its own SKILL.md Step 5b branch:
              - "iterate"        → next iteration on the concept page only
              - "implement"      → apply real code changes + final-report
              - "create-issues"  → apply the user-value gate (SKILL.md Step 5b,
@@ -212,26 +251,32 @@ AND provides HTTP endpoints for heartbeat and decision exchange.
 
          • After the file rewrite AND the `/reload` POST have completed,
            reset conditionally — pass the noted version:
-           Bash: curl -s -o /dev/null -w "%{http_code}" -X POST \
-                       -H "Content-Type: application/json" \
-                       -d '{"version": <noted>}' http://localhost:{port}/reset
+           `curl -s -o /dev/null -w "%{http_code}" -X POST -H "Content-Type: application/json" -d '{"version": <noted>}' http://localhost:{port}/reset`
          • If the HTTP code is 409 (version mismatch) → the user submitted
            again while you were processing. Re-fetch /decisions, process the
            new payload (which supersedes what you just finished), then retry
            the conditional reset with the new `_version`.
-         • Report the outcome to the user. The visible panel reset happens
-           via the `/reload`-triggered `location.reload()` in the browser —
-           the page reloads onto the new iteration with a fresh ready panel.
-           The `_processed_at` poll is only a safety-net for stuck states.
-   EOF)
-   ```
+         • Re-launch the pickup waker immediately after `/reset`, then report
+           the outcome to the user. The visible panel reset happens via the
+           `/reload`-triggered `location.reload()` in the browser — the page
+           reloads onto the new iteration with a fresh ready panel. The
+           `_processed_at` poll is only a safety-net for stuck states.
 
-   **Why `/pending` + `python -c` instead of a substring check?** The
-   `/decisions` JSON response is formatted via Python's default
-   `json.dumps`, which emits `"submitted": true` **with** a space after the
-   colon — a literal `contains "submitted":true` test silently misses every
-   submission. `/pending` collapses the signal to a strict boolean so the
-   cron body cannot drift into false negatives between ticks.
+   **Why `/pending` and not a substring check on `/decisions`?** The
+   `/decisions` JSON response is formatted via Python's default `json.dumps`,
+   which emits `"submitted": true` **with** a space after the colon — a literal
+   `contains "submitted":true` test silently misses every submission.
+   `/pending` collapses the signal to a strict boolean, and `concept-tick.js`
+   parses it as JSON rather than string-matching it, so the check cannot drift
+   into false negatives between ticks.
+
+   **Why a script and not a Read per tick.** The other way to shorten the
+   prompt would be to have the cron read the procedure from a file. That costs
+   tokens on *every* tick, and the idle tick is the overwhelmingly common case
+   — a submission arrives once every few minutes at best. A Bash call that
+   prints nothing costs nothing, and it replaces the TWO curl calls the old
+   body already made per tick, so this is strictly cheaper than what it
+   replaced rather than a new per-tick cost.
 
    **Side effect — submit-panel progress list.** The first `/pending=true`
    response also stamps `_picked_up_at` on the server. The browser reads

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.129.0",
+  "version": "0.130.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

Claude Code renders a cron's full prompt text as its card in the background tasks panel. The concept bridge's cron body was 1128 characters — self-cleanup gate, heartbeat POST, `curl | python -c` probe of `/pending`, and the entire pending-branch procedure — so one card filled the panel and hid every other background task. The git-sync cron had the same problem and was removed in #287; this one cannot be, because it drives a live interaction (heartbeat + submission pickup, once a minute).

Nothing was dropped. The procedure moved into `scripts/concept-tick.js`.

## What changed

- **`scripts/concept-tick.js`** (new) performs all three documented steps and prints an instruction only on the ticks that need one:
  - idle tick → **nothing** on stdout, so it costs zero tokens (previously it restated the procedure every minute)
  - cleanup tick → the `CronDelete` instruction, the one step a script cannot execute
  - submission tick → the pending-branch procedure verbatim (five action branches, zero-prompt invariant, `/reload` before `/reset`, 409 retry)
  - One Bash call replaces the two `curl` calls the old body already made, so this is strictly cheaper than what it replaces.
- **Cron prompt: 1128 → 375 characters**, most of it the script path.
- **Two load-bearing phrasings kept and documented**, because both read like noise:
  - opens with `Silently run` — `prompt.flow.silent-turn` flags a tick as silent only when the prompt *opens* with a marker; a lead-in would fire the completion-card reminder once a minute for the whole session
  - names `port N` in prose — the orphan sweep deletes crons whose prompt mentions exactly that, the only way to reap this cron once `cron_id` is gone
- **Glob-resolved script path** (same shape as `ss.git.sync`): a cron outlives a plugin rebuild, so an in-session `/ship` would leave a baked-in versioned path failing `MODULE_NOT_FOUND` every minute.

## Docs contract

The `bridge-server.md` § step 3 pin got **stricter**, not weaker:

- the whole prompt is now compared **byte-for-byte** (`toBe`), where it used to be one line of a 1128-character body
- the displaced procedure is pinned against the script that inherited it (five actions, ordering, 409, zero-prompt invariant)
- a length ceiling guards the card against the procedure creeping back
- `ss.concept.resume.test.js`'s three-watcher re-arm assertions are unchanged and green

Also fixes a merge artifact in `bridge-server.md`: a step-3 paragraph had been spliced into the timestamp-convention code block of the preamble.

## Verification

- `npm test` — 1670/1670 green (68 files), `npm run lint` clean
- Test profile pinned `cli-node`; tool-chain step 2 run against a live fixture bridge: idle tick emits 0 bytes, pending tick emits the full procedure with the version, deleting the concept HTML POSTs `/shutdown` (bridge observed dead) and emits `CronDelete <cron_id>`
- Codex review gate: usage limit reached, no review (skill contract: continue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)