### PR TITLE
fix(hooks): light-verification gate no longer fires on foreign state

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.132.0"
+    "version": "0.132.1"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.132.0",
+      "version": "0.132.1",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.132.0",
+      "version": "0.132.1",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.132.1] — 2026-08-16
+
+### Fixed
+
+- **The Light-verification gate no longer blocks sessions that changed nothing** ([#290](https://github.com/Jerry0022/dotclaude/issues/290)). A purely read-only turn was blocked twice with "Code changed but no Light verification ran this session" and its completion card stamped ⚠ UNVERIFIED, in a session where `git status` was clean and no Edit or Write had run. Two independent causes compounded.
+
+  The first is the glob fallback in `readSessionFile`. When no file exists for this session's id, it returns the newest file with a matching prefix from *any* session in the last two hours — a workaround for Claude Code delivering different session ids to different hook types. Its inline comment claimed this prevented cross-session state bleeding; it was the cause of it. The gate read four foreign `light-pending` flags belonging to concurrent sessions, and worse, on reset it unlinked the file it had read — deleting another session's still-owed verification flag, so a session that really had changed code could finish unverified. Enforcement flags now read exact-only: every flag `stop.flow.browsertest`, `stop.flow.guard`, and the card's own `readVVState` block on. The fallback remains for advisory counters, where borrowing a neighbour's number costs nothing. That last one also explains a symptom nobody had connected to this issue: a card could be stamped ⚠ UNVERIFIED with all of its own tests green, because a *different* session still owed a check.
+
+  The second is that throwaway probe scripts in the harness scratchpad counted as code edits. The scratchpad (`<tmpdir>/claude/<project>/<session>/scratchpad/`) is the sanctioned place for one-off probe scripts, and all four live pending flags pointed at `.js`/`.cjs`/`.py` files there. Nothing under the OS temp directory is project source, whatever its extension, so `isCodeChange` and `isWebRenderableChange` now reject temp paths before any extension test — recognised both by tmpdir prefix and by the scratchpad's shape, so a path rooted in a different tmpdir is caught too. A project directory that merely happens to be named `scratchpad` is unaffected.
+
 ## [0.132.0] — 2026-08-16
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.132.0**
+**Version: 0.132.1**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.132.0",
+  "version": "0.132.1",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/hooks/lib/browsertest-guard.js
+++ b/plugins/devops/hooks/lib/browsertest-guard.js
@@ -38,6 +38,8 @@
 // Change detection
 // ---------------------------------------------------------------------------
 
+const os = require('os');
+
 // Markup / style / framework-component files are ALWAYS browser-renderable.
 const ALWAYS_WEB_RE = /\.(html?|css|scss|sass|less|vue|svelte|astro|tsx|jsx)$/i;
 // Bare scripts count as renderable only when they live under a UI source dir.
@@ -50,6 +52,31 @@ const CODE_EXT_RE =
 const TEST_FILE_RE = /\.(test|spec)\.[a-z]+$/i;
 // concept artifacts — generated analysis pages, NOT product UI.
 const CONCEPT_RE = /(^|\/)docs\/concepts\//i;
+// Harness scratchpad — the sanctioned, project-isolated temp dir for throwaway
+// probe scripts (`<tmpdir>/claude/<project>/<session>/scratchpad/`). Writing one
+// is not a project change and must never arm a project verification gate.
+// Matched by shape so a path from a differently-rooted tmpdir still qualifies.
+const SCRATCHPAD_RE = /(^|\/)claude\/[^/]+\/[^/]+\/scratchpad\//i;
+
+/**
+ * Is this path outside the project entirely — i.e. under the OS temp dir?
+ * Nothing there is project source, whatever its extension. Checked before any
+ * extension test so a `.js` probe script in the scratchpad cannot arm the gate.
+ * @param {string} normalizedPath — forward-slash path
+ * @returns {boolean}
+ */
+function isTempPath(normalizedPath) {
+  if (SCRATCHPAD_RE.test(normalizedPath)) return true;
+  let tmp;
+  try { tmp = String(os.tmpdir() || '').replace(/\\/g, '/').replace(/\/+$/, ''); }
+  catch { return false; }
+  if (!tmp) return false;
+  // Windows paths are case-insensitive; comparing lowercased is safe on POSIX
+  // too, where a genuine project path under /tmp is not something we track.
+  const p = normalizedPath.toLowerCase();
+  const t = tmp.toLowerCase();
+  return p === t || p.startsWith(t + '/');
+}
 
 /**
  * Compile project-configured carve-out patterns (no-runtime static paths that
@@ -123,6 +150,7 @@ const BLOCK_CAP = 2;
 function isWebRenderableChange(filePath, carveOuts) {
   if (!filePath) return false;
   const p = String(filePath).replace(/\\/g, '/');
+  if (isTempPath(p)) return false;          // scratchpad / temp — not the project
   if (CONCEPT_RE.test(p)) return false;     // concept carve-out
   if (isCarvedOut(p, carveOuts)) return false; // project no-runtime carve-out
   if (TEST_FILE_RE.test(p)) return false;   // *.test / *.spec — not a view
@@ -144,6 +172,7 @@ function isWebRenderableChange(filePath, carveOuts) {
 function isCodeChange(filePath, carveOuts) {
   if (!filePath) return false;
   const p = String(filePath).replace(/\\/g, '/');
+  if (isTempPath(p)) return false;
   if (CONCEPT_RE.test(p)) return false;
   if (isCarvedOut(p, carveOuts)) return false;
   if (TEST_FILE_RE.test(p)) return false;
@@ -486,6 +515,7 @@ module.exports = {
   BLOCK_CAP,
   isWebRenderableChange,
   isCodeChange,
+  isTempPath,
   classifyProfile,
   compileCarveOuts,
   carveOutsFromProfile,

--- a/plugins/devops/hooks/lib/browsertest-guard.test.js
+++ b/plugins/devops/hooks/lib/browsertest-guard.test.js
@@ -1,8 +1,10 @@
 import { describe, test, expect } from "vitest";
+import os from "os";
 import {
   BLOCK_CAP,
   isWebRenderableChange,
   isCodeChange,
+  isTempPath,
   classifyProfile,
   compileCarveOuts,
   carveOutsFromProfile,
@@ -207,6 +209,42 @@ describe("configured carve-outs in change detection", () => {
   test("default behavior unchanged without carve-outs", () => {
     expect(isWebRenderableChange("ideas/pitch.html")).toBe(true);
     expect(isCodeChange("ideas/inline.js")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// scratchpad / temp carve-out (#290b)
+// ---------------------------------------------------------------------------
+
+describe("harness scratchpad is never a project change", () => {
+  const scratch = (f) =>
+    `${os.tmpdir()}\\claude\\C--Users-x-IdeaProjects-proj\\d27f6d54-e962\\scratchpad\\${f}`;
+
+  test("a probe script in the scratchpad does not arm the gate", () => {
+    for (const f of ["probe.js", "check.cjs", "dump.py", "render.html", "patch.ts"]) {
+      expect(isCodeChange(scratch(f))).toBe(false);
+      expect(isWebRenderableChange(scratch(f))).toBe(false);
+      expect(needsLightVerification("runner", scratch(f))).toBe(false);
+      expect(needsLightVerification("dom", scratch(f))).toBe(false);
+    }
+  });
+
+  test("recognised by shape too — any tmpdir root, both separators", () => {
+    expect(isTempPath("/var/folders/t9/claude/proj/sess/scratchpad/probe.js")).toBe(true);
+    expect(isCodeChange("D:\\other-temp\\claude\\proj\\sess\\scratchpad\\probe.js")).toBe(false);
+  });
+
+  test("anything else under the OS temp dir is not project source either", () => {
+    expect(isTempPath(`${os.tmpdir()}/some-tool/out.js`.replace(/\\/g, "/"))).toBe(true);
+    expect(isCodeChange(`${os.tmpdir()}\\some-tool\\out.js`)).toBe(false);
+  });
+
+  test("a real project file is unaffected", () => {
+    expect(isTempPath("src/app/store.ts")).toBe(false);
+    expect(isCodeChange("src/app/store.ts")).toBe(true);
+    expect(isWebRenderableChange("src/App.vue")).toBe(true);
+    // A project directory that merely contains the word 'scratchpad' still counts.
+    expect(isCodeChange("src/scratchpad/editor.ts")).toBe(true);
   });
 });
 

--- a/plugins/devops/hooks/lib/session-id.js
+++ b/plugins/devops/hooks/lib/session-id.js
@@ -13,12 +13,18 @@
  * PreToolUse). readSessionFile() handles this by falling back to a glob
  * search when the exact file is not found.
  *
+ * That fallback reads the newest matching file from ANY session, so it is
+ * scoped to advisory state only. **Enforcement flags — anything a gate blocks
+ * on — must pass `{ exact: true }`** (issue #290).
+ *
  * Usage:
  *   const { sessionFile, readSessionFile } = require('../lib/session-id');
  *   // Write: always use sessionFile() for the path
  *   const file = sessionFile('dotclaude-devops-edits', hookInput.session_id);
- *   // Read: use readSessionFile() which handles session_id mismatches
+ *   // Read (advisory): glob fallback handles session_id mismatches
  *   const content = readSessionFile('dotclaude-devops-edits', hookInput.session_id);
+ *   // Read (enforcement): this session's file or nothing
+ *   const flag = readSessionFile('dotclaude-devops-light-pending', id, { exact: true });
  */
 
 const path = require('path');
@@ -44,8 +50,20 @@ function writeSessionFile(filePath, content) {
  * Read a session file with glob fallback for session_id mismatches.
  * Tries exact match first, then searches for any file matching the prefix.
  * Returns { content, filePath } or null if not found.
+ *
+ * @param {string} prefix
+ * @param {string} sessionId
+ * @param {{ exact?: boolean }} [opts] — `exact: true` disables the glob
+ *   fallback entirely. **Mandatory for every enforcement flag** (issue #290):
+ *   the fallback returns the newest file with a matching prefix from ANY
+ *   concurrent session, so a gate reading it fires on foreign state — and a
+ *   gate that then unlinks `filePath` deletes the other session's still-owed
+ *   flag, letting a session that really did change code finish unverified. The
+ *   2-hour mtime window narrows that race, it does not close it. The fallback
+ *   exists for the issue-#10 session_id mismatch and is acceptable only for
+ *   advisory counters, where reading a neighbour's value costs nothing.
  */
-function readSessionFile(prefix, sessionId) {
+function readSessionFile(prefix, sessionId, opts) {
   // 1. Try exact match
   const exact = sessionFile(prefix, sessionId);
   try {
@@ -57,9 +75,11 @@ function readSessionFile(prefix, sessionId) {
     }
   }
 
+  if (opts && opts.exact === true) return null;
+
   // 2. Glob fallback — find any file matching the prefix.
-  //    Only consider files modified in the last 2 hours to prevent
-  //    cross-session state bleeding in concurrent sessions.
+  //    The 2-hour mtime window bounds how stale a foreign file may be; it does
+  //    NOT make the result this session's state. Never use it for enforcement.
   try {
     const tmpdir = os.tmpdir();
     const maxAgeMs = 2 * 60 * 60 * 1000; // 2 hours

--- a/plugins/devops/hooks/lib/session-id.test.js
+++ b/plugins/devops/hooks/lib/session-id.test.js
@@ -81,3 +81,42 @@ describe("writeSessionFile + readSessionFile", () => {
     expect(result.content).toBe("glob-content");
   });
 });
+
+// ---------------------------------------------------------------------------
+// exact mode — enforcement flags must never read a foreign session's file (#290)
+// ---------------------------------------------------------------------------
+
+describe("readSessionFile — { exact: true }", () => {
+  test("a foreign session's file is NOT returned", () => {
+    const foreign = sessionFile(TEST_PREFIX, "exact-foreign-writer");
+    cleanupFiles.push(foreign, foreign + ".tmp");
+    writeSessionFile(foreign, "foreign-content");
+
+    // Without exact: the glob fallback hands over the neighbour's state.
+    expect(readSessionFile(TEST_PREFIX, "exact-reader").content).toBe("foreign-content");
+    // With exact: this session has no file, so it gets nothing — and crucially
+    // no `filePath` a gate could then unlink out from under the other session.
+    expect(readSessionFile(TEST_PREFIX, "exact-reader", { exact: true })).toBeNull();
+  });
+
+  test("this session's own file is still returned", () => {
+    const own = sessionFile(TEST_PREFIX, "exact-own");
+    cleanupFiles.push(own, own + ".tmp");
+    writeSessionFile(own, "own-content");
+
+    const result = readSessionFile(TEST_PREFIX, "exact-own", { exact: true });
+    expect(result).not.toBeNull();
+    expect(result.content).toBe("own-content");
+    expect(result.filePath).toBe(own);
+  });
+
+  test("only exact:true disables the fallback — other option shapes do not", () => {
+    const foreign = sessionFile(TEST_PREFIX, "exact-shape-writer");
+    cleanupFiles.push(foreign, foreign + ".tmp");
+    writeSessionFile(foreign, "shape-content");
+
+    for (const opts of [undefined, {}, { exact: false }, { exact: "yes" }]) {
+      expect(readSessionFile(TEST_PREFIX, "exact-shape-reader", opts)).not.toBeNull();
+    }
+  });
+});

--- a/plugins/devops/hooks/post-tool-use/post.flow.completion.js
+++ b/plugins/devops/hooks/post-tool-use/post.flow.completion.js
@@ -109,7 +109,9 @@ process.stdin.on('end', () => {
   // user turn already rendered its card; this background tick must not trigger
   // a second one. Flag is written by prompt.flow.silent-turn and cleared by
   // stop.flow.guard at turn end.
-  const silentResult = readSessionFile('dotclaude-devops-silent-turn', hook.session_id);
+  // Exact match only (issue #290): a neighbouring session's silent-turn flag
+  // must not suppress this session's card reminder and light-pending bookkeeping.
+  const silentResult = readSessionFile('dotclaude-devops-silent-turn', hook.session_id, { exact: true });
   if (silentResult) process.exit(0);
 
   const toolName = hook.tool_name || '';

--- a/plugins/devops/hooks/stop/stop.flow.browsertest.js
+++ b/plugins/devops/hooks/stop/stop.flow.browsertest.js
@@ -49,12 +49,16 @@ process.stdin.on('end', () => {
 
   const sessionId = hook.session_id;
 
-  const pendingResult = readSessionFile('dotclaude-devops-light-pending', sessionId);
-  const verifiedResult = readSessionFile('dotclaude-devops-light-verified', sessionId);
-  const redResult = readSessionFile('dotclaude-devops-light-red', sessionId);
-  const kindResult = readSessionFile('dotclaude-devops-light-kind', sessionId);
-  const silentResult = readSessionFile('dotclaude-devops-silent-turn', sessionId);
-  const blockCountResult = readSessionFile('dotclaude-devops-light-blockcount', sessionId);
+  // Every flag here is read EXACT (issue #290). This gate blocks on them and
+  // unlinks them on reset — a glob fallback would let it fire on a concurrent
+  // session's state and then delete that session's still-owed pending flag.
+  const EXACT = { exact: true };
+  const pendingResult = readSessionFile('dotclaude-devops-light-pending', sessionId, EXACT);
+  const verifiedResult = readSessionFile('dotclaude-devops-light-verified', sessionId, EXACT);
+  const redResult = readSessionFile('dotclaude-devops-light-red', sessionId, EXACT);
+  const kindResult = readSessionFile('dotclaude-devops-light-kind', sessionId, EXACT);
+  const silentResult = readSessionFile('dotclaude-devops-silent-turn', sessionId, EXACT);
+  const blockCountResult = readSessionFile('dotclaude-devops-light-blockcount', sessionId, EXACT);
 
   const blockCount = blockCountResult ? (parseInt(blockCountResult.content, 10) || 0) : 0;
 

--- a/plugins/devops/hooks/stop/stop.flow.guard.js
+++ b/plugins/devops/hooks/stop/stop.flow.guard.js
@@ -39,11 +39,15 @@ process.stdin.on('end', () => {
 
   const sessionId = hook.session_id;
 
-  const workResult = readSessionFile('dotclaude-devops-work-happened', sessionId);
-  const cardResult = readSessionFile('dotclaude-devops-card-rendered', sessionId);
-  const silentResult = readSessionFile('dotclaude-devops-silent-turn', sessionId);
-  const valPendingResult = readSessionFile('dotclaude-devops-validation-pending', sessionId);
-  const valAttestedResult = readSessionFile('dotclaude-devops-validation-attested', sessionId);
+  // Enforcement flags — exact match only, never the glob fallback (issue #290):
+  // this gate blocks the stop on them, so a neighbouring session's file must not
+  // be able to answer for this one in either direction.
+  const EXACT = { exact: true };
+  const workResult = readSessionFile('dotclaude-devops-work-happened', sessionId, EXACT);
+  const cardResult = readSessionFile('dotclaude-devops-card-rendered', sessionId, EXACT);
+  const silentResult = readSessionFile('dotclaude-devops-silent-turn', sessionId, EXACT);
+  const valPendingResult = readSessionFile('dotclaude-devops-validation-pending', sessionId, EXACT);
+  const valAttestedResult = readSessionFile('dotclaude-devops-validation-attested', sessionId, EXACT);
 
   const workHappened = workResult !== null;
   const flagCardRendered = cardResult !== null;

--- a/plugins/devops/mcp-server/index.js
+++ b/plugins/devops/mcp-server/index.js
@@ -717,9 +717,10 @@ function renderContextHealth(toolCallCount) {
 
 const FLAG_MAX_AGE_MS = 2 * 60 * 60 * 1000; // 2h \u2014 matches session-id.js
 
-function readSessionFlagRaw(prefix, sessionId) {
+function readSessionFlagRaw(prefix, sessionId, opts) {
   const key = sessionId || 'unknown';
   try { return readFileSync(join(tmpdir(), `${prefix}-${key}`), 'utf8'); } catch { /* fall through */ }
+  if (opts && opts.exact === true) return null;
   try {
     const p = `${prefix}-`;
     const tmp = tmpdir();
@@ -734,8 +735,8 @@ function readSessionFlagRaw(prefix, sessionId) {
   return null;
 }
 
-function sessionFlagExists(prefix, sessionId) {
-  return readSessionFlagRaw(prefix, sessionId) !== null;
+function sessionFlagExists(prefix, sessionId, opts) {
+  return readSessionFlagRaw(prefix, sessionId, opts) !== null;
 }
 
 /**
@@ -743,11 +744,17 @@ function sessionFlagExists(prefix, sessionId) {
  * code change still owes a passing Light check (pending && !verified) \u2014 i.e. the
  * turn is finishing without verification (a silent skip, an order violation, or
  * a red run). `red` distinguishes "a test ran but failed" for the stamp wording.
+ *
+ * Read EXACT (issue #290). These three flags decide whether the card carries the
+ * \u26a0 UNVERIFIED stamp, so the glob fallback would let a concurrent session's
+ * pending flag stamp this card \u2014 the observed symptom: a turn whose tests all
+ * passed rendered as unverified because a neighbouring session still owed one.
  */
 function readVVState(sessionId) {
-  const pending = sessionFlagExists('dotclaude-devops-light-pending', sessionId);
-  const verified = sessionFlagExists('dotclaude-devops-light-verified', sessionId);
-  const red = sessionFlagExists('dotclaude-devops-light-red', sessionId);
+  const EXACT = { exact: true };
+  const pending = sessionFlagExists('dotclaude-devops-light-pending', sessionId, EXACT);
+  const verified = sessionFlagExists('dotclaude-devops-light-verified', sessionId, EXACT);
+  const red = sessionFlagExists('dotclaude-devops-light-red', sessionId, EXACT);
   return { unverified: pending && !verified, red };
 }
 

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.132.0",
+  "version": "0.132.1",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
Closes #290

## Summary

A purely read-only turn was blocked twice with "Code changed but no Light verification ran this session" and had its completion card stamped ⚠ UNVERIFIED — in a session with a clean `git status` and zero Edit/Write calls. Two independent causes compounded.

### Foreign session state fed the gate

`readSessionFile`'s glob fallback returns the newest file with a matching prefix from **any** session within two hours. Its inline comment claimed this prevented cross-session state bleeding; it was the cause of it. The gate read four concurrent sessions' `light-pending` flags — and on reset it `unlinkSync`'d the file it had read, deleting another session's still-owed verification flag, so a session that really did change code could finish unverified.

Enforcement flags now read exact-only via `{ exact: true }`: everything `stop.flow.browsertest`, `stop.flow.guard`, and the MCP server's own `readVVState` block on. The fallback (the issue-#10 session_id-mismatch workaround) stays for advisory counters, where borrowing a neighbour's number costs nothing.

`readVVState` is worth calling out separately: it decides the ⚠ UNVERIFIED stamp at card-render time, so the same bug could stamp a card whose own tests were all green because a *different* session still owed a check. That symptom was observed on this repo's own ship card while working this issue.

### Scratchpad probe scripts counted as code edits

All four live `light-pending` flags pointed at throwaway `.js`/`.cjs`/`.py` files under the harness scratchpad (`<tmpdir>/claude/<project>/<session>/scratchpad/`). Nothing under the OS temp dir is project source, whatever its extension, so `isCodeChange` / `isWebRenderableChange` now reject temp paths before any extension test — recognised both by tmpdir prefix and by the scratchpad's shape, so a path rooted in a different tmpdir is caught too. A project directory merely named `scratchpad` is unaffected.

## Test plan

- 7 new regression tests: exact mode ignores a foreign session's file but still returns this session's own; only literal `exact: true` disables the fallback; scratchpad probe scripts in every relevant extension do not arm the gate, by prefix and by shape; a real project file and a project dir named `scratchpad` are unaffected
- `npm test` — 1766 tests, 71 files, all green
- `npm run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)