### PR TITLE
fix(batch): file the activating prompt's notes, don't execute them

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.133.2"
+    "version": "0.133.3"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.133.2",
+      "version": "0.133.3",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.133.2",
+      "version": "0.133.3",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.133.3] — 2026-08-23
+
+### Fixed
+
+- **Starting `/claude-batch` and typing your first notes into the same prompt no longer executes them.** The activating prompt is the one prompt collect mode can never catch: the hook arms the mode *in the turn that prompt starts*, so it necessarily sees that prompt while the mode is still off and has to let it through. When the prompt also carried the first observations — `/claude-batch on der Header ist rot …`, or "Sammelmodus an, erste Notiz: …" — the model read actionable text, started working it, and skipped the marker question on the way. The notes were never filed. The mode ended up **on and empty** while the work it exists to defer was already half-done, which is the entire feature inverted. Reported after it happened on two consecutive days. Step 1's routing table made it worse by matching `$ARGUMENTS` as a whole, so `on der Header ist rot` fell through to the `status` branch.
+
+  The hook cannot fix this by storing the text itself. Nothing has activated at `UserPromptSubmit` time, and a "note" written for a prompt that turns out to be a question *about* the mode would be corruption, not rescue. So the fix splits: `detectActivation()` recognises an activating prompt — an expanded `/claude-batch`, or a trigger phrase sharing its clause with an intent word — and reports whether anything beyond the route word rides along; the hook then injects a guard into that turn saying the extra content is a note, not an instruction, that no step of the skill may be skipped because the prompt looks busy, and that it belongs in `appendNote` verbatim. `SKILL.md` routes on the first token only and gained Step 2.4, which files the remainder as one note before the confirmation.
+
+  Requiring the intent word is what keeps the guard from becoming noise. The trigger phrases are substrings tested against the whole prompt, so a first cut fired on any sentence that merely named the feature ("wir sollten den Sammelmodus dokumentieren, aber davor …") and on machine prompts mentioning `batch-mode`, where nothing would ever read the guard's self-escape clause. Naming the mode is not asking for it: the trigger now needs `an`/`on`/`aktivier…` in the same clause, machine prompts are excluded up front as they already are in collection, and `erstmal sammeln` / `nicht sofort umsetzen` are exempt because they cannot be said about the mode without asking for it.
+
+  Guidance, not enforcement — deliberately. The detection is a heuristic and the guard says so in its own last line: a false positive must cost nothing but a few ignored lines, never a swallowed prompt.
+
 ## [0.133.2] — 2026-08-18
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.133.2**
+**Version: 0.133.3**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/docs/superpowers/specs/2026-08-16-claude-batch-design.md
+++ b/docs/superpowers/specs/2026-08-16-claude-batch-design.md
@@ -49,6 +49,35 @@ rejects them (`reason: 'harness-reserved'`) instead of warning, and `loadConfig`
 re-validates on every read so a config written before this rule (`!`) falls back
 to the default rather than trapping the user.
 
+#### The activation race
+
+The activating prompt is the one prompt collection can never catch. The hook arms
+the mode *in the turn that prompt starts*, so it necessarily sees that prompt
+while the mode is still off and has to let it through. When the user activates
+and types their first observations into the same prompt — `/claude-batch on der
+Header ist rot …`, or "Sammelmodus an, erste Notiz: …" — the model reads
+actionable text, starts working it, and skips the marker question. The notes are
+never filed: the mode ends up **on and empty** while the work it exists to defer
+is already half-done. Observed twice in real use.
+
+The hook cannot fix this by storing the text itself. Nothing has activated at
+UserPromptSubmit time, and a "note" written for a prompt that turns out to be a
+question *about* the mode would be pure corruption. So the split is:
+
+- `detectActivation()` (`batch-state.js`) recognises an activating prompt —
+  either an expanded `/claude-batch`, or a trigger phrase that shares its clause
+  with an intent word (`an`, `on`, `aktivier…`); naming the mode in passing is
+  not activating it. Machine prompts are excluded, same as in collection. It
+  then reports whether anything beyond the route word rides along.
+- The hook injects a **guard** into that turn: the extra content is a note, do
+  not act on it, do not skip Step 2.1, file it in Step 2.4.
+- `SKILL.md` Step 1 routes on the first token only and Step 2.4 seeds the
+  remainder verbatim as one note via `appendNote`.
+
+Guidance, not enforcement — deliberately. The detection is a heuristic, and the
+guard says so: a false positive must cost nothing but a few ignored lines, never
+a swallowed prompt.
+
 ### Collection
 
 While the mode is active, `prompt.batch.collect` (UserPromptSubmit) blocks the

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.133.2",
+  "version": "0.133.3",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/hooks/lib/batch-state.js
+++ b/plugins/devops/hooks/lib/batch-state.js
@@ -1,6 +1,6 @@
 /**
  * @module batch-state
- * @version 0.1.0
+ * @version 0.2.0
  * @description State and classification for the `/claude-batch` collect mode.
  *
  * Collect mode batches user prompts into `.claude/batch.md` instead of acting
@@ -93,6 +93,46 @@ const ACTIVATION_PATTERNS = [
   /erstmal\s+sammeln/i,
   /nicht\s+sofort\s+umsetzen/i,
 ];
+
+/**
+ * Triggers that ARE the request, not just the mode's name. "Erstmal sammeln"
+ * cannot be said about the mode without asking for it, so these need no
+ * separate on-word.
+ */
+const SELF_ACTIVATING_PATTERNS = [
+  /erstmal\s+sammeln/i,
+  /nicht\s+sofort\s+umsetzen/i,
+];
+
+/**
+ * Words that turn a mention of the mode into a request to switch it on.
+ *
+ * Naming the mode is not asking for it: "wir sollten den Sammelmodus
+ * dokumentieren" is prose, "Sammelmodus an" is an invocation. Requiring one of
+ * these in the SAME clause as the trigger is what separates the two.
+ */
+const ACTIVATION_INTENT = /\b(an|on|start\w*|aktivier\w*|ein|los|bitte)\b/i;
+
+/** Clause boundaries — an intent word two sentences away is not this clause. */
+const CLAUSE_BOUNDARIES = ['.', ',', ';', ':', '!', '?', '\n'];
+
+/**
+ * The clause `index` sits in — the text between the nearest clause boundaries
+ * on either side.
+ * @param {string} s
+ * @param {number} index
+ */
+function clauseAround(s, index) {
+  let start = 0;
+  let end = s.length;
+  for (const c of CLAUSE_BOUNDARIES) {
+    const before = s.lastIndexOf(c, index);
+    if (before !== -1 && before + 1 > start) start = before + 1;
+    const after = s.indexOf(c, index);
+    if (after !== -1 && after < end) end = after;
+  }
+  return s.slice(start, end);
+}
 
 /** Words that are pure routing (Step 1 of the skill), never note content. */
 const ROUTE_WORDS = /\b(on|an|start|off|aus|stop|go|los|merge|marker|status|bitte|mal|jetzt)\b/gi;
@@ -441,6 +481,10 @@ function detectActivation(text) {
   const none = { activating: false, viaCommand: false, carriesContent: false, payload: '' };
   const s = typeof text === 'string' ? text : '';
   if (!s.trim()) return none;
+  // A cron or an AFK resume that happens to say "batch-mode" is not a user
+  // turning the mode on, and nothing in such a turn would read the guard's
+  // self-escape clause. Same exclusion the collect path already makes.
+  if (isMachinePrompt(s)) return none;
 
   let residue;
   let viaCommand = false;
@@ -453,7 +497,15 @@ function detectActivation(text) {
     const args = /<command-args>([\s\S]*?)<\/command-args>/i.exec(s);
     residue = args ? args[1] : '';
   } else {
-    if (!ACTIVATION_PATTERNS.some(rx => rx.test(s))) return none;
+    const hit = ACTIVATION_PATTERNS.map(rx => rx.exec(s)).find(Boolean);
+    if (!hit) return none;
+    // Naming the mode is not asking for it. Without this, ordinary prose about
+    // the feature ("wir sollten den Sammelmodus dokumentieren, aber davor …")
+    // drew the guard into a turn that had nothing to do with collecting.
+    if (!SELF_ACTIVATING_PATTERNS.some(rx => rx.test(s))) {
+      const clause = clauseAround(s, hit.index).replace(hit[0], ' ');
+      if (!ACTIVATION_INTENT.test(clause)) return none;
+    }
     residue = s;
     for (const rx of ACTIVATION_PATTERNS) {
       residue = residue.replace(new RegExp(rx.source, 'gi'), ' ');

--- a/plugins/devops/hooks/lib/batch-state.js
+++ b/plugins/devops/hooks/lib/batch-state.js
@@ -80,6 +80,31 @@ const ATTACHMENT_PATTERNS = [
   /(^|\s)@[\w.\-/\\]+\.[A-Za-z0-9]{1,8}(\s|$)/,
 ];
 
+/**
+ * Phrases that turn an ordinary prompt into a claude-batch invocation.
+ *
+ * Mirrors the skill's own trigger list. Used ONLY to recognise an activating
+ * prompt while the mode is still OFF — never to decide collect vs. execute.
+ */
+const ACTIVATION_PATTERNS = [
+  /sammel[-\s]?modus/i,
+  /collect[-\s]?mode/i,
+  /batch[-\s]?mode/i,
+  /erstmal\s+sammeln/i,
+  /nicht\s+sofort\s+umsetzen/i,
+];
+
+/** Words that are pure routing (Step 1 of the skill), never note content. */
+const ROUTE_WORDS = /\b(on|an|start|off|aus|stop|go|los|merge|marker|status|bitte|mal|jetzt)\b/gi;
+
+/**
+ * Below this many characters of residue, an invocation is "activation only" —
+ * `/claude-batch on` and friends. Above it the user typed work into the very
+ * prompt that turns collection on, and that work must be filed as a note
+ * instead of executed.
+ */
+const ACTIVATION_CONTENT_MIN = 12;
+
 // ── paths ──────────────────────────────────────────────────────────────────
 
 function configPath() {
@@ -393,6 +418,63 @@ function looksLikeQuestion(text) {
 }
 
 /**
+ * Does this prompt turn collect mode ON — and does it carry work on top?
+ *
+ * The failure this exists for: the user activates the mode and already types
+ * their first observations into the SAME prompt. Collection is not armed yet,
+ * so the collect hook cannot catch them; the model sees actionable text, starts
+ * working it, and skips the skill's own dialogs. The notes are never filed, the
+ * mode is on but empty, and the whole point of batching is gone.
+ *
+ * The hook cannot fix that by storing the text itself: at UserPromptSubmit time
+ * nothing has activated yet, and a note written for a prompt that turns out to
+ * be a question ABOUT the mode would be pure corruption. So this only reports
+ * the shape, and the hook injects a guard telling the turn what to do with it.
+ *
+ * `payload` is best-effort and exists for the length heuristic — the split into
+ * activation vs. content is made in the turn, against the user's actual words.
+ *
+ * @param {string} text raw prompt text
+ * @returns {{activating:boolean,viaCommand:boolean,carriesContent:boolean,payload:string}}
+ */
+function detectActivation(text) {
+  const none = { activating: false, viaCommand: false, carriesContent: false, payload: '' };
+  const s = typeof text === 'string' ? text : '';
+  if (!s.trim()) return none;
+
+  let residue;
+  let viaCommand = false;
+  const cmd = /<command-name>\s*\/?([\w.-]+)\s*<\/command-name>/i.exec(s);
+  if (cmd) {
+    // An expanded slash command is unambiguous: either it IS /claude-batch, or
+    // it is some other command and none of this applies.
+    if (!/claude-batch/i.test(cmd[1])) return none;
+    viaCommand = true;
+    const args = /<command-args>([\s\S]*?)<\/command-args>/i.exec(s);
+    residue = args ? args[1] : '';
+  } else {
+    if (!ACTIVATION_PATTERNS.some(rx => rx.test(s))) return none;
+    residue = s;
+    for (const rx of ACTIVATION_PATTERNS) {
+      residue = residue.replace(new RegExp(rx.source, 'gi'), ' ');
+    }
+  }
+
+  const payload = residue.replace(ROUTE_WORDS, ' ').replace(/[\s.,;:!?]+/g, ' ').trim();
+  // "Was macht der Sammelmodus?" is a question ABOUT the mode, not an activation
+  // carrying notes. Short + interrogative is the reliable shape of that; a long
+  // one still trips the guard, which is harmless — the guard says to ignore it
+  // when the prompt is not actually activating.
+  const asking = looksLikeQuestion(s) && payload.length < 40;
+  return {
+    activating: true,
+    viaCommand,
+    carriesContent: !asking && payload.length >= ACTIVATION_CONTENT_MIN,
+    payload: residue.trim(),
+  };
+}
+
+/**
  * The single decision.
  * @returns {'passthrough'|'collect'|'execute'}
  */
@@ -439,12 +521,14 @@ module.exports = {
   HARNESS_RESERVED_PREFIXES,
   MACHINE_PATTERNS,
   ATTACHMENT_PATTERNS,
+  ACTIVATION_PATTERNS,
+  ACTIVATION_CONTENT_MIN,
   configPath, claudeDir, notesPath, modePath, activityPath, lockPath,
   loadConfig, saveConfig,
   readMode, isModeActive, expiryReason, activate, deactivate,
   appendNote, readNotes, countNotes, clearNotes, archiveNotes,
   touchActivity, readActivity,
-  isMachinePrompt, isExpandedCommand, hasAttachment,
+  isMachinePrompt, isExpandedCommand, hasAttachment, detectActivation,
   startsWithMarker, stripMarker, looksLikeQuestion,
   validateMarker, markerMatch, effectiveMarker, MARKER_MAX_LENGTH,
   classify, willBeCollected,

--- a/plugins/devops/hooks/lib/batch-state.test.js
+++ b/plugins/devops/hooks/lib/batch-state.test.js
@@ -6,7 +6,7 @@ import {
   activate, deactivate, isModeActive, expiryReason, readMode,
   appendNote, readNotes, countNotes, clearNotes, archiveNotes,
   touchActivity, readActivity,
-  isMachinePrompt, isExpandedCommand, hasAttachment,
+  isMachinePrompt, isExpandedCommand, hasAttachment, detectActivation,
   startsWithMarker, stripMarker, looksLikeQuestion, validateMarker,
   classify, willBeCollected, notesPath, modePath,
   loadConfig, saveConfig, configPath, effectiveMarker,
@@ -459,5 +459,55 @@ describe("question hint is advisory only", () => {
   test("a question is still collected — the hook never classifies it away", () => {
     expect(classify({ text: "gibt es das schon?", marker: ">>", modeActive: true }))
       .toBe("collect");
+  });
+});
+
+describe("detectActivation — the prompt that turns the mode on", () => {
+  // Regression guard for the mode's worst failure: the user activates AND types
+  // their first notes into the same prompt. Collection is not armed yet, so the
+  // notes were executed instead of filed and the marker dialog got skipped.
+  test("a bare activation carries no content", () => {
+    for (const t of [
+      "<command-name>/claude-batch</command-name><command-args>on</command-args>",
+      "<command-name>/claude-batch</command-name>",
+      "sammelmodus an",
+      "Sammelmodus bitte an",
+      "collect mode on",
+    ]) {
+      const d = detectActivation(t);
+      expect(d.activating).toBe(true);
+      expect(d.carriesContent).toBe(false);
+    }
+  });
+
+  test("an activation with notes typed into it is flagged", () => {
+    const cmd = detectActivation(
+      "<command-name>/claude-batch</command-name>" +
+      "<command-args>on der Header ist rot und die Filter-API fehlt</command-args>",
+    );
+    expect(cmd).toMatchObject({ activating: true, viaCommand: true, carriesContent: true });
+    expect(cmd.payload).toContain("Header ist rot");
+
+    const nl = detectActivation(
+      "Sammelmodus an, erste Notiz: der Header ist rot, zweite: die Filter-API fehlt",
+    );
+    expect(nl).toMatchObject({ activating: true, viaCommand: false, carriesContent: true });
+  });
+
+  test("another slash command with a long payload is not an activation", () => {
+    expect(detectActivation(
+      "<command-name>/ship</command-name><command-args>der Header ist rot</command-args>",
+    ).activating).toBe(false);
+  });
+
+  test("an ordinary prompt is not an activation", () => {
+    expect(detectActivation("Der Button ist verrutscht").activating).toBe(false);
+    expect(detectActivation("").activating).toBe(false);
+    expect(detectActivation(null).activating).toBe(false);
+  });
+
+  test("a short question ABOUT the mode does not count as carried content", () => {
+    expect(detectActivation("was macht der sammelmodus?").carriesContent).toBe(false);
+    expect(detectActivation("wie funktioniert collect mode?").carriesContent).toBe(false);
   });
 });

--- a/plugins/devops/hooks/lib/batch-state.test.js
+++ b/plugins/devops/hooks/lib/batch-state.test.js
@@ -500,6 +500,42 @@ describe("detectActivation — the prompt that turns the mode on", () => {
     ).activating).toBe(false);
   });
 
+  test("naming the mode is not asking for it", () => {
+    // Regression guard: the trigger phrases are substrings, so prose ABOUT the
+    // feature used to drag the guard into an unrelated turn.
+    for (const t of [
+      "Wir sollten den Sammelmodus im Team dokumentieren, aber davor klaeren wir die Architektur",
+      "der batch mode war letzte Woche kaputt, siehe Issue #289",
+      "wie funktioniert collect mode eigentlich intern?",
+    ]) {
+      expect(detectActivation(t).activating).toBe(false);
+    }
+  });
+
+  test("intent in the same clause still activates", () => {
+    for (const t of [
+      "Sammelmodus an",
+      "aktiviere den Sammelmodus",
+      "mach den batch mode bitte an",
+    ]) {
+      expect(detectActivation(t).activating).toBe(true);
+    }
+  });
+
+  test("a self-activating phrase needs no on-word", () => {
+    const d = detectActivation("erstmal sammeln: der Header ist rot und die Filter-API fehlt");
+    expect(d).toMatchObject({ activating: true, carriesContent: true });
+  });
+
+  test("a machine prompt that mentions the mode is never an activation", () => {
+    // An AFK resume or a cron cannot switch the mode on, and nothing in such a
+    // turn would read the guard's self-escape clause.
+    expect(detectActivation("AUTONOMOUS_RESUME: continue the batch mode parser work").activating)
+      .toBe(false);
+    expect(detectActivation("Silently run the sammelmodus watchdog tick").activating)
+      .toBe(false);
+  });
+
   test("an ordinary prompt is not an activation", () => {
     expect(detectActivation("Der Button ist verrutscht").activating).toBe(false);
     expect(detectActivation("").activating).toBe(false);

--- a/plugins/devops/hooks/user-prompt-submit/prompt.batch.collect.js
+++ b/plugins/devops/hooks/user-prompt-submit/prompt.batch.collect.js
@@ -109,6 +109,42 @@ function buildMergeContext(notes, rest, notesFile) {
   ].join('\n');
 }
 
+/**
+ * Guard injected when the prompt that ACTIVATES collect mode already carries the
+ * user's first observations.
+ *
+ * That prompt is the one prompt the mode can never catch: collection is armed by
+ * the turn it starts, so the hook sees it while the mode is still off and has to
+ * let it through. What used to happen then is the whole failure mode of the
+ * feature — the model reads actionable text, starts working it, skips the
+ * marker dialog, and the notes are never filed. The mode ends up ON and EMPTY
+ * while the work it was supposed to defer is already half-done.
+ *
+ * Guidance, not enforcement: the hook cannot store the text itself (nothing has
+ * activated yet, and a "note" written for a question ABOUT the mode would be
+ * corruption), so it states the rule in the turn where the decision is made.
+ */
+function buildActivationGuard() {
+  return [
+    '[claude-batch] Dieser Prompt startet den Sammelmodus UND trägt zusätzlichen Inhalt.',
+    '',
+    'Der Inhalt neben der Aktivierung ist NOTIZ, nicht Auftrag:',
+    '1. Setze nichts davon um. Nicht planen, nicht recherchieren, nicht den Code',
+    '   dafür lesen — der Modus existiert genau dafür, dass das später und',
+    '   gebündelt passiert.',
+    '2. Überspringe KEINEN Schritt des claude-batch-Skills. Die Marker-Rückfrage',
+    '   (AskUserQuestion, Step 2.1) kommt zuerst, auch wenn der Prompt schon',
+    '   Arbeit beschreibt. Ein Prompt voller Aufgaben ist kein Grund, den Dialog',
+    '   zu überspringen — er ist der Grund, warum es ihn gibt.',
+    '3. Nach dem Aktivieren: lege den Inhalt WÖRTLICH als erste Notiz ab',
+    '   (`appendNote` aus hooks/lib/batch-state.js, Step 2.4) und nenne die',
+    '   Notizzahl im Bestätigungsblock.',
+    '',
+    'Falls dieser Prompt den Modus gar nicht aktiviert — eine Frage ÜBER den',
+    'Modus, Status, oder /claude-batch off —, ignoriere diesen Hinweis.',
+  ].join('\n');
+}
+
 let inputData = '';
 process.stdin.setEncoding('utf8');
 process.stdin.on('data', d => { inputData += d; });
@@ -127,6 +163,12 @@ process.stdin.on('end', () => {
     // Not collecting — but a real user prompt still advances the clock the
     // watchdog reads, so a later activation starts from a truthful timestamp.
     try { if (!B.isMachinePrompt(text)) B.touchActivity(cwd); } catch { /* non-fatal */ }
+    // The one prompt collection can never catch is the one that turns it on.
+    // When it also carries work, say so before the model starts doing it.
+    try {
+      const act = B.detectActivation(text);
+      if (act.activating && act.carriesContent) process.stdout.write(buildActivationGuard() + '\n');
+    } catch { /* advisory only — never let this cost a turn */ }
     process.exit(0);
   }
 
@@ -173,4 +215,4 @@ process.stdin.on('end', () => {
   }
 });
 
-module.exports = { buildAck, buildMergeContext, INLINE_LIMIT };
+module.exports = { buildAck, buildMergeContext, buildActivationGuard, INLINE_LIMIT };

--- a/plugins/devops/hooks/user-prompt-submit/prompt.batch.collect.js
+++ b/plugins/devops/hooks/user-prompt-submit/prompt.batch.collect.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * @hook prompt.batch.collect
- * @version 0.1.0
+ * @version 0.2.0
  * @event UserPromptSubmit
  * @plugin devops
  * @description Collect mode for `/claude-batch`: while active, blocks the user
@@ -141,7 +141,9 @@ function buildActivationGuard() {
     '   Notizzahl im Bestätigungsblock.',
     '',
     'Falls dieser Prompt den Modus gar nicht aktiviert — eine Frage ÜBER den',
-    'Modus, Status, oder /claude-batch off —, ignoriere diesen Hinweis.',
+    'Modus, ein Status, /claude-batch off, oder einfach ein Satz, in dem der',
+    'Sammelmodus nur vorkommt —, ignoriere diesen Hinweis vollständig und',
+    'bearbeite den Prompt normal. Die Erkennung ist eine Heuristik.',
   ].join('\n');
 }
 

--- a/plugins/devops/hooks/user-prompt-submit/prompt.batch.collect.test.js
+++ b/plugins/devops/hooks/user-prompt-submit/prompt.batch.collect.test.js
@@ -4,7 +4,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { buildAck, buildMergeContext, INLINE_LIMIT } from "./prompt.batch.collect.js";
+import { buildAck, buildMergeContext, buildActivationGuard, INLINE_LIMIT } from "./prompt.batch.collect.js";
 import { activate, appendNote, readNotes, isModeActive } from "../lib/batch-state.js";
 
 const HOOK = fileURLToPath(new URL("./prompt.batch.collect.js", import.meta.url));
@@ -254,5 +254,42 @@ describe("message builders", () => {
     expect(ctx.length).toBeLessThan(INLINE_LIMIT);
     expect(ctx).toContain("/tmp/p/.claude/batch.md");
     expect(ctx).toContain("los");
+  });
+});
+
+describe("mode off — the activating prompt gets a guard, not a turn of work", () => {
+  test("an activation carrying notes injects the guard", () => {
+    const r = runHook({
+      prompt:
+        "<command-name>/claude-batch</command-name>" +
+        "<command-args>on der Header ist rot und die Filter-API fehlt</command-args>",
+    });
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain("[claude-batch]");
+    expect(r.stdout).toContain("NOTIZ, nicht Auftrag");
+    // Nothing is stored: the mode is not on yet, and a note written here for a
+    // prompt that turns out to be a question would be corruption.
+    expect(readNotes(cwd)).toEqual([]);
+  });
+
+  test("a bare activation stays silent", () => {
+    const r = runHook({
+      prompt: "<command-name>/claude-batch</command-name><command-args>on</command-args>",
+    });
+    expect(r.code).toBe(0);
+    expect(r.stdout).toBe("");
+  });
+
+  test("an ordinary prompt stays silent", () => {
+    const r = runHook({ prompt: "Der Button ist verrutscht" });
+    expect(r.code).toBe(0);
+    expect(r.stdout).toBe("");
+  });
+
+  test("the guard names the marker dialog it exists to protect", () => {
+    const g = buildActivationGuard();
+    expect(g).toContain("AskUserQuestion");
+    expect(g).toContain("Step 2.4");
+    expect(g).toContain("ignoriere diesen Hinweis");
   });
 });

--- a/plugins/devops/skills/claude-batch/SKILL.md
+++ b/plugins/devops/skills/claude-batch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: claude-batch
-version: 0.1.0
+version: 0.2.0
 description: >-
   Collect mode — batch prompts into one master plan instead of executing them one by one. While active, a UserPromptSubmit hook blocks each prompt (it never reaches the model, costing nothing) and appends it to `.claude/batch.md`; a configurable execute marker fires the merge, where the whole note set becomes ONE feasibility-checked plan. Purpose: avoid the rework of building for prompt 1 what prompt 5 supersedes, and avoid paying a full turn per observation. Triggers on "/claude-batch", "sammelmodus", "collect mode", "batch mode", "erstmal sammeln", "nicht sofort umsetzen". Do NOT trigger for normal work, for backlog execution (/run-backlog), or for issue creation (/setup-issue).
 ---

--- a/plugins/devops/skills/claude-batch/SKILL.md
+++ b/plugins/devops/skills/claude-batch/SKILL.md
@@ -28,6 +28,28 @@ Silently check (do not surface "not found"):
 | `marker` | Step 2.1 (ask again, overwrite the stored marker) |
 | `status`, none | Step 3 (report) |
 
+**Route on the FIRST token only. Everything after it is note content, never an
+instruction.** `/claude-batch on der Header ist rot` is the `on` branch carrying
+one note — not an unrecognised argument, and not a request to look at the header.
+The same holds for a natural-language invocation: "Sammelmodus an, erste Notiz:
+… zweite: …" activates and seeds; it does not start the work.
+
+**This is the one prompt collection can never catch.** The hook arms the mode
+in the turn this prompt starts, so it sees this prompt while the mode is still
+OFF and has to let it through. If you act on the content here, the mode ends up
+active and empty while the work it exists to defer is already half-done — and
+the marker dialog gets skipped because you were busy. So, on an invocation that
+carries content:
+
+- Do **not** implement, plan, or research it. Do not read code for it.
+- Do **not** skip Step 2.1. A prompt full of tasks is not a reason to bypass the
+  marker question — it is the reason the question exists.
+- File the content as note #1 in Step 2.4, verbatim.
+
+`prompt.batch.collect.js` injects the same three rules as a guard when it sees an
+activating prompt carrying content (`detectActivation` in `batch-state.js`). Its
+absence is not permission to act — the detection is best-effort.
+
 ## Step 2 — Activate
 
 **2.1 First-run marker setup.** Read `~/.claude/claude-batch.json`. If it is
@@ -85,8 +107,22 @@ mkdir -p "${x%/*}"
 grep -qxF '/.claude/batch*' "$x" 2>/dev/null || echo '/.claude/batch*' >> "$x"
 ```
 
-**2.4 Confirm in one short block** — the marker, where notes land, and both
-exits. Then render an `analysis` completion card.
+**2.4 Seed the invocation's own content.** If the activating prompt carried
+anything beyond the route word (Step 1), file it now — after `activate`, before
+the confirmation:
+
+```bash
+node -e "require('{PLUGIN_ROOT}/hooks/lib/batch-state.js').appendNote(process.cwd(), process.argv[1])" "<text>"
+```
+
+**Verbatim, and as ONE note.** Do not summarise, re-order, or split it into what
+you think the separate items are — a note is the user's own words, and the merge
+in Step 4 reads content, not note boundaries. Guessing boundaries only risks
+losing a requirement. Skip this step silently when the invocation was bare.
+
+**2.5 Confirm in one short block** — the marker, where notes land, both exits,
+and (when 2.4 ran) that the first note is already stored, with the count. Then
+render an `analysis` completion card.
 
 ## Step 3 — Status
 
@@ -191,6 +227,9 @@ The dependency is soft. Resolve the plugin path and skip silently if absent —
   harness has no quieter rendering for it. If the user reports it as an error,
   confirm the note actually landed (Step 3) and explain the mechanism — do not
   start debugging the hook.
+- **The activating prompt is never executed.** Whatever it carries beyond the
+  route word becomes note #1 (Step 2.4). Acting on it defeats the mode in the
+  very turn that starts it, and it is how the marker dialog gets skipped.
 - **Never resolve a contradiction silently.** Name it, then decide.
 - **Never delete notes.** Archive them.
 - **A question in the queue is a defect, not content.** If a note is clearly a

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.133.2",
+  "version": "0.133.3",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Problem

The activating prompt is the one prompt collect mode can never catch. The collect hook arms the mode *in the turn that prompt starts*, so it sees that prompt while the mode is still OFF and has to let it through.

When the user activated **and** typed their first observations into the same prompt — `/claude-batch on der Header ist rot …` or "Sammelmodus an, erste Notiz: …" — the model read actionable text, started working it, and skipped the skill's marker dialog. The notes were never filed: the mode ended up **on and empty** while the work it exists to defer was already half-done. Reported after it happened on two consecutive days.

Step 1's routing table made it worse — it matched `$ARGUMENTS` as a whole, so `on der Header ist rot` fell through to the `status` branch.

## Fix

- **`batch-state.js` — `detectActivation()`**: recognises an activating prompt (expanded `/claude-batch`, or a trigger phrase sharing its clause with an intent word `an`/`on`/`aktivier…`) and reports whether it carries content beyond the route word. Machine prompts and short questions *about* the mode are excluded; `erstmal sammeln` / `nicht sofort umsetzen` are self-activating and need no intent word.
- **`prompt.batch.collect.js`**: while the mode is off, such a prompt gets a guard injected — the content is a note, don't act on it, don't skip Step 2.1, file it in Step 2.4. Guidance only: nothing can be stored yet because nothing has activated, and a "note" written for a question about the mode would be corruption. The guard's last line says outright that the detection is a heuristic.
- **`SKILL.md`**: routes on the first token only; new Step 2.4 seeds the remainder verbatim as one note via `appendNote`; new entry in `## Rules`.
- Hook, lib and skill versions bumped to 0.2.0 per `CONVENTIONS.md` (new detection).
- Design spec gained "The activation race".

## Verification

`npm test` — 1873 passed (74 files). `npm run lint` — clean. 13 new tests cover activation detection (including the false-positive shapes a QA pass surfaced: prose merely naming the mode, machine prompts mentioning `batch-mode`) and the guard's emit/silence conditions.

Codex review gate: skipped — the CLI returned a provider usage-limit error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)