### PR TITLE
fix(batch): reject reserved marker prefixes, end collection on fire

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.132.4"
+    "version": "0.132.5"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.132.4",
+      "version": "0.132.5",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.132.4",
+      "version": "0.132.5",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
   `/claude-batch marker` was documented in the skill's prose as the way to change a stored marker but was missing from the routing table, so the argument did nothing. It is now routed.
 
+- **Firing the merge now ends collection instead of collecting the conversation about it.** The mode stayed armed after the merge had been triggered, so the prompts that follow — approving the plan, answering Claude's questions, correcting course — were blocked, erased and appended to a note queue that had already been archived. The user was answering questions nobody received. Collection is single-shot per activation: the hook deactivates the mode in the same run that injects the notes, the watchdog retires with it, and re-arming is an explicit `/claude-batch on`. A marker prompt on an *empty* queue fires nothing and therefore leaves the mode armed. The skill's Step 4.7 no longer asks whether to stay in the mode — that question was asking whether to keep blocking the answers to its own questions.
+
 ### Changed
 
 - **The test suite no longer fails on machine load.** Hook tests spawn real node processes — that is the contract under test, since the harness invokes hooks as child processes — and on Windows a single spawn costs 1–20 s once 70+ test files compete. Against vitest's 5 s default that produced up to 9 red tests per run, all of them timeouts rather than assertions, in whichever suites happened to lose the scheduling lottery; individual files had begun pinning `30_000` by hand. The default is now 60 s repo-wide, which turns the same suite from 1799/1808 into 1808/1808 without touching a single test's logic.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.132.5] — 2026-08-17
+
+### Fixed
+
+- **The execute marker can no longer be a character the harness swallows.** `/claude-batch` shipped `!` as its recommended marker, and `!` at the start of an input line is the harness's bash mode: the line runs as a shell command and never arrives as a prompt, so the collect hook never sees it. The consequence was the worst shape a mode like this has — collection kept blocking and storing every prompt while the single documented escape did nothing, silently, until the failsafe expiry hours later. `/`, `#` and `@` fail identically (slash command, memory capture, file mention), so all four are now rejected as the first character of a marker (`reason: 'harness-reserved'`) instead of being offered, and the shipped default is `>>`.
+
+  Rejecting them at write time is not enough: a config written before this rule carries `!`. `loadConfig` therefore re-validates the stored marker on every read and falls back to the default when it cannot work, reporting the substitution as `markerFallback` so the skill tells the user instead of quietly behaving differently than the config file says. The same applies one level down — the mode file pins the marker collection started with, and `effectiveMarker(cwd)` now sanitises that pin rather than trusting it. This is the one hard exception to the rule added in 0.132.4 that a free-text answer outranks every offered option: `deep-knowledge/decision-format.md` already carves out values that are technically impossible for the mechanism behind them, and this is precisely such a value.
+
+  `/claude-batch marker` was documented in the skill's prose as the way to change a stored marker but was missing from the routing table, so the argument did nothing. It is now routed.
+
+### Changed
+
+- **The test suite no longer fails on machine load.** Hook tests spawn real node processes — that is the contract under test, since the harness invokes hooks as child processes — and on Windows a single spawn costs 1–20 s once 70+ test files compete. Against vitest's 5 s default that produced up to 9 red tests per run, all of them timeouts rather than assertions, in whichever suites happened to lose the scheduling lottery; individual files had begun pinning `30_000` by hand. The default is now 60 s repo-wide, which turns the same suite from 1799/1808 into 1808/1808 without touching a single test's logic.
+
 ## [0.132.4] — 2026-08-17
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.132.4**
+**Version: 0.132.5**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/docs/superpowers/specs/2026-08-16-claude-batch-design.md
+++ b/docs/superpowers/specs/2026-08-16-claude-batch-design.md
@@ -102,6 +102,14 @@ After approval: `/concept` when the conflicts justify a decision page, otherwise
 straight to implementation. Implementation is deliberately broad — code,
 concepting, UI concepting, or only a first step.
 
+**Firing deactivates the mode**, in the same hook run that injects the notes.
+Everything after the fired prompt is the conversation *about* the implementation —
+plan approval, answers to Claude's questions, course corrections — and collecting
+those blocks and erases the very prompts the work depends on, with the note queue
+already archived. The mode is single-shot per activation: re-arming is an explicit
+`/claude-batch on`. A marker prompt on an **empty** queue fires nothing and
+therefore leaves the mode armed.
+
 ### Reminder
 
 A detached watchdog (`scripts/batch-watchdog.js`) fires a Windows toast after 10

--- a/docs/superpowers/specs/2026-08-16-claude-batch-design.md
+++ b/docs/superpowers/specs/2026-08-16-claude-batch-design.md
@@ -36,8 +36,18 @@ consumes GitHub issues as its input. What is missing is lightweight capture
 
 Opt-in per session. `/claude-batch on` writes a mode file; `/claude-batch off`
 removes it. On very first use the skill asks once for the **execute marker** and
-stores it user-globally in `~/.claude/claude-batch.json`. Default proposal: `!`
+stores it user-globally in `~/.claude/claude-batch.json`. Default proposal: `>>`
 at the start of the line.
+
+**A marker may not start with `!`, `/`, `#` or `@`.** The harness claims those
+before a prompt exists — `!` switches the input line to bash mode and runs it as
+a shell command, `/` expands a slash command, `#` appends to CLAUDE.md, `@`
+expands a file mention. None of them arrive at UserPromptSubmit as a prompt, so a
+marker built on one is dead on arrival: collection keeps blocking every prompt
+while the single documented escape does nothing. `validateMarker` therefore
+rejects them (`reason: 'harness-reserved'`) instead of warning, and `loadConfig`
+re-validates on every read so a config written before this rule (`!`) falls back
+to the default rather than trapping the user.
 
 ### Collection
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.132.4",
+  "version": "0.132.5",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/hooks/lib/batch-state.js
+++ b/plugins/devops/hooks/lib/batch-state.js
@@ -20,8 +20,25 @@ const fs   = require('fs');
 const os   = require('os');
 const path = require('path');
 
+/**
+ * First characters the harness claims before a prompt exists.
+ *
+ * A prompt starting with one of these never arrives at UserPromptSubmit as a
+ * prompt at all, so a marker built on them can never fire the merge:
+ *   `!` → bash mode, the line runs as a shell command
+ *   `/` → slash command, expanded into a different payload
+ *   `#` → memory capture, appended to CLAUDE.md
+ *   `@` → file mention, expanded into file content (also an ATTACHMENT_PATTERN)
+ *
+ * The failure is silent and total: collection keeps swallowing prompts while the
+ * one escape the user was told about does nothing. Hence a hard reject, not a
+ * warning.
+ */
+const HARNESS_RESERVED_PREFIXES = ['!', '/', '#', '@'];
+
 const DEFAULTS = {
-  marker: '!',
+  // `>>` and not `!`: see HARNESS_RESERVED_PREFIXES.
+  marker: '>>',
   inactivityMinutes: 10,
   // Failsafe bounds — either one deactivates collection on its own, so a bug in
   // marker comparison can never lock the user out of their own session.
@@ -83,14 +100,36 @@ function lockPath(cwd)     { return path.join(claudeDir(cwd), 'batch-watchdog.lo
 
 // ── config ─────────────────────────────────────────────────────────────────
 
-/** @returns {{marker:string,inactivityMinutes:number,expiryHours:number,maxNotes:number}} */
+/**
+ * Config with an ALWAYS-USABLE marker.
+ *
+ * A stored marker is re-validated on every read, not just on write: configs
+ * written before the reserved-prefix rule existed carry `!`, and honouring one
+ * would leave collection running with no way to fire the merge. When that
+ * happens the default takes over and `markerFallback` records it, so the skill
+ * can tell the user instead of the mode silently behaving differently than the
+ * config file says.
+ *
+ * @returns {{marker:string,inactivityMinutes:number,expiryHours:number,maxNotes:number,markerFallback?:{was:string,reason:string}}}
+ */
 function loadConfig() {
+  let raw = {};
   try {
-    const raw = JSON.parse(fs.readFileSync(configPath(), 'utf8'));
-    return { ...DEFAULTS, ...(raw && typeof raw === 'object' ? raw : {}) };
-  } catch {
-    return { ...DEFAULTS };
+    const parsed = JSON.parse(fs.readFileSync(configPath(), 'utf8'));
+    if (parsed && typeof parsed === 'object') raw = parsed;
+  } catch { /* missing or corrupt — defaults below */ }
+  const cfg = { ...DEFAULTS, ...raw };
+  delete cfg.markerFallback;
+  const v = validateMarker(cfg.marker);
+  if (!v.ok) {
+    return {
+      ...cfg,
+      marker: DEFAULTS.marker,
+      markerFallback: { was: String(cfg.marker ?? ''), reason: v.reason },
+    };
   }
+  cfg.marker = v.marker;
+  return cfg;
 }
 
 function saveConfig(cfg) {
@@ -101,6 +140,8 @@ function saveConfig(cfg) {
     incoming.marker = v.marker;
   }
   const merged = { ...loadConfig(), ...incoming };
+  // Derived state, never persisted — it would outlive the condition it reports.
+  delete merged.markerFallback;
   const dir = path.dirname(configPath());
   fs.mkdirSync(dir, { recursive: true });
   fs.writeFileSync(configPath(), JSON.stringify(merged, null, 2) + '\n', 'utf8');
@@ -149,6 +190,7 @@ function expiryReason(cwd, now) {
 
 function activate(cwd, opts = {}) {
   const cfg = loadConfig();
+  const asked = validateMarker(opts.marker);
   const startedAt = opts.startedAt ? new Date(opts.startedAt) : new Date();
   const hours = opts.expiryHours ?? cfg.expiryHours;
   const mode = {
@@ -156,7 +198,9 @@ function activate(cwd, opts = {}) {
     startedAt: startedAt.toISOString(),
     expiresAt: new Date(startedAt.getTime() + hours * 3600_000).toISOString(),
     maxNotes: opts.maxNotes ?? cfg.maxNotes,
-    marker: opts.marker ?? cfg.marker,
+    // Pinned so a later config edit cannot change the marker mid-collection —
+    // but never an unusable one, or the mode starts with no way out.
+    marker: asked.ok ? asked.marker : cfg.marker,
   };
   fs.mkdirSync(claudeDir(cwd), { recursive: true });
   fs.writeFileSync(modePath(cwd), JSON.stringify(mode, null, 2) + '\n', 'utf8');
@@ -272,13 +316,20 @@ const MARKER_MAX_LENGTH = 32;
  * file. Only genuinely unusable input is rejected, and always with a reason
  * the skill can quote back.
  *
- * @returns {{ok:true,marker:string,warning:?'wordy'}|{ok:false,reason:'empty'|'too-long'}}
+ * The one hard exception to "the user's own answer wins": a marker the harness
+ * intercepts before the hook runs (see HARNESS_RESERVED_PREFIXES) cannot work at
+ * all, so it is rejected rather than accepted with a warning.
+ *
+ * @returns {{ok:true,marker:string,warning:?'wordy'}|{ok:false,reason:'empty'|'too-long'|'harness-reserved'}}
  */
 function validateMarker(raw) {
   if (typeof raw !== 'string') return { ok: false, reason: 'empty' };
   const marker = raw.trim().replace(/\s+/g, ' ');
   if (!marker) return { ok: false, reason: 'empty' };
   if (marker.length > MARKER_MAX_LENGTH) return { ok: false, reason: 'too-long' };
+  if (HARNESS_RESERVED_PREFIXES.includes(marker[0])) {
+    return { ok: false, reason: 'harness-reserved' };
+  }
   // A letters-only phrase can also be the honest start of a collected prompt.
   // Word-boundary matching keeps that rare, but the user should hear it once.
   const wordy = /^[\p{L}\p{N} ]+$/u.test(marker) ? 'wordy' : null;
@@ -313,6 +364,22 @@ function stripMarker(text, marker) {
   const s = String(text ?? '');
   const m = markerMatch(s, marker);
   return m ? s.slice(m[0].length).trimStart() : s;
+}
+
+/**
+ * The marker actually in force for this project.
+ *
+ * The mode file wins over the config (it pins the marker the mode was started
+ * with), but only if it is still usable: a mode file written before the
+ * reserved-prefix rule carries `!`, and returning it would mean no prompt can
+ * ever fire the merge.
+ *
+ * @param {string} cwd
+ * @returns {string}
+ */
+function effectiveMarker(cwd) {
+  const pinned = validateMarker(readMode(cwd)?.marker);
+  return pinned.ok ? pinned.marker : loadConfig().marker;
 }
 
 /**
@@ -361,8 +428,7 @@ function willBeCollected(hookInput) {
     const cwd = hookInput.cwd || process.cwd();
     if (!isModeActive(cwd)) return false;
     const text = hookInput.prompt || hookInput.user_message || hookInput.message || '';
-    const marker = readMode(cwd)?.marker || loadConfig().marker;
-    return classify({ text, hookInput, marker, modeActive: true }) === 'collect';
+    return classify({ text, hookInput, marker: effectiveMarker(cwd), modeActive: true }) === 'collect';
   } catch {
     return false;
   }
@@ -370,6 +436,7 @@ function willBeCollected(hookInput) {
 
 module.exports = {
   DEFAULTS,
+  HARNESS_RESERVED_PREFIXES,
   MACHINE_PATTERNS,
   ATTACHMENT_PATTERNS,
   configPath, claudeDir, notesPath, modePath, activityPath, lockPath,
@@ -379,6 +446,6 @@ module.exports = {
   touchActivity, readActivity,
   isMachinePrompt, isExpandedCommand, hasAttachment,
   startsWithMarker, stripMarker, looksLikeQuestion,
-  validateMarker, markerMatch, MARKER_MAX_LENGTH,
+  validateMarker, markerMatch, effectiveMarker, MARKER_MAX_LENGTH,
   classify, willBeCollected,
 };

--- a/plugins/devops/hooks/lib/batch-state.test.js
+++ b/plugins/devops/hooks/lib/batch-state.test.js
@@ -9,6 +9,8 @@ import {
   isMachinePrompt, isExpandedCommand, hasAttachment,
   startsWithMarker, stripMarker, looksLikeQuestion, validateMarker,
   classify, willBeCollected, notesPath, modePath,
+  loadConfig, saveConfig, configPath, effectiveMarker,
+  DEFAULTS, HARNESS_RESERVED_PREFIXES,
 } from "./batch-state.js";
 
 let cwd;
@@ -60,12 +62,12 @@ describe("escape hatch survives slash-command expansion", () => {
   test("expanded command is detected and passed through", () => {
     const expanded = "<command-message>claude-batch</command-message>\n<command-name>/claude-batch</command-name>\n<command-args>off</command-args>";
     expect(isExpandedCommand(expanded)).toBe(true);
-    expect(classify({ text: expanded, marker: "!", modeActive: true })).toBe("passthrough");
+    expect(classify({ text: expanded, marker: ">>", modeActive: true })).toBe("passthrough");
   });
 
   test("plain text mentioning a slash command is still collected", () => {
     expect(isExpandedCommand("wir sollten /ship mal aufräumen")).toBe(false);
-    expect(classify({ text: "wir sollten /ship mal aufräumen", marker: "!", modeActive: true }))
+    expect(classify({ text: "wir sollten /ship mal aufräumen", marker: ">>", modeActive: true }))
       .toBe("collect");
   });
 });
@@ -91,30 +93,30 @@ describe("attachments pass through", () => {
   });
 
   test("classify routes attachments to passthrough even in collect mode", () => {
-    expect(classify({ text: "so wie hier [Image #2]", marker: "!", modeActive: true }))
+    expect(classify({ text: "so wie hier [Image #2]", marker: ">>", modeActive: true }))
       .toBe("passthrough");
   });
 });
 
 describe("marker handling", () => {
   test("marker at line start fires execute", () => {
-    expect(startsWithMarker("! leg los", "!")).toBe(true);
-    expect(classify({ text: "! leg los", marker: "!", modeActive: true })).toBe("execute");
+    expect(startsWithMarker(">> leg los", ">>")).toBe(true);
+    expect(classify({ text: ">> leg los", marker: ">>", modeActive: true })).toBe("execute");
   });
 
   test("leading whitespace does not defeat the marker", () => {
-    expect(startsWithMarker("   ! leg los", "!")).toBe(true);
+    expect(startsWithMarker("   >> leg los", ">>")).toBe(true);
   });
 
   test("marker elsewhere in the text does not fire", () => {
-    expect(startsWithMarker("das ist wichtig! jetzt", "!")).toBe(false);
-    expect(classify({ text: "das ist wichtig! jetzt", marker: "!", modeActive: true }))
+    expect(startsWithMarker("das ist wichtig >> jetzt", ">>")).toBe(false);
+    expect(classify({ text: "das ist wichtig >> jetzt", marker: ">>", modeActive: true }))
       .toBe("collect");
   });
 
   test("stripMarker removes the marker and surrounding space", () => {
-    expect(stripMarker("!  leg los mit allem", "!")).toBe("leg los mit allem");
-    expect(stripMarker("kein marker", "!")).toBe("kein marker");
+    expect(stripMarker(">>  leg los mit allem", ">>")).toBe("leg los mit allem");
+    expect(stripMarker("kein marker", ">>")).toBe("kein marker");
   });
 
   test("multi-character phrase works as a marker", () => {
@@ -168,14 +170,109 @@ describe("custom markers typed via the 'Sonstiges' option", () => {
   test("a letters-only marker is accepted but flagged as collision-prone", () => {
     expect(validateMarker("Let's go").warning).toBe(null);
     expect(validateMarker("jetzt").warning).toBe("wordy");
-    expect(validateMarker("!").warning).toBe(null);
+    expect(validateMarker(">>").warning).toBe(null);
+  });
+});
+
+describe("harness-reserved prefixes cannot be markers", () => {
+  // `!` opens bash mode, `/` expands a slash command, `#` writes to CLAUDE.md,
+  // `@` expands a file mention. None of them reach UserPromptSubmit as a prompt,
+  // so such a marker can never fire the merge while collection keeps blocking
+  // every other prompt — a silent, total lock-out.
+  test.each(HARNESS_RESERVED_PREFIXES)("%s is rejected as the first character", (ch) => {
+    expect(validateMarker(ch)).toMatchObject({ ok: false, reason: "harness-reserved" });
+    expect(validateMarker(`${ch}go`)).toMatchObject({ ok: false, reason: "harness-reserved" });
+  });
+
+  test("the same characters are fine anywhere but the start", () => {
+    expect(validateMarker("los!")).toMatchObject({ ok: true, marker: "los!" });
+    expect(validateMarker(">>!")).toMatchObject({ ok: true, marker: ">>!" });
+  });
+
+  test("the shipped default is not reserved", () => {
+    expect(validateMarker(DEFAULTS.marker).ok).toBe(true);
+    expect(HARNESS_RESERVED_PREFIXES).not.toContain(DEFAULTS.marker[0]);
+  });
+
+  test("saveConfig refuses one", () => {
+    expect(() => saveConfig({ marker: "!" })).toThrow(/harness-reserved/);
+  });
+
+  test("a reserved marker never matches, so it cannot masquerade as working", () => {
+    expect(startsWithMarker("! leg los", "!")).toBe(false);
+    expect(classify({ text: "! leg los", marker: "!", modeActive: true })).toBe("collect");
+  });
+});
+
+describe("stored config with an unusable marker falls back instead of trapping", () => {
+  // Configs written before the reserved-prefix rule carry `!`. Honouring one
+  // would leave collect mode running with no way to fire the merge.
+  let home, prevHome, prevProfile;
+
+  beforeEach(() => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), "batch-home-"));
+    prevHome = process.env.HOME;
+    prevProfile = process.env.USERPROFILE;
+    process.env.HOME = home;
+    process.env.USERPROFILE = home;
+    fs.mkdirSync(path.join(home, ".claude"), { recursive: true });
+  });
+
+  afterEach(() => {
+    if (prevHome === undefined) delete process.env.HOME; else process.env.HOME = prevHome;
+    if (prevProfile === undefined) delete process.env.USERPROFILE; else process.env.USERPROFILE = prevProfile;
+    try { fs.rmSync(home, { recursive: true, force: true }); } catch { /* best effort */ }
+  });
+
+  function writeConfig(obj) {
+    fs.writeFileSync(configPath(), JSON.stringify(obj), "utf8");
+  }
+
+  test("the temp home is actually in use", () => {
+    expect(configPath().startsWith(home)).toBe(true);
+  });
+
+  test("a legacy `!` config yields the default marker plus a fallback report", () => {
+    writeConfig({ marker: "!" });
+    const cfg = loadConfig();
+    expect(cfg.marker).toBe(DEFAULTS.marker);
+    expect(cfg.markerFallback).toEqual({ was: "!", reason: "harness-reserved" });
+  });
+
+  test("a usable stored marker is honoured with no fallback", () => {
+    writeConfig({ marker: "los:" });
+    const cfg = loadConfig();
+    expect(cfg.marker).toBe("los:");
+    expect(cfg.markerFallback).toBeUndefined();
+  });
+
+  test("the fallback flag is never persisted back into the config file", () => {
+    writeConfig({ marker: "!" });
+    saveConfig({ inactivityMinutes: 5 });
+    expect(JSON.parse(fs.readFileSync(configPath(), "utf8")).markerFallback).toBeUndefined();
+  });
+
+  test("a mode file pinned to `!` still fires on the fallback marker", () => {
+    writeConfig({ marker: "los:" });
+    activate(cwd);
+    // Simulate a mode file written before the rule existed.
+    const mode = { ...readMode(cwd), marker: "!" };
+    fs.writeFileSync(modePath(cwd), JSON.stringify(mode), "utf8");
+    expect(effectiveMarker(cwd)).toBe("los:");
+    expect(willBeCollected({ cwd, prompt: "los: leg los" })).toBe(false);
+  });
+
+  test("effectiveMarker prefers the pinned mode marker while it is usable", () => {
+    writeConfig({ marker: "los:" });
+    activate(cwd, { marker: ">>" });
+    expect(effectiveMarker(cwd)).toBe(">>");
   });
 });
 
 describe("classification is inert when the mode is off", () => {
   test("everything passes through", () => {
-    expect(classify({ text: "irgendwas", marker: "!", modeActive: false })).toBe("passthrough");
-    expect(classify({ text: "! irgendwas", marker: "!", modeActive: false })).toBe("passthrough");
+    expect(classify({ text: "irgendwas", marker: ">>", modeActive: false })).toBe("passthrough");
+    expect(classify({ text: ">> irgendwas", marker: ">>", modeActive: false })).toBe("passthrough");
   });
 });
 
@@ -328,10 +425,13 @@ describe("willBeCollected — the guard sibling hooks use", () => {
   });
 
   test("false for machine prompts, marker prompts and attachments", () => {
-    activate(cwd);
+    // Marker pinned: activate() would otherwise inherit the developer's own
+    // ~/.claude/claude-batch.json and the marker assertion below would depend
+    // on it.
+    activate(cwd, { marker: ">>" });
     expect(willBeCollected({ cwd, prompt: "Silently run via Bash: node x.js" })).toBe(false);
     expect(willBeCollected({ cwd, prompt: "AUTONOMOUS_RESUME: weiter" })).toBe(false);
-    expect(willBeCollected({ cwd, prompt: "! leg los" })).toBe(false);
+    expect(willBeCollected({ cwd, prompt: ">> leg los" })).toBe(false);
     expect(willBeCollected({ cwd, prompt: "so wie hier [Image #1]" })).toBe(false);
   });
 
@@ -357,7 +457,7 @@ describe("question hint is advisory only", () => {
   });
 
   test("a question is still collected — the hook never classifies it away", () => {
-    expect(classify({ text: "gibt es das schon?", marker: "!", modeActive: true }))
+    expect(classify({ text: "gibt es das schon?", marker: ">>", modeActive: true }))
       .toBe("collect");
   });
 });

--- a/plugins/devops/hooks/user-prompt-submit/prompt.batch.collect.js
+++ b/plugins/devops/hooks/user-prompt-submit/prompt.batch.collect.js
@@ -20,6 +20,10 @@
  *     - expanded slash commands (<command-name> tag)
  *     - prompts carrying attachments or @file mentions
  *
+ *   The marker can never start with `!`, `/`, `#` or `@`: the harness claims
+ *   those before a prompt exists (bash mode, slash command, memory capture, file
+ *   mention), so this hook would never see the escape at all.
+ *
  *   Failsafe: the mode file carries an expiry and a note cap, so a bug in the
  *   marker comparison can never lock the user out of their own session.
  *
@@ -122,7 +126,7 @@ process.stdin.on('end', () => {
     process.exit(0);
   }
 
-  const marker = B.readMode(cwd)?.marker || B.loadConfig().marker;
+  const marker = B.effectiveMarker(cwd);
   let verdict;
   try {
     verdict = B.classify({ text, hookInput: hook, marker, modeActive: true });

--- a/plugins/devops/hooks/user-prompt-submit/prompt.batch.collect.js
+++ b/plugins/devops/hooks/user-prompt-submit/prompt.batch.collect.js
@@ -89,6 +89,10 @@ function buildMergeContext(notes, rest, notesFile) {
     'Umsetzung ist breit gemeint — Code, Concepting, UI-Concepting, oder auch nur',
     'ein erster Schritt.',
     '',
+    'Der Sammelmodus ist mit diesem Prompt automatisch BEENDET. Folgeprompts sind',
+    'die Unterhaltung über die Umsetzung und laufen wieder normal — frage NICHT,',
+    'ob der Modus aktiv bleiben soll. Nur ein neues /claude-batch on sammelt wieder.',
+    '',
   ];
 
   const body = notes.map((n, i) => `--- Notiz #${i + 1} (${n.at}) ---\n${n.text}`).join('\n\n');
@@ -143,9 +147,14 @@ process.stdin.on('end', () => {
     try {
       B.touchActivity(cwd);
       const notes = B.readNotes(cwd);
-      if (notes.length === 0) process.exit(0); // nothing collected — normal turn
+      if (notes.length === 0) process.exit(0); // nothing collected — mode stays armed
       const rest = B.stripMarker(text, marker);
       process.stdout.write(buildMergeContext(notes, rest, B.notesPath(cwd)) + '\n');
+      // Firing the merge ENDS collection. What follows is the conversation about
+      // the implementation — approvals, answers to Claude's questions, course
+      // corrections — and collecting those is actively wrong: they are blocked,
+      // erased and answered by nobody. Re-arming is an explicit `/claude-batch on`.
+      B.deactivate(cwd);
     } catch { /* non-fatal — the turn still runs */ }
     process.exit(0);
   }

--- a/plugins/devops/hooks/user-prompt-submit/prompt.batch.collect.test.js
+++ b/plugins/devops/hooks/user-prompt-submit/prompt.batch.collect.test.js
@@ -5,7 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { buildAck, buildMergeContext, INLINE_LIMIT } from "./prompt.batch.collect.js";
-import { activate, appendNote, readNotes } from "../lib/batch-state.js";
+import { activate, appendNote, readNotes, isModeActive } from "../lib/batch-state.js";
 
 const HOOK = fileURLToPath(new URL("./prompt.batch.collect.js", import.meta.url));
 
@@ -154,6 +154,26 @@ describe("mode on — firing the merge", () => {
     const r = runHook({ prompt: ">> leg los" });
     expect(r.code).toBe(0);
     expect(r.stdout).toBe("");
+  });
+
+  test("firing the merge ends collection — follow-up prompts run normally", () => {
+    // Everything after the fired prompt is the conversation ABOUT the work:
+    // plan approval, answers to Claude's questions. Collecting those blocks and
+    // erases exactly the prompts the implementation depends on.
+    appendNote(cwd, "Button verrutscht");
+    expect(runHook({ prompt: ">> leg los" }).code).toBe(0);
+    expect(isModeActive(cwd)).toBe(false);
+
+    const followUp = runHook({ prompt: "ja, so umsetzen" });
+    expect(followUp.code).toBe(0);
+    expect(followUp.stderr).not.toContain("gespeichert");
+  });
+
+  test("a marker prompt on an empty queue leaves the mode armed", () => {
+    // Nothing fired, so nothing ended — the user just typed the marker early.
+    expect(runHook({ prompt: ">> leg los" }).code).toBe(0);
+    expect(isModeActive(cwd)).toBe(true);
+    expect(runHook({ prompt: "noch eine beobachtung" }).code).toBe(2);
   });
 
   test("a mode file pinned to the old `!` marker still has a working escape", () => {

--- a/plugins/devops/hooks/user-prompt-submit/prompt.batch.collect.test.js
+++ b/plugins/devops/hooks/user-prompt-submit/prompt.batch.collect.test.js
@@ -16,13 +16,23 @@ let cwd;
  * The temp project carries its own settings.json so plugin-guard passes
  * regardless of the machine's global plugin state.
  */
-function runHook(payload) {
+function runHook(payload, env) {
   const res = spawnSync(process.execPath, [HOOK], {
     input: JSON.stringify({ cwd, ...payload }),
     cwd,
     encoding: "utf8",
+    env: { ...process.env, ...(env || {}) },
   });
   return { code: res.status, stdout: res.stdout || "", stderr: res.stderr || "" };
+}
+
+/** A throwaway home dir holding a known claude-batch.json, so a test never
+ *  depends on the developer's own global marker config. */
+function fakeHome(config) {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "batch-hook-home-"));
+  fs.mkdirSync(path.join(home, ".claude"), { recursive: true });
+  fs.writeFileSync(path.join(home, ".claude", "claude-batch.json"), JSON.stringify(config), "utf8");
+  return { HOME: home, USERPROFILE: home };
 }
 
 beforeEach(() => {
@@ -119,12 +129,14 @@ describe("mode on — what is never collected", () => {
 });
 
 describe("mode on — firing the merge", () => {
-  beforeEach(() => activate(cwd));
+  // Marker pinned into the mode file: without it these tests would inherit the
+  // developer's own ~/.claude/claude-batch.json.
+  beforeEach(() => activate(cwd, { marker: ">>" }));
 
   test("the marker injects every note as context and does not block", () => {
     appendNote(cwd, "Button verrutscht");
     appendNote(cwd, "Fehlertext falsch");
-    const r = runHook({ prompt: "! leg los" });
+    const r = runHook({ prompt: ">> leg los" });
     expect(r.code).toBe(0);
     expect(r.stdout).toContain("Button verrutscht");
     expect(r.stdout).toContain("Fehlertext falsch");
@@ -134,14 +146,30 @@ describe("mode on — firing the merge", () => {
 
   test("the marked prompt itself is not stored as a note", () => {
     appendNote(cwd, "eine notiz");
-    runHook({ prompt: "! jetzt umsetzen" });
+    runHook({ prompt: ">> jetzt umsetzen" });
     expect(readNotes(cwd).map(n => n.text)).toEqual(["eine notiz"]);
   });
 
   test("the marker with an empty queue is just a normal turn", () => {
-    const r = runHook({ prompt: "! leg los" });
+    const r = runHook({ prompt: ">> leg los" });
     expect(r.code).toBe(0);
     expect(r.stdout).toBe("");
+  });
+
+  test("a mode file pinned to the old `!` marker still has a working escape", () => {
+    // `!` never reaches this hook — the harness runs the line as a shell command.
+    // A mode file written before that rule must not be honoured, or the merge
+    // could never be fired again.
+    const mode = JSON.parse(fs.readFileSync(path.join(cwd, ".claude", "batch-mode.json"), "utf8"));
+    fs.writeFileSync(
+      path.join(cwd, ".claude", "batch-mode.json"),
+      JSON.stringify({ ...mode, marker: "!" }),
+      "utf8",
+    );
+    appendNote(cwd, "eine notiz");
+    const r = runHook({ prompt: "los: leg los" }, fakeHome({ marker: "los:" }));
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain("eine notiz");
   });
 });
 
@@ -180,9 +208,9 @@ describe("failsafe — collection cannot trap the user", () => {
 
 describe("message builders", () => {
   test("the acknowledgement names the count and both exits", () => {
-    const ack = buildAck(3, "!", false);
+    const ack = buildAck(3, ">>", false);
     expect(ack).toContain("Notiz #3 gespeichert");
-    expect(ack).toContain('"! <text>"');
+    expect(ack).toContain('">> <text>"');
     expect(ack).toContain("/claude-batch off");
     expect(ack).not.toContain("Frage");
   });
@@ -190,11 +218,11 @@ describe("message builders", () => {
   test("the acknowledgement defuses the harness's red block panel", () => {
     // The user reads a red "a hook blocked your input" box. The first line has
     // to say the note landed, or a correct collection reads as a failure.
-    expect(buildAck(3, "!", false).split("\n")[0]).toContain("kein Fehler");
+    expect(buildAck(3, ">>", false).split("\n")[0]).toContain("kein Fehler");
   });
 
   test("the question hint appears only for question-shaped notes", () => {
-    expect(buildAck(1, "!", true)).toContain("Frage");
+    expect(buildAck(1, ">>", true)).toContain("Frage");
   });
 
   test("oversized note sets fall back to a file pointer", () => {

--- a/plugins/devops/skills/claude-batch/SKILL.md
+++ b/plugins/devops/skills/claude-batch/SKILL.md
@@ -25,35 +25,49 @@ Silently check (do not surface "not found"):
 | `on`, `an`, `start` | Step 2 (activate) |
 | `off`, `aus`, `stop` | Step 5 (deactivate) |
 | `go`, `los`, `merge` | Step 4 (fire) |
+| `marker` | Step 2.1 (ask again, overwrite the stored marker) |
 | `status`, none | Step 3 (report) |
 
 ## Step 2 — Activate
 
 **2.1 First-run marker setup.** Read `~/.claude/claude-batch.json`. If it is
-missing or has no `marker`, ask ONCE via `AskUserQuestion`:
+missing, has no `marker`, or `loadConfig()` reports a `markerFallback` (a stored
+marker that cannot work — see below), ask via `AskUserQuestion`. Reached via
+`/claude-batch marker`, always ask and then stop — that route only rewrites the
+marker, it does not activate the mode:
 
 > header: "Marker"
 > question: "Womit sagst du mir, dass ein Prompt NICHT gesammelt, sondern
 > bearbeitet werden soll? Alles ohne dieses Zeichen wird ab jetzt gesammelt."
 > Options (fixed order):
-> 1. `!` am Zeilenanfang (empfohlen) — ein Zeichen, kein Shift, kollidiert mit nichts
+> 1. `>>` am Zeilenanfang (empfohlen) — kurz, visuell eindeutig, kollidiert mit nichts
 > 2. `los:` am Zeilenanfang — ausgeschrieben, praktisch nie versehentlich getippt
-> 3. `>>` am Zeilenanfang — kurz und visuell eindeutig
+> 3. `jetzt:` am Zeilenanfang — wie ein Zuruf, mit Doppelpunkt eindeutig
 
-**The three options are suggestions, not a closed set.** A free-text answer via
-"Sonstiges" IS the answer — it is what the user wants their marker to be, and it
-outranks every offered option. Never read it as "the question wasn't answered"
-and never fall back to the recommendation instead. `validateMarker(raw)` from
-`batch-state.js` normalises it; only `ok: false` goes back to the user, quoting
-the reason (`empty`, `too-long` = over 32 characters). A `warning: 'wordy'`
-marker (letters only, e.g. `Let's go`) is **accepted** — say once, in a single
-clause, that a collected prompt starting with those words would fire the merge,
-then move on. Matching is case-insensitive and requires a word boundary, so
-retyping it in lower case still works.
+**`!`, `/`, `#` and `@` cannot be the first character of a marker.** The harness
+claims those before a prompt exists — `!` opens bash mode and runs the line as a
+shell command, `/` expands a slash command, `#` writes to CLAUDE.md, `@` expands
+a file mention. Such a prompt never reaches the collect hook, so the marker would
+be dead: collection keeps swallowing everything and the advertised escape does
+nothing. `validateMarker` rejects them with `reason: 'harness-reserved'`; never
+suggest one, and never write one into the config by hand.
+
+**Otherwise the three options are suggestions, not a closed set.** A free-text
+answer via "Sonstiges" IS the answer — it is what the user wants their marker to
+be, and it outranks every offered option. Never read it as "the question wasn't
+answered" and never fall back to the recommendation instead. `validateMarker(raw)`
+from `batch-state.js` normalises it; only `ok: false` goes back to the user,
+quoting the reason (`empty`, `too-long` = over 32 characters,
+`harness-reserved` = starts with `!`, `/`, `#` or `@` — name the mechanism in one
+clause and ask for a different one). A `warning: 'wordy'` marker (letters only,
+e.g. `Let's go`) is **accepted** — say once, in a single clause, that a collected
+prompt starting with those words would fire the merge, then move on. Matching is
+case-insensitive and requires a word boundary, so retyping it in lower case still
+works.
 
 Persist the choice via `saveConfig({ marker })` from `hooks/lib/batch-state.js`.
-Never ask again — a later change is a manual edit of that file, or
-`/claude-batch marker`.
+Never ask again unless the stored marker is unusable — a later change is
+`/claude-batch marker`, or a manual edit of that file.
 
 **2.2 Activate and start the watchdog:**
 
@@ -79,10 +93,14 @@ exits. Then render an `analysis` completion card.
 Read the mode and notes via `batch-state.js`, plus
 `node "{PLUGIN_ROOT}/scripts/batch-watchdog.js" status .`
 
-Report: active or not, note count, time since the last note, whether the
-watchdog runs, and — when `expiryReason()` is non-null — that collection stopped
-on its own (`expired` / `full`) and why. Do NOT dump every note unless asked;
-name the count and the first few.
+Report: active or not, note count, time since the last note, the marker actually
+in force (`effectiveMarker(cwd)`), and — when `expiryReason()` is non-null — that
+collection stopped on its own (`expired` / `full`) and why. Do NOT dump every
+note unless asked; name the count and the first few.
+
+When `loadConfig()` returns a `markerFallback`, say so: the stored marker is
+unusable, the default is in force instead, and `/claude-batch marker` fixes it
+permanently. Never report the config value as if it were live.
 
 ## Step 4 — Fire the merge
 

--- a/plugins/devops/skills/claude-batch/SKILL.md
+++ b/plugins/devops/skills/claude-batch/SKILL.md
@@ -108,6 +108,12 @@ Reached either by `/claude-batch go` or automatically: the collect hook injects
 the full note set into the turn when the user sends a marker-prefixed prompt.
 In both cases the procedure is identical.
 
+**Firing ends collection.** The hook deactivates the mode in the same run that
+injects the notes, because everything after it — plan approval, answers to your
+questions, course corrections — is the conversation *about* the implementation.
+Collecting those would block and erase exactly the prompts the work depends on.
+Treat the mode as OFF for the rest of this turn and all following ones.
+
 **4.1 Read every note.** `.claude/batch.md`, verbatim. Notes are the user's own
 words — never paraphrase them away before analysing.
 
@@ -139,8 +145,18 @@ a first step of what the notes ask for.
 originals stay recoverable; a merge must never be the only record of what the
 user actually wrote.
 
-**4.7 Ask whether to stay in collect mode.** After a fired merge the mode is
-usually no longer wanted. Ask once, default off.
+**4.7 Retire the mode — never ask whether to stay in it.** Collection is already
+off (the hook deactivated it when the merge fired; on the `/claude-batch go` path
+do it yourself — `deactivate(cwd)` is idempotent). Stop the watchdog so it does
+not linger for its next poll:
+
+```bash
+node "{PLUGIN_ROOT}/scripts/batch-watchdog.js" stop .
+```
+
+Say in one clause that follow-up prompts run normally again and `/claude-batch on`
+re-arms collection. A question here would be asking whether to keep blocking the
+answers to your own questions.
 
 ## Step 5 — Deactivate
 

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.132.4",
+  "version": "0.132.5",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -5,5 +5,14 @@ export default defineConfig({
     globals: true,
     environment: "node",
     include: ["plugins/**/*.test.js"],
+    // Hook tests spawn real node processes (that IS the contract under test —
+    // the harness invokes hooks as child processes). On Windows a single spawn
+    // costs 1-20s once 70+ test files compete for the machine, so vitest's 5s
+    // default fails on machine load rather than on behaviour: whole suites of
+    // passing tests go red with "Test timed out", and the ship's test gate
+    // blocks on noise. Individual files had started pinning 30_000 by hand;
+    // this makes the real budget the default for all of them.
+    testTimeout: 60_000,
+    hookTimeout: 60_000,
   },
 });


### PR DESCRIPTION
## Summary

Two defects in `/claude-batch` collect mode, both reported by the user from live use, both with the same failure shape: the mode keeps swallowing prompts and the user gets no signal that anything is wrong.

1. **`!` cannot be the execute marker — and it was the recommended one.** A line starting with `!` is the harness's bash mode: it runs as a shell command and never arrives as a prompt, so the collect hook never sees it. Collection kept blocking and storing every prompt while the single documented escape did nothing, until the failsafe expiry hours later. `/`, `#` and `@` fail identically (slash command, memory capture, file mention).
2. **Firing the merge left the mode armed.** Everything after the fired prompt is the conversation *about* the implementation — approving the plan, answering Claude's questions, correcting course — and all of it was blocked, erased, and appended to a note queue that had already been archived. The user was answering questions nobody received.

## Changes

**Marker validation**
- `validateMarker` rejects `!`, `/`, `#`, `@` as the first character (`reason: 'harness-reserved'`) instead of accepting them with a warning. This is the one hard exception to #300's rule that a free-text answer outranks every offered option — `deep-knowledge/decision-format.md` already carves out values that are technically impossible for the mechanism behind them, and this is exactly such a value. Every other free-text answer still wins unchanged.
- Default marker is now `>>`; the offered options are `>>`, `los:`, `jetzt:`.
- `loadConfig` re-validates on every read. A config written before this rule carries `!`; honouring it would leave collect mode running with no way to fire the merge. It falls back to the default and reports the substitution as `markerFallback`, which the skill surfaces instead of quietly behaving differently than the config file says.
- New `effectiveMarker(cwd)` sanitises the marker pinned in the mode file (same legacy-`!` problem one level down); used by the hook and by `willBeCollected`.
- `/claude-batch marker` was documented in the skill prose but missing from the routing table, so the argument did nothing. Routed.

**Single-shot collection**
- The hook deactivates the mode in the same run that injects the notes; the watchdog retires with it (`decide` already returns `stop` on an inactive mode). Re-arming is an explicit `/claude-batch on`.
- A marker prompt on an **empty** queue fires nothing and therefore leaves the mode armed.
- The injected merge context states the mode is over, and Step 4.7 no longer asks whether to stay in it — that question was asking whether to keep blocking the answers to its own questions.

**Test infrastructure**
- vitest `testTimeout`/`hookTimeout` → 60 s (`vitest.config.mjs`). Hook tests spawn real node processes — that is the contract under test — and on Windows one spawn costs 1–20 s once 70+ files compete. The 5 s default produced up to 9 red tests per run, all timeouts rather than assertions, in whichever suites lost the scheduling lottery; individual files had already begun pinning `30_000` by hand. Not a test-logic change: the same suite goes from 1799/1808 to green.

## Tests

New coverage: all four reserved prefixes rejected (bare and as prefix), the same characters still legal anywhere but the start, `saveConfig` refusing one, a reserved marker never matching so it cannot masquerade as working, the shipped default not being reserved, a legacy `!` config yielding default + `markerFallback`, the flag never persisting back into the file, `effectiveMarker` preferring a usable pin, a legacy `!` **mode file** still having a working escape through the real hook, firing ending collection with a follow-up prompt running normally, and an empty queue leaving the mode armed. The hook suite no longer depends on the developer's own `~/.claude/claude-batch.json` (pinned marker + throwaway `HOME`).

Full suite: **1810 passed (72 files)**, lint clean.

Codex review gate: rc=1 — `ERROR: You've hit your usage limit`. No review performed; proceeded per the skill's non-zero policy.
