### PR TITLE
fix(git-sync): stop visible terminal windows from detached sync

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.133.1"
+    "version": "0.133.2"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.133.1",
+      "version": "0.133.2",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.133.1",
+      "version": "0.133.2",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.133.2] — 2026-08-18
+
+### Fixed
+
+- **The detached background git sync no longer opens a visible terminal window for every git command it runs.** v0.129.0 moved the sync out of the ten-minute cron into a detached, console-less child process — correct in itself, but the script it detached ran each of its ~13 git commands through `execSync`, i.e. a `cmd.exe` shell string. From a parent that owns no console, every one of those `cmd.exe` launches gets a fresh console, and on Windows 11 with Windows Terminal as the default terminal each fresh console is rendered as a visible, focus-stealing window. Measured on the affected machine: one sync run produced 20 WindowsTerminal/OpenConsole processes. With the sync triggering on every SessionStart and every 30 minutes per worktree across several active worktrees, this was the reported storm of "thousands of terminal windows" — and it pattern-matched to graphify only because graphify had the identical bug before 0.116.2 fixed it there.
+
+  `git()` now spawns `git` directly in argv form (`execFileSync`, no shell layer) with `windowsHide`, the exact mechanism `graphify-state.js` documents and measures for its own background runner. Re-measured end-to-end: a full detached sync run spawns zero visible windows and still fetches and merges. The conversion also retires the string-quoted `add -- "<file>"` interpolation, which a filename with shell metacharacters could break. `post-merge-watcher.js` gets `windowsHide` on its `gh`/`git` spawns as defense-in-depth — it currently runs with its own hidden console that children inherit, but a future console-less launch mode would otherwise reintroduce the same class of window.
+
 ## [0.133.1] — 2026-08-17
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.133.1**
+**Version: 0.133.2**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.133.1",
+  "version": "0.133.2",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/scripts/git-sync.js
+++ b/plugins/devops/scripts/git-sync.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * @script git-sync
- * @version 0.3.0
+ * @version 0.3.1
  * @plugin devops
  * @description Core git sync logic — fetch remote, merge parent chain into
  *   current branch. Supports branch hierarchy (feat/auth/login merges
@@ -11,20 +11,27 @@
  *   Standalone: called by prompt.git.sync hook and session-start cron.
  */
 
-const { execSync } = require('child_process');
+const { execFileSync } = require('child_process');
 const { readFileSync, writeFileSync } = require('fs');
 const { join } = require('path');
 
 const cwd = process.cwd();
 const MAIN = 'main';
 
-function git(cmd) {
+// argv-form + windowsHide, NEVER a shell string: this script runs as a DETACHED,
+// console-less child (git-sync-bg.js). From such a parent every execSync string
+// goes through a fresh cmd.exe that cannot inherit a console, and Windows
+// Terminal's default-terminal delegation surfaces each one as a visible,
+// focus-stealing window — one per git call, measured on this machine (same
+// mechanism as documented in hooks/lib/graphify-state.js spawnBgRunner).
+function git(args) {
   try {
-    return execSync(`git ${cmd}`, {
+    return execFileSync('git', args, {
       cwd,
       encoding: 'utf8',
       timeout: 15000,
       stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
     }).trim();
   } catch {
     return null;
@@ -32,21 +39,21 @@ function git(cmd) {
 }
 
 // Only run in a git repo
-if (git('rev-parse --is-inside-work-tree') !== 'true') {
+if (git(['rev-parse', '--is-inside-work-tree']) !== 'true') {
   process.exit(0);
 }
 
-const remote = git('remote');
+const remote = git(['remote']);
 if (!remote) process.exit(0);
 const origin = remote.split('\n')[0];
 
-const branch = git('rev-parse --abbrev-ref HEAD');
+const branch = git(['rev-parse', '--abbrev-ref', 'HEAD']);
 if (!branch || branch === MAIN) process.exit(0);
 
 // Ensure diff3 is set for meaningful conflict markers
-const conflictStyle = git('config --get merge.conflictstyle');
+const conflictStyle = git(['config', '--get', 'merge.conflictstyle']);
 if (conflictStyle !== 'diff3' && conflictStyle !== 'zdiff3') {
-  git('config merge.conflictstyle diff3');
+  git(['config', 'merge.conflictstyle', 'diff3']);
 }
 
 // Build parent chain from branch name hierarchy.
@@ -192,7 +199,7 @@ function resolveFile(filePath) {
   }
 
   writeFileSync(fullPath, result, 'utf8');
-  git(`add -- "${filePath}"`);
+  git(['add', '--', filePath]);
   return { resolved: true, content: result };
 }
 
@@ -200,22 +207,22 @@ function resolveFile(filePath) {
 // warn only for genuinely ambiguous conflicts that need semantic resolution.
 // See deep-knowledge/merge-safety.md for the full resolution protocol.
 function tryMerge(source) {
-  const behind = git(`rev-list --count HEAD..${source}`);
+  const behind = git(['rev-list', '--count', `HEAD..${source}`]);
   if (!behind || parseInt(behind) === 0) return null; // already up to date
 
   const count = parseInt(behind);
 
   // Normal merge (clean — no conflicts)
-  if (git(`merge ${source} --no-edit --quiet`) !== null) {
+  if (git(['merge', source, '--no-edit', '--quiet']) !== null) {
     return { source, commits: count };
   }
 
   // Merge conflicted — try resolving trivial conflicts
-  const conflictOutput = git('diff --name-only --diff-filter=U');
+  const conflictOutput = git(['diff', '--name-only', '--diff-filter=U']);
   const files = conflictOutput ? conflictOutput.split('\n').filter(Boolean) : [];
 
   if (files.length === 0) {
-    git('merge --abort');
+    git(['merge', '--abort']);
     return { source, commits: count, conflict: true, files: [] };
   }
 
@@ -232,10 +239,10 @@ function tryMerge(source) {
 
   if (totalAmbiguous > 0) {
     // Some conflicts couldn't be resolved — abort and warn
-    git('merge --abort');
+    git(['merge', '--abort']);
 
     // Verify abort succeeded — if tree is still dirty, the abort failed
-    const postAbort = git('status --porcelain');
+    const postAbort = git(['status', '--porcelain']);
     if (postAbort) {
       return { source, commits: count, failed: true };
     }
@@ -250,22 +257,22 @@ function tryMerge(source) {
   }
 
   // All conflicts resolved — complete the merge
-  git('commit --no-edit');
+  git(['commit', '--no-edit']);
   return { source, commits: count, autoResolved: files.length };
 }
 
 // Fetch main
-if (git(`fetch ${origin} ${MAIN} --quiet`) === null) {
+if (git(['fetch', origin, MAIN, '--quiet']) === null) {
   process.exit(0);
 }
-git(`fetch ${origin} ${MAIN}:${MAIN} --quiet`);
+git(['fetch', origin, `${MAIN}:${MAIN}`, '--quiet']);
 
 // Build parent chain, fetch each from origin, keep only existing branches
 const parents = getParentChain(branch).filter(p => {
   if (p === MAIN) return true;
   // Fetch and update local ref from origin (fast-forward)
-  git(`fetch ${origin} ${p}:${p} --quiet`);
-  return git(`rev-parse --verify ${p}`) !== null;
+  git(['fetch', origin, `${p}:${p}`, '--quiet']);
+  return git(['rev-parse', '--verify', p]) !== null;
 });
 
 // Merge each parent into current branch (root → closest parent)

--- a/plugins/devops/scripts/post-merge-watcher.js
+++ b/plugins/devops/scripts/post-merge-watcher.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * @script post-merge-watcher
- * @version 0.1.0
+ * @version 0.1.1
  * @plugin devops
  * @description Background watcher that runs after ship_release succeeds.
  *   Waits for the GitHub Actions run on the merge commit, optionally probes
@@ -66,7 +66,7 @@ function resolveMainRepoRoot(cwd) {
     const commonDir = execFileSync(
       "git",
       ["rev-parse", "--path-format=absolute", "--git-common-dir"],
-      { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
+      { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"], windowsHide: true },
     ).trim();
     // Only trust the parent when the common dir actually ends in `.git` — for an
     // unusual layout (bare repo, separate git dir) the parent is NOT the worktree
@@ -89,6 +89,10 @@ function resolveStateDir({ stateDir, cwd }) {
   return join(resolveMainRepoRoot(cwd), ".claude", ".ship-watcher");
 }
 
+// windowsHide on every child spawn: the watcher normally runs with its own
+// hidden console (Start-Process -WindowStyle Hidden), but if it is ever
+// launched DETACHED (console-less), children would otherwise get a fresh
+// visible console each — see scripts/git-sync.js git() for the measured case.
 function gh(args, cwd, { timeout = 30_000, allowFail = false } = {}) {
   try {
     return execFileSync("gh", args, {
@@ -96,6 +100,7 @@ function gh(args, cwd, { timeout = 30_000, allowFail = false } = {}) {
       encoding: "utf8",
       timeout,
       stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true,
     }).trim();
   } catch (e) {
     if (allowFail) return null;
@@ -127,6 +132,7 @@ function watchRun({ cwd, runId, maxWaitSec }) {
       encoding: "utf8",
       timeout: maxWaitSec * 1000,
       stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true,
     });
     return { ok: true };
   } catch (e) {

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.133.1",
+  "version": "0.133.2",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary
The detached background git sync (introduced v0.129.0, #287) ran every git command through `execSync` — a `cmd.exe` shell string. From a detached, **console-less** parent, each `cmd.exe` gets a fresh console, and with Windows Terminal as the Win11 default terminal every fresh console renders as a visible, focus-stealing window. One sync run ≈ 13 git calls ≈ a measured **20 WindowsTerminal/OpenConsole processes**. Triggered on every SessionStart plus every 30 minutes per worktree across several active worktrees, this produced the reported "thousands of terminal windows" (initially suspected to be graphify, which had the identical bug before 0.116.2).

## Fix
- `scripts/git-sync.js`: `git()` now spawns git directly in argv form (`execFileSync`, no shell layer) with `windowsHide: true` — the same mechanism `hooks/lib/graphify-state.js` documents and measures for its background runner. Also retires the fragile string-quoted `add -- "<file>"` interpolation.
- `scripts/post-merge-watcher.js`: `windowsHide: true` on its `gh`/`git` spawns as defense-in-depth for any future console-less launch mode (currently launched with its own hidden console — no active issue).

## Verification
- Repro probe (exact hook chain, detached node → git): **before** 20 visible-terminal processes, **after** 0.
- End-to-end run of the real fixed script, spawned exactly like `git-sync-bg.js` does: 0 windows, fetch/merge still functional (FETCH_HEAD updated).
- Purpose-alignment sweep over all other `detached: true` spawn sites (mcp-reaper, batch-watchdog, session-open-tracker, plugin-update toast, local-llm): all already shell-less/GUI-only — git-sync was the only active window source.
- `npm test`: 1860/1860 passed; `npm run lint`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)