### PR TITLE
fix(batch): keep notes, attachments and marker intact at merge

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.133.4"
+    "version": "0.133.5"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.133.4",
+      "version": "0.133.5",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.133.4",
+      "version": "0.133.5",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.133.5] — 2026-08-23
+
+### Fixed
+
+- **Firing a `/claude-batch` merge with a screenshot or a question attached no longer reports an empty queue.** Reported after the first real collection run: ten notes visibly collected, then `>>` with an enriched prompt, and the answer was that there were no notes. The classifier checked the attachment rule *before* the execute marker, so `>> so wie hier [Image #1]` — the most natural way to fire a merge while pointing at something — was demoted to an ordinary turn. No notes were injected, and the model then truthfully reported an empty batch while the file held all ten. The two rules exist for opposite reasons: attachments pass through so that a *blocked* prompt can never erase an image, and an execute prompt is never blocked in the first place. The marker now wins over everything except machine prompts and expanded slash commands, and it reaches the notes even after the mode auto-deactivated on its expiry or note cap — the notes outlive the mode that collected them.
+
+- **Screenshots stay attached to the note they belong to.** A prompt carrying an image, pasted text, or an `@file` mention still cannot be collected — blocking erases the prompt, and an erased screenshot is unrecoverable — but passing it through silently was worse than it looked: the model acted on it immediately, which is the one thing the mode exists to prevent, and the merge never learned the prompt had happened. By the time the plan was written, "mach das so wie hier" had no "hier". The turn is the only place the attachment is ever visible, so the hook now injects a guard telling that turn to file the prompt verbatim as a note plus an `[Anhang]` description written while the image is still in context, and `[Anhang-Datei]` lines for every path the hook could extract. The merge context binds those lines to their own note and requires the referenced files to be opened before the note is judged.
+
+- **A hand-edited notes file no longer reads as an empty one.** `readNotes` matched `-->\n`, and `batch.md` carries a header inviting manual editing — so the first save from any Windows editor rewrote it CRLF and the entire queue parsed as zero notes, with no error anywhere. Line endings are normalised before parsing. Independently, the execute path used to exit silently on zero parsed notes, which is indistinguishable from "no notes were ever taken"; it now injects a notice naming the file, whether it exists and its size, and where the file holds content the parser could not split it forbids the denial and requires a raw read instead.
+
+- **Long queues no longer lose their tail in the merge.** Above the inline limit the merge context dropped every note in favour of a bare "read this file" pointer — the turn read part of the file, and nothing in the context said what was missing. It now always carries a numbered index of every note alongside a mandatory full read, and says explicitly when the index itself had to be truncated. The limit itself rose from 8K to 24K characters. Completeness is enforced rather than hoped for: the context requires a coverage list of exactly N lines, `#1` … `#N`, each with a disposition (übernommen · zusammengeführt · Konflikt · nicht machbar · Frage). A note without a line is a lost requirement, not a shorter plan.
+
 ## [0.133.4] — 2026-08-23
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.133.4**
+**Version: 0.133.5**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/docs/superpowers/specs/2026-08-16-claude-batch-design.md
+++ b/docs/superpowers/specs/2026-08-16-claude-batch-design.md
@@ -218,3 +218,45 @@ for something else is a real comprehension cost.
 | `skills/claude-batch/SKILL.md` | Activation, marker setup, merge and routing |
 | `.claude/batch.md` | The notes (git-excluded, per project) |
 | `~/.claude/claude-batch.json` | Marker + defaults (user-global) |
+
+## 0.3.0 — hardening after the first real collection run
+
+Five defects, all with the same visible symptom: notes went in and did not come
+out.
+
+1. **The marker lost to the attachment rule.** `classify()` checked
+   `hasAttachment` before `startsWithMarker`, so `>> so wie hier [Image #1]` —
+   the natural way to fire a merge while pointing at something — was demoted to
+   a plain turn. No notes were injected, and the model correctly reported an
+   empty batch while ten notes sat in the file. The two rules exist for opposite
+   reasons: attachments pass through so a *blocked* prompt can never erase an
+   image, and an execute prompt is never blocked. The marker now wins.
+2. **Attachment prompts left no trace.** While collecting, a prompt carrying an
+   image passed through untouched: the model acted on it immediately (the one
+   thing the mode exists to prevent) and the merge never learned it happened.
+   It still cannot be collected — blocking erases the image — so the hook now
+   injects a guard telling the turn to file it as a note with a written
+   `[Anhang]` description and `[Anhang-Datei]` paths. The turn is the only place
+   the attachment is ever visible, so it is the only place that can preserve it.
+3. **CRLF emptied the queue.** `readNotes` matched `-->\n`. The file header
+   invites manual editing and every Windows editor rewrites it CRLF on save, at
+   which point the whole queue parsed as zero notes with no error anywhere.
+   Line endings are normalised before parsing.
+4. **An unreadable queue was reported as an empty one.** The execute path exited
+   silently on zero notes, which is indistinguishable from "no notes were ever
+   taken". It now injects a notice naming the file, whether it exists and its
+   size, and — when the file has content the parser could not split — forbids
+   the denial and requires a raw read instead.
+5. **Long queues lost their tail.** Over `INLINE_LIMIT` the merge context
+   dropped every note for a bare file pointer. It now always carries a numbered
+   index of all notes plus a mandatory full read, and says explicitly when the
+   index itself had to be truncated.
+
+Two behavioural additions follow from the same principle — the notes outlive the
+mode that collected them:
+
+- The marker fires the merge even when collection already ended (expiry, note
+  cap, manual off). Otherwise the failsafes silently strand the queue.
+- The merge context requires a coverage list: one line per note, `#1` … `#N`,
+  each with a disposition. A note without a line is a lost requirement, not a
+  shorter plan.

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.133.4",
+  "version": "0.133.5",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/hooks/lib/batch-state.js
+++ b/plugins/devops/hooks/lib/batch-state.js
@@ -1,6 +1,6 @@
 /**
  * @module batch-state
- * @version 0.2.0
+ * @version 0.3.0
  * @description State and classification for the `/claude-batch` collect mode.
  *
  * Collect mode batches user prompts into `.claude/batch.md` instead of acting
@@ -295,10 +295,20 @@ function appendNote(cwd, text, when) {
   return countNotes(cwd);
 }
 
-/** Parsed notes in collection order. @returns {{at:string,text:string}[]} */
+/**
+ * Parsed notes in collection order.
+ *
+ * Line endings are normalised before parsing. The file header invites manual
+ * editing, and every Windows editor rewrites it CRLF on save — a CRLF
+ * separator after `-->`
+ * separator matches nothing, so the whole queue would read as EMPTY and the
+ * merge would fire on zero notes with no error anywhere.
+ *
+ * @returns {{at:string,text:string}[]}
+ */
 function readNotes(cwd) {
   let raw;
-  try { raw = fs.readFileSync(notesPath(cwd), 'utf8'); } catch { return []; }
+  try { raw = fs.readFileSync(notesPath(cwd), 'utf8').replace(/\r\n?/g, '\n'); } catch { return []; }
   const out = [];
   const re = /<!--\s*(\S+?)\s*-->\n([\s\S]*?)(?=\n<!--\s*\S+?\s*-->\n|$)/g;
   for (const m of raw.matchAll(re)) {
@@ -369,6 +379,38 @@ function hasAttachment(text, hookInput) {
   }
   if (typeof text !== 'string' || !text) return false;
   return ATTACHMENT_PATTERNS.some(rx => rx.test(text));
+}
+
+/**
+ * Best-effort references for whatever is attached to this prompt.
+ *
+ * An attached prompt is passed through instead of collected (blocking would
+ * erase the image), so the only way it can still reach the merge is as a note
+ * the TURN writes. That note is useless without a pointer back to the file it
+ * belonged to — "make it like the screenshot" with no screenshot named is
+ * exactly the lost linkage this exists to prevent.
+ *
+ * @returns {string[]} paths / filenames / urls, de-duplicated, capped
+ */
+function attachmentRefs(text, hookInput) {
+  const refs = [];
+  if (hookInput && typeof hookInput === 'object') {
+    for (const key of ['attachments', 'images', 'files']) {
+      const v = hookInput[key];
+      if (!v) continue;
+      for (const item of (Array.isArray(v) ? v : [v])) {
+        if (typeof item === 'string') { refs.push(item); continue; }
+        if (item && typeof item === 'object') {
+          const p = item.path || item.file_path || item.filename || item.name || item.url;
+          if (p) refs.push(String(p));
+        }
+      }
+    }
+  }
+  if (typeof text === 'string') {
+    for (const m of text.matchAll(/(^|\s)@([\w.\-/\\]+\.[A-Za-z0-9]{1,8})(\s|$)/g)) refs.push(m[2]);
+  }
+  return [...new Set(refs.filter(Boolean))].slice(0, 20);
 }
 
 const MARKER_MAX_LENGTH = 32;
@@ -528,14 +570,26 @@ function detectActivation(text) {
 
 /**
  * The single decision.
+ *
+ * Order matters. The marker is checked BEFORE the attachment rule, because the
+ * two rules exist for opposite reasons: attachments pass through so a blocked
+ * prompt can never erase an image, but an execute prompt is never blocked in
+ * the first place. Checking attachments first meant `>> so wie hier [Image #1]`
+ * — the most natural way to fire a merge — silently downgraded to a plain turn:
+ * no notes injected, and the model truthfully reporting that it sees no batch
+ * while ten notes sat in the file.
+ *
  * @returns {'passthrough'|'collect'|'execute'}
  */
 function classify({ text, hookInput, marker, modeActive }) {
-  if (!modeActive) return 'passthrough';
   if (isMachinePrompt(text)) return 'passthrough';
   if (isExpandedCommand(text)) return 'passthrough';
-  if (hasAttachment(text, hookInput)) return 'passthrough';
+  // The marker fires the merge even with the mode already off: an expired or
+  // note-capped mode must not swallow the user's only way to reach the queue.
+  // The caller decides whether notes actually exist.
   if (startsWithMarker(text, marker)) return 'execute';
+  if (!modeActive) return 'passthrough';
+  if (hasAttachment(text, hookInput)) return 'passthrough';
   return 'collect';
 }
 
@@ -580,7 +634,7 @@ module.exports = {
   readMode, isModeActive, expiryReason, activate, deactivate,
   appendNote, readNotes, countNotes, clearNotes, archiveNotes,
   touchActivity, readActivity,
-  isMachinePrompt, isExpandedCommand, hasAttachment, detectActivation,
+  isMachinePrompt, isExpandedCommand, hasAttachment, attachmentRefs, detectActivation,
   startsWithMarker, stripMarker, looksLikeQuestion,
   validateMarker, markerMatch, effectiveMarker, MARKER_MAX_LENGTH,
   classify, willBeCollected,

--- a/plugins/devops/hooks/lib/batch-state.test.js
+++ b/plugins/devops/hooks/lib/batch-state.test.js
@@ -6,7 +6,7 @@ import {
   activate, deactivate, isModeActive, expiryReason, readMode,
   appendNote, readNotes, countNotes, clearNotes, archiveNotes,
   touchActivity, readActivity,
-  isMachinePrompt, isExpandedCommand, hasAttachment, detectActivation,
+  isMachinePrompt, isExpandedCommand, hasAttachment, attachmentRefs, detectActivation,
   startsWithMarker, stripMarker, looksLikeQuestion, validateMarker,
   classify, willBeCollected, notesPath, modePath,
   loadConfig, saveConfig, configPath, effectiveMarker,
@@ -270,9 +270,66 @@ describe("stored config with an unusable marker falls back instead of trapping",
 });
 
 describe("classification is inert when the mode is off", () => {
-  test("everything passes through", () => {
+  test("an ordinary prompt passes through", () => {
     expect(classify({ text: "irgendwas", marker: ">>", modeActive: false })).toBe("passthrough");
-    expect(classify({ text: ">> irgendwas", marker: ">>", modeActive: false })).toBe("passthrough");
+  });
+
+  test("the marker still fires — notes outlive the mode that collected them", () => {
+    // The mode auto-deactivates on expiry and on the note cap. If the marker
+    // went inert with it, the queue would be unreachable by the one gesture the
+    // user was told about, and the merge would read as "there are no notes".
+    // The caller decides whether notes actually exist.
+    expect(classify({ text: ">> irgendwas", marker: ">>", modeActive: false })).toBe("execute");
+  });
+});
+
+describe("classification — the marker outranks the attachment rule", () => {
+  test("a marker prompt carrying an image still fires the merge", () => {
+    // Attachments pass through so a BLOCKED prompt can never erase an image.
+    // An execute prompt is never blocked, so the rule does not apply to it —
+    // and `>> so wie hier [Image #1]` is the most natural way to fire a merge.
+    expect(
+      classify({ text: ">> so wie hier [Image #1]", hookInput: {}, marker: ">>", modeActive: true }),
+    ).toBe("execute");
+  });
+
+  test("a marker prompt carrying an @file mention still fires the merge", () => {
+    expect(
+      classify({ text: ">> und @src/app/Header.tsx anschauen", marker: ">>", modeActive: true }),
+    ).toBe("execute");
+  });
+
+  test("an attachment WITHOUT the marker still passes through unstored", () => {
+    expect(
+      classify({ text: "mach das so wie hier [Image #1]", marker: ">>", modeActive: true }),
+    ).toBe("passthrough");
+  });
+});
+
+describe("readNotes survives a hand-edited file", () => {
+  test("CRLF line endings still parse — an editor save must not empty the queue", () => {
+    // The file header invites editing, and every Windows editor rewrites it
+    // CRLF on save. A `-->\r\n` separator matches nothing, so the whole queue
+    // read as empty and the merge fired on zero notes with no error anywhere.
+    appendNote(cwd, "erste notiz");
+    appendNote(cwd, "zweite notiz");
+    const file = notesPath(cwd);
+    fs.writeFileSync(file, fs.readFileSync(file, "utf8").replace(/\n/g, "\r\n"), "utf8");
+    expect(readNotes(cwd).map(n => n.text)).toEqual(["erste notiz", "zweite notiz"]);
+  });
+});
+
+describe("attachmentRefs — keeping a note tied to its file", () => {
+  test("collects hook-provided paths and @file mentions, de-duplicated", () => {
+    const refs = attachmentRefs("schau in @src/app/Header.tsx und @src/app/Header.tsx", {
+      images: [{ path: "/tmp/shot.png" }],
+      files: ["notes/spec.md"],
+    });
+    expect(refs).toEqual(["/tmp/shot.png", "notes/spec.md", "src/app/Header.tsx"]);
+  });
+
+  test("an attachment-free prompt yields nothing", () => {
+    expect(attachmentRefs("ganz normaler text", {})).toEqual([]);
   });
 });
 

--- a/plugins/devops/hooks/user-prompt-submit/prompt.batch.collect.js
+++ b/plugins/devops/hooks/user-prompt-submit/prompt.batch.collect.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * @hook prompt.batch.collect
- * @version 0.2.0
+ * @version 0.3.0
  * @event UserPromptSubmit
  * @plugin devops
  * @description Collect mode for `/claude-batch`: while active, blocks the user
@@ -20,23 +20,47 @@
  *     - expanded slash commands (<command-name> tag)
  *     - prompts carrying attachments or @file mentions
  *
+ *   An attachment-carrying prompt is passed through, but NOT silently: the turn
+ *   gets a guard telling it to file the prompt as a note together with a written
+ *   description of the attachment. Without that the screenshot the note refers
+ *   to is gone by merge time, and the note reads as "make it like the image"
+ *   with no image anywhere.
+ *
  *   The marker can never start with `!`, `/`, `#` or `@`: the harness claims
  *   those before a prompt exists (bash mode, slash command, memory capture, file
  *   mention), so this hook would never see the escape at all.
  *
  *   Failsafe: the mode file carries an expiry and a note cap, so a bug in the
- *   marker comparison can never lock the user out of their own session.
+ *   marker comparison can never lock the user out of their own session. The
+ *   marker still fires the merge after such an auto-deactivation — the notes
+ *   outlive the mode, and reaching them must not depend on it.
  *
  *   Spec: docs/superpowers/specs/2026-08-16-claude-batch-design.md
  */
 
 require('../lib/plugin-guard');
 
+const fs   = require('fs');
+const path = require('path');
 const B = require('../lib/batch-state');
 
-/** Inline the notes up to this size; beyond it, point Claude at the file so the
- *  token guard governs the read instead of the hook forcing it. */
-const INLINE_LIMIT = 8000;
+/** Absolute path to the state module, so injected guidance can quote a command
+ *  that actually runs — a relative require resolves against the wrong cwd. */
+const STATE_MODULE = path.resolve(__dirname, '..', 'lib', 'batch-state.js');
+
+/**
+ * Inline the full note text up to this size.
+ *
+ * Beyond it the notes are NOT dropped in favour of a bare file pointer — that
+ * was how a long queue lost items: the turn was told to read a file, read part
+ * of it, and nothing in the context said what was missing. Over the limit the
+ * context carries a numbered index of every note plus a mandatory full read, so
+ * the count stays checkable even when the text does not fit.
+ */
+const INLINE_LIMIT = 24000;
+
+/** Per-note excerpt length in the over-limit index. */
+const EXCERPT_CHARS = 200;
 
 /**
  * Acknowledgement shown to the user on a blocked (collected) prompt.
@@ -67,15 +91,47 @@ function buildAck(count, marker, question) {
   return lines.join('\n');
 }
 
+/** One line per note: number, timestamp, first EXCERPT_CHARS characters. */
+function noteIndexLine(note, i) {
+  const flat = note.text.replace(/\s+/g, ' ').trim();
+  const cut = flat.length > EXCERPT_CHARS ? `${flat.slice(0, EXCERPT_CHARS)} …` : flat;
+  return `#${i + 1} (${note.at}) ${cut}`;
+}
+
 /**
  * Context injected into the merge turn.
+ *
  * @param {{at:string,text:string}[]} notes
  * @param {string} rest the user's text after the marker
  * @param {string} notesFile absolute path to the notes file
+ * @param {{stale?:boolean}} [opts] stale = the mode had already ended (expired,
+ *   note cap, or manually off) and the merge fires off the surviving notes
  */
-function buildMergeContext(notes, rest, notesFile) {
+function buildMergeContext(notes, rest, notesFile, opts = {}) {
+  const n = notes.length;
   const head = [
-    `[claude-batch] Der Nutzer hat ${notes.length} Notiz(en) gesammelt und löst jetzt die Umsetzung aus.`,
+    `[claude-batch] Der Nutzer hat ${n} Notiz(en) gesammelt und löst jetzt die Umsetzung aus.`,
+    `Notizdatei: ${notesFile}`,
+  ];
+  if (opts.stale) {
+    head.push(
+      'Der Sammelmodus war zu diesem Zeitpunkt bereits beendet (abgelaufen, Notizlimit',
+      'erreicht oder manuell aus). Die Notizen leben weiter und werden jetzt umgesetzt —',
+      'sag das dem Nutzer in einer Zeile, statt es zu verschweigen.',
+    );
+  }
+  head.push(
+    '',
+    `PFLICHT — Vollständigkeit. Es sind ${n} Notizen. Bevor du planst, schreibe eine`,
+    `Abdeckungsliste mit GENAU ${n} Zeilen, #1 bis #${n}, jede mit einer Disposition:`,
+    'übernommen · zusammengeführt mit #x · Konflikt mit #x · nicht machbar (Grund) ·',
+    'Frage (wird zuerst beantwortet). Eine Notiz ohne eigene Zeile ist ein Fehler,',
+    'kein Kürzen. Prüfe die Zeilenzahl gegen die Zahl oben, bevor du weitermachst.',
+    '',
+    'Anhänge gehören zu ihrer Notiz. Zeilen "[Anhang]" und "[Anhang-Datei]" innerhalb',
+    'einer Notiz beschreiben genau diese Notiz — nie ein eigenes Thema, nie einer',
+    'anderen Notiz zugeordnet. Wo eine "[Anhang-Datei]" existiert, sieh sie dir an,',
+    'bevor du die Notiz bewertest.',
     '',
     'Arbeite NICHT die Notizen einzeln ab. Gehe so vor:',
     '1. Führe die Notizen zu EINEM Gesamtvorhaben zusammen.',
@@ -92,21 +148,136 @@ function buildMergeContext(notes, rest, notesFile) {
     'Der Sammelmodus ist mit diesem Prompt automatisch BEENDET. Folgeprompts sind',
     'die Unterhaltung über die Umsetzung und laufen wieder normal — frage NICHT,',
     'ob der Modus aktiv bleiben soll. Nur ein neues /claude-batch on sammelt wieder.',
-    '',
-  ];
+  );
+  if (rest) {
+    head.push(
+      '',
+      '--- Der Nutzer schreibt zusätzlich zum Auslöser ---',
+      rest,
+      '--- Ende ---',
+      'Das ist Teil des Auftrags, kein Beiwerk. Ist es eine Frage, beantworte sie',
+      `ZUERST und mach dann weiter. Enthält es Anforderungen, behandle sie wie Notiz #${n + 1}`,
+      'und nimm sie in die Abdeckungsliste auf.',
+    );
+  }
+  head.push('');
 
-  const body = notes.map((n, i) => `--- Notiz #${i + 1} (${n.at}) ---\n${n.text}`).join('\n\n');
-  const tail = rest ? ['', '--- Zusätzlich zu diesen Notizen sagt der Nutzer jetzt ---', rest] : [];
-
-  const inline = [...head, body, ...tail].join('\n');
+  const body = notes.map((x, i) => `--- Notiz #${i + 1} (${x.at}) ---\n${x.text}`).join('\n\n');
+  const inline = [...head, body].join('\n');
   if (inline.length <= INLINE_LIMIT) return inline;
 
-  return [
+  // Over the limit: never emit a context without note content. An index of ALL
+  // notes plus a forced full read keeps the count checkable; a bare pointer did
+  // not, and that is how items went missing.
+  const fixed = [
     ...head,
-    `Die Notizen sind zu umfangreich für die Injektion (${inline.length} Zeichen).`,
-    `Lies sie zuerst vollständig aus: ${notesFile}`,
-    ...tail,
-  ].join('\n');
+    `Die Notizen sind zu umfangreich für die vollständige Injektion (${inline.length} Zeichen).`,
+    `Lies ${notesFile} VOLLSTÄNDIG, bevor du irgendetwas planst. Unten steht nur ein`,
+    'gekürzter Index — er ersetzt den Notiztext nicht, er macht nur prüfbar, ob du',
+    'alles hast.',
+    '',
+    `--- Index aller ${n} Notizen (gekürzt) ---`,
+  ];
+  const budget = INLINE_LIMIT - fixed.join('\n').length - 200;
+  const shown = [];
+  let used = 0;
+  for (const [i, note] of notes.entries()) {
+    const line = noteIndexLine(note, i);
+    if (used + line.length + 1 > budget) break;
+    shown.push(line);
+    used += line.length + 1;
+  }
+  const out = [...fixed, ...shown];
+  if (shown.length < n) {
+    // No silent cap: a truncated index that looks complete is the same failure
+    // as a dropped note.
+    out.push(`… #${shown.length + 1} bis #${n} sind hier NICHT gelistet — hol sie aus der Datei.`);
+  }
+  return out.join('\n');
+}
+
+/**
+ * Injected when the marker fires but the queue parses to nothing.
+ *
+ * Exiting silently here was data loss disguised as a normal turn: the model saw
+ * a bare `>> mach jetzt` with no context and truthfully answered that it had no
+ * notes, while `.claude/batch.md` sat there with ten. Anything that can make the
+ * parse fail — a manual edit, a destroyed separator, an editor's CRLF — has to
+ * end in a report naming the file, not in a confident denial.
+ */
+function buildEmptyQueueNotice(notesFile, exists, bytes, marker) {
+  const lines = [
+    `[claude-batch] Der Ausführungs-Marker "${marker}" wurde erkannt, aber aus der`,
+    `Notizdatei ließ sich KEINE Notiz lesen: ${notesFile}`,
+    `Datei vorhanden: ${exists ? `ja (${bytes} Bytes)` : 'nein'}`,
+    '',
+  ];
+  if (exists && bytes > 0) {
+    lines.push(
+      'Sag dem Nutzer NICHT, es gebe keine Notizen. Die Datei hat Inhalt, nur der',
+      'Parser findet darin keine Trenner (manuell editiert, Trennzeile zerstört).',
+      'Vorgehen:',
+      '1. Lies die Datei roh und vollständig.',
+      '2. Steht dort Inhalt, benutze ihn als Notizen und führe den Merge normal durch',
+      '   (zusammenführen, Machbarkeit prüfen, Widersprüche einzeln nennen, Plan zur',
+      '   Freigabe). Sag in einer Zeile, dass die Datei repariert werden sollte.',
+      '3. Ist sie wirklich leer, sag genau das — mit dem Pfad.',
+    );
+  } else {
+    lines.push(
+      'Die Warteschlange ist tatsächlich leer. Sag das mit dem Pfad dazu und dass der',
+      'Sammelmodus weiter aktiv ist — er wurde nicht beendet. Bearbeite den Prompt',
+      'ansonsten normal.',
+    );
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Injected when a prompt carrying an attachment arrives while collecting.
+ *
+ * Such a prompt cannot be blocked — the harness erases blocked prompts, and an
+ * erased screenshot is unrecoverable. So it passes through, and used to leave no
+ * trace at all: the model acted on it immediately (the one thing the mode exists
+ * to prevent) and the merge never learned it happened. The image, the whole
+ * reason the note was written, was gone by merge time.
+ *
+ * The turn is the only place that can fix this, because the turn is the only
+ * place the attachment is actually visible. So it is told to describe it into
+ * the note while it can still see it.
+ */
+function buildAttachmentGuard(marker, refs) {
+  const lines = [
+    '[claude-batch] Sammelmodus ist AKTIV, aber dieser Prompt trägt einen Anhang',
+    '(Bild, eingefügten Text oder @Datei) und konnte deshalb nicht automatisch',
+    'abgelegt werden: ein blockierter Prompt wird aus der UI gelöscht, ein',
+    'Screenshot wäre unwiederbringlich weg.',
+    '',
+    'Setze NICHTS davon um — nicht planen, nicht recherchieren, keinen Code dafür',
+    'lesen. Lege den Prompt stattdessen JETZT als Notiz ab:',
+    '',
+    '1. Notiztext = der Prompt-Text WÖRTLICH, unverändert.',
+    '2. Danach eine Zeile "[Anhang] <sachliche Beschreibung>". Du siehst den Anhang',
+    '   in diesem Turn — beim Merge ist er nicht mehr im Kontext. Die Beschreibung',
+    '   muss die Notiz ohne den Anhang verständlich machen: was ist zu sehen, was',
+    '   ist daran das Problem.',
+  ];
+  if (refs.length) {
+    lines.push(`3. Zusätzlich je eine Zeile "[Anhang-Datei] <pfad>". Bekannt: ${refs.join(', ')}`);
+  } else {
+    lines.push(
+      '3. Ist ein Pfad bekannt (@Datei, gespeicherter Screenshot), zusätzlich eine',
+      '   Zeile "[Anhang-Datei] <pfad>".',
+    );
+  }
+  lines.push(
+    '4. Speichern — eine Notiz, ein Aufruf:',
+    `   node -e "require(process.argv[1]).appendNote(process.cwd(), process.argv[2])" "${STATE_MODULE}" "<notiztext>"`,
+    '5. Antworte mit EINER Zeile: Notiz #<n> gespeichert, Anhang beschrieben.',
+    '',
+    `Alles Weitere bleibt gesammelt. "${marker} <text>" startet später die Umsetzung.`,
+  );
+  return lines.join('\n');
 }
 
 /**
@@ -138,13 +309,42 @@ function buildActivationGuard() {
     '   zu überspringen — er ist der Grund, warum es ihn gibt.',
     '3. Nach dem Aktivieren: lege den Inhalt WÖRTLICH als erste Notiz ab',
     '   (`appendNote` aus hooks/lib/batch-state.js, Step 2.4) und nenne die',
-    '   Notizzahl im Bestätigungsblock.',
+    '   Notizzahl im Bestätigungsblock. Trägt der Prompt einen Anhang, beschreibe',
+    '   ihn in derselben Notiz als "[Anhang] <Beschreibung>" — beim Merge ist er',
+    '   nicht mehr sichtbar.',
     '',
     'Falls dieser Prompt den Modus gar nicht aktiviert — eine Frage ÜBER den',
     'Modus, ein Status, /claude-batch off, oder einfach ein Satz, in dem der',
     'Sammelmodus nur vorkommt —, ignoriere diesen Hinweis vollständig und',
     'bearbeite den Prompt normal. Die Erkennung ist eine Heuristik.',
   ].join('\n');
+}
+
+/**
+ * Fire the merge: inject every note, then end collection.
+ * @param {{cwd:string,text:string,marker:string,modeActive:boolean}} ctx
+ */
+function fireMerge({ cwd, text, marker, modeActive }) {
+  const notes = B.readNotes(cwd);
+  if (notes.length === 0) {
+    // Nothing parsed. Never a silent exit — see buildEmptyQueueNotice.
+    let exists = false;
+    let bytes = 0;
+    try { bytes = fs.statSync(B.notesPath(cwd)).size; exists = true; } catch { /* absent */ }
+    if (modeActive || (exists && bytes > 0)) {
+      process.stdout.write(`${buildEmptyQueueNotice(B.notesPath(cwd), exists, bytes, marker)}\n`);
+    }
+    return; // mode stays armed — the user just fired early
+  }
+  const rest = B.stripMarker(text, marker);
+  process.stdout.write(
+    `${buildMergeContext(notes, rest, B.notesPath(cwd), { stale: !modeActive })}\n`,
+  );
+  // Firing the merge ENDS collection. What follows is the conversation about
+  // the implementation — approvals, answers to Claude's questions, course
+  // corrections — and collecting those is actively wrong: they are blocked,
+  // erased and answered by nobody. Re-arming is an explicit `/claude-batch on`.
+  B.deactivate(cwd);
 }
 
 let inputData = '';
@@ -160,54 +360,51 @@ process.stdin.on('end', () => {
   const cwd  = hook.cwd || process.cwd();
 
   let modeActive;
-  try { modeActive = B.isModeActive(cwd); } catch { process.exit(0); }
-  if (!modeActive) {
-    // Not collecting — but a real user prompt still advances the clock the
-    // watchdog reads, so a later activation starts from a truthful timestamp.
-    try { if (!B.isMachinePrompt(text)) B.touchActivity(cwd); } catch { /* non-fatal */ }
-    // The one prompt collection can never catch is the one that turns it on.
-    // When it also carries work, say so before the model starts doing it.
-    try {
-      const act = B.detectActivation(text);
-      if (act.activating && act.carriesContent) process.stdout.write(buildActivationGuard() + '\n');
-    } catch { /* advisory only — never let this cost a turn */ }
-    process.exit(0);
-  }
-
-  const marker = B.effectiveMarker(cwd);
+  let marker;
   let verdict;
   try {
-    verdict = B.classify({ text, hookInput: hook, marker, modeActive: true });
+    modeActive = B.isModeActive(cwd);
+    marker = B.effectiveMarker(cwd);
+    verdict = B.classify({ text, hookInput: hook, marker, modeActive });
   } catch {
     process.exit(0); // never let a classification bug swallow a prompt
   }
 
-  if (verdict === 'passthrough') {
-    try { if (!B.isMachinePrompt(text)) B.touchActivity(cwd); } catch { /* non-fatal */ }
+  // A real user prompt advances the clock the watchdog reads whatever happens to
+  // it next, so a later activation starts from a truthful timestamp.
+  try { if (!B.isMachinePrompt(text)) B.touchActivity(cwd); } catch { /* non-fatal */ }
+
+  if (verdict === 'execute') {
+    // Reached with the mode off as well: an expired or note-capped mode must not
+    // strand the notes it collected.
+    try { fireMerge({ cwd, text, marker, modeActive }); } catch { /* non-fatal — the turn still runs */ }
     process.exit(0);
   }
 
-  if (verdict === 'execute') {
+  if (verdict === 'passthrough') {
+    if (modeActive) {
+      // The only user prompts that reach here while collecting carry an
+      // attachment; machine prompts and expanded commands never need a guard.
+      try {
+        if (B.hasAttachment(text, hook)) {
+          process.stdout.write(`${buildAttachmentGuard(marker, B.attachmentRefs(text, hook))}\n`);
+        }
+      } catch { /* advisory only */ }
+      process.exit(0);
+    }
+    // Mode off. The one prompt collection can never catch is the one that turns
+    // it on — when it also carries work, say so before the model starts doing it.
     try {
-      B.touchActivity(cwd);
-      const notes = B.readNotes(cwd);
-      if (notes.length === 0) process.exit(0); // nothing collected — mode stays armed
-      const rest = B.stripMarker(text, marker);
-      process.stdout.write(buildMergeContext(notes, rest, B.notesPath(cwd)) + '\n');
-      // Firing the merge ENDS collection. What follows is the conversation about
-      // the implementation — approvals, answers to Claude's questions, course
-      // corrections — and collecting those is actively wrong: they are blocked,
-      // erased and answered by nobody. Re-arming is an explicit `/claude-batch on`.
-      B.deactivate(cwd);
-    } catch { /* non-fatal — the turn still runs */ }
+      const act = B.detectActivation(text);
+      if (act.activating && act.carriesContent) process.stdout.write(`${buildActivationGuard()}\n`);
+    } catch { /* advisory only — never let this cost a turn */ }
     process.exit(0);
   }
 
   // verdict === 'collect' — block the prompt and store it.
   try {
     const count = B.appendNote(cwd, text);
-    B.touchActivity(cwd);
-    process.stderr.write(buildAck(count, marker, B.looksLikeQuestion(text)) + '\n');
+    process.stderr.write(`${buildAck(count, marker, B.looksLikeQuestion(text))}\n`);
     process.exit(2);
   } catch (err) {
     // Storing failed — blocking now would erase the prompt with nothing kept.
@@ -217,4 +414,11 @@ process.stdin.on('end', () => {
   }
 });
 
-module.exports = { buildAck, buildMergeContext, buildActivationGuard, INLINE_LIMIT };
+module.exports = {
+  buildAck,
+  buildMergeContext,
+  buildActivationGuard,
+  buildAttachmentGuard,
+  buildEmptyQueueNotice,
+  INLINE_LIMIT,
+};

--- a/plugins/devops/hooks/user-prompt-submit/prompt.batch.collect.test.js
+++ b/plugins/devops/hooks/user-prompt-submit/prompt.batch.collect.test.js
@@ -4,7 +4,10 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { buildAck, buildMergeContext, buildActivationGuard, INLINE_LIMIT } from "./prompt.batch.collect.js";
+import {
+  buildAck, buildMergeContext, buildActivationGuard, buildAttachmentGuard,
+  buildEmptyQueueNotice, INLINE_LIMIT,
+} from "./prompt.batch.collect.js";
 import { activate, appendNote, readNotes, isModeActive } from "../lib/batch-state.js";
 
 const HOOK = fileURLToPath(new URL("./prompt.batch.collect.js", import.meta.url));
@@ -150,9 +153,99 @@ describe("mode on — firing the merge", () => {
     expect(readNotes(cwd).map(n => n.text)).toEqual(["eine notiz"]);
   });
 
-  test("the marker with an empty queue is just a normal turn", () => {
+  test("the marker with an empty queue reports the empty queue by path", () => {
+    // Exiting silently here was data loss disguised as a normal turn: the model
+    // saw a bare `>> leg los` and truthfully said it had no notes — which is
+    // indistinguishable from ten notes the parser failed to read.
     const r = runHook({ prompt: ">> leg los" });
     expect(r.code).toBe(0);
+    expect(r.stdout).toContain("KEINE Notiz lesen");
+    expect(r.stdout).toContain(path.join(cwd, ".claude", "batch.md"));
+    expect(r.stdout).toContain("Datei vorhanden: nein");
+  });
+
+  test("a queue the parser cannot read is reported, never denied", () => {
+    // The classic cause: the user edits batch.md and the editor rewrites it, or
+    // a separator is destroyed. The file has content; the parse yields nothing.
+    appendNote(cwd, "eine notiz");
+    const file = path.join(cwd, ".claude", "batch.md");
+    fs.writeFileSync(file, "hier stehen zehn Beobachtungen, aber ohne Trenner\n", "utf8");
+    const r = runHook({ prompt: ">> leg los" });
+    expect(r.stdout).toContain("Sag dem Nutzer NICHT, es gebe keine Notizen");
+    expect(r.stdout).toContain("Lies die Datei roh");
+    expect(isModeActive(cwd)).toBe(true);
+  });
+
+  test("a marker prompt carrying an image still fires the merge", () => {
+    // The reported bug: the attachment rule was checked BEFORE the marker, so
+    // enriching the execute prompt with a screenshot downgraded it to a plain
+    // turn — no notes injected, and Claude reporting an empty batch while ten
+    // notes sat in the file.
+    appendNote(cwd, "Button verrutscht");
+    const r = runHook({ prompt: ">> so wie auf dem Screenshot [Image #1]" });
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain("Button verrutscht");
+    expect(r.stdout).toContain("so wie auf dem Screenshot");
+  });
+
+  test("a marker prompt carrying an @file mention still fires the merge", () => {
+    appendNote(cwd, "Fehlertext falsch");
+    const r = runHook({ prompt: ">> und @src/app/Header.tsx dabei beachten" });
+    expect(r.stdout).toContain("Fehlertext falsch");
+    expect(r.stdout).toContain("Header.tsx");
+  });
+
+  test("the enriched execute prompt is carried as part of the job", () => {
+    appendNote(cwd, "eine notiz");
+    const r = runHook({ prompt: ">> und warum ist das eigentlich so langsam?" });
+    expect(r.stdout).toContain("warum ist das eigentlich so langsam?");
+    expect(r.stdout).toContain("Ist es eine Frage, beantworte sie");
+  });
+
+  test("an expired mode still lets the marker reach its notes", () => {
+    // Expiry and the note cap end collection on their own. If the marker died
+    // with the mode, the queue would be unreachable by the one gesture the user
+    // was taught, and the merge would read as "there are no notes".
+    appendNote(cwd, "Button verrutscht");
+    activate(cwd, { marker: ">>", startedAt: Date.now() - 9 * 3600_000, expiryHours: 8 });
+    expect(isModeActive(cwd)).toBe(false);
+    const r = runHook({ prompt: ">> leg los" });
+    expect(r.stdout).toContain("Button verrutscht");
+    expect(r.stdout).toContain("bereits beendet");
+  });
+
+  test("the merge context demands a per-note disposition", () => {
+    appendNote(cwd, "eins");
+    appendNote(cwd, "zwei");
+    const r = runHook({ prompt: ">> leg los" });
+    expect(r.stdout).toContain("GENAU 2 Zeilen");
+    expect(r.stdout).toContain("Abdeckungsliste");
+  });
+});
+
+describe("mode on — an attachment prompt is filed, not executed", () => {
+  beforeEach(() => activate(cwd, { marker: ">>" }));
+
+  test("a prompt with an image gets the note-it-down guard", () => {
+    // It cannot be blocked (a blocked prompt is erased and the screenshot with
+    // it), so it passes through — but silently passing it through meant the
+    // model acted on it immediately AND the merge never learned it existed.
+    const r = runHook({ prompt: "so soll es aussehen [Image #1]" });
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain("Setze NICHTS davon um");
+    expect(r.stdout).toContain("[Anhang]");
+    expect(r.stdout).toContain("appendNote");
+  });
+
+  test("known attachment paths are named so the note can point at them", () => {
+    const r = runHook({ prompt: "vergleich mit @docs/spec.md", files: ["/tmp/shot.png"] });
+    expect(r.stdout).toContain("/tmp/shot.png");
+    expect(r.stdout).toContain("docs/spec.md");
+  });
+
+  test("an attachment-free collected prompt gets no guard", () => {
+    const r = runHook({ prompt: "ganz normale beobachtung" });
+    expect(r.code).toBe(2);
     expect(r.stdout).toBe("");
   });
 
@@ -245,7 +338,9 @@ describe("message builders", () => {
     expect(buildAck(1, ">>", true)).toContain("Frage");
   });
 
-  test("oversized note sets fall back to a file pointer", () => {
+  test("oversized note sets keep an index, never a bare file pointer", () => {
+    // A pointer alone is how a long queue lost items: the turn was told to read
+    // a file, read part of it, and nothing said what was missing.
     const notes = Array.from({ length: 400 }, (_, i) => ({
       at: "2026-08-16T10:00:00.000Z",
       text: `Notiz ${i} mit reichlich Text, damit die Grenze sicher überschritten wird.`,
@@ -254,6 +349,31 @@ describe("message builders", () => {
     expect(ctx.length).toBeLessThan(INLINE_LIMIT);
     expect(ctx).toContain("/tmp/p/.claude/batch.md");
     expect(ctx).toContain("los");
+    expect(ctx).toContain("Index aller 400 Notizen");
+    expect(ctx).toContain("#1 (2026-08-16T10:00:00.000Z) Notiz 0");
+  });
+
+  test("a truncated index says so instead of looking complete", () => {
+    const notes = Array.from({ length: 400 }, (_, i) => ({
+      at: "2026-08-16T10:00:00.000Z",
+      text: `Notiz ${i} `.repeat(20),
+    }));
+    const ctx = buildMergeContext(notes, "", "/tmp/p/.claude/batch.md");
+    expect(ctx).toMatch(/bis #400 sind hier NICHT gelistet/);
+  });
+
+  test("the empty-queue notice separates 'no file' from 'unreadable file'", () => {
+    expect(buildEmptyQueueNotice("/p/.claude/batch.md", false, 0, ">>"))
+      .toContain("tatsächlich leer");
+    expect(buildEmptyQueueNotice("/p/.claude/batch.md", true, 4096, ">>"))
+      .toContain("Sag dem Nutzer NICHT");
+  });
+
+  test("the attachment guard tells the turn to describe what only it can see", () => {
+    const g = buildAttachmentGuard(">>", ["/tmp/shot.png"]);
+    expect(g).toContain("beim Merge ist er nicht mehr im Kontext");
+    expect(g).toContain("/tmp/shot.png");
+    expect(g).toContain("WÖRTLICH");
   });
 });
 

--- a/plugins/devops/skills/claude-batch/SKILL.md
+++ b/plugins/devops/skills/claude-batch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: claude-batch
-version: 0.2.0
+version: 0.3.0
 description: >-
   Collect mode — batch prompts into one master plan instead of executing them one by one. While active, a UserPromptSubmit hook blocks each prompt (it never reaches the model, costing nothing) and appends it to `.claude/batch.md`; a configurable execute marker fires the merge, where the whole note set becomes ONE feasibility-checked plan. Purpose: avoid the rework of building for prompt 1 what prompt 5 supersedes, and avoid paying a full turn per observation. Triggers on "/claude-batch", "sammelmodus", "collect mode", "batch mode", "erstmal sammeln", "nicht sofort umsetzen". Do NOT trigger for normal work, for backlog execution (/run-backlog), or for issue creation (/setup-issue).
 ---
@@ -120,9 +120,36 @@ you think the separate items are — a note is the user's own words, and the mer
 in Step 4 reads content, not note boundaries. Guessing boundaries only risks
 losing a requirement. Skip this step silently when the invocation was bare.
 
+If the activating prompt carried an attachment, follow Step 2.6 for it in the
+same note.
+
 **2.5 Confirm in one short block** — the marker, where notes land, both exits,
 and (when 2.4 ran) that the first note is already stored, with the count. Then
 render an `analysis` completion card.
+
+**2.6 Attachments are filed by you, because only you can see them.** This is a
+standing rule for the whole collection window, not a one-off part of activation:
+it applies every time such a prompt arrives while the mode is on.
+
+A prompt carrying an image, pasted text, or an `@file` mention is never collected
+by the hook — blocking it would erase the prompt, and an erased screenshot is
+unrecoverable. So it passes through to you, and `prompt.batch.collect.js` injects
+a guard telling you to file it. Do that, and nothing else:
+
+1. **Do not act on it.** No planning, no research, no reading code for it. The
+   whole point of the mode is that this happens later, once.
+2. Note text = the prompt **verbatim**.
+3. Add a line `[Anhang] <sachliche Beschreibung>`. You see the attachment in this
+   turn; at merge time it is gone from the context. The description has to make
+   the note usable without it — what is visible, and what is wrong with it. "Bild
+   angehängt" is not a description.
+4. Add `[Anhang-Datei] <pfad>` for every path you know (`@file` targets, saved
+   screenshots). The guard lists the ones the hook could extract.
+5. Store it as ONE note via `appendNote`, then answer with a single line naming
+   the note number.
+
+Without this, the note reaches the merge as "mach das so wie hier" with no
+"hier" — the linkage the user actually cared about is the first thing lost.
 
 ## Step 3 — Status
 
@@ -151,17 +178,41 @@ Collecting those would block and erase exactly the prompts the work depends on.
 Treat the mode as OFF for the rest of this turn and all following ones.
 
 **4.1 Read every note.** `.claude/batch.md`, verbatim. Notes are the user's own
-words — never paraphrase them away before analysing.
+words — never paraphrase them away before analysing. When the injected context
+says the notes were too large to inline, read the file **completely** first; the
+index it carries is a checksum, not a substitute.
 
-**4.2 Feasibility-check against the real code BEFORE planning.** This is the
+**A note's `[Anhang]` / `[Anhang-Datei]` lines belong to that note and to no
+other.** Where an `[Anhang-Datei]` path still exists, open it before judging the
+note. Where only the `[Anhang]` description survives, that description IS the
+evidence — do not silently drop the note for lacking the image.
+
+**4.2 Write the coverage list before planning.** Exactly one line per note,
+`#1` … `#N`, each with a disposition:
+
+| Disposition | Meaning |
+|---|---|
+| übernommen | goes into the plan as written |
+| zusammengeführt mit #x | same surface as another note |
+| Konflikt mit #x | contradicts another note — Step 4.4 |
+| nicht machbar (Grund) | fails the feasibility check — named, not skipped |
+| Frage | answered first, then merged |
+
+Count the lines against the note count in the injected context before you go on.
+A note without a line is the defect this whole mode exists to prevent: it is not
+a shorter plan, it is a lost requirement. If the user enriched the execute prompt
+with extra text, it becomes `#N+1` and gets its own line — and if it was a
+question, answer it before the plan.
+
+**4.3 Feasibility-check against the real code BEFORE planning.** This is the
 step that pays for the whole mode: the notes were written blind, without Claude
 looking at anything. Some of them will be impossible, and later notes may depend
 on those. Check the substantive ones against the codebase.
 
-**4.3 Merge into ONE plan.** Not a list of n tasks executed in sequence — one
+**4.4 Merge into ONE plan.** Not a list of n tasks executed in sequence — one
 coherent piece of work. Where notes describe the same surface, they merge.
 
-**4.4 Surface conflicts individually — never resolve them silently.**
+**4.5 Surface conflicts individually — never resolve them silently.**
 
 > "#2 wollte den Header rot, #6 blau — ich nehme blau (später), sag Bescheid falls nicht."
 > "#3 setzt eine Filter-API voraus, die es nicht gibt. #5 und #9 hängen daran und fallen mit."
@@ -169,19 +220,19 @@ coherent piece of work. Where notes describe the same surface, they merge.
 Silent "later wins" resolution is the failure mode this step exists to prevent.
 An impossible item is **named**, never quietly routed around.
 
-**4.5 Present the plan and get approval.** After the OK:
+**4.6 Present the plan and get approval.** After the OK:
 - conflicts substantial enough to deserve clickable decisions → invoke `/concept`
 - otherwise → straight into implementation
 
 "Implementation" is deliberately broad: code, concepting, UI concepting, or only
 a first step of what the notes ask for.
 
-**4.6 Archive, do not delete.** After the plan is approved, call
+**4.7 Archive, do not delete.** After the plan is approved, call
 `archiveNotes(cwd)` — it renames `batch.md` to `batch-<timestamp>.md`. The
 originals stay recoverable; a merge must never be the only record of what the
 user actually wrote.
 
-**4.7 Retire the mode — never ask whether to stay in it.** Collection is already
+**4.8 Retire the mode — never ask whether to stay in it.** Collection is already
 off (the hook deactivated it when the merge fired; on the `/claude-batch go` path
 do it yourself — `deactivate(cwd)` is idempotent). Stop the watchdog so it does
 not linger for its next poll:
@@ -221,7 +272,19 @@ The dependency is soft. Resolve the plugin path and skip silently if absent —
 ## Rules
 
 - **Never collect** machine prompts, expanded slash commands, or prompts with
-  attachments. The hook enforces this; do not add exceptions in the skill.
+  attachments. The hook enforces this; do not add exceptions in the skill. An
+  attachment prompt is not collected *automatically*, but it is still filed —
+  by you, per Step 2.6. Passing it through untouched loses it entirely.
+- **The execute marker outranks everything except machine prompts and slash
+  commands.** `>> so wie hier [Image #1]` fires the merge; the attachment rule
+  does not apply, because an execute prompt is never blocked. And the marker
+  reaches the notes even when the mode already expired or hit its cap — the
+  notes outlive the mode.
+- **Never report an empty queue without looking.** If the marker fired and the
+  hook says nothing could be parsed, read `.claude/batch.md` raw before saying
+  there were no notes. A hand-edited file, a destroyed separator, or an editor
+  rewriting the file are all cases where content exists and the parse fails —
+  and "there are no notes" is then simply false.
 - **The red "Ein Hook hat deine Eingabe blockiert" panel is the normal collect
   path, not a failure.** Blocking the prompt is how the mode saves the turn; the
   harness has no quieter rendering for it. If the user reports it as an error,

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.133.4",
+  "version": "0.133.5",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

Hardening pass on `/claude-batch` after the first real collection run. Five defects with one visible symptom: notes went into the queue and did not come out.

- **The marker lost to the attachment rule.** `classify()` checked `hasAttachment` before `startsWithMarker`, so `>> so wie hier [Image #1]` was demoted to a plain turn — no notes injected, and Claude truthfully reporting an empty batch while ten notes sat in the file. The two rules exist for opposite reasons: attachments pass through so a *blocked* prompt can never erase an image, and an execute prompt is never blocked. The marker now wins.
- **Attachment prompts left no trace.** While collecting, an image-carrying prompt passed through untouched: the model acted on it immediately and the merge never learned it happened. It still cannot be collected, so the hook now injects a guard telling the turn to file it as a note with an `[Anhang]` description and `[Anhang-Datei]` paths — the turn is the only place the attachment is ever visible.
- **CRLF emptied the queue.** `readNotes` matched `-->\n`; the file header invites manual editing and every Windows editor rewrites it CRLF on save, at which point the whole queue parsed as zero notes with no error anywhere.
- **An unreadable queue was reported as an empty one.** The execute path exited silently on zero notes. It now names the file, its existence and size, and forbids the denial when the file has content the parser could not split.
- **Long queues lost their tail.** Over the inline limit the merge context dropped every note for a bare file pointer. It now always carries a numbered index plus a mandatory full read, and says so when the index itself was truncated.

Two behavioural additions follow from the same principle — the notes outlive the mode that collected them:

- The marker fires the merge even after collection auto-ended (expiry, note cap, manual off).
- The merge context requires a coverage list: one line per note, `#1` … `#N`, each with a disposition. A note without a line is a lost requirement, not a shorter plan.

## Tests

- `npm test` — 1904/1904 green (+21 new regression tests across `batch-state.test.js` and `prompt.batch.collect.test.js`)
- `npm run lint` — clean
- E2E replay of the reported case: 10 notes collected, then `>> und warum ist das so? [Image #1]` → all 10 notes injected, the question carried, mode ended

🤖 Generated with [Claude Code](https://claude.com/claude-code)