### PR TITLE
fix(batch): accept a custom marker phrase typed under "Sonstiges"

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.132.3"
+    "version": "0.132.4"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.132.3",
+      "version": "0.132.4",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.132.3",
+      "version": "0.132.4",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.132.4] — 2026-08-17
+
+### Fixed
+
+- **A marker phrase typed under "Sonstiges" is now accepted as the answer it is.** `/claude-batch` asks once what should fire the merge and offers three options; a user typed their own phrase into the free-text field and it was dismissed as "that doesn't answer the question", with the recommended `!` silently applied instead. The options were always suggestions — typing something else is the user saying the list was incomplete, not refusing to choose. Step 2.1 of the skill now makes the free-text value binding, and the same rule is stated cross-cutting in `deep-knowledge/decision-format.md`, since nothing about it is specific to this skill.
+
+  Accepting the phrase is only half of it: a phrase is retyped by hand every time, so the stored marker now matches case-insensitively and tolerates extra inner whitespace. Without that, a marker saved as `Let's go` and retyped as `let's go` would fail to fire — and failing to fire is not a visible error here, it silently collects the prompt that was meant to start the work. Markers ending in a word character additionally require a word boundary, so a short marker like `go` no longer fires on "google das mal", and `saveConfig` normalises what it persists rather than storing whatever was passed.
+
+- **A correctly collected note no longer reads like a crash.** Collect mode works by blocking the prompt, and the harness renders every blocked prompt as a red "a hook blocked your input" panel — the only rendering available, and not the plugin's to change. The acknowledgement's first line now leads with the all-clear ("Notiz #N gespeichert — alles korrekt, kein Fehler") instead of burying it behind the count.
+
 ## [0.132.3] — 2026-08-16
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.132.3**
+**Version: 0.132.4**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.132.3",
+  "version": "0.132.4",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/deep-knowledge/decision-format.md
+++ b/plugins/devops/deep-knowledge/decision-format.md
@@ -27,6 +27,14 @@ structured format with risk markers and a clear recommendation.
 - Risk levels are relative to the specific decision context
 - If all options have equal risk, say so explicitly
 - For AskUserQuestion: use the `description` field for risk/strength info
+- **A free-text answer via "Sonstiges" (Other) is a real answer and outranks
+  every offered option.** The options are suggestions; typing something else is
+  the user telling you the list was incomplete. Take the typed value as the
+  decision — never dismiss it as "that doesn't answer the question", and never
+  silently fall back to your own recommendation. Only push back when the value
+  is genuinely unusable for the mechanism behind it (wrong type, out of range,
+  technically impossible), and then say exactly why and ask again. If it merely
+  carries a downside, apply it and name the downside in one clause.
 - For AskUserQuestion after inline results: if the preceding output contains
   substantial inline content (analysis, report, long text), the **first option
   of the first question** must always be **"Erstmal in Ruhe durchlesen"** with

--- a/plugins/devops/hooks/lib/batch-state.js
+++ b/plugins/devops/hooks/lib/batch-state.js
@@ -94,7 +94,13 @@ function loadConfig() {
 }
 
 function saveConfig(cfg) {
-  const merged = { ...loadConfig(), ...cfg };
+  const incoming = { ...(cfg || {}) };
+  if ('marker' in incoming) {
+    const v = validateMarker(incoming.marker);
+    if (!v.ok) throw new Error(`invalid marker (${v.reason})`);
+    incoming.marker = v.marker;
+  }
+  const merged = { ...loadConfig(), ...incoming };
   const dir = path.dirname(configPath());
   fs.mkdirSync(dir, { recursive: true });
   fs.writeFileSync(configPath(), JSON.stringify(merged, null, 2) + '\n', 'utf8');
@@ -256,14 +262,57 @@ function hasAttachment(text, hookInput) {
   return ATTACHMENT_PATTERNS.some(rx => rx.test(text));
 }
 
+const MARKER_MAX_LENGTH = 32;
+
+/**
+ * Normalise and sanity-check a marker the user typed themselves.
+ *
+ * The three offered options are suggestions, not a closed set — a free-text
+ * answer ("Let's go") is a legitimate marker and must survive to the config
+ * file. Only genuinely unusable input is rejected, and always with a reason
+ * the skill can quote back.
+ *
+ * @returns {{ok:true,marker:string,warning:?'wordy'}|{ok:false,reason:'empty'|'too-long'}}
+ */
+function validateMarker(raw) {
+  if (typeof raw !== 'string') return { ok: false, reason: 'empty' };
+  const marker = raw.trim().replace(/\s+/g, ' ');
+  if (!marker) return { ok: false, reason: 'empty' };
+  if (marker.length > MARKER_MAX_LENGTH) return { ok: false, reason: 'too-long' };
+  // A letters-only phrase can also be the honest start of a collected prompt.
+  // Word-boundary matching keeps that rare, but the user should hear it once.
+  const wordy = /^[\p{L}\p{N} ]+$/u.test(marker) ? 'wordy' : null;
+  return { ok: true, marker, warning: wordy };
+}
+
+/**
+ * Anchored matcher for a marker.
+ *
+ * Case-insensitive and whitespace-tolerant, because a phrase marker is retyped
+ * by hand every time: "let's go" must fire a marker stored as "Let's go", or
+ * the prompt is silently collected instead of executed — the exact lock-out the
+ * failsafe bounds exist to make impossible.
+ *
+ * A marker ending in a word character additionally requires a word boundary, so
+ * `go` does not fire on "google das mal".
+ */
+function markerMatch(text, marker) {
+  if (typeof text !== 'string' || !text) return null;
+  const v = validateMarker(marker);
+  if (!v.ok) return null;
+  const escaped = v.marker.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replace(/ /g, '\\s+');
+  const boundary = /[\p{L}\p{N}_]$/u.test(v.marker) ? '(?![\\p{L}\\p{N}_])' : '';
+  return new RegExp(`^\\s*${escaped}${boundary}`, 'iu').exec(text);
+}
+
 function startsWithMarker(text, marker) {
-  if (typeof text !== 'string' || !text || !marker) return false;
-  return text.trimStart().startsWith(marker);
+  return markerMatch(text, marker) !== null;
 }
 
 function stripMarker(text, marker) {
-  if (!startsWithMarker(text, marker)) return String(text ?? '');
-  return text.trimStart().slice(marker.length).trimStart();
+  const s = String(text ?? '');
+  const m = markerMatch(s, marker);
+  return m ? s.slice(m[0].length).trimStart() : s;
 }
 
 /**
@@ -330,5 +379,6 @@ module.exports = {
   touchActivity, readActivity,
   isMachinePrompt, isExpandedCommand, hasAttachment,
   startsWithMarker, stripMarker, looksLikeQuestion,
+  validateMarker, markerMatch, MARKER_MAX_LENGTH,
   classify, willBeCollected,
 };

--- a/plugins/devops/hooks/lib/batch-state.test.js
+++ b/plugins/devops/hooks/lib/batch-state.test.js
@@ -7,7 +7,7 @@ import {
   appendNote, readNotes, countNotes, clearNotes, archiveNotes,
   touchActivity, readActivity,
   isMachinePrompt, isExpandedCommand, hasAttachment,
-  startsWithMarker, stripMarker, looksLikeQuestion,
+  startsWithMarker, stripMarker, looksLikeQuestion, validateMarker,
   classify, willBeCollected, notesPath, modePath,
 } from "./batch-state.js";
 
@@ -120,6 +120,55 @@ describe("marker handling", () => {
   test("multi-character phrase works as a marker", () => {
     expect(startsWithMarker("los: bau das", "los:")).toBe(true);
     expect(stripMarker("los: bau das", "los:")).toBe("bau das");
+  });
+});
+
+describe("custom markers typed via the 'Sonstiges' option", () => {
+  // The user answered the marker question with their own phrase. Anything that
+  // silently fails to match here collects a prompt the user meant to execute.
+  test("a free-text phrase is a valid marker", () => {
+    const v = validateMarker("Let's go");
+    expect(v.ok).toBe(true);
+    expect(v.marker).toBe("Let's go");
+    expect(startsWithMarker("Let's go bau das um", "Let's go")).toBe(true);
+    expect(stripMarker("Let's go bau das um", "Let's go")).toBe("bau das um");
+    expect(classify({ text: "Let's go bau das um", marker: "Let's go", modeActive: true }))
+      .toBe("execute");
+  });
+
+  test("a retyped phrase matches regardless of case and inner spacing", () => {
+    expect(startsWithMarker("let's go weiter", "Let's go")).toBe(true);
+    expect(startsWithMarker("LET'S GO weiter", "Let's go")).toBe(true);
+    expect(startsWithMarker("Let's   go weiter", "Let's go")).toBe(true);
+    expect(stripMarker("let's go weiter", "Let's go")).toBe("weiter");
+  });
+
+  test("a word marker needs a word boundary", () => {
+    expect(startsWithMarker("google das mal", "go")).toBe(false);
+    expect(startsWithMarker("go bau das", "go")).toBe(true);
+    expect(classify({ text: "google das mal", marker: "go", modeActive: true }))
+      .toBe("collect");
+  });
+
+  test("regex metacharacters in a phrase are literal", () => {
+    expect(startsWithMarker("mach.es jetzt", "mach.es")).toBe(true);
+    expect(startsWithMarker("machxes jetzt", "mach.es")).toBe(false);
+  });
+
+  test("normalisation trims and collapses whitespace", () => {
+    expect(validateMarker("  jetzt   los  ")).toMatchObject({ ok: true, marker: "jetzt los" });
+  });
+
+  test("only genuinely unusable input is rejected", () => {
+    expect(validateMarker("   ")).toMatchObject({ ok: false, reason: "empty" });
+    expect(validateMarker(undefined)).toMatchObject({ ok: false, reason: "empty" });
+    expect(validateMarker("x".repeat(33))).toMatchObject({ ok: false, reason: "too-long" });
+  });
+
+  test("a letters-only marker is accepted but flagged as collision-prone", () => {
+    expect(validateMarker("Let's go").warning).toBe(null);
+    expect(validateMarker("jetzt").warning).toBe("wordy");
+    expect(validateMarker("!").warning).toBe(null);
   });
 });
 

--- a/plugins/devops/hooks/user-prompt-submit/prompt.batch.collect.js
+++ b/plugins/devops/hooks/user-prompt-submit/prompt.batch.collect.js
@@ -36,12 +36,21 @@ const INLINE_LIMIT = 8000;
 
 /**
  * Acknowledgement shown to the user on a blocked (collected) prompt.
+ *
+ * The harness renders every UserPromptSubmit block as a red "a hook blocked
+ * your input" panel — that framing is not ours to change, and blocking IS the
+ * mechanism the mode runs on. So the first line has to carry the all-clear:
+ * the note landed, nothing failed.
+ *
  * @param {number} count total notes after this one
  * @param {string} marker configured execute marker
  * @param {boolean} question whether the note reads like a question
  */
 function buildAck(count, marker, question) {
-  const lines = [`[claude-batch] ✓ #${count} gesammelt — nicht ausgeführt.`];
+  const lines = [
+    `[claude-batch] ✓ Notiz #${count} gespeichert — alles korrekt, kein Fehler.`,
+    'Der Sammelmodus stoppt den Prompt absichtlich, statt ihn zu bearbeiten.',
+  ];
   if (question) {
     // Advisory only. The hook never decides what is a question; it just makes a
     // forgotten marker visible instead of silent.

--- a/plugins/devops/hooks/user-prompt-submit/prompt.batch.collect.test.js
+++ b/plugins/devops/hooks/user-prompt-submit/prompt.batch.collect.test.js
@@ -53,14 +53,14 @@ describe("mode on — collecting", () => {
   test("an ordinary prompt is blocked and stored", () => {
     const r = runHook({ prompt: "Der Button im Header ist verrutscht" });
     expect(r.code).toBe(2);
-    expect(r.stderr).toContain("#1 gesammelt");
+    expect(r.stderr).toContain("Notiz #1 gespeichert");
     expect(readNotes(cwd).map(n => n.text)).toEqual(["Der Button im Header ist verrutscht"]);
   });
 
   test("the counter advances across prompts", () => {
     runHook({ prompt: "erste" });
     const r = runHook({ prompt: "zweite" });
-    expect(r.stderr).toContain("#2 gesammelt");
+    expect(r.stderr).toContain("Notiz #2 gespeichert");
     expect(readNotes(cwd)).toHaveLength(2);
   });
 
@@ -181,10 +181,16 @@ describe("failsafe — collection cannot trap the user", () => {
 describe("message builders", () => {
   test("the acknowledgement names the count and both exits", () => {
     const ack = buildAck(3, "!", false);
-    expect(ack).toContain("#3 gesammelt");
+    expect(ack).toContain("Notiz #3 gespeichert");
     expect(ack).toContain('"! <text>"');
     expect(ack).toContain("/claude-batch off");
     expect(ack).not.toContain("Frage");
+  });
+
+  test("the acknowledgement defuses the harness's red block panel", () => {
+    // The user reads a red "a hook blocked your input" box. The first line has
+    // to say the note landed, or a correct collection reads as a failure.
+    expect(buildAck(3, "!", false).split("\n")[0]).toContain("kein Fehler");
   });
 
   test("the question hint appears only for question-shaped notes", () => {

--- a/plugins/devops/skills/claude-batch/SKILL.md
+++ b/plugins/devops/skills/claude-batch/SKILL.md
@@ -40,6 +40,17 @@ missing or has no `marker`, ask ONCE via `AskUserQuestion`:
 > 2. `los:` am Zeilenanfang — ausgeschrieben, praktisch nie versehentlich getippt
 > 3. `>>` am Zeilenanfang — kurz und visuell eindeutig
 
+**The three options are suggestions, not a closed set.** A free-text answer via
+"Sonstiges" IS the answer — it is what the user wants their marker to be, and it
+outranks every offered option. Never read it as "the question wasn't answered"
+and never fall back to the recommendation instead. `validateMarker(raw)` from
+`batch-state.js` normalises it; only `ok: false` goes back to the user, quoting
+the reason (`empty`, `too-long` = over 32 characters). A `warning: 'wordy'`
+marker (letters only, e.g. `Let's go`) is **accepted** — say once, in a single
+clause, that a collected prompt starting with those words would fire the merge,
+then move on. Matching is case-insensitive and requires a word boundary, so
+retyping it in lower case still works.
+
 Persist the choice via `saveConfig({ marker })` from `hooks/lib/batch-state.js`.
 Never ask again — a later change is a manual edit of that file, or
 `/claude-batch marker`.
@@ -141,6 +152,11 @@ The dependency is soft. Resolve the plugin path and skip silently if absent —
 
 - **Never collect** machine prompts, expanded slash commands, or prompts with
   attachments. The hook enforces this; do not add exceptions in the skill.
+- **The red "Ein Hook hat deine Eingabe blockiert" panel is the normal collect
+  path, not a failure.** Blocking the prompt is how the mode saves the turn; the
+  harness has no quieter rendering for it. If the user reports it as an error,
+  confirm the note actually landed (Step 3) and explain the mechanism — do not
+  start debugging the hook.
 - **Never resolve a contradiction silently.** Name it, then decide.
 - **Never delete notes.** Archive them.
 - **A question in the queue is a defect, not content.** If a note is clearly a

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.132.3",
+  "version": "0.132.4",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

`/claude-batch` asks once what should fire the merge and offers three markers. A user typed their own phrase into the free-text field ("Sonstiges") and it was dismissed as "that doesn't answer the question" — the recommended `!` was applied instead. The options were always suggestions; typing something else is the user saying the list was incomplete.

## Changes

- **Skill Step 2.1** — a free-text answer IS the answer and outranks every offered option. Only `validateMarker`'s `empty` / `too-long` go back to the user; a letters-only phrase is accepted with a one-clause note about collisions.
- **`deep-knowledge/decision-format.md`** — the same rule cross-cutting for every skill using AskUserQuestion. Nothing about it was specific to this skill.
- **Marker matching** (`batch-state.js`) — case-insensitive and tolerant of extra inner whitespace, because a phrase is retyped by hand every time. A marker saved as `Let's go` and retyped as `let's go` would otherwise fail to fire, and failing to fire is invisible here: it silently collects the prompt that was meant to start the work. Markers ending in a word character now require a word boundary, so `go` does not fire on "google das mal". `saveConfig` normalises what it persists.
- **Collect acknowledgement** — the first line leads with the all-clear. The harness renders every blocked prompt as a red "a hook blocked your input" panel (the only rendering available, not ours to change), which made a correct collection read as a crash.

## Tests

9 new marker tests (free-text phrase, case/whitespace retyping, word boundary, regex metacharacters, normalisation, rejection reasons) plus an ack assertion. Full suite: 1793 passed, lint clean.

Codex review gate returned rc=1 (`You've hit your usage limit`) — no review performed; proceeded per the skill's non-zero policy.
