### PR TITLE
feat(batch): collect prompts into one merged plan

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.130.0"
+    "version": "0.131.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.130.0",
+      "version": "0.131.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.130.0",
+      "version": "0.131.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.131.0] — 2026-08-16
+
+### Added
+
+- **`/claude-batch` collects prompts instead of executing them, then merges the whole set into one plan.** Working alongside a running app produces a stream of small observations — a misplaced button, a wrong error string, an idea for a filter — and sending each as its own prompt costs a full turn apiece, every one of them paying the entire accumulated context as input. The larger cost is not the tokens, though: observation five routinely supersedes observation one, and whatever was built for one was built for nothing. Collecting first removes both. While the mode is active a UserPromptSubmit hook blocks each prompt — the harness erases it, so it never reaches the model — and appends it to `.claude/batch.md`. A configurable marker at the start of a line (`!` by default, chosen once on first use) means "work on it now": the full note set is injected as context, checked for feasibility against the actual code, and merged into a single plan whose contradictions are listed one by one rather than quietly resolved by "later wins". After approval it routes to `/concept` when the conflicts deserve a decision page, and straight into implementation when they do not.
+
+  The notes live in the project, not in the temp directory: they survive a crash, a reboot, and `/clear` — which mints a new session id and would orphan session-scoped state — and they can be read, corrected, or filled entirely without Claude running. Four things are never collected, each for a reason that would otherwise cost the user something real. Machine prompts pass through, including `AUTONOMOUS_AUTOSTART:` and `AUTONOMOUS_RESUME:`, which do not match the existing silent-turn patterns and would leave an AFK run to never start; the `/concept` bridge polls once a minute and would die inside the window. Expanded slash commands pass through, because a real command arrives carrying a `<command-name>` tag rather than the typed text, and a naive comparison would miss exactly the escape hatch it is meant to protect. Prompts with attachments or `@file` mentions pass through, because a blocked prompt is erased and a collected screenshot would be gone for good. And any failure to store a note lets the prompt run normally instead of blocking it — a lost prompt is worse than a missed collection.
+
+  Being locked out is structurally impossible rather than merely unlikely: the mode carries both a time limit and a note cap, and either one ends collection on its own. A detached watchdog reminds via a Windows toast after ten minutes without a *user* prompt — its clock is a dedicated file, not the notes' timestamp, because the once-a-minute bridge cron would otherwise reset it forever and the threshold would never be reached. Sibling hooks in the same event group run in parallel and are not short-circuited by a block, so the four that write one-shot state now check whether the prompt is being collected and stand down; `prompt.git.sync` in particular no longer consumes its background-sync result into a turn that does not exist. The optional local-LLM path is limited to de-duplication and formatting, never interpretation — the delegation rules classify ambiguous user requests as never-delegate, and a wrong compaction would drop a requirement whose original is no longer on screen to check against.
+
+  **Two limits worth knowing.** A question sent without the marker lands silently in the queue instead of being answered; a hint is appended when a note ends in a question mark, but the hook deliberately never guesses what a question is. And zero token cost is a reasonable inference, not a guarantee — the documentation states only that a blocked prompt never reaches the model, and Anthropic promises nothing about billing.
+
 ## [0.130.0] — 2026-08-16
 
 ### Changed
@@ -16,6 +28,7 @@
 
 - **A merge artifact in the concept bridge documentation.** A paragraph from step 3 had been spliced into the middle of the timestamp-convention code block in the file's preamble, breaking that block's markdown and leaving the unit contract — the single most expensive silent-failure mode the document warns about — sitting behind mangled formatting.
 
+||||||| parent of 366426a (chore(release): v0.130.0)
 ## [0.129.0] — 2026-08-16
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.130.0**
+**Version: 0.131.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 
@@ -167,8 +167,8 @@ For the full extension guide with examples per skill, see `deep-knowledge/skill-
 
 ## Features
 
-- **<!--devops:count:hooks-->41<!--/devops:count:hooks--> Hooks** — automated guards and triggers across the full session lifecycle
-- **<!--devops:count:skills-->21<!--/devops:count:skills--> Skills** — ship, promote, commit, fix, setup-issue, setup-project, setup-readme, auto-usage, claude-extend-skill, setup-cleanup, auto-update, concept, run-agents, run-autonomous, run-burn, run-backlog, claude-learn, tune-harden, tune-polish, tune-rethink, auto-graph
+- **<!--devops:count:hooks-->42<!--/devops:count:hooks--> Hooks** — automated guards and triggers across the full session lifecycle
+- **<!--devops:count:skills-->22<!--/devops:count:skills--> Skills** — ship, promote, commit, fix, setup-issue, setup-project, setup-readme, auto-usage, claude-extend-skill, setup-cleanup, auto-update, concept, run-agents, run-autonomous, run-burn, run-backlog, claude-learn, tune-harden, tune-polish, tune-rethink, auto-graph
 - **<!--devops:count:agents-->12<!--/devops:count:agents--> Agents** — AI, Core, Designer, Feature, Frontend, Gamer, PO, QA, Redteam, Research, Windows
 - **Completion Flow** — mandatory card after every task (8 variants), visual verification, ship recommendation
 - **Ship Enforcement** — intent detection, PR command blocking, automatic /ship skill routing
@@ -178,7 +178,7 @@ For the full extension guide with examples per skill, see `deep-knowledge/skill-
 
 ### Hooks (automatic, no user action needed)
 
-<!--devops:count:hooks-->41<!--/devops:count:hooks--> hooks fire automatically across the session lifecycle — no user action needed.
+<!--devops:count:hooks-->42<!--/devops:count:hooks--> hooks fire automatically across the session lifecycle — no user action needed.
 
 <details>
 <summary><strong>By session lifecycle</strong> — when does it fire?</summary>
@@ -208,6 +208,7 @@ SessionStart  ──>  UserPromptSubmit  ──>  PreToolUse  ──>  PostToolU
 
 #### UserPromptSubmit — runs when the user sends a message
 
+- `prompt.batch.collect` — Collect mode for `/claude-batch`: while active, blocks the user prompt (exit 2 — the…
 - `prompt.flow.silent-turn` — Detects background/cron-injected prompts and marks the turn as "silent" so post.flow.…
 - `prompt.knowledge.dispatch` — On-demand deep-knowledge injection based on prompt keywords.
 - `prompt.git.sync` — Delivers the result of a background git sync — nothing else.
@@ -272,6 +273,7 @@ SessionStart  ──>  UserPromptSubmit  ──>  PreToolUse  ──>  PostToolU
 
 - `post.flow.completion` — Track code edits, inject completion reminder *(PostToolUse)*
 - `post.flow.debug` — Recommend /fix after repeated failures *(PostToolUse)*
+- `prompt.batch.collect` — Collect prompts instead of executing them, in `/claude-batch` mode *(UserPromptSubmit)*
 - `prompt.flow.appstart` — Detect app start intent, enforce completion card *(UserPromptSubmit)*
 - `prompt.flow.silent-turn` — Mark background/cron-injected turns *(UserPromptSubmit)*
 - `stop.flow.guard` — Enforce completion card before response ends *(Stop)*
@@ -329,6 +331,7 @@ SessionStart  ──>  UserPromptSubmit  ──>  PreToolUse  ──>  PostToolU
 | `/tune-polish` | Explicit | UI refinement: visual consistency, state-visuals, UI-side functionality checks |
 | `/auto-graph` | Explicit + Hook | On-demand code knowledge graph via graphify, with opt-in auto-build + hard-gate enforcement |
 | `/tune-rethink` | Explicit | Strategic reset for stuck development: code-blind fresh approaches, concept decision, autonomous implementation |
+| `/claude-batch` | Explicit + Hook | Collect mode: batch prompts into `.claude/batch.md` instead of executing them, then merge into one feasibility-checked plan |
 
 #### The `run-*` family — let Claude execute autonomously
 
@@ -692,8 +695,8 @@ Wk  ━━──╏─────────   15% +1%   · 4d 22h left
 devops/
 ├── .claude-plugin/plugin.json     ← Plugin manifest
 ├── CONVENTIONS.md                 ← Naming, versioning, extension rules
-├── hooks/                         ← <!--devops:count:hooks-->41<!--/devops:count:hooks--> hooks (JS) registered in hooks.json
-├── skills/                        ← <!--devops:count:skills-->21<!--/devops:count:skills--> skill definitions (SKILL.md)
+├── hooks/                         ← <!--devops:count:hooks-->42<!--/devops:count:hooks--> hooks (JS) registered in hooks.json
+├── skills/                        ← <!--devops:count:skills-->22<!--/devops:count:skills--> skill definitions (SKILL.md)
 ├── agents/                        ← <!--devops:count:agents-->12<!--/devops:count:agents--> agent definitions
 ├── deep-knowledge/                ← Cross-cutting reference docs
 ├── templates/                     ← Output format templates

--- a/docs/superpowers/specs/2026-08-16-claude-batch-design.md
+++ b/docs/superpowers/specs/2026-08-16-claude-batch-design.md
@@ -1,0 +1,173 @@
+# claude-batch — Collect Prompts, Merge Once
+
+**Date:** 2026-08-16
+**Status:** Approved for implementation
+**Skill:** `/claude-batch`
+
+## Problem
+
+Working on a running app produces a stream of small observations — a misplaced
+button, a wrong error string, an idea for a filter. Sending each as its own
+prompt has two costs:
+
+1. **Turn cost.** Every prompt pays the full accumulated context as input plus
+   orientation reads and output. Eight observations are eight turns, not eight
+   prompts' worth of tokens.
+2. **Rework.** Observation 5 frequently supersedes observation 1. Anything built
+   for 1 was built for nothing. This is the larger cost by an order of
+   magnitude, and it is the cost this feature is primarily designed against.
+
+The repo already covers the ends of this pipeline but not the middle:
+`/setup-issue` rejects small observations by design (the user-value gate refuses
+issues that are "only valuable together with other issues"), and `/run-backlog`
+consumes GitHub issues as its input. What is missing is lightweight capture
+*below* the issue threshold.
+
+## Non-goals
+
+- Replacing `/setup-issue` + `/run-backlog` for work that deserves an issue.
+- Persisting a second backlog representation that must stay in sync with
+  GitHub issues.
+- Interpreting or judging notes during the collection phase.
+
+## Design
+
+### Activation
+
+Opt-in per session. `/claude-batch on` writes a mode file; `/claude-batch off`
+removes it. On very first use the skill asks once for the **execute marker** and
+stores it user-globally in `~/.claude/claude-batch.json`. Default proposal: `!`
+at the start of the line.
+
+### Collection
+
+While the mode is active, `prompt.batch.collect` (UserPromptSubmit) blocks the
+prompt via `{"decision": "block", "reason": …}` and appends it to
+`.claude/batch.md`.
+
+Per the official hook docs, exit-2 / `decision: block` on UserPromptSubmit
+"blocks prompt processing and erases the prompt" — it never reaches the model
+and never enters the transcript. The `reason` is surfaced to the user, which is
+the acknowledgement channel.
+
+**Appends use `fs.appendFileSync`, never read-modify-write.** A read-modify-write
+loses entries when the optional compaction child rewrites the file concurrently.
+
+**Storage is a project file, not `os.tmpdir()`:**
+- survives crash, reboot, and `/clear` (which mints a new `session_id` and would
+  orphan a session-scoped temp file)
+- is readable and editable in the editor, and can be filled without Claude
+  running at all
+- is not subject to Windows Storage Sense cleanup
+- avoids the glob fallback in `hooks/lib/session-id.js`, which can return
+  another window's file
+
+`.claude/batch.md` is registered in the repo-local git exclude, not `.gitignore`
+(it is machine state, not a project decision).
+
+### What is never collected
+
+Passthrough is unconditional for:
+
+| Class | Why |
+|---|---|
+| Machine prompts | Cron re-entries arrive as UserPromptSubmit. Collecting them kills the concept bridge (1 poll/min) and stops git-sync for the whole window. |
+| `AUTONOMOUS_AUTOSTART:` / `AUTONOMOUS_RESUME:` | These do **not** match the existing patterns in `prompt.flow.silent-turn.js` — an allowlist reusing only that module misses them, and an AFK run would never start. |
+| Expanded slash commands | Arrive with a `<command-name>` tag; the raw text is not literally `/claude-batch off`. A naive text comparison misses exactly the escape hatch it is meant to protect. |
+| Prompts with attachments or `@file` | The prompt is *erased* from the UI on block. A collected screenshot is unrecoverable, and an expanded `@file` would dump whole files into the queue — inverting the saving. |
+
+### Firing
+
+A prompt starting with the execute marker means "work on it now", not "handle
+this one prompt normally". The hook passes it through and injects the full note
+list as context. Claude then:
+
+1. reads every collected note (verbatim; summarised only when oversized),
+2. feasibility-checks the merged intent against the actual code,
+3. lists contradictions **individually** rather than silently resolving them by
+   "later wins",
+4. presents the plan for approval.
+
+After approval: `/concept` when the conflicts justify a decision page, otherwise
+straight to implementation. Implementation is deliberately broad — code,
+concepting, UI concepting, or only a first step.
+
+### Reminder
+
+A detached watchdog (`scripts/batch-watchdog.js`) fires a Windows toast after 10
+minutes without a **user** prompt.
+
+The inactivity clock reads a dedicated timestamp file, **not** the notes file's
+mtime. Machine prompts touch the session every minute; a clock hanging off
+general activity would never reach 10 minutes.
+
+Against orphans: PID lockfile with a liveness check before spawning, hard
+self-expiry after 2 hours, and self-exit as soon as the mode file disappears.
+
+Reuses `spawnBgRunner` semantics from `hooks/lib/graphify-state.js` (spawn
+`node` directly, never `shell: true` — a shell layer pops a visible Windows
+Terminal tab) and the PowerShell `NotifyIcon` pattern from
+`scripts/post-merge-watcher.js`.
+
+### Local LLM (optional)
+
+Deduplication and formatting only. **No interpretation, no contradiction
+detection, no summarisation of intent** — `plugins/local-llm/deep-knowledge/delegation-rules.md`
+classifies ambiguous user requests as RED (never delegate) and caps practical
+context at ~8K tokens. A wrong compaction is worse than none: the master plan
+silently loses a requirement and the original is no longer in the UI to check
+against.
+
+Contradiction detection stays with Claude at fire time, where the code is
+visible. If AnythingLLM is not running, the list simply stays raw.
+
+The dependency is soft: `devops` and `local-llm` are independently installable,
+so the call is a guarded path resolution, never a hard cross-plugin `require`.
+
+### Failsafe
+
+The mode file carries `expiresAt` and `maxNotes`. Either limit deactivates
+collection automatically. A bug in marker comparison can therefore never lock
+the user out of their own session — the worst case is a bounded collection
+window, after which prompts flow normally again.
+
+## Accepted residual risks
+
+1. **A forgotten marker on a real question.** The question lands silently in the
+   queue instead of being answered, and subsequent notes may build on an
+   unverified assumption. Mitigation (not elimination): when a note ends in a
+   question mark, the acknowledgement appends a hint that it was stored as a
+   note and would be answered if re-sent with the marker. This is a hint, not a
+   classification — the hook never decides what is a question.
+2. **Sibling hooks run on a blocked prompt.** Hooks in one event group execute
+   in parallel with no ordering guarantee and are not short-circuited by a
+   sibling's block. State-writing UserPromptSubmit hooks therefore burn one-shot
+   state on a prompt that produces no turn. Fixed by having each affected hook
+   check the mode file itself; tracked as its own implementation step.
+3. **Token-freedom is not contractually guaranteed.** The docs state only that a
+   blocked prompt never reaches the model. Zero billing follows logically but is
+   nowhere promised by Anthropic. Verify experimentally against the usage
+   dashboard before relying on it.
+4. **Context growth at execution time.** A ten-item master plan executed in one
+   session maximises context growth and compaction loss; ten fresh sessions
+   would each carry only their own. Where items are independent, prefer routing
+   them through `/run-backlog`'s per-issue cycle rather than one long run.
+
+## Naming
+
+`/claude-batch`. The `claude-*` prefix in this repo marks skills that govern
+*how Claude works* (`claude-learn`, `claude-lint`, `claude-extend-skill`) rather
+than what happens to the project. A collection mode belongs there. `queue` was
+rejected: `run-backlog` already uses it for its work queue, and reusing the word
+for something else is a real comprehension cost.
+
+## Files
+
+| Path | Role |
+|---|---|
+| `hooks/lib/batch-state.js` | Mode file, marker config, classification, note I/O |
+| `hooks/user-prompt-submit/prompt.batch.collect.js` | The collecting hook |
+| `scripts/batch-watchdog.js` | Inactivity watchdog + toast |
+| `skills/claude-batch/SKILL.md` | Activation, marker setup, merge and routing |
+| `.claude/batch.md` | The notes (git-excluded, per project) |
+| `~/.claude/claude-batch.json` | Marker + defaults (user-global) |

--- a/docs/superpowers/specs/2026-08-16-claude-batch-design.md
+++ b/docs/superpowers/specs/2026-08-16-claude-batch-design.md
@@ -71,7 +71,7 @@ Passthrough is unconditional for:
 
 | Class | Why |
 |---|---|
-| Machine prompts | Cron re-entries arrive as UserPromptSubmit. Collecting them kills the concept bridge (1 poll/min) and stops git-sync for the whole window. |
+| Machine prompts | Cron re-entries arrive as UserPromptSubmit. Collecting them kills the `/concept` bridge, which polls once a minute. (Note: git-sync no longer re-enters via cron since #287 moved it to a detached background sync — the `Silently run …` shape stays on the allowlist because other crons use it.) |
 | `AUTONOMOUS_AUTOSTART:` / `AUTONOMOUS_RESUME:` | These do **not** match the existing patterns in `prompt.flow.silent-turn.js` — an allowlist reusing only that module misses them, and an AFK run would never start. |
 | Expanded slash commands | Arrive with a `<command-name>` tag; the raw text is not literally `/claude-batch off`. A naive text comparison misses exactly the escape hatch it is meant to protect. |
 | Prompts with attachments or `@file` | The prompt is *erased* from the UI on block. A collected screenshot is unrecoverable, and an expanded `@file` would dump whole files into the queue — inverting the saving. |

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.130.0",
+  "version": "0.131.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/docs/architecture.html
+++ b/plugins/devops/docs/architecture.html
@@ -169,7 +169,7 @@
 <section id="overview">
 <h1>Architecture Documentation <small>devops v0.87.0</small></h1>
 <p class="lead">
-  A comprehensive DevOps automation plugin for Claude Code &mdash; <!--devops:count:hooks-->41<!--/devops:count:hooks--> hooks, <!--devops:count:skills-->21<!--/devops:count:skills--> skills, <!--devops:count:agents-->12<!--/devops:count:agents--> agents,
+  A comprehensive DevOps automation plugin for Claude Code &mdash; <!--devops:count:hooks-->42<!--/devops:count:hooks--> hooks, <!--devops:count:skills-->22<!--/devops:count:skills--> skills, <!--devops:count:agents-->12<!--/devops:count:agents--> agents,
   2 MCP servers, a deterministic completion card engine, and a 3-layer extension system.
 </p>
 <div role="note" style="margin:.4rem 0 1.4rem;padding:.6rem .9rem;background:var(--bg2);border-left:3px solid var(--warn);border-radius:4px;color:var(--text2);font-size:.85rem;">
@@ -180,16 +180,16 @@
 
 <div class="card-grid">
   <div class="card">
-    <h4><!--devops:count:hooks-->41<!--/devops:count:hooks--> Hooks</h4>
+    <h4><!--devops:count:hooks-->42<!--/devops:count:hooks--> Hooks</h4>
     <p style="color:var(--text2);font-size:.85rem">Lifecycle guards across SessionStart, UserPromptSubmit, PreToolUse, PostToolUse, Stop</p>
     <span class="badge b-hook">SessionStart &times;<!--devops:count:hooks:ss-->15<!--/devops:count:hooks:ss--></span>
-    <span class="badge b-hook">Prompt &times;<!--devops:count:hooks:prompt-->9<!--/devops:count:hooks:prompt--></span>
+    <span class="badge b-hook">Prompt &times;<!--devops:count:hooks:prompt-->10<!--/devops:count:hooks:prompt--></span>
     <span class="badge b-hook">Pre &times;<!--devops:count:hooks:pre-->7<!--/devops:count:hooks:pre--></span>
     <span class="badge b-hook">Post &times;<!--devops:count:hooks:post-->5<!--/devops:count:hooks:post--></span>
     <span class="badge b-hook">Stop &times;<!--devops:count:hooks:stop-->5<!--/devops:count:hooks:stop--></span>
   </div>
   <div class="card">
-    <h4><!--devops:count:skills-->21<!--/devops:count:skills--> Skills</h4>
+    <h4><!--devops:count:skills-->22<!--/devops:count:skills--> Skills</h4>
     <p style="color:var(--text2);font-size:.85rem">Slash commands: ship, release, commit, fix, setup-issue, setup-project, setup-readme, auto-usage, claude-extend-skill, setup-cleanup, auto-update, concept, run-agents, run-autonomous, run-burn, run-backlog, claude-learn, tune-harden, tune-polish, tune-rethink, auto-graph</p>
   </div>
   <div class="card">
@@ -218,7 +218,7 @@
 │   ├── hooks.json             <span style="color:var(--purple)"># Hook registry (event &rarr; command mapping)</span>
 │   ├── lib/                   <span style="color:var(--text2)"># plugin-guard, run-once, session-id</span>
 │   ├── session-start/         <span style="color:var(--purple)"># <!--devops:count:hooks:ss-->15<!--/devops:count:hooks:ss--> hooks (ss.*)</span>
-│   ├── user-prompt-submit/    <span style="color:var(--purple)"># <!--devops:count:hooks:prompt-->9<!--/devops:count:hooks:prompt--> hooks (prompt.*)</span>
+│   ├── user-prompt-submit/    <span style="color:var(--purple)"># <!--devops:count:hooks:prompt-->10<!--/devops:count:hooks:prompt--> hooks (prompt.*)</span>
 │   ├── pre-tool-use/          <span style="color:var(--purple)"># <!--devops:count:hooks:pre-->7<!--/devops:count:hooks:pre--> hooks (pre.*)</span>
 │   ├── post-tool-use/         <span style="color:var(--purple)"># <!--devops:count:hooks:post-->5<!--/devops:count:hooks:post--> hooks (post.*)</span>
 │   └── stop/                  <span style="color:var(--purple)"># <!--devops:count:hooks:stop-->5<!--/devops:count:hooks:stop--> hooks (stop.*)</span>
@@ -235,7 +235,7 @@
 │   ├── render-card.js         <span style="color:var(--warn)"># Completion card template engine</span>
 │   ├── build-id.js            <span style="color:var(--text2)"># Deterministic content hash</span>
 │   └── lib/usage-meter.js     <span style="color:var(--text2)"># Usage bar renderer</span>
-├── skills/                    <span style="color:var(--accent)"># <!--devops:count:skills-->21<!--/devops:count:skills--> skill definitions (SKILL.md + deep-knowledge/)</span>
+├── skills/                    <span style="color:var(--accent)"># <!--devops:count:skills-->22<!--/devops:count:skills--> skill definitions (SKILL.md + deep-knowledge/)</span>
 │   ├── ship/  release/  commit/  fix/  setup-issue/  setup-project/  setup-readme/
 │   ├── auto-usage/  claude-extend-skill/  setup-cleanup/  auto-update/
 │   ├── concept/  run-agents/  run-autonomous/  run-burn/  run-backlog/  claude-learn/

--- a/plugins/devops/hooks/hooks.json
+++ b/plugins/devops/hooks/hooks.json
@@ -92,6 +92,7 @@
     "UserPromptSubmit": [
       {
         "hooks": [
+          { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/user-prompt-submit/prompt.batch.collect.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/user-prompt-submit/prompt.flow.silent-turn.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/user-prompt-submit/prompt.knowledge.dispatch.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/user-prompt-submit/prompt.git.sync.js" },

--- a/plugins/devops/hooks/lib/batch-state.js
+++ b/plugins/devops/hooks/lib/batch-state.js
@@ -1,0 +1,334 @@
+/**
+ * @module batch-state
+ * @version 0.1.0
+ * @description State and classification for the `/claude-batch` collect mode.
+ *
+ * Collect mode batches user prompts into `.claude/batch.md` instead of acting
+ * on them, until the user fires the merge with an execute marker.
+ *
+ * Storage is deliberately a PROJECT file, not `os.tmpdir()`:
+ *   - survives crash, reboot and `/clear` (which mints a new session_id and
+ *     would orphan a session-scoped temp file)
+ *   - is readable/editable in the editor, and fillable without Claude running
+ *   - avoids the glob fallback in `session-id.js`, which can hand back another
+ *     window's file — harmless for advisory state, unacceptable for a mode flag
+ *
+ * Spec: docs/superpowers/specs/2026-08-16-claude-batch-design.md
+ */
+
+const fs   = require('fs');
+const os   = require('os');
+const path = require('path');
+
+const DEFAULTS = {
+  marker: '!',
+  inactivityMinutes: 10,
+  // Failsafe bounds — either one deactivates collection on its own, so a bug in
+  // marker comparison can never lock the user out of their own session.
+  expiryHours: 8,
+  maxNotes: 100,
+};
+
+/**
+ * Machine-prompt patterns. Prompts matching these are NEVER collected.
+ *
+ * Deliberately re-declared instead of imported from
+ * `user-prompt-submit/prompt.flow.silent-turn.js`: that module registers
+ * `process.stdin` listeners at load time, so requiring it from inside another
+ * hook that reads stdin would fight over the stream.
+ *
+ * The AUTONOMOUS_* entries are ADDITIONS — they do not match silent-turn's
+ * patterns. Without them an AFK `/run-backlog` or `/run-autonomous` resume
+ * would be swallowed into the queue and the night run would never start.
+ */
+const MACHINE_PATTERNS = [
+  /^\s*silent\s*:/i,
+  /^\s*silently\s+(?:run|service|post|get|curl|fetch|heartbeat|keep|check|trigger|update|sync|reset|tick|reload|shutdown|execute|poll|invoke|call)\b/i,
+  /^\s*run\s+silently\b/i,
+  /<<autonomous-loop(-dynamic)?>>/i,
+  /^\s*AUTONOMOUS_AUTOSTART\s*:/i,
+  /^\s*AUTONOMOUS_RESUME\s*:/i,
+  /^\s*RUN_BACKLOG_AUTOSTART\s*:/i,
+];
+
+/**
+ * Attachment indicators. A blocked prompt is ERASED from the UI, so a collected
+ * screenshot is unrecoverable and an expanded @file would dump whole files into
+ * the queue — inverting the saving the mode exists for. Both pass through.
+ */
+const ATTACHMENT_PATTERNS = [
+  /\[Image\s*#?\d*\]/i,
+  /\[Pasted text\s*#?\d*/i,
+  // @path/to/file.ext — the harness expands these into the prompt
+  /(^|\s)@[\w.\-/\\]+\.[A-Za-z0-9]{1,8}(\s|$)/,
+];
+
+// ── paths ──────────────────────────────────────────────────────────────────
+
+function configPath() {
+  return path.join(os.homedir(), '.claude', 'claude-batch.json');
+}
+
+function claudeDir(cwd) {
+  return path.join(cwd || process.cwd(), '.claude');
+}
+
+function notesPath(cwd)    { return path.join(claudeDir(cwd), 'batch.md'); }
+function modePath(cwd)     { return path.join(claudeDir(cwd), 'batch-mode.json'); }
+/** Dedicated user-activity clock. Must NOT be the notes file's mtime: machine
+ *  prompts touch the session every minute, so a clock hanging off general
+ *  activity would never reach the inactivity threshold. */
+function activityPath(cwd) { return path.join(claudeDir(cwd), 'batch-activity'); }
+function lockPath(cwd)     { return path.join(claudeDir(cwd), 'batch-watchdog.lock'); }
+
+// ── config ─────────────────────────────────────────────────────────────────
+
+/** @returns {{marker:string,inactivityMinutes:number,expiryHours:number,maxNotes:number}} */
+function loadConfig() {
+  try {
+    const raw = JSON.parse(fs.readFileSync(configPath(), 'utf8'));
+    return { ...DEFAULTS, ...(raw && typeof raw === 'object' ? raw : {}) };
+  } catch {
+    return { ...DEFAULTS };
+  }
+}
+
+function saveConfig(cfg) {
+  const merged = { ...loadConfig(), ...cfg };
+  const dir = path.dirname(configPath());
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(configPath(), JSON.stringify(merged, null, 2) + '\n', 'utf8');
+  return merged;
+}
+
+// ── mode ───────────────────────────────────────────────────────────────────
+
+/** Raw mode record, or null when collect mode was never activated here. */
+function readMode(cwd) {
+  try {
+    const raw = JSON.parse(fs.readFileSync(modePath(cwd), 'utf8'));
+    return raw && typeof raw === 'object' ? raw : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Is collect mode active AND within its failsafe bounds?
+ * @param {string} cwd
+ * @param {number} [now] epoch ms — injectable for tests
+ */
+function isModeActive(cwd, now) {
+  const mode = readMode(cwd);
+  if (!mode || mode.active !== true) return false;
+  const t = typeof now === 'number' ? now : Date.now();
+  if (mode.expiresAt && t >= Date.parse(mode.expiresAt)) return false;
+  if (mode.maxNotes && countNotes(cwd) >= mode.maxNotes) return false;
+  return true;
+}
+
+/**
+ * Why is the mode not active, given that a mode file exists? Lets the skill
+ * explain an auto-deactivation instead of silently resuming normal prompts.
+ * @returns {'expired'|'full'|null}
+ */
+function expiryReason(cwd, now) {
+  const mode = readMode(cwd);
+  if (!mode || mode.active !== true) return null;
+  const t = typeof now === 'number' ? now : Date.now();
+  if (mode.expiresAt && t >= Date.parse(mode.expiresAt)) return 'expired';
+  if (mode.maxNotes && countNotes(cwd) >= mode.maxNotes) return 'full';
+  return null;
+}
+
+function activate(cwd, opts = {}) {
+  const cfg = loadConfig();
+  const startedAt = opts.startedAt ? new Date(opts.startedAt) : new Date();
+  const hours = opts.expiryHours ?? cfg.expiryHours;
+  const mode = {
+    active: true,
+    startedAt: startedAt.toISOString(),
+    expiresAt: new Date(startedAt.getTime() + hours * 3600_000).toISOString(),
+    maxNotes: opts.maxNotes ?? cfg.maxNotes,
+    marker: opts.marker ?? cfg.marker,
+  };
+  fs.mkdirSync(claudeDir(cwd), { recursive: true });
+  fs.writeFileSync(modePath(cwd), JSON.stringify(mode, null, 2) + '\n', 'utf8');
+  return mode;
+}
+
+function deactivate(cwd) {
+  try { fs.unlinkSync(modePath(cwd)); } catch { /* already gone */ }
+}
+
+// ── notes ──────────────────────────────────────────────────────────────────
+
+/**
+ * Append one note. Uses appendFileSync, never read-modify-write: the optional
+ * compaction child rewrites the file, and a read-modify-write here would lose
+ * whichever side held the stale snapshot.
+ * @returns {number} note count after the append
+ */
+function appendNote(cwd, text, when) {
+  const stamp = (when ? new Date(when) : new Date()).toISOString();
+  fs.mkdirSync(claudeDir(cwd), { recursive: true });
+  const file = notesPath(cwd);
+  const header = fs.existsSync(file)
+    ? ''
+    : '# claude-batch notes\n\nCollected prompts, newest last. Edit freely — the merge reads this file.\n';
+  fs.appendFileSync(file, `${header}\n<!-- ${stamp} -->\n${String(text).trim()}\n`, 'utf8');
+  return countNotes(cwd);
+}
+
+/** Parsed notes in collection order. @returns {{at:string,text:string}[]} */
+function readNotes(cwd) {
+  let raw;
+  try { raw = fs.readFileSync(notesPath(cwd), 'utf8'); } catch { return []; }
+  const out = [];
+  const re = /<!--\s*(\S+?)\s*-->\n([\s\S]*?)(?=\n<!--\s*\S+?\s*-->\n|$)/g;
+  for (const m of raw.matchAll(re)) {
+    const text = m[2].trim();
+    if (text) out.push({ at: m[1], text });
+  }
+  return out;
+}
+
+function countNotes(cwd) { return readNotes(cwd).length; }
+
+function clearNotes(cwd) {
+  try { fs.unlinkSync(notesPath(cwd)); } catch { /* already gone */ }
+}
+
+/** Archive the notes next to the file so a merge never destroys the original. */
+function archiveNotes(cwd, stampSource) {
+  const file = notesPath(cwd);
+  if (!fs.existsSync(file)) return null;
+  const stamp = (stampSource ? new Date(stampSource) : new Date())
+    .toISOString().replace(/[:.]/g, '-');
+  const dest = path.join(claudeDir(cwd), `batch-${stamp}.md`);
+  fs.renameSync(file, dest);
+  return dest;
+}
+
+// ── activity clock ─────────────────────────────────────────────────────────
+
+function touchActivity(cwd, when) {
+  const t = typeof when === 'number' ? when : Date.now();
+  fs.mkdirSync(claudeDir(cwd), { recursive: true });
+  fs.writeFileSync(activityPath(cwd), String(t), 'utf8');
+  return t;
+}
+
+/** @returns {number|null} epoch ms of the last real user prompt */
+function readActivity(cwd) {
+  try {
+    const n = Number(fs.readFileSync(activityPath(cwd), 'utf8').trim());
+    return Number.isFinite(n) ? n : null;
+  } catch {
+    return null;
+  }
+}
+
+// ── classification ─────────────────────────────────────────────────────────
+
+function isMachinePrompt(text) {
+  if (typeof text !== 'string' || !text) return false;
+  return MACHINE_PATTERNS.some(rx => rx.test(text));
+}
+
+/**
+ * An expanded slash command carries a <command-name> tag — the raw text is NOT
+ * literally "/claude-batch off". Comparing against the typed form would miss
+ * exactly the escape hatch it is meant to protect.
+ */
+function isExpandedCommand(text) {
+  return typeof text === 'string' && text.includes('<command-name>');
+}
+
+function hasAttachment(text, hookInput) {
+  if (hookInput && typeof hookInput === 'object') {
+    for (const key of ['attachments', 'images', 'files']) {
+      const v = hookInput[key];
+      if (Array.isArray(v) ? v.length > 0 : v) return true;
+    }
+  }
+  if (typeof text !== 'string' || !text) return false;
+  return ATTACHMENT_PATTERNS.some(rx => rx.test(text));
+}
+
+function startsWithMarker(text, marker) {
+  if (typeof text !== 'string' || !text || !marker) return false;
+  return text.trimStart().startsWith(marker);
+}
+
+function stripMarker(text, marker) {
+  if (!startsWithMarker(text, marker)) return String(text ?? '');
+  return text.trimStart().slice(marker.length).trimStart();
+}
+
+/**
+ * Advisory only — never used to decide collect vs. execute. The hook does not
+ * guess what a question is; this only enriches the acknowledgement so a
+ * forgotten marker on a real question is visible instead of silent.
+ */
+function looksLikeQuestion(text) {
+  if (typeof text !== 'string' || !text) return false;
+  return text.trimEnd().endsWith('?');
+}
+
+/**
+ * The single decision.
+ * @returns {'passthrough'|'collect'|'execute'}
+ */
+function classify({ text, hookInput, marker, modeActive }) {
+  if (!modeActive) return 'passthrough';
+  if (isMachinePrompt(text)) return 'passthrough';
+  if (isExpandedCommand(text)) return 'passthrough';
+  if (hasAttachment(text, hookInput)) return 'passthrough';
+  if (startsWithMarker(text, marker)) return 'execute';
+  return 'collect';
+}
+
+/**
+ * Will this prompt be collected — i.e. blocked, erased, and never producing a
+ * turn? Every state-writing UserPromptSubmit hook must no-op when this is true.
+ *
+ * Hooks in one event group run in PARALLEL and are NOT short-circuited by a
+ * sibling's block, so without this guard they burn one-shot state (a
+ * deep-knowledge doc marked "already injected", a tracked issue marked "already
+ * seen", a git merge) on a prompt that no longer exists. The payload they emit
+ * goes nowhere, but the state change sticks — a silent degradation with no
+ * error anywhere.
+ *
+ * Fails open: any error means "not collected", so a bug here can never suppress
+ * a hook on an ordinary turn.
+ *
+ * @param {object} hookInput parsed hook stdin JSON
+ * @returns {boolean}
+ */
+function willBeCollected(hookInput) {
+  try {
+    if (!hookInput || typeof hookInput !== 'object') return false;
+    const cwd = hookInput.cwd || process.cwd();
+    if (!isModeActive(cwd)) return false;
+    const text = hookInput.prompt || hookInput.user_message || hookInput.message || '';
+    const marker = readMode(cwd)?.marker || loadConfig().marker;
+    return classify({ text, hookInput, marker, modeActive: true }) === 'collect';
+  } catch {
+    return false;
+  }
+}
+
+module.exports = {
+  DEFAULTS,
+  MACHINE_PATTERNS,
+  ATTACHMENT_PATTERNS,
+  configPath, claudeDir, notesPath, modePath, activityPath, lockPath,
+  loadConfig, saveConfig,
+  readMode, isModeActive, expiryReason, activate, deactivate,
+  appendNote, readNotes, countNotes, clearNotes, archiveNotes,
+  touchActivity, readActivity,
+  isMachinePrompt, isExpandedCommand, hasAttachment,
+  startsWithMarker, stripMarker, looksLikeQuestion,
+  classify, willBeCollected,
+};

--- a/plugins/devops/hooks/lib/batch-state.test.js
+++ b/plugins/devops/hooks/lib/batch-state.test.js
@@ -1,0 +1,314 @@
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  activate, deactivate, isModeActive, expiryReason, readMode,
+  appendNote, readNotes, countNotes, clearNotes, archiveNotes,
+  touchActivity, readActivity,
+  isMachinePrompt, isExpandedCommand, hasAttachment,
+  startsWithMarker, stripMarker, looksLikeQuestion,
+  classify, willBeCollected, notesPath, modePath,
+} from "./batch-state.js";
+
+let cwd;
+
+beforeEach(() => {
+  cwd = fs.mkdtempSync(path.join(os.tmpdir(), "batch-state-test-"));
+});
+
+afterEach(() => {
+  try { fs.rmSync(cwd, { recursive: true, force: true }); } catch { /* best effort */ }
+});
+
+describe("machine prompts are never collected", () => {
+  // Regression guard: collecting these kills the concept bridge (1 poll/min)
+  // and stops git-sync for the whole collection window.
+  test.each([
+    ["git-sync cron", 'Silently run via Bash: node "C:/.../git-sync.js". If output contains ⚠…'],
+    ["concept bridge (service form)", "Silently service the concept bridge on port 8742."],
+    ["concept bridge (colon form)", "Silent: POST http://localhost:8883/heartbeat"],
+    ["run silently", "Run silently: curl -s -X POST http://localhost:8734/heartbeat"],
+    ["autonomous loop sentinel", "<<autonomous-loop>>"],
+    ["autonomous loop dynamic", "<<autonomous-loop-dynamic>>"],
+  ])("%s", (_label, prompt) => {
+    expect(isMachinePrompt(prompt)).toBe(true);
+  });
+
+  // These do NOT match prompt.flow.silent-turn.js — an allowlist reusing only
+  // that module would swallow them and the AFK run would never start.
+  test.each([
+    ["run-autonomous autostart", "AUTONOMOUS_AUTOSTART: resume Step 5 with task=…"],
+    ["worktree resume nudge", "AUTONOMOUS_RESUME: weiter"],
+    ["run-backlog autostart", "RUN_BACKLOG_AUTOSTART: presence timeout. phase=presence, queue=1,2,3"],
+  ])("%s (silent-turn gap)", (_label, prompt) => {
+    expect(isMachinePrompt(prompt)).toBe(true);
+  });
+
+  test("ordinary prose is not a machine prompt", () => {
+    expect(isMachinePrompt("Silently explain what this hook does")).toBe(false);
+    expect(isMachinePrompt("Der Button im Header ist verrutscht")).toBe(false);
+    expect(isMachinePrompt("")).toBe(false);
+    expect(isMachinePrompt(null)).toBe(false);
+  });
+});
+
+describe("escape hatch survives slash-command expansion", () => {
+  // A real slash command arrives pre-expanded with a <command-name> tag — the
+  // raw text is not literally "/claude-batch off". A naive text comparison
+  // would miss exactly the escape it protects, locking the user out.
+  test("expanded command is detected and passed through", () => {
+    const expanded = "<command-message>claude-batch</command-message>\n<command-name>/claude-batch</command-name>\n<command-args>off</command-args>";
+    expect(isExpandedCommand(expanded)).toBe(true);
+    expect(classify({ text: expanded, marker: "!", modeActive: true })).toBe("passthrough");
+  });
+
+  test("plain text mentioning a slash command is still collected", () => {
+    expect(isExpandedCommand("wir sollten /ship mal aufräumen")).toBe(false);
+    expect(classify({ text: "wir sollten /ship mal aufräumen", marker: "!", modeActive: true }))
+      .toBe("collect");
+  });
+});
+
+describe("attachments pass through", () => {
+  // A blocked prompt is erased from the UI — a collected screenshot is gone.
+  test("image marker", () => {
+    expect(hasAttachment("mach das so wie hier [Image #1]")).toBe(true);
+  });
+
+  test("@file mention", () => {
+    expect(hasAttachment("schau dir @src/components/Header.tsx an")).toBe(true);
+  });
+
+  test("hook input carrying attachments", () => {
+    expect(hasAttachment("kurzer text", { attachments: [{ name: "a.png" }] })).toBe(true);
+    expect(hasAttachment("kurzer text", { images: ["…"] })).toBe(true);
+  });
+
+  test("plain prose has no attachment", () => {
+    expect(hasAttachment("Der Button ist verrutscht")).toBe(false);
+    expect(hasAttachment("mail an foo@bar", {})).toBe(false);
+  });
+
+  test("classify routes attachments to passthrough even in collect mode", () => {
+    expect(classify({ text: "so wie hier [Image #2]", marker: "!", modeActive: true }))
+      .toBe("passthrough");
+  });
+});
+
+describe("marker handling", () => {
+  test("marker at line start fires execute", () => {
+    expect(startsWithMarker("! leg los", "!")).toBe(true);
+    expect(classify({ text: "! leg los", marker: "!", modeActive: true })).toBe("execute");
+  });
+
+  test("leading whitespace does not defeat the marker", () => {
+    expect(startsWithMarker("   ! leg los", "!")).toBe(true);
+  });
+
+  test("marker elsewhere in the text does not fire", () => {
+    expect(startsWithMarker("das ist wichtig! jetzt", "!")).toBe(false);
+    expect(classify({ text: "das ist wichtig! jetzt", marker: "!", modeActive: true }))
+      .toBe("collect");
+  });
+
+  test("stripMarker removes the marker and surrounding space", () => {
+    expect(stripMarker("!  leg los mit allem", "!")).toBe("leg los mit allem");
+    expect(stripMarker("kein marker", "!")).toBe("kein marker");
+  });
+
+  test("multi-character phrase works as a marker", () => {
+    expect(startsWithMarker("los: bau das", "los:")).toBe(true);
+    expect(stripMarker("los: bau das", "los:")).toBe("bau das");
+  });
+});
+
+describe("classification is inert when the mode is off", () => {
+  test("everything passes through", () => {
+    expect(classify({ text: "irgendwas", marker: "!", modeActive: false })).toBe("passthrough");
+    expect(classify({ text: "! irgendwas", marker: "!", modeActive: false })).toBe("passthrough");
+  });
+});
+
+describe("mode lifecycle and failsafe", () => {
+  test("activate then deactivate", () => {
+    activate(cwd);
+    expect(isModeActive(cwd)).toBe(true);
+    deactivate(cwd);
+    expect(isModeActive(cwd)).toBe(false);
+    expect(readMode(cwd)).toBeNull();
+  });
+
+  test("expiry deactivates without any user action", () => {
+    const start = Date.UTC(2026, 7, 16, 10, 0, 0);
+    activate(cwd, { startedAt: start, expiryHours: 2 });
+    expect(isModeActive(cwd, start + 60 * 60_000)).toBe(true);
+    expect(isModeActive(cwd, start + 3 * 60 * 60_000)).toBe(false);
+    expect(expiryReason(cwd, start + 3 * 60 * 60_000)).toBe("expired");
+  });
+
+  test("note cap deactivates without any user action", () => {
+    activate(cwd, { maxNotes: 2 });
+    appendNote(cwd, "eins");
+    expect(isModeActive(cwd)).toBe(true);
+    appendNote(cwd, "zwei");
+    expect(isModeActive(cwd)).toBe(false);
+    expect(expiryReason(cwd)).toBe("full");
+  });
+
+  test("no mode file means inactive — a fresh project is never in collect mode", () => {
+    expect(isModeActive(cwd)).toBe(false);
+    expect(expiryReason(cwd)).toBeNull();
+  });
+});
+
+describe("mode does not leak between projects or windows", () => {
+  // The session-id glob fallback can hand back another window's file. Scoping
+  // to the project directory removes that failure mode entirely.
+  test("activating in A leaves B untouched", () => {
+    const other = fs.mkdtempSync(path.join(os.tmpdir(), "batch-state-other-"));
+    try {
+      activate(cwd);
+      expect(isModeActive(cwd)).toBe(true);
+      expect(isModeActive(other)).toBe(false);
+    } finally {
+      fs.rmSync(other, { recursive: true, force: true });
+    }
+  });
+
+  test("state lives in the project, not the temp dir", () => {
+    activate(cwd);
+    appendNote(cwd, "notiz");
+    expect(fs.existsSync(path.join(cwd, ".claude", "batch-mode.json"))).toBe(true);
+    expect(fs.existsSync(path.join(cwd, ".claude", "batch.md"))).toBe(true);
+    expect(modePath(cwd).startsWith(cwd)).toBe(true);
+    expect(notesPath(cwd).startsWith(cwd)).toBe(true);
+  });
+});
+
+describe("notes I/O", () => {
+  test("appends preserve order and content", () => {
+    appendNote(cwd, "Button im Header verrutscht");
+    appendNote(cwd, "Fehlertext bei Login ist falsch");
+    const notes = readNotes(cwd);
+    expect(notes.map(n => n.text)).toEqual([
+      "Button im Header verrutscht",
+      "Fehlertext bei Login ist falsch",
+    ]);
+    expect(countNotes(cwd)).toBe(2);
+  });
+
+  test("multi-line notes survive round-trip", () => {
+    appendNote(cwd, "Zeile eins\nZeile zwei\n\nZeile drei");
+    expect(readNotes(cwd)[0].text).toBe("Zeile eins\nZeile zwei\n\nZeile drei");
+  });
+
+  test("a note containing an HTML comment does not split the entry", () => {
+    appendNote(cwd, "siehe <!-- inline --> hier");
+    const notes = readNotes(cwd);
+    expect(notes).toHaveLength(1);
+    expect(notes[0].text).toBe("siehe <!-- inline --> hier");
+  });
+
+  test("interleaved appends never lose an entry", () => {
+    for (let i = 0; i < 25; i++) appendNote(cwd, `notiz ${i}`);
+    expect(countNotes(cwd)).toBe(25);
+    expect(readNotes(cwd)[24].text).toBe("notiz 24");
+  });
+
+  test("no notes file yields an empty list, not a throw", () => {
+    expect(readNotes(cwd)).toEqual([]);
+    expect(countNotes(cwd)).toBe(0);
+  });
+
+  test("archiveNotes keeps the original recoverable after a merge", () => {
+    appendNote(cwd, "wichtige notiz");
+    const dest = archiveNotes(cwd, Date.UTC(2026, 7, 16, 12, 0, 0));
+    expect(dest).toBeTruthy();
+    expect(fs.existsSync(dest)).toBe(true);
+    expect(fs.readFileSync(dest, "utf8")).toContain("wichtige notiz");
+    expect(fs.existsSync(notesPath(cwd))).toBe(false);
+    expect(countNotes(cwd)).toBe(0);
+  });
+
+  test("archiveNotes on an empty project is a no-op", () => {
+    expect(archiveNotes(cwd)).toBeNull();
+  });
+
+  test("clearNotes is idempotent", () => {
+    appendNote(cwd, "x");
+    clearNotes(cwd);
+    clearNotes(cwd);
+    expect(countNotes(cwd)).toBe(0);
+  });
+});
+
+describe("activity clock", () => {
+  // The clock must be its own file. Hanging it off general session activity
+  // means the 1-min concept cron resets it forever and the threshold is
+  // never reached.
+  test("round-trips an explicit timestamp", () => {
+    const t = Date.UTC(2026, 7, 16, 9, 30, 0);
+    touchActivity(cwd, t);
+    expect(readActivity(cwd)).toBe(t);
+  });
+
+  test("absent clock reads as null", () => {
+    expect(readActivity(cwd)).toBeNull();
+  });
+
+  test("clock file is separate from the notes file", () => {
+    const t = Date.UTC(2026, 7, 16, 9, 30, 0);
+    touchActivity(cwd, t);
+    appendNote(cwd, "spätere notiz");
+    expect(readActivity(cwd)).toBe(t);
+  });
+});
+
+describe("willBeCollected — the guard sibling hooks use", () => {
+  // Hooks in one event group run in parallel and are NOT short-circuited by a
+  // sibling's block. Without this guard they burn one-shot state on a prompt
+  // that was erased and never produced a turn.
+  test("true for a prompt that will be collected", () => {
+    activate(cwd);
+    expect(willBeCollected({ cwd, prompt: "Button verrutscht" })).toBe(true);
+  });
+
+  test("false when the mode is off", () => {
+    expect(willBeCollected({ cwd, prompt: "Button verrutscht" })).toBe(false);
+  });
+
+  test("false for machine prompts, marker prompts and attachments", () => {
+    activate(cwd);
+    expect(willBeCollected({ cwd, prompt: "Silently run via Bash: node x.js" })).toBe(false);
+    expect(willBeCollected({ cwd, prompt: "AUTONOMOUS_RESUME: weiter" })).toBe(false);
+    expect(willBeCollected({ cwd, prompt: "! leg los" })).toBe(false);
+    expect(willBeCollected({ cwd, prompt: "so wie hier [Image #1]" })).toBe(false);
+  });
+
+  test("reads whichever prompt field the hook type delivers", () => {
+    activate(cwd);
+    expect(willBeCollected({ cwd, user_message: "über user_message" })).toBe(true);
+    expect(willBeCollected({ cwd, message: "über message" })).toBe(true);
+  });
+
+  test("fails open on garbage input — never suppresses a hook by accident", () => {
+    expect(willBeCollected(null)).toBe(false);
+    expect(willBeCollected(undefined)).toBe(false);
+    expect(willBeCollected("not an object")).toBe(false);
+    expect(willBeCollected({})).toBe(false);
+  });
+});
+
+describe("question hint is advisory only", () => {
+  test("detects a trailing question mark", () => {
+    expect(looksLikeQuestion("gibt es das schon?")).toBe(true);
+    expect(looksLikeQuestion("gibt es das schon?  ")).toBe(true);
+    expect(looksLikeQuestion("bau das um")).toBe(false);
+  });
+
+  test("a question is still collected — the hook never classifies it away", () => {
+    expect(classify({ text: "gibt es das schon?", marker: "!", modeActive: true }))
+      .toBe("collect");
+  });
+});

--- a/plugins/devops/hooks/user-prompt-submit/prompt.batch.collect.js
+++ b/plugins/devops/hooks/user-prompt-submit/prompt.batch.collect.js
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+/**
+ * @hook prompt.batch.collect
+ * @version 0.1.0
+ * @event UserPromptSubmit
+ * @plugin devops
+ * @description Collect mode for `/claude-batch`: while active, blocks the user
+ *   prompt (exit 2 — the harness erases it, so it never reaches the model) and
+ *   appends it to `.claude/batch.md`. A prompt starting with the configured
+ *   execute marker instead fires the merge: the whole note list is injected as
+ *   context and Claude works the collected intent as ONE plan.
+ *
+ *   Why: eight observations sent one by one are eight turns, each paying the
+ *   full accumulated context. Worse, observation five routinely supersedes
+ *   observation one — anything built for one was built for nothing. Collecting
+ *   first and merging once removes both costs.
+ *
+ *   Never collects (see batch-state.js for the reasoning):
+ *     - machine prompts (crons, AUTONOMOUS_*, silent markers)
+ *     - expanded slash commands (<command-name> tag)
+ *     - prompts carrying attachments or @file mentions
+ *
+ *   Failsafe: the mode file carries an expiry and a note cap, so a bug in the
+ *   marker comparison can never lock the user out of their own session.
+ *
+ *   Spec: docs/superpowers/specs/2026-08-16-claude-batch-design.md
+ */
+
+require('../lib/plugin-guard');
+
+const B = require('../lib/batch-state');
+
+/** Inline the notes up to this size; beyond it, point Claude at the file so the
+ *  token guard governs the read instead of the hook forcing it. */
+const INLINE_LIMIT = 8000;
+
+/**
+ * Acknowledgement shown to the user on a blocked (collected) prompt.
+ * @param {number} count total notes after this one
+ * @param {string} marker configured execute marker
+ * @param {boolean} question whether the note reads like a question
+ */
+function buildAck(count, marker, question) {
+  const lines = [`[claude-batch] ✓ #${count} gesammelt — nicht ausgeführt.`];
+  if (question) {
+    // Advisory only. The hook never decides what is a question; it just makes a
+    // forgotten marker visible instead of silent.
+    lines.push(
+      `Das sah nach einer Frage aus. Als Notiz gespeichert — schick sie mit "${marker}" davor,`,
+      'wenn du jetzt eine Antwort willst.',
+    );
+  }
+  lines.push(`"${marker} <text>" startet die Umsetzung aller ${count} Notizen · /claude-batch off beendet den Modus.`);
+  return lines.join('\n');
+}
+
+/**
+ * Context injected into the merge turn.
+ * @param {{at:string,text:string}[]} notes
+ * @param {string} rest the user's text after the marker
+ * @param {string} notesFile absolute path to the notes file
+ */
+function buildMergeContext(notes, rest, notesFile) {
+  const head = [
+    `[claude-batch] Der Nutzer hat ${notes.length} Notiz(en) gesammelt und löst jetzt die Umsetzung aus.`,
+    '',
+    'Arbeite NICHT die Notizen einzeln ab. Gehe so vor:',
+    '1. Führe die Notizen zu EINEM Gesamtvorhaben zusammen.',
+    '2. Prüfe die Machbarkeit gegen den echten Code, bevor du planst.',
+    '3. Liste Widersprüche EINZELN auf ("#2 wollte rot, #6 blau") statt sie still',
+    '   nach "später gewinnt" aufzulösen. Unmögliche Punkte werden benannt,',
+    '   nicht umgangen.',
+    '4. Lege den Plan zur Freigabe vor. Danach: /concept wenn die Konflikte eine',
+    '   Entscheidungsseite rechtfertigen, sonst direkt in die Umsetzung.',
+    '',
+    'Umsetzung ist breit gemeint — Code, Concepting, UI-Concepting, oder auch nur',
+    'ein erster Schritt.',
+    '',
+  ];
+
+  const body = notes.map((n, i) => `--- Notiz #${i + 1} (${n.at}) ---\n${n.text}`).join('\n\n');
+  const tail = rest ? ['', '--- Zusätzlich zu diesen Notizen sagt der Nutzer jetzt ---', rest] : [];
+
+  const inline = [...head, body, ...tail].join('\n');
+  if (inline.length <= INLINE_LIMIT) return inline;
+
+  return [
+    ...head,
+    `Die Notizen sind zu umfangreich für die Injektion (${inline.length} Zeichen).`,
+    `Lies sie zuerst vollständig aus: ${notesFile}`,
+    ...tail,
+  ].join('\n');
+}
+
+let inputData = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', d => { inputData += d; });
+process.stdin.on('end', () => {
+  let hook;
+  try { hook = JSON.parse(inputData); } catch { process.exit(0); }
+
+  // Field name varies across hook types in this codebase — cover all three.
+  // Reading only `user_message` would yield '' here and destroy every prompt.
+  const text = hook.prompt || hook.user_message || hook.message || '';
+  const cwd  = hook.cwd || process.cwd();
+
+  let modeActive;
+  try { modeActive = B.isModeActive(cwd); } catch { process.exit(0); }
+  if (!modeActive) {
+    // Not collecting — but a real user prompt still advances the clock the
+    // watchdog reads, so a later activation starts from a truthful timestamp.
+    try { if (!B.isMachinePrompt(text)) B.touchActivity(cwd); } catch { /* non-fatal */ }
+    process.exit(0);
+  }
+
+  const marker = B.readMode(cwd)?.marker || B.loadConfig().marker;
+  let verdict;
+  try {
+    verdict = B.classify({ text, hookInput: hook, marker, modeActive: true });
+  } catch {
+    process.exit(0); // never let a classification bug swallow a prompt
+  }
+
+  if (verdict === 'passthrough') {
+    try { if (!B.isMachinePrompt(text)) B.touchActivity(cwd); } catch { /* non-fatal */ }
+    process.exit(0);
+  }
+
+  if (verdict === 'execute') {
+    try {
+      B.touchActivity(cwd);
+      const notes = B.readNotes(cwd);
+      if (notes.length === 0) process.exit(0); // nothing collected — normal turn
+      const rest = B.stripMarker(text, marker);
+      process.stdout.write(buildMergeContext(notes, rest, B.notesPath(cwd)) + '\n');
+    } catch { /* non-fatal — the turn still runs */ }
+    process.exit(0);
+  }
+
+  // verdict === 'collect' — block the prompt and store it.
+  try {
+    const count = B.appendNote(cwd, text);
+    B.touchActivity(cwd);
+    process.stderr.write(buildAck(count, marker, B.looksLikeQuestion(text)) + '\n');
+    process.exit(2);
+  } catch (err) {
+    // Storing failed — blocking now would erase the prompt with nothing kept.
+    // Let it through instead; a lost prompt is worse than a missed collection.
+    process.stderr.write(`[claude-batch] Notiz konnte nicht gespeichert werden (${err.message}) — Prompt läuft normal weiter.\n`);
+    process.exit(0);
+  }
+});
+
+module.exports = { buildAck, buildMergeContext, INLINE_LIMIT };

--- a/plugins/devops/hooks/user-prompt-submit/prompt.batch.collect.test.js
+++ b/plugins/devops/hooks/user-prompt-submit/prompt.batch.collect.test.js
@@ -1,0 +1,204 @@
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { buildAck, buildMergeContext, INLINE_LIMIT } from "./prompt.batch.collect.js";
+import { activate, appendNote, readNotes } from "../lib/batch-state.js";
+
+const HOOK = fileURLToPath(new URL("./prompt.batch.collect.js", import.meta.url));
+
+let cwd;
+
+/**
+ * Run the hook exactly as the harness does: JSON on stdin, project as cwd.
+ * The temp project carries its own settings.json so plugin-guard passes
+ * regardless of the machine's global plugin state.
+ */
+function runHook(payload) {
+  const res = spawnSync(process.execPath, [HOOK], {
+    input: JSON.stringify({ cwd, ...payload }),
+    cwd,
+    encoding: "utf8",
+  });
+  return { code: res.status, stdout: res.stdout || "", stderr: res.stderr || "" };
+}
+
+beforeEach(() => {
+  cwd = fs.mkdtempSync(path.join(os.tmpdir(), "batch-hook-test-"));
+  fs.mkdirSync(path.join(cwd, ".claude"), { recursive: true });
+  fs.writeFileSync(
+    path.join(cwd, ".claude", "settings.json"),
+    JSON.stringify({ enabledPlugins: { "devops@dotclaude": true } }),
+    "utf8",
+  );
+});
+
+afterEach(() => {
+  try { fs.rmSync(cwd, { recursive: true, force: true }); } catch { /* best effort */ }
+});
+
+describe("mode off — the hook is inert", () => {
+  test("prompt passes through and nothing is stored", () => {
+    const r = runHook({ prompt: "Der Button ist verrutscht" });
+    expect(r.code).toBe(0);
+    expect(readNotes(cwd)).toEqual([]);
+  });
+});
+
+describe("mode on — collecting", () => {
+  beforeEach(() => activate(cwd));
+
+  test("an ordinary prompt is blocked and stored", () => {
+    const r = runHook({ prompt: "Der Button im Header ist verrutscht" });
+    expect(r.code).toBe(2);
+    expect(r.stderr).toContain("#1 gesammelt");
+    expect(readNotes(cwd).map(n => n.text)).toEqual(["Der Button im Header ist verrutscht"]);
+  });
+
+  test("the counter advances across prompts", () => {
+    runHook({ prompt: "erste" });
+    const r = runHook({ prompt: "zweite" });
+    expect(r.stderr).toContain("#2 gesammelt");
+    expect(readNotes(cwd)).toHaveLength(2);
+  });
+
+  test("a question is collected but flagged in the acknowledgement", () => {
+    const r = runHook({ prompt: "gibt es das schon?" });
+    expect(r.code).toBe(2);
+    expect(r.stderr).toContain("Frage");
+    expect(readNotes(cwd)).toHaveLength(1);
+  });
+
+  test("the prompt field name does not matter", () => {
+    // Half the hooks in this repo read `prompt`, the other half
+    // `user_message || message`. Reading only one yields '' and would block
+    // every prompt while storing nothing.
+    expect(runHook({ user_message: "über user_message" }).code).toBe(2);
+    expect(runHook({ message: "über message" }).code).toBe(2);
+    expect(readNotes(cwd).map(n => n.text)).toEqual(["über user_message", "über message"]);
+  });
+});
+
+describe("mode on — what is never collected", () => {
+  beforeEach(() => activate(cwd));
+
+  test.each([
+    ["git-sync cron", 'Silently run via Bash: node "git-sync.js"'],
+    ["concept bridge", "Silently service the concept bridge on port 8742."],
+    ["autonomous autostart", "AUTONOMOUS_AUTOSTART: resume Step 5"],
+    ["autonomous resume", "AUTONOMOUS_RESUME: weiter"],
+    ["backlog autostart", "RUN_BACKLOG_AUTOSTART: presence timeout. phase=gate"],
+    ["loop sentinel", "<<autonomous-loop>>"],
+  ])("%s passes through unstored", (_label, prompt) => {
+    const r = runHook({ prompt });
+    expect(r.code).toBe(0);
+    expect(readNotes(cwd)).toEqual([]);
+  });
+
+  test("an expanded slash command passes through — the escape hatch holds", () => {
+    const r = runHook({
+      prompt: "<command-name>/claude-batch</command-name>\n<command-args>off</command-args>",
+    });
+    expect(r.code).toBe(0);
+    expect(readNotes(cwd)).toEqual([]);
+  });
+
+  test("a prompt with an image passes through — blocking would erase it", () => {
+    const r = runHook({ prompt: "mach das so wie hier [Image #1]" });
+    expect(r.code).toBe(0);
+    expect(readNotes(cwd)).toEqual([]);
+  });
+
+  test("a prompt with an @file mention passes through", () => {
+    const r = runHook({ prompt: "schau in @src/app/Header.tsx" });
+    expect(r.code).toBe(0);
+    expect(readNotes(cwd)).toEqual([]);
+  });
+});
+
+describe("mode on — firing the merge", () => {
+  beforeEach(() => activate(cwd));
+
+  test("the marker injects every note as context and does not block", () => {
+    appendNote(cwd, "Button verrutscht");
+    appendNote(cwd, "Fehlertext falsch");
+    const r = runHook({ prompt: "! leg los" });
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain("Button verrutscht");
+    expect(r.stdout).toContain("Fehlertext falsch");
+    expect(r.stdout).toContain("leg los");
+    expect(r.stdout).toContain("Widersprüche");
+  });
+
+  test("the marked prompt itself is not stored as a note", () => {
+    appendNote(cwd, "eine notiz");
+    runHook({ prompt: "! jetzt umsetzen" });
+    expect(readNotes(cwd).map(n => n.text)).toEqual(["eine notiz"]);
+  });
+
+  test("the marker with an empty queue is just a normal turn", () => {
+    const r = runHook({ prompt: "! leg los" });
+    expect(r.code).toBe(0);
+    expect(r.stdout).toBe("");
+  });
+});
+
+describe("failsafe — collection cannot trap the user", () => {
+  test("an expired mode stops collecting on its own", () => {
+    activate(cwd, { startedAt: Date.now() - 9 * 3600_000, expiryHours: 8 });
+    const r = runHook({ prompt: "sollte durchlaufen" });
+    expect(r.code).toBe(0);
+    expect(readNotes(cwd)).toEqual([]);
+  });
+
+  test("the note cap stops collecting on its own", () => {
+    activate(cwd, { maxNotes: 2 });
+    expect(runHook({ prompt: "eins" }).code).toBe(2);
+    expect(runHook({ prompt: "zwei" }).code).toBe(2);
+    const r = runHook({ prompt: "drei" });
+    expect(r.code).toBe(0);
+    expect(readNotes(cwd)).toHaveLength(2);
+  });
+
+  test("an unwritable notes path lets the prompt through instead of erasing it", () => {
+    activate(cwd);
+    // Make .claude/batch.md a directory so appendFileSync fails.
+    fs.mkdirSync(path.join(cwd, ".claude", "batch.md"), { recursive: true });
+    const r = runHook({ prompt: "darf nicht verloren gehen" });
+    expect(r.code).toBe(0);
+    expect(r.stderr).toContain("normal weiter");
+  });
+
+  test("malformed stdin never blocks a prompt", () => {
+    activate(cwd);
+    const res = spawnSync(process.execPath, [HOOK], { input: "not json", cwd, encoding: "utf8" });
+    expect(res.status).toBe(0);
+  });
+});
+
+describe("message builders", () => {
+  test("the acknowledgement names the count and both exits", () => {
+    const ack = buildAck(3, "!", false);
+    expect(ack).toContain("#3 gesammelt");
+    expect(ack).toContain('"! <text>"');
+    expect(ack).toContain("/claude-batch off");
+    expect(ack).not.toContain("Frage");
+  });
+
+  test("the question hint appears only for question-shaped notes", () => {
+    expect(buildAck(1, "!", true)).toContain("Frage");
+  });
+
+  test("oversized note sets fall back to a file pointer", () => {
+    const notes = Array.from({ length: 400 }, (_, i) => ({
+      at: "2026-08-16T10:00:00.000Z",
+      text: `Notiz ${i} mit reichlich Text, damit die Grenze sicher überschritten wird.`,
+    }));
+    const ctx = buildMergeContext(notes, "los", "/tmp/p/.claude/batch.md");
+    expect(ctx.length).toBeLessThan(INLINE_LIMIT);
+    expect(ctx).toContain("/tmp/p/.claude/batch.md");
+    expect(ctx).toContain("los");
+  });
+});

--- a/plugins/devops/hooks/user-prompt-submit/prompt.flow.appstart.js
+++ b/plugins/devops/hooks/user-prompt-submit/prompt.flow.appstart.js
@@ -23,6 +23,11 @@ process.stdin.on('end', () => {
   try { hook = JSON.parse(inputData); }
   catch { process.exit(0); }
 
+  // A collected prompt produces no turn — recording a start intent from it
+  // would leave the flag set for a prompt that was erased.
+  try { if (require('../lib/batch-state').willBeCollected(hook)) process.exit(0); }
+  catch { /* fail open */ }
+
   const userMessage = (hook.user_message || hook.message || '').toLowerCase().trim();
   if (!userMessage) process.exit(0);
 

--- a/plugins/devops/hooks/user-prompt-submit/prompt.git.sync.js
+++ b/plugins/devops/hooks/user-prompt-submit/prompt.git.sync.js
@@ -24,6 +24,18 @@ require('../lib/plugin-guard');
 
 const { takeResult, renderContext } = require('../lib/git-sync-bg');
 
+// While /claude-batch collect mode is active, do not TAKE the result.
+// takeResult() consumes the file, and the payload leaves via stdout — i.e. as
+// turn context. A collected prompt is erased and produces no turn, so the
+// result would be consumed into nothing and a ⚠ conflict would never reach
+// anyone. Hooks in one event group run in PARALLEL and are not short-circuited
+// by a sibling's block, so the collect hook cannot prevent this for us.
+// Nothing is lost: the result file stays put and is delivered by the first
+// prompt that is not collected.
+try {
+  if (require('../lib/batch-state').isModeActive(process.cwd())) process.exit(0);
+} catch { /* batch state unreadable — deliver as usual */ }
+
 const result = takeResult(process.cwd());
 if (!result) process.exit(0);
 

--- a/plugins/devops/hooks/user-prompt-submit/prompt.issue.detect.js
+++ b/plugins/devops/hooks/user-prompt-submit/prompt.issue.detect.js
@@ -26,6 +26,11 @@ process.stdin.on('end', () => {
   try { hook = JSON.parse(inputData); }
   catch { process.exit(0); }
 
+  // A collected prompt produces no turn — recording a tracked issue or fixing
+  // the session locale from it would stick while the payload goes nowhere.
+  try { if (require('../lib/batch-state').willBeCollected(hook)) process.exit(0); }
+  catch { /* fail open */ }
+
   const message = hook.user_message || hook.message || '';
   if (!message) process.exit(0);
 

--- a/plugins/devops/hooks/user-prompt-submit/prompt.knowledge.dispatch.js
+++ b/plugins/devops/hooks/user-prompt-submit/prompt.knowledge.dispatch.js
@@ -156,6 +156,11 @@ process.stdin.on('end', () => {
   try { hook = JSON.parse(inputData); }
   catch { process.exit(0); }
 
+  // A collected prompt produces no turn — marking a doc "already injected" here
+  // would burn the one-shot for a prompt nobody ever sees. See willBeCollected().
+  try { if (require('../lib/batch-state').willBeCollected(hook)) process.exit(0); }
+  catch { /* fail open */ }
+
   const userMessage = (hook.user_message || hook.message || '').toLowerCase().trim();
   if (!userMessage || userMessage.length < 5) process.exit(0);
 

--- a/plugins/devops/scripts/batch-watchdog.js
+++ b/plugins/devops/scripts/batch-watchdog.js
@@ -1,0 +1,245 @@
+#!/usr/bin/env node
+/**
+ * @script batch-watchdog
+ * @version 0.1.0
+ * @plugin devops
+ * @description Inactivity reminder for `/claude-batch` collect mode. Polls the
+ *   dedicated user-activity clock and fires ONE Windows toast once the user has
+ *   been quiet for the configured window, so a collection session started
+ *   before a coffee break does not sit forgotten.
+ *
+ *   Costs zero tokens: this is a plain Node process talking to PowerShell. It
+ *   never re-enters Claude.
+ *
+ *   The clock is `.claude/batch-activity`, written only for REAL user prompts.
+ *   Hanging the timer off general session activity would never fire — the
+ *   concept bridge cron polls once a minute and git-sync every ten.
+ *
+ *   Orphan protection (a detached, unref'd process on Windows survives Claude
+ *   Code exit, crashes and `/clear`):
+ *     - PID lockfile with a liveness check before spawning a second one
+ *     - hard self-expiry after MAX_LIFETIME_MS
+ *     - self-exit as soon as the mode file disappears
+ *
+ *   Usage:
+ *     node batch-watchdog.js start <project>   # spawn detached (idempotent)
+ *     node batch-watchdog.js stop  <project>   # stop and clear the lock
+ *     node batch-watchdog.js status <project>
+ *     node batch-watchdog.js --run <project>   # internal: the polling loop
+ *
+ *   Spec: docs/superpowers/specs/2026-08-16-claude-batch-design.md
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { spawn, spawnSync } = require('child_process');
+
+const B = require(path.join(__dirname, '..', 'hooks', 'lib', 'batch-state.js'));
+
+const POLL_MS         = 30_000;
+const MAX_LIFETIME_MS = 2 * 60 * 60 * 1000; // hard stop — never outlive a workday
+const RUN_FLAG        = '--run';
+
+// ── lock ───────────────────────────────────────────────────────────────────
+
+function readLock(cwd) {
+  try {
+    const raw = JSON.parse(fs.readFileSync(B.lockPath(cwd), 'utf8'));
+    return raw && typeof raw.pid === 'number' ? raw : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Signal 0 probes existence without touching the process. */
+function isAlive(pid) {
+  if (!pid) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return err.code === 'EPERM'; // exists but owned by someone else
+  }
+}
+
+function writeLock(cwd, pid) {
+  fs.mkdirSync(B.claudeDir(cwd), { recursive: true });
+  fs.writeFileSync(
+    B.lockPath(cwd),
+    JSON.stringify({ pid, startedAt: new Date().toISOString() }, null, 2) + '\n',
+    'utf8',
+  );
+}
+
+function clearLock(cwd) {
+  try { fs.unlinkSync(B.lockPath(cwd)); } catch { /* already gone */ }
+}
+
+// ── toast ──────────────────────────────────────────────────────────────────
+
+/**
+ * Windows balloon tip via NotifyIcon — same approach as post-merge-watcher.js.
+ * Best-effort by design: a failed notification must never take the loop down.
+ */
+function notifyToast(title, message) {
+  if (process.platform !== 'win32') return false;
+  const safe = s => String(s).replace(/'/g, "''");
+  const ps =
+    'Add-Type -AssemblyName System.Windows.Forms; ' +
+    '$n = New-Object System.Windows.Forms.NotifyIcon; ' +
+    '$n.Icon = [System.Drawing.SystemIcons]::Information; ' +
+    '$n.Visible = $true; ' +
+    `$n.ShowBalloonTip(8000, '${safe(title)}', '${safe(message)}', 'Info'); ` +
+    'Start-Sleep -Seconds 9; ' +
+    '$n.Dispose()';
+  try {
+    spawnSync('powershell', ['-NoProfile', '-WindowStyle', 'Hidden', '-Command', ps], {
+      timeout: 15_000, stdio: 'ignore', detached: true,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// ── decision ───────────────────────────────────────────────────────────────
+
+/**
+ * Should the watchdog fire right now? Pure so it can be tested without timers.
+ * @param {object} o
+ * @param {boolean} o.modeActive
+ * @param {number} o.noteCount
+ * @param {number|null} o.lastActivity epoch ms
+ * @param {number} o.now epoch ms
+ * @param {number} o.inactivityMs
+ * @param {boolean} o.alreadyNotified
+ * @returns {'fire'|'wait'|'stop'}
+ */
+function decide({ modeActive, noteCount, lastActivity, now, inactivityMs, alreadyNotified }) {
+  if (!modeActive) return 'stop';
+  if (!noteCount) return 'wait';            // nothing collected — nothing to remind about
+  if (lastActivity == null) return 'wait';  // no clock yet
+  if (now - lastActivity < inactivityMs) return 'wait';
+  return alreadyNotified ? 'wait' : 'fire';
+}
+
+// ── loop ───────────────────────────────────────────────────────────────────
+
+function runLoop(cwd) {
+  const cfg = B.loadConfig();
+  const inactivityMs = Math.max(1, cfg.inactivityMinutes) * 60_000;
+  const bornAt = Date.now();
+  let lastSeenActivity = B.readActivity(cwd);
+  let notified = false;
+
+  writeLock(cwd, process.pid);
+
+  let timer = null;
+  const stop = () => {
+    if (timer) clearInterval(timer);
+    clearLock(cwd);
+    process.exit(0);
+  };
+  process.on('SIGTERM', stop);
+  process.on('SIGINT', stop);
+
+  const tick = () => {
+    const now = Date.now();
+    if (now - bornAt >= MAX_LIFETIME_MS) return stop();
+
+    let modeActive, noteCount, lastActivity;
+    try {
+      modeActive   = B.isModeActive(cwd);
+      noteCount    = B.countNotes(cwd);
+      lastActivity = B.readActivity(cwd);
+    } catch {
+      return stop(); // project gone / unreadable — do not linger
+    }
+
+    // Fresh user activity re-arms the reminder for the next quiet stretch.
+    if (lastActivity != null && lastActivity !== lastSeenActivity) {
+      lastSeenActivity = lastActivity;
+      notified = false;
+    }
+
+    const verdict = decide({
+      modeActive, noteCount, lastActivity, now, inactivityMs, alreadyNotified: notified,
+    });
+    if (verdict === 'stop') return stop();
+    if (verdict === 'fire') {
+      const mins = Math.round((now - lastActivity) / 60_000);
+      notifyToast(
+        `claude-batch — ${noteCount} Notiz${noteCount === 1 ? '' : 'en'} offen`,
+        `Seit ${mins} Minuten still. "${cfg.marker} los" startet die Umsetzung, /claude-batch off beendet den Modus.`,
+      );
+      notified = true;
+    }
+  };
+
+  // A referenced interval keeps the process alive on its own — no extra handle.
+  timer = setInterval(tick, POLL_MS);
+}
+
+// ── commands ───────────────────────────────────────────────────────────────
+
+/**
+ * Spawn the loop detached and windowless. Spawns `node` directly with no shell
+ * layer — a shell layer makes Windows Terminal open a visible tab even with
+ * windowsHide (see the long note in hooks/lib/graphify-state.js).
+ * @returns {number|null} pid, or null when one is already running
+ */
+function start(cwd) {
+  const existing = readLock(cwd);
+  if (existing && isAlive(existing.pid)) return null; // idempotent
+  if (existing) clearLock(cwd);                       // stale lock from a crash
+
+  try {
+    const child = spawn(process.execPath, [__filename, RUN_FLAG, cwd], {
+      cwd, detached: true, stdio: 'ignore', windowsHide: true,
+    });
+    child.unref();
+    if (child.pid) writeLock(cwd, child.pid);
+    return child.pid || null;
+  } catch {
+    return null; // never let a failed watchdog break the skill
+  }
+}
+
+function stopCmd(cwd) {
+  const lock = readLock(cwd);
+  if (lock && isAlive(lock.pid)) {
+    try { process.kill(lock.pid, 'SIGTERM'); } catch { /* already gone */ }
+  }
+  clearLock(cwd);
+  return true;
+}
+
+function status(cwd) {
+  const lock = readLock(cwd);
+  return {
+    running: !!(lock && isAlive(lock.pid)),
+    pid: lock?.pid ?? null,
+    startedAt: lock?.startedAt ?? null,
+    notes: (() => { try { return B.countNotes(cwd); } catch { return 0; } })(),
+    modeActive: (() => { try { return B.isModeActive(cwd); } catch { return false; } })(),
+  };
+}
+
+if (require.main === module) {
+  const [cmd, arg] = process.argv.slice(2);
+  const cwd = arg || process.cwd();
+  switch (cmd) {
+    case RUN_FLAG:  runLoop(cwd); break;
+    case 'start':   process.stdout.write(JSON.stringify({ started: start(cwd) }) + '\n'); break;
+    case 'stop':    stopCmd(cwd); process.stdout.write('{"stopped":true}\n'); break;
+    case 'status':  process.stdout.write(JSON.stringify(status(cwd)) + '\n'); break;
+    default:
+      process.stderr.write('usage: batch-watchdog.js <start|stop|status> [project]\n');
+      process.exit(1);
+  }
+}
+
+module.exports = {
+  decide, start, stopCmd, status, readLock, writeLock, clearLock, isAlive,
+  notifyToast, POLL_MS, MAX_LIFETIME_MS,
+};

--- a/plugins/devops/scripts/batch-watchdog.test.js
+++ b/plugins/devops/scripts/batch-watchdog.test.js
@@ -1,0 +1,140 @@
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { decide, start, stopCmd, status, readLock, writeLock, isAlive } from "./batch-watchdog.js";
+import { activate, deactivate, appendNote, touchActivity, lockPath } from "../hooks/lib/batch-state.js";
+
+let cwd;
+let strays = [];
+
+/**
+ * A real, live, foreign process to stand in for a running watchdog.
+ * Never use `process.pid` here — stopCmd sends SIGTERM to whatever the lock
+ * names, and that would kill the test worker itself.
+ */
+function spawnIdleProcess() {
+  const child = spawn(process.execPath, ["-e", "setTimeout(()=>{}, 60000)"], {
+    detached: true, stdio: "ignore", windowsHide: true,
+  });
+  child.unref();
+  strays.push(child);
+  return child.pid;
+}
+
+beforeEach(() => {
+  cwd = fs.mkdtempSync(path.join(os.tmpdir(), "batch-wd-test-"));
+  strays = [];
+});
+
+afterEach(() => {
+  try { stopCmd(cwd); } catch { /* best effort */ }
+  for (const c of strays) { try { c.kill("SIGKILL"); } catch { /* already gone */ } }
+  try { fs.rmSync(cwd, { recursive: true, force: true }); } catch { /* best effort */ }
+});
+
+const MIN = 60_000;
+const base = {
+  modeActive: true,
+  noteCount: 3,
+  lastActivity: 0,
+  now: 11 * MIN,
+  inactivityMs: 10 * MIN,
+  alreadyNotified: false,
+};
+
+describe("decide — when the reminder fires", () => {
+  test("fires once the quiet window is exceeded", () => {
+    expect(decide(base)).toBe("fire");
+  });
+
+  test("waits inside the quiet window", () => {
+    expect(decide({ ...base, now: 9 * MIN })).toBe("wait");
+  });
+
+  test("does not fire twice for the same quiet stretch", () => {
+    expect(decide({ ...base, alreadyNotified: true })).toBe("wait");
+  });
+
+  test("an empty queue is never worth a toast", () => {
+    expect(decide({ ...base, noteCount: 0 })).toBe("wait");
+  });
+
+  test("no clock yet means wait, not fire", () => {
+    expect(decide({ ...base, lastActivity: null })).toBe("wait");
+  });
+
+  test("a deactivated mode stops the watchdog", () => {
+    expect(decide({ ...base, modeActive: false })).toBe("stop");
+  });
+
+  test("mode deactivation outranks everything else", () => {
+    expect(decide({ ...base, modeActive: false, noteCount: 0, lastActivity: null })).toBe("stop");
+  });
+});
+
+describe("lock file — orphan protection", () => {
+  test("a live PID is detected, a dead one is not", () => {
+    expect(isAlive(process.pid)).toBe(true);
+    expect(isAlive(0)).toBe(false);
+    // PID 2^31-1 is above Windows' and Linux' practical range.
+    expect(isAlive(2147483647)).toBe(false);
+  });
+
+  test("start is idempotent while a live watchdog holds the lock", () => {
+    activate(cwd);
+    const alive = spawnIdleProcess();
+    writeLock(cwd, alive);
+    expect(start(cwd)).toBeNull();
+    expect(readLock(cwd).pid).toBe(alive);
+  });
+
+  test("a stale lock from a crashed watchdog does not block a restart", () => {
+    activate(cwd);
+    writeLock(cwd, 2147483647);
+    const pid = start(cwd);
+    expect(pid).toBeTruthy();
+    expect(pid).not.toBe(2147483647);
+  });
+
+  test("stop clears the lock file and the process it named", () => {
+    activate(cwd);
+    const alive = spawnIdleProcess();
+    writeLock(cwd, alive);
+    stopCmd(cwd);
+    expect(fs.existsSync(lockPath(cwd))).toBe(false);
+  });
+
+  test("stop on a project that never ran a watchdog is harmless", () => {
+    expect(stopCmd(cwd)).toBe(true);
+  });
+});
+
+describe("status", () => {
+  test("reports mode and note count for a fresh collection", () => {
+    activate(cwd);
+    appendNote(cwd, "eine notiz");
+    touchActivity(cwd);
+    const s = status(cwd);
+    expect(s.modeActive).toBe(true);
+    expect(s.notes).toBe(1);
+    expect(s.running).toBe(false);
+  });
+
+  test("reports inactive after the mode is switched off", () => {
+    activate(cwd);
+    deactivate(cwd);
+    expect(status(cwd).modeActive).toBe(false);
+  });
+
+  test("survives a project with no .claude directory at all", () => {
+    const bare = fs.mkdtempSync(path.join(os.tmpdir(), "batch-wd-bare-"));
+    try {
+      const s = status(bare);
+      expect(s).toEqual({ running: false, pid: null, startedAt: null, notes: 0, modeActive: false });
+    } finally {
+      fs.rmSync(bare, { recursive: true, force: true });
+    }
+  });
+});

--- a/plugins/devops/skills/claude-batch/SKILL.md
+++ b/plugins/devops/skills/claude-batch/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: claude-batch
+version: 0.1.0
+description: >-
+  Collect mode — batch prompts into one master plan instead of executing them one by one. While active, a UserPromptSubmit hook blocks each prompt (it never reaches the model, costing nothing) and appends it to `.claude/batch.md`; a configurable execute marker fires the merge, where the whole note set becomes ONE feasibility-checked plan. Purpose: avoid the rework of building for prompt 1 what prompt 5 supersedes, and avoid paying a full turn per observation. Triggers on "/claude-batch", "sammelmodus", "collect mode", "batch mode", "erstmal sammeln", "nicht sofort umsetzen". Do NOT trigger for normal work, for backlog execution (/run-backlog), or for issue creation (/setup-issue).
+---
+
+# claude-batch — Collect Prompts, Merge Once
+
+Spec: `docs/superpowers/specs/2026-08-16-claude-batch-design.md`
+
+## Step 0 — Load Extensions
+
+Silently check (do not surface "not found"):
+1. `~/.claude/skills/claude-batch/SKILL.md` + `reference.md`
+2. `{project}/.claude/skills/claude-batch/SKILL.md` + `reference.md`
+3. Merge: project > global > plugin defaults
+
+## Step 1 — Route the invocation
+
+`$ARGUMENTS` decides the branch. No argument → **status**.
+
+| Argument | Branch |
+|---|---|
+| `on`, `an`, `start` | Step 2 (activate) |
+| `off`, `aus`, `stop` | Step 5 (deactivate) |
+| `go`, `los`, `merge` | Step 4 (fire) |
+| `status`, none | Step 3 (report) |
+
+## Step 2 — Activate
+
+**2.1 First-run marker setup.** Read `~/.claude/claude-batch.json`. If it is
+missing or has no `marker`, ask ONCE via `AskUserQuestion`:
+
+> header: "Marker"
+> question: "Womit sagst du mir, dass ein Prompt NICHT gesammelt, sondern
+> bearbeitet werden soll? Alles ohne dieses Zeichen wird ab jetzt gesammelt."
+> Options (fixed order):
+> 1. `!` am Zeilenanfang (empfohlen) — ein Zeichen, kein Shift, kollidiert mit nichts
+> 2. `los:` am Zeilenanfang — ausgeschrieben, praktisch nie versehentlich getippt
+> 3. `>>` am Zeilenanfang — kurz und visuell eindeutig
+
+Persist the choice via `saveConfig({ marker })` from `hooks/lib/batch-state.js`.
+Never ask again — a later change is a manual edit of that file, or
+`/claude-batch marker`.
+
+**2.2 Activate and start the watchdog:**
+
+```bash
+node -e "require('{PLUGIN_ROOT}/hooks/lib/batch-state.js').activate(process.cwd())"
+node "{PLUGIN_ROOT}/scripts/batch-watchdog.js" start .
+```
+
+**2.3 Register the notes file in the git exclude** (machine state, not a project
+decision — never `.gitignore`):
+
+```bash
+x="$(git rev-parse --path-format=absolute --git-common-dir)/info/exclude"
+mkdir -p "${x%/*}"
+grep -qxF '/.claude/batch*' "$x" 2>/dev/null || echo '/.claude/batch*' >> "$x"
+```
+
+**2.4 Confirm in one short block** — the marker, where notes land, and both
+exits. Then render an `analysis` completion card.
+
+## Step 3 — Status
+
+Read the mode and notes via `batch-state.js`, plus
+`node "{PLUGIN_ROOT}/scripts/batch-watchdog.js" status .`
+
+Report: active or not, note count, time since the last note, whether the
+watchdog runs, and — when `expiryReason()` is non-null — that collection stopped
+on its own (`expired` / `full`) and why. Do NOT dump every note unless asked;
+name the count and the first few.
+
+## Step 4 — Fire the merge
+
+Reached either by `/claude-batch go` or automatically: the collect hook injects
+the full note set into the turn when the user sends a marker-prefixed prompt.
+In both cases the procedure is identical.
+
+**4.1 Read every note.** `.claude/batch.md`, verbatim. Notes are the user's own
+words — never paraphrase them away before analysing.
+
+**4.2 Feasibility-check against the real code BEFORE planning.** This is the
+step that pays for the whole mode: the notes were written blind, without Claude
+looking at anything. Some of them will be impossible, and later notes may depend
+on those. Check the substantive ones against the codebase.
+
+**4.3 Merge into ONE plan.** Not a list of n tasks executed in sequence — one
+coherent piece of work. Where notes describe the same surface, they merge.
+
+**4.4 Surface conflicts individually — never resolve them silently.**
+
+> "#2 wollte den Header rot, #6 blau — ich nehme blau (später), sag Bescheid falls nicht."
+> "#3 setzt eine Filter-API voraus, die es nicht gibt. #5 und #9 hängen daran und fallen mit."
+
+Silent "later wins" resolution is the failure mode this step exists to prevent.
+An impossible item is **named**, never quietly routed around.
+
+**4.5 Present the plan and get approval.** After the OK:
+- conflicts substantial enough to deserve clickable decisions → invoke `/concept`
+- otherwise → straight into implementation
+
+"Implementation" is deliberately broad: code, concepting, UI concepting, or only
+a first step of what the notes ask for.
+
+**4.6 Archive, do not delete.** After the plan is approved, call
+`archiveNotes(cwd)` — it renames `batch.md` to `batch-<timestamp>.md`. The
+originals stay recoverable; a merge must never be the only record of what the
+user actually wrote.
+
+**4.7 Ask whether to stay in collect mode.** After a fired merge the mode is
+usually no longer wanted. Ask once, default off.
+
+## Step 5 — Deactivate
+
+```bash
+node "{PLUGIN_ROOT}/scripts/batch-watchdog.js" stop .
+node -e "require('{PLUGIN_ROOT}/hooks/lib/batch-state.js').deactivate(process.cwd())"
+```
+
+If notes remain, say how many and that they survive in `.claude/batch.md` for a
+later `/claude-batch go`. Never discard them on deactivation.
+
+## Optional — local compaction
+
+When the `local-llm` plugin is installed AND AnythingLLM answers, the notes may
+be de-duplicated and reformatted locally at zero API cost.
+
+**Strictly formatting only.** No interpretation, no contradiction detection, no
+summarising of intent — `plugins/local-llm/deep-knowledge/delegation-rules.md`
+classifies ambiguous user requests as RED (never delegate) and caps practical
+context at ~8K tokens. A wrong compaction is worse than none: the plan silently
+loses a requirement and the original is no longer in the UI to check against.
+
+The dependency is soft. Resolve the plugin path and skip silently if absent —
+`devops` and `local-llm` are independently installable and must stay that way.
+
+## Rules
+
+- **Never collect** machine prompts, expanded slash commands, or prompts with
+  attachments. The hook enforces this; do not add exceptions in the skill.
+- **Never resolve a contradiction silently.** Name it, then decide.
+- **Never delete notes.** Archive them.
+- **A question in the queue is a defect, not content.** If a note is clearly a
+  question the user expected an answer to, answer it first, then continue with
+  the merge.
+- **The mode expires on its own** (time and note cap). If collection stopped
+  mid-session, say so — do not let the user believe prompts are still landing
+  in the queue.

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.130.0",
+  "version": "0.131.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

Adds `/claude-batch`, an opt-in mode that collects prompts into `.claude/batch.md` instead of executing them, then merges the whole set into ONE feasibility-checked plan.

The point is not the tokens saved while collecting — it is the rework avoided. Observation 5 routinely supersedes observation 1, and whatever was built for 1 was built for nothing.

## How it works

- A UserPromptSubmit hook blocks each prompt (`exit 2` — the harness erases it, so it never reaches the model) and appends it to a **project** file, which survives crash, reboot and `/clear`, and can be edited or filled without Claude running.
- A configurable marker (`!` by default, asked once on first use) means "work on it now": the full note set is injected, feasibility-checked against the real code, and merged into one plan whose contradictions are listed **individually** instead of silently resolved by "later wins".
- A detached watchdog fires a Windows toast after 10 min without a *user* prompt.

## What is never collected, and why

| Class | Reason |
|---|---|
| Machine prompts, incl. `AUTONOMOUS_AUTOSTART:` / `AUTONOMOUS_RESUME:` | These do **not** match the existing silent-turn patterns — collecting them means an AFK run never starts. The `/concept` bridge cron still opens with `Silently run` (deliberately, per #288), so it is covered. |
| Expanded slash commands | A real command arrives with a `<command-name>` tag, not the typed text. A naive comparison would miss exactly the escape hatch it protects. |
| Attachments / `@file` | A blocked prompt is erased — a collected screenshot is unrecoverable. |
| Any storage failure | The prompt runs normally instead of being blocked. A lost prompt is worse than a missed collection. |

## Safety

Lockout is structurally impossible, not merely unlikely: a time limit **and** a note cap each end collection on their own. Sibling hooks run in parallel and are not short-circuited by a block, so the four that write one-shot state now stand down when a prompt is being collected — `prompt.git.sync` in particular no longer consumes its background-sync result (`takeResult`) into a turn that does not exist.

The optional local-LLM path is limited to de-duplication and formatting. Interpretation stays with Claude at merge time, where the code is visible: the delegation rules classify ambiguous user requests as never-delegate, and a wrong compaction would drop a requirement whose original is no longer on screen.

## Known limits

- A question sent without the marker lands silently in the queue. A hint is appended when a note ends in `?`, but the hook deliberately never guesses what a question is.
- Zero token cost is an inference, not a guarantee — the docs state only that a blocked prompt never reaches the model.
- **The Codex review gate did not run for this PR**: the Codex CLI reported a usage limit. Reviewed instead by three adversarial agents (red-team, PO, feasibility) during design.

## Verification

- 1763 tests / 71 files pass; eslint clean; README markers regenerated.
- End-to-end run: collect → passthrough cases → watchdog start/status/stop → marker merge → failsafe expiry (18/18).
- Rebased onto #287 (git-sync now detached, no cron) and #288 (bridge cron body moved to a tick script); both purposes re-verified against this branch.

Spec: `docs/superpowers/specs/2026-08-16-claude-batch-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)