### PR TITLE
fix(graphify): declined refresh no longer burns its throttle token

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.132.1"
+    "version": "0.132.2"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.132.1",
+      "version": "0.132.2",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.132.1",
+      "version": "0.132.2",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.132.2] — 2026-08-16
+
+### Fixed
+
+- **A declined graph refresh no longer burns the throttle token that guarded it** ([#291](https://github.com/Jerry0022/dotclaude/issues/291)). `/auto-graph` promises the knowledge graph is kept fresh windowlessly, yet a project's graph had gone a month without a rebuild while graphify was installed, enabled, and the graph stale by the plugin's own definition.
+
+  The trigger consumed its throttle as a side effect of the condition — `runOnce(…, { cooldownMs: 10min })` wrote its marker *before* `bgWithSentinel` decided whether to spawn at all. That call declines silently whenever the per-project PID lock is held or the machine-wide build cap is reached, so the token was spent, no build ran, and nothing was recorded: the next session redrew the same losing ticket. With roughly fifteen worktrees competing for a default cap of two, most projects lose that draw every time and starve indefinitely. `runOnce` gained a `releaseOnce` counterpart, and every trigger now hands the token back when the spawn is declined, so the next attempt lands the moment a slot frees up.
+
+  Both PreToolUse self-heal paths had the same shape and are fixed with it — plus a detail that made the starvation hard to see from the logs: they recorded a `self_heal_kicked` metric unconditionally, so the log claimed self-heals that had never spawned. The metric now only records a spawn that actually issued.
+
+  Losing every draw for a long stretch is worse than an ordinary skip, because `pre.tokens.guard` hard-gates broad searches *toward* the graph — a starved project quietly steers agents to a month-old view of its code. So declines are now counted per project and, every fifth consecutive one, the session says so and names the two ways out (`graphify update .`, or raising `DOTCLAUDE_GRAPH_MAX_BUILDS`). A spawn that issues resets the streak.
+
+  One pre-existing test turned out to depend on the old dishonest behaviour: it asserted the refresh flag existed after a self-heal, which now holds only when the spawn was not declined — so under a loaded full-suite run, with the shared lock directory saturated by other tests, it failed about one run in three. It now isolates the lock directory, measuring the gate's logic instead of the machine's load.
+
 ## [0.132.1] — 2026-08-16
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.132.1**
+**Version: 0.132.2**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.132.1",
+  "version": "0.132.2",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/hooks/lib/graphify-state.js
+++ b/plugins/devops/hooks/lib/graphify-state.js
@@ -178,6 +178,17 @@ function markRefresh(cwd, cooldownMs) {
   }
 }
 
+/**
+ * Give back a throttle slot taken by `markRefresh` when the spawn it guarded
+ * was declined downstream (issue #291). Without this the cooldown is spent on a
+ * build that never started, and the self-heal cannot retry until it expires —
+ * on a machine whose global cap is usually saturated, that is a graph which
+ * never converges. Never throws; an already-absent flag is the desired state.
+ */
+function releaseRefresh(cwd) {
+  try { fs.unlinkSync(refreshFlagPath(cwd)); } catch { /* already gone */ }
+}
+
 function queryFlagPath(sessionId, cwd) {
   const key = crypto.createHash('md5').update(`${sessionId || 'nosid'}:${cwd}`).digest('hex').slice(0, 12);
   return path.join(os.tmpdir(), `dotclaude-graphq-${key}.flag`);
@@ -261,6 +272,43 @@ function updateGlobalCap() {
 function updateLockPath(cwd) {
   const key = crypto.createHash('md5').update(`updatelock:${cwd}`).digest('hex').slice(0, 12);
   return path.join(lockBaseDir(), `dotclaude-graphupdate-${key}.lock`);
+}
+
+/**
+ * Per-project counter of consecutive DECLINED spawns (issue #291).
+ *
+ * A decline is normally harmless — the project already has a build, or the
+ * machine is at its cap, and the next trigger picks it up. On a machine with
+ * many active worktrees, though, a project can lose that draw every single
+ * time: ~15 cwds competing for a global cap of 2 leaves most of them silently
+ * stale for weeks. That matters more than an ordinary skip, because
+ * `pre.tokens.guard` steers broad searches TOWARD the graph — a starved project
+ * quietly serves a month-old view of its code. The counter makes a persistent
+ * loser visible; a spawn that issues resets it.
+ */
+function declineCountPath(cwd) {
+  const key = crypto.createHash('md5').update(`updatelock:${cwd}`).digest('hex').slice(0, 12);
+  return path.join(lockBaseDir(), `dotclaude-graphdecline-${key}`);
+}
+
+/** Consecutive declined spawns for `cwd`. 0 when unknown. Never throws. */
+function declineCount(cwd) {
+  try {
+    const n = parseInt(fs.readFileSync(declineCountPath(cwd), 'utf8'), 10);
+    return Number.isInteger(n) && n > 0 ? n : 0;
+  } catch { return 0; }
+}
+
+/** Record one more declined spawn; returns the new count. Never throws. */
+function noteDecline(cwd) {
+  const n = declineCount(cwd) + 1;
+  try { fs.writeFileSync(declineCountPath(cwd), String(n)); } catch { /* best effort */ }
+  return n;
+}
+
+/** Forget the decline streak — called when a spawn actually issues. */
+function clearDeclines(cwd) {
+  try { fs.unlinkSync(declineCountPath(cwd)); } catch { /* already gone */ }
 }
 
 /**
@@ -442,13 +490,17 @@ function bgWindowless(cmd, args, cwd) {
  *   already building, or global cap reached) or the spawn errored.
  */
 function bgWithSentinel(cmd, args, cwd) {
-  if (updateInFlight(cwd)) return false; // this project already has a live build
-  if (globalUpdatesInFlight() >= updateGlobalCap()) return false; // machine-wide cap reached
+  // A decline is bookkept (issue #291): callers throttle themselves before
+  // getting here, so a declined spawn that leaves no trace burns the caller's
+  // throttle window for work that never ran.
+  if (updateInFlight(cwd)) { noteDecline(cwd); return false; } // this project already has a live build
+  if (globalUpdatesInFlight() >= updateGlobalCap()) { noteDecline(cwd); return false; } // machine-wide cap reached
   const sentinel = sentinelPath(cwd);
   const lock = updateLockPath(cwd);
   try { fs.unlinkSync(sentinel); } catch { /* no previous sentinel */ }
   const pid = spawnBgRunner(cmd, args, cwd, sentinel, lock);
-  if (pid != null) writeUpdateLock(cwd, pid);
+  if (pid != null) { writeUpdateLock(cwd, pid); clearDeclines(cwd); }
+  else noteDecline(cwd);
   return pid != null;
 }
 
@@ -501,6 +553,11 @@ module.exports = {
   updateLockPath,
   updateInFlight,
   globalUpdatesInFlight,
+  declineCountPath,
+  declineCount,
+  noteDecline,
+  clearDeclines,
+  releaseRefresh,
   writeUpdateLock,
   clearUpdateLock,
   bgWindowless,

--- a/plugins/devops/hooks/lib/graphify-state.test.js
+++ b/plugins/devops/hooks/lib/graphify-state.test.js
@@ -29,6 +29,11 @@ import {
   clearUpdateLock,
   globalUpdatesInFlight,
   updateGlobalCap,
+  releaseRefresh,
+  declineCount,
+  declineCountPath,
+  noteDecline,
+  clearDeclines,
 } from "./graphify-state.js";
 
 function tmp() {
@@ -634,4 +639,82 @@ describe("globalUpdatesInFlight / machine-wide cap", () => {
     clearSentinel(fresh);
     try { fs.rmSync(fresh, { recursive: true, force: true }); } catch {}
   }, 10000);
+});
+
+// ---------------------------------------------------------------------------
+// #291 — a declined spawn must not spend the caller's throttle token
+// ---------------------------------------------------------------------------
+
+describe("releaseRefresh — declined spawn gives the cooldown back", () => {
+  test("released slot lets the next self-heal attempt run immediately", () => {
+    const d = tmp();
+    expect(markRefresh(d, 120_000)).toBe(true);   // first attempt takes the slot
+    expect(markRefresh(d, 120_000)).toBe(false);  // throttled for 2 min
+
+    // The spawn was declined (PID lock / global cap), so nothing ran — the
+    // cooldown must not be charged for it.
+    releaseRefresh(d);
+    expect(markRefresh(d, 120_000)).toBe(true);
+    expect(fs.existsSync(refreshFlagPath(d))).toBe(true);
+  });
+
+  test("releasing without a flag is a no-op", () => {
+    const d = tmp();
+    expect(() => releaseRefresh(d)).not.toThrow();
+    expect(markRefresh(d, 120_000)).toBe(true);
+  });
+});
+
+describe("decline bookkeeping — a permanently starved project is visible", () => {
+  let origLockDir, isoDir;
+  beforeEach(() => {
+    origLockDir = process.env.DOTCLAUDE_GRAPHLOCK_DIR;
+    isoDir = fs.mkdtempSync(path.join(os.tmpdir(), "gstate-decline-iso-"));
+    process.env.DOTCLAUDE_GRAPHLOCK_DIR = isoDir;
+  });
+  afterEach(() => {
+    try { fs.rmSync(isoDir, { recursive: true, force: true }); } catch {}
+    if (origLockDir === undefined) delete process.env.DOTCLAUDE_GRAPHLOCK_DIR;
+    else process.env.DOTCLAUDE_GRAPHLOCK_DIR = origLockDir;
+  });
+
+  test("counts consecutive declines per project, independently", () => {
+    const a = tmp(), b = tmp();
+    expect(declineCount(a)).toBe(0);
+    expect(noteDecline(a)).toBe(1);
+    expect(noteDecline(a)).toBe(2);
+    expect(declineCount(a)).toBe(2);
+    expect(declineCount(b)).toBe(0); // a neighbour's streak is not ours
+  });
+
+  test("clearDeclines resets the streak", () => {
+    const d = tmp();
+    noteDecline(d); noteDecline(d);
+    clearDeclines(d);
+    expect(declineCount(d)).toBe(0);
+  });
+
+  test("a garbled counter file reads as 0 rather than throwing", () => {
+    const d = tmp();
+    fs.writeFileSync(declineCountPath(d), "not-a-number");
+    expect(declineCount(d)).toBe(0);
+    expect(noteDecline(d)).toBe(1);
+  });
+
+  test("bgWithSentinel records a decline when the per-project lock is held", () => {
+    const d = tmp();
+    writeUpdateLock(d, process.pid); // this project already has a live build
+    expect(bgWithSentinel("ver", [], d)).toBe(false);
+    expect(declineCount(d)).toBe(1);
+    clearUpdateLock(d);
+  });
+
+  test("bgWithSentinel records a decline when the machine-wide cap is reached", () => {
+    const d = tmp();
+    // Fill the cap with foreign live locks, then attempt this project's build.
+    for (let i = 0; i < updateGlobalCap(); i++) writeUpdateLock(tmp(), process.pid);
+    expect(globalUpdatesInFlight()).toBeGreaterThanOrEqual(updateGlobalCap());
+    expect(bgWithSentinel("ver", [], d)).toBe(false);
+    expect(declineCount(d)).toBe(1);
+  });
 });

--- a/plugins/devops/hooks/lib/run-once.js
+++ b/plugins/devops/hooks/lib/run-once.js
@@ -15,10 +15,22 @@
  * Returns true if the hook should run, false if it should skip.
  * Automatically writes the marker file when returning true.
  *
+ *   releaseOnce(hookName, sessionId)
+ *     → give the token back, so the next call is allowed again
+ *
+ * `releaseOnce` exists for the case where the guarded work turns out not to
+ * happen after all — the classic shape being a throttled spawn that a
+ * downstream concurrency guard then declines (issue #291). Consuming a
+ * 10-minute token for an action that never ran means the next session redraws
+ * the same losing ticket, and on a machine where the downstream guard is
+ * usually saturated the work is starved indefinitely with nothing recorded.
+ * Release the token whenever the run did not actually occur.
+ *
  * Usage:
- *   const { runOnce } = require('../lib/run-once');
+ *   const { runOnce, releaseOnce } = require('../lib/run-once');
  *   const input = JSON.parse(require('fs').readFileSync('/dev/stdin', 'utf8'));
  *   if (!runOnce('ss-tokens-scan', input.session_id, { cooldownMs: 600000 })) process.exit(0);
+ *   if (!spawnActuallyIssued()) releaseOnce('ss-tokens-scan', input.session_id);
  */
 
 const fs = require('fs');
@@ -53,4 +65,25 @@ function runOnce(hookName, sessionId, opts = {}) {
   return true;
 }
 
-module.exports = { runOnce };
+/**
+ * Hand back a token taken by `runOnce` — the guarded work did not run, so the
+ * next caller must not be throttled on its behalf. Removing the marker restores
+ * the pre-`runOnce` state exactly: a missing marker is "first run".
+ *
+ * Never throws. A marker that is already gone (another session released it, or
+ * temp was swept) is the desired end state, not an error.
+ *
+ * @param {string} hookName
+ * @param {string} sessionId — the same key `runOnce` was called with
+ * @returns {boolean} true if a marker was removed
+ */
+function releaseOnce(hookName, sessionId) {
+  try {
+    fs.unlinkSync(markerPath(hookName, sessionId));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+module.exports = { runOnce, releaseOnce };

--- a/plugins/devops/hooks/lib/run-once.test.js
+++ b/plugins/devops/hooks/lib/run-once.test.js
@@ -2,7 +2,7 @@ import { describe, test, expect, afterEach } from "vitest";
 import fs from "fs";
 import os from "os";
 import path from "path";
-import { runOnce } from "./run-once.js";
+import { runOnce, releaseOnce } from "./run-once.js";
 
 const TEST_HOOK = "vitest-runonce";
 const TEST_SESSION = "test-" + Date.now();
@@ -48,5 +48,39 @@ describe("runOnce", () => {
     const past = new Date(Date.now() - 120_000);
     fs.utimesSync(marker, past, past);
     expect(runOnce(TEST_HOOK, TEST_SESSION, { cooldownMs: 60000 })).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// releaseOnce — hand the token back when the guarded work never ran (#291)
+// ---------------------------------------------------------------------------
+
+describe("releaseOnce", () => {
+  test("a released token lets the very next call run again", () => {
+    expect(runOnce(TEST_HOOK, TEST_SESSION, { cooldownMs: 600_000 })).toBe(true);
+    // Without the release this stays throttled for the full 10 minutes even
+    // though the guarded work was declined and never ran.
+    expect(runOnce(TEST_HOOK, TEST_SESSION, { cooldownMs: 600_000 })).toBe(false);
+
+    expect(releaseOnce(TEST_HOOK, TEST_SESSION)).toBe(true);
+    expect(runOnce(TEST_HOOK, TEST_SESSION, { cooldownMs: 600_000 })).toBe(true);
+  });
+
+  test("releasing restores the exact pre-runOnce state — no marker left", () => {
+    runOnce(TEST_HOOK, TEST_SESSION);
+    releaseOnce(TEST_HOOK, TEST_SESSION);
+    expect(fs.existsSync(markerPath())).toBe(false);
+  });
+
+  test("releasing a token that was never taken is a no-op, not an error", () => {
+    expect(() => releaseOnce(TEST_HOOK, "never-ran-" + Date.now())).not.toThrow();
+    expect(releaseOnce(TEST_HOOK, "never-ran-" + Date.now())).toBe(false);
+  });
+
+  test("works for the strict once-per-session mode too", () => {
+    expect(runOnce(TEST_HOOK, TEST_SESSION)).toBe(true);
+    expect(runOnce(TEST_HOOK, TEST_SESSION)).toBe(false);
+    releaseOnce(TEST_HOOK, TEST_SESSION);
+    expect(runOnce(TEST_HOOK, TEST_SESSION)).toBe(true);
   });
 });

--- a/plugins/devops/hooks/pre-tool-use/pre.tokens.guard.graphgate.test.js
+++ b/plugins/devops/hooks/pre-tool-use/pre.tokens.guard.graphgate.test.js
@@ -1,10 +1,15 @@
-import { describe, test, expect } from "vitest";
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
-import { markQueryDone, refreshFlagPath } from "../lib/graphify-state.js";
+import {
+  markQueryDone,
+  refreshFlagPath,
+  writeUpdateLock,
+  updateGlobalCap,
+} from "../lib/graphify-state.js";
 
 // This file spawns real processes (hooks, scripts, or a server). The full suite
 // runs 64 files in parallel, all starting `node` at once, so process-start tail
@@ -77,6 +82,24 @@ function cleanup(dir) {
 }
 
 describe("pre.tokens.guard — graphify hard-gate (integration)", () => {
+  // Isolate the graphify update-lock dir (#291). The self-heal now releases its
+  // refresh slot when bgWithSentinel declines the spawn, so a machine-wide cap
+  // filled by OTHER tests — or by real builds on this machine — turns
+  // "refresh kicked" into "refresh correctly not kicked" and the assertions
+  // below flip. An isolated lock dir makes the live-build count start at 0, so
+  // these tests measure the gate's logic instead of the machine's load.
+  let origLockDir, isoLockDir;
+  beforeEach(() => {
+    origLockDir = process.env.DOTCLAUDE_GRAPHLOCK_DIR;
+    isoLockDir = fs.mkdtempSync(path.join(os.tmpdir(), "graphgate-lockiso-"));
+    process.env.DOTCLAUDE_GRAPHLOCK_DIR = isoLockDir;
+  });
+  afterEach(() => {
+    try { fs.rmSync(isoLockDir, { recursive: true, force: true }); } catch {}
+    if (origLockDir === undefined) delete process.env.DOTCLAUDE_GRAPHLOCK_DIR;
+    else process.env.DOTCLAUDE_GRAPHLOCK_DIR = origLockDir;
+  });
+
   test("consent + fresh graph → first broad search is BLOCKED by the graph gate", () => {
     const dir = project({ consent: true, graph: "fresh" });
     const r = runGrep(dir, "s-block", "alpha");
@@ -152,6 +175,26 @@ describe("pre.tokens.guard — graphify hard-gate (integration)", () => {
     const r = runGrep(dir, "s-heal", "omega");
     expect(r.stderr).not.toContain("GRAPHIFY GATE"); // never block beyond tolerance
     expect(fs.existsSync(refreshFlagPath(dir))).toBe(true); // background refresh kicked
+    cleanup(dir);
+  });
+
+  test("declined self-heal hands the refresh slot back instead of burning it (#291)", () => {
+    const dir = project({ consent: true, graph: "stale" });
+    for (let i = 0; i < 30; i++) {
+      const p = path.join(dir, `extra${i}.js`);
+      fs.writeFileSync(p, "x");
+      fs.utimesSync(p, NOW, NOW);
+    }
+    // Saturate the machine-wide build cap so bgWithSentinel must decline.
+    for (let i = 0; i < updateGlobalCap(); i++) {
+      writeUpdateLock(fs.mkdtempSync(path.join(os.tmpdir(), "graphgate-busy-")), process.pid);
+    }
+
+    const r = runGrep(dir, "s-heal-declined", "omega");
+    expect(r.stderr).not.toContain("GRAPHIFY GATE"); // still never blocks beyond tolerance
+    // The spawn never happened, so the 2-minute cooldown must NOT be charged —
+    // otherwise the next search cannot retry and the graph never converges.
+    expect(fs.existsSync(refreshFlagPath(dir))).toBe(false);
     cleanup(dir);
   });
 });

--- a/plugins/devops/hooks/pre-tool-use/pre.tokens.guard.js
+++ b/plugins/devops/hooks/pre-tool-use/pre.tokens.guard.js
@@ -318,10 +318,18 @@ process.stdin.on('end', () => {
           // sentinel-tracked — see Gap #5) so the graph converges and the gate
           // can enforce on LATER searches this session. Never blocks.
           if (gstate.markRefresh(cwd, 2 * 60 * 1000)) {
-            gstate.bgWithSentinel('graphify', ['update', '.'], cwd);
-            // Infinity is JSON-null; -1 keeps "unbounded" distinguishable in the log.
-            const newerCount = Number.isFinite(info.newerCount) ? info.newerCount : -1;
-            metrics.record('self_heal_kicked', { newerCount, truncated: info.truncated }, { cwd, sid });
+            // Release the throttle slot when the spawn is declined (PID lock /
+            // global cap) — otherwise the cooldown is spent on a build that
+            // never ran and the graph cannot converge (issue #291). The metric
+            // must only record a spawn that actually issued, or the log claims
+            // self-heals that never happened.
+            if (gstate.bgWithSentinel('graphify', ['update', '.'], cwd)) {
+              // Infinity is JSON-null; -1 keeps "unbounded" distinguishable in the log.
+              const newerCount = Number.isFinite(info.newerCount) ? info.newerCount : -1;
+              metrics.record('self_heal_kicked', { newerCount, truncated: info.truncated }, { cwd, sid });
+            } else {
+              gstate.releaseRefresh(cwd);
+            }
           }
         } else if (!gstate.queryDone(sid, cwd)) {
           // Same keying discipline as the confirmation flag below: hashing the
@@ -334,8 +342,11 @@ process.stdin.on('end', () => {
             // Within tolerance but still lagging by >0 files — enforce AND kick
             // a refresh in parallel so it converges toward newerCount 0.
             if (info.newerCount > 0 && gstate.markRefresh(cwd, 2 * 60 * 1000)) {
-              gstate.bgWithSentinel('graphify', ['update', '.'], cwd);
-              metrics.record('self_heal_kicked', { newerCount: info.newerCount, truncated: false }, { cwd, sid });
+              if (gstate.bgWithSentinel('graphify', ['update', '.'], cwd)) {
+                metrics.record('self_heal_kicked', { newerCount: info.newerCount, truncated: false }, { cwd, sid });
+              } else {
+                gstate.releaseRefresh(cwd); // declined — do not spend the cooldown (#291)
+              }
             }
             const suggestion = graphNudge.suggestQuery(toolInput.pattern);
             console.error('\n⛔  GRAPHIFY GATE — broad search blocked (graph available)');

--- a/plugins/devops/hooks/session-start/ss.graphify.js
+++ b/plugins/devops/hooks/session-start/ss.graphify.js
@@ -46,12 +46,15 @@ require('../lib/plugin-guard');
 const fs = require('fs');
 const crypto = require('crypto');
 const { execSync } = require('child_process');
-const { runOnce } = require('../lib/run-once');
+const { runOnce, releaseOnce } = require('../lib/run-once');
 const gstate = require('../lib/graphify-state');
 const graphNudge = require('../lib/graph-nudge');
 
 const cwd = process.cwd();
 const cwdKey = crypto.createHash('md5').update(cwd).digest('hex').slice(0, 12);
+
+/** Report a starved refresh every Nth consecutive decline, not every session. */
+const DECLINE_REPORT_EVERY = 5;
 
 /**
  * Gap #5/#6: surface a background-build failure or a graph that looks
@@ -178,6 +181,28 @@ const needsRebuild = !graphNudge.hasGraph(cwd)
 // gstate.bgWithSentinel (a per-project PID lock) — it is what actually caps
 // concurrency at one build per project across all spawn triggers.
 if (needsRebuild && runOnce('ss-graphify-update', cwdKey, { cooldownMs: 10 * 60 * 1000 })) {
-  gstate.bgWithSentinel('graphify', ['update', '.'], cwd); // background, key-less, AST-only, free
+  // background, key-less, AST-only, free
+  const spawned = gstate.bgWithSentinel('graphify', ['update', '.'], cwd);
+  if (!spawned) {
+    // The throttle token was consumed as a side effect of the condition above,
+    // BEFORE bgWithSentinel got to decline (PID lock held, or the machine-wide
+    // cap reached). Keeping it would mean the next session redraws the same
+    // losing ticket for 10 minutes with no build having run — on a machine with
+    // many worktrees competing for a cap of 2, that starves a project
+    // indefinitely, and silently (issue #291). Hand the token back so the next
+    // trigger gets a real attempt the moment a slot frees up.
+    releaseOnce('ss-graphify-update', cwdKey);
+    // Losing every draw for a long stretch is not an ordinary skip: the search
+    // hard-gate steers agents toward a graph that is now weeks old. Say so —
+    // once per streak-threshold, not every session.
+    const declines = gstate.declineCount(cwd);
+    if (declines > 0 && declines % DECLINE_REPORT_EVERY === 0) {
+      console.log(
+        `[graphify] Graph-Refresh ${declines}× in Folge abgelehnt (andere Builds laufen, ` +
+        `Cap ${gstate.updateGlobalCap()}). Der Graph dieses Projekts ist womöglich veraltet — ` +
+        `mit \`graphify update .\` manuell erzwingen oder DOTCLAUDE_GRAPH_MAX_BUILDS erhöhen.`,
+      );
+    }
+  }
 }
 process.exit(0);

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.132.1",
+  "version": "0.132.2",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
Closes #291

## Summary

`/auto-graph` promises the knowledge graph is kept fresh windowlessly, yet a project's graph had gone a month without a rebuild while graphify was installed, enabled, and stale by the plugin's own definition.

### The token was spent before the decision to spawn

```js
if (needsRebuild && runOnce('ss-graphify-update', cwdKey, { cooldownMs: 10 * 60 * 1000 })) {
  gstate.bgWithSentinel('graphify', ['update', '.'], cwd);
}
```

`runOnce` writes its marker as a side effect of the condition — before `bgWithSentinel` decides anything. That call declines silently whenever the per-project PID lock is held or the machine-wide cap is reached, so the token was spent, no build ran, and nothing was recorded. The next session redrew the same losing ticket. With ~15 worktrees competing for a default cap of 2, most projects lose that draw every time and starve indefinitely.

`runOnce` gains a `releaseOnce` counterpart; the trigger hands the token back on a decline, so the next attempt lands the moment a slot frees up.

### Both self-heal paths had the same shape — and lied about it

The two PreToolUse self-heal sites burned `markRefresh`'s 2-minute slot the same way (fixed via `releaseRefresh`), and recorded a `self_heal_kicked` metric *unconditionally* — so the log claimed self-heals that had never spawned, which is why the starvation was invisible in the metrics. The metric now only records a spawn that actually issued.

### Declines are counted, and a persistent loser says so

Losing every draw is worse than an ordinary skip: `pre.tokens.guard` hard-gates broad searches *toward* the graph, so a starved project quietly steers agents to a month-old view of its code. Declines are counted per project; every fifth consecutive one reports itself and names both ways out (`graphify update .`, or raising `DOTCLAUDE_GRAPH_MAX_BUILDS`). A spawn that issues resets the streak.

### A pre-existing flaky test, surfaced by this fix

`pre.tokens.guard.graphgate.test.js` asserted the refresh flag exists after a self-heal — which now holds only when the spawn was not declined. Under a loaded full-suite run, with the shared lock directory saturated by other tests, it failed about one run in three. It now isolates the lock directory, measuring the gate's logic instead of the machine's load. Verified over six consecutive full-suite runs: 6/6 green.

## Test plan

- 12 new tests: `releaseOnce` restores the exact pre-`runOnce` state and re-allows the very next call, in both cooldown and once-per-session mode, and is a no-op for a token never taken; `releaseRefresh` likewise; the decline counter is per project, survives a garbled counter file, resets on a spawn, and is recorded for both the PID-lock and the global-cap decline; an end-to-end case asserting a declined self-heal leaves the cooldown unspent
- `npm test` — 1778 tests, 71 files; six consecutive full runs green
- `npm run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)