### PR TITLE
fix(ship): clamp over-long titles instead of failing the release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.133.5"
+    "version": "0.133.6"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.133.5",
+      "version": "0.133.6",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.133.5",
+      "version": "0.133.6",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.133.6] — 2026-08-23
+
+### Fixed
+
+- **A PR title a few characters too long no longer kills the release.** The title was enforced as a hard `z.string().max(70)`, so an over-long one was rejected by the MCP layer rather than shortened — and the reject landed at the worst possible point in the pipeline. By the time `ship_release` is called, preflight has passed, the build is green, and the version bump plus CHANGELOG have already been committed; the ship then died with the version raised and no PR to show for it. Nothing in the failure said "your title was too long", so it read as a crash, and it recurred across several projects over the past weeks. The title is now clamped on a word boundary instead — no ellipsis, because a squash merge turns the title into the commit subject and a subject trailing off in dots is worse than one that simply ends early. The cut is reported back as `titleClamped` (`{ original, applied, max }`), so a shortened title is visible rather than silent, and the 70-char budget survives as guidance in the tool description.
+
+- **The completion card no longer refuses to render over one bullet too many.** The same defect sat on `summary` (80 chars) and on the `changes`, `tests` and `validation` arrays (3/3/4 entries). Here it was worse than cosmetic: the stop hook *requires* a card before a turn may end, so the one call able to satisfy that requirement could be rejected for a formatting overrun — leaving the turn with no way out. All four caps now clamp instead of rejecting.
+
 ## [0.133.5] — 2026-08-23
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.133.5**
+**Version: 0.133.6**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.133.5",
+  "version": "0.133.6",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/mcp-server/index.js
+++ b/plugins/devops/mcp-server/index.js
@@ -25,6 +25,7 @@ import { join, resolve, dirname } from "node:path";
 import { homedir, tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { correctShipVariant, renderDowngradeNote } from "./lib/variant-guard.js";
+import { clampText, clampList } from "./lib/soft-limits.js";
 import {
   assessFreshness,
   isLiveSnapshot,
@@ -1182,7 +1183,8 @@ server.registerTool(
         "ship-successful", "ready", "released", "ship-blocked", "test",
         "test-minimal", "analysis", "aborted", "fallback",
       ]).describe("Card variant based on task outcome. `released` is the channel-promotion card (promote alpha→beta→stable) rendered by the promote skill."),
-      summary: z.string().max(80).describe("Max ~10 words, user's language"),
+      summary: z.string().transform(v => clampText(v, 80).value)
+        .describe("Max ~10 words, user's language (over-long summaries are clamped, not rejected)"),
       lang: z.enum(["en", "de"]).default("de").describe("UI language for CTA"),
       cwd: z.string().optional().describe("Working directory of the target repo. STRONGLY RECOMMENDED for ship-* variants — without it, getRepoUrl falls back to the MCP server's own cwd (plugin dir) and the card cannot render clickable PR/commit/branch links."),
       buildId: z.string().optional().describe("Pre-computed build-ID (from ship_build). If provided, skips internal computation. Use this when the worktree/branch state may have changed after building (e.g. post-merge)."),
@@ -1192,14 +1194,14 @@ server.registerTool(
         z.array(z.object({
           area: z.string().describe("Functional surface the user perceives or the change is about (e.g. 'Completion card', 'Ship pipeline', 'Branch cleanup', 'Skill fix'). NOT a file path or internal module name. Technical wording only when the topic itself is purely technical (parser, flag, protocol)."),
           description: z.string().describe("What behaves differently now, in user-domain language. Describe the functional/user-visible effect — same rule as `area`: technical phrasing only when the topic is genuinely technical."),
-        })).max(3).optional(),
+        })).transform(v => clampList(v, 3).value).optional(),
       ).describe("Top 3 FUNCTIONAL changes — both `area` AND description should describe what the user perceives or what behaves differently, not which files were edited. Keep the 'area → description' shape. Files/paths only when the file IS the deliverable (skill, keybindings.json, settings.json, CLAUDE.md, hook script). Internal helpers/renderers/libs never appear. Good: 'Completion card → Changes-Bullets jetzt funktional formuliert'. Good (purely technical topic): 'JSON parser → akzeptiert trailing commas'. Bad: 'mcp-server/index.js → renderChanges() angepasst'."),
       tests: z.preprocess(
         v => typeof v === 'string' ? tryParse(v) : v,
         z.array(z.object({
           method: z.string(),
           result: z.string(),
-        })).max(3).optional(),
+        })).transform(v => clampList(v, 3).value).optional(),
       ).describe("Test results (max 3)"),
       state: z.preprocess(
         v => typeof v === 'string' ? tryParse(v) : v,
@@ -1261,7 +1263,7 @@ server.registerTool(
           requirement: z.string().describe("A requirement / acceptance criterion the change had to satisfy — in user-domain language."),
           status: z.enum(["met", "partial", "unmet"]).optional().describe("Whether this change satisfies the requirement."),
           evidence: z.string().optional().describe("How you CONFIRMED it (the test that proves it, the behaviour observed) — not a restatement of the requirement."),
-        })).max(4).optional(),
+        })).transform(v => clampList(v, 4).value).optional(),
       ).describe("V&V gate — validation attestation (“did we build the RIGHT thing”). REQUIRED for any turn that changed source code: map each requirement / acceptance criterion to how this change meets it and how you confirmed it. A code-change card without `validation` is blocked once by stop.flow.guard and re-requested. For a pure refactor/chore with no explicit requirement, pass one item stating the intent and how behaviour was kept equivalent. Each item: { requirement, status: met|partial|unmet, evidence }."),
       delivery: z.preprocess(
         v => typeof v === 'string' ? tryParse(v) : v,

--- a/plugins/devops/mcp-server/lib/soft-limits.js
+++ b/plugins/devops/mcp-server/lib/soft-limits.js
@@ -1,0 +1,48 @@
+/**
+ * Soft length limits for cosmetic fields.
+ *
+ * A PR title or card summary that runs a few characters long is a formatting
+ * nit. Enforced as a hard `z.string().max()` it becomes a rejected MCP call —
+ * and `ship_release` is rejected *after* preflight, build and the version bump
+ * have already committed. The pipeline then dies with the version raised, the
+ * CHANGELOG written and no PR to show for it, which reads as a crash rather
+ * than as "your title was too long".
+ *
+ * These helpers keep the budget as guidance (it stays in `.describe()`, so the
+ * caller still aims for it) but clamp at the boundary instead of throwing, and
+ * report what was cut so the truncation is visible rather than silent.
+ */
+
+/** Cut no further back than this fraction of the budget when seeking a word boundary. */
+const WORD_BOUNDARY_FLOOR = 0.6;
+
+/**
+ * Clamp `value` to `limit` characters, preferring a word boundary.
+ *
+ * Returns the original untouched (and `clamped: false`) when it already fits or
+ * is not a string — callers may hand this optional fields.
+ */
+export function clampText(value, limit) {
+  if (typeof value !== "string" || value.length <= limit) {
+    return { value, clamped: false, original: null };
+  }
+
+  const head = value.slice(0, limit);
+  const lastSpace = head.lastIndexOf(" ");
+  // A boundary too close to the start would discard most of the subject; a hard
+  // cut keeps more meaning than a two-word fragment.
+  const cut = lastSpace >= limit * WORD_BOUNDARY_FLOOR ? head.slice(0, lastSpace) : head;
+
+  // No ellipsis: a squash merge turns the PR title into the commit subject, and
+  // a subject trailing off in dots is worse than one that simply ends early.
+  return { value: cut.replace(/[\s,;:\-–—]+$/, ""), clamped: true, original: value };
+}
+
+/** Clamp `value` to `limit` entries, reporting how many were dropped. */
+export function clampList(value, limit) {
+  if (!Array.isArray(value) || value.length <= limit) {
+    return { value, clamped: false, dropped: 0 };
+  }
+  return { value: value.slice(0, limit), clamped: true, dropped: value.length - limit };
+}
+

--- a/plugins/devops/mcp-server/lib/soft-limits.test.js
+++ b/plugins/devops/mcp-server/lib/soft-limits.test.js
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { clampText, clampList } from "./soft-limits.js";
+
+describe("clampText", () => {
+  it("passes a value that fits through untouched", () => {
+    expect(clampText("fix(ship): short title", 70))
+      .toEqual({ value: "fix(ship): short title", clamped: false, original: null });
+  });
+
+  it("passes a value exactly at the limit", () => {
+    const exact = "x".repeat(70);
+    expect(clampText(exact, 70)).toEqual({ value: exact, clamped: false, original: null });
+  });
+
+  it("clamps an over-long value to the limit instead of rejecting it", () => {
+    const long = "fix(ship): a conventional commit subject that runs well past the seventy character budget";
+    const r = clampText(long, 70);
+    expect(r.clamped).toBe(true);
+    expect(r.value.length).toBeLessThanOrEqual(70);
+    expect(r.original).toBe(long);
+  });
+
+  it("cuts on a word boundary so the subject stays readable", () => {
+    const long = "fix(ship): clamp over-long PR titles instead of crashing the whole pipeline";
+    const r = clampText(long, 70);
+    expect(r.value).toBe("fix(ship): clamp over-long PR titles instead of crashing the whole");
+    expect(r.value.endsWith(" ")).toBe(false);
+  });
+
+  it("hard-cuts when no word boundary is close enough to the limit", () => {
+    const r = clampText(`${"a".repeat(90)} tail`, 70);
+    expect(r.value).toBe("a".repeat(70));
+    expect(r.clamped).toBe(true);
+  });
+
+  it("appends no ellipsis — a commit subject must stay clean", () => {
+    const r = clampText("feat(x): ".concat("word ".repeat(40)), 70);
+    expect(r.value).not.toMatch(/[.…]{1,3}$/);
+  });
+
+  it("trims trailing separators left by the cut", () => {
+    const r = clampText("fix(ship): clamp titles, verify tags, and never crash the pipeline again", 70);
+    expect(r.value).not.toMatch(/[,\s-]$/);
+  });
+
+  it("treats a non-string as a pass-through rather than throwing", () => {
+    expect(clampText(undefined, 70)).toEqual({ value: undefined, clamped: false, original: null });
+  });
+});
+
+describe("clampList", () => {
+  it("passes a list within budget untouched", () => {
+    const list = [1, 2, 3];
+    expect(clampList(list, 3)).toEqual({ value: list, clamped: false, dropped: 0 });
+  });
+
+  it("slices an over-long list and reports how many were dropped", () => {
+    expect(clampList([1, 2, 3, 4, 5], 3)).toEqual({ value: [1, 2, 3], clamped: true, dropped: 2 });
+  });
+
+  it("treats a non-array as a pass-through", () => {
+    expect(clampList(undefined, 3)).toEqual({ value: undefined, clamped: false, dropped: 0 });
+  });
+});
+

--- a/plugins/devops/mcp-server/ship/tools/release.js
+++ b/plugins/devops/mcp-server/ship/tools/release.js
@@ -11,10 +11,14 @@ import { detectRepoMode } from "../lib/repo-mode.js";
 import { remoteTagExists } from "../lib/remote-tags.js";
 import { retryUntil } from "../lib/retry.js";
 import { scanConflictMarkers, describeMarkers } from "../lib/conflict-markers.js";
+import { clampText } from "../../lib/soft-limits.js";
+
+/** Soft budget for the PR title — over-long titles are clamped, never rejected. */
+export const PR_TITLE_MAX = 70;
 
 export const schema = z.object({
   base: z.string().default("main").describe("Base branch for PR (may be a feature branch for intermediate merges)"),
-  title: z.string().max(70).describe("PR title (conventional commit format)"),
+  title: z.string().describe("PR title (conventional commit format). Aim for ≤70 chars — a longer title is clamped on a word boundary, not rejected."),
   body: z.string().describe("PR body (must start with Closes #N if applicable)"),
   tag: z.string().nullable().default(null).describe("Bare version tag (e.g. v0.18.0) — the tool publishes it as alpha/<tag> (ring model), null to skip. Ignored for intermediate merges"),
   releaseNotes: z.string().nullable().default(null).describe("CHANGELOG entry — NOT published at ship time (releases happen at promotion via ship_promote); recorded as releaseDeferred"),
@@ -29,7 +33,12 @@ export const schema = z.object({
 });
 
 export async function handler(params) {
-  const { base, title, body, tag, releaseNotes, commitMessage, mergeStrategy, skipChecks, checksTimeoutSec } = params;
+  const { base, body, tag, releaseNotes, commitMessage, mergeStrategy, skipChecks, checksTimeoutSec } = params;
+  // Clamp rather than reject: by the time we get here preflight, build and the
+  // version bump have already committed, so failing on title length would abort
+  // the pipeline with the version raised and no PR to show for it.
+  const titleClamp = clampText(params.title, PR_TITLE_MAX);
+  const title = titleClamp.value;
   // Schema defaults apply in production; `??` keeps direct callers/tests working.
   const tagVerifyAttempts = params.tagVerifyAttempts ?? 4;
   const tagRetryDelayMs = params.tagRetryDelayMs ?? 1_000;
@@ -178,6 +187,9 @@ export async function handler(params) {
       pr = createPR({ title, body, base, head: branch }, opts);
     }
     result.pr = { number: pr.number, url: pr.url, title };
+    if (titleClamp.clamped) {
+      result.titleClamped = { original: titleClamp.original, applied: title, max: PR_TITLE_MAX };
+    }
     result.mergeStrategy = mergeStrategy;
 
     // Pre-Merge Checks Gate — wait for CI on the PR before merging.

--- a/plugins/devops/mcp-server/ship/tools/release.test.js
+++ b/plugins/devops/mcp-server/ship/tools/release.test.js
@@ -51,7 +51,7 @@ vi.mock("../lib/conflict-markers.js", async (importOriginal) => ({
   scanConflictMarkers: vi.fn(() => ({ clean: true, scanned: 0, scope: "diff+worktree", offenders: [], repoOffenders: [], repoScanned: 0, repoTruncated: false })),
 }));
 
-import { handler } from "./release.js";
+import { handler, PR_TITLE_MAX } from "./release.js";
 import * as gitLib from "../lib/git.js";
 import * as ghLib from "../lib/github.js";
 import { scanConflictMarkers } from "../lib/conflict-markers.js";
@@ -558,5 +558,42 @@ describe("ship_release — #251 channel-tag verification", () => {
     const push = gitLib.gitStrict.mock.calls.find((c) => c[0] === "push origin alpha/v1.0.0");
     expect(push).toBeDefined();
     expect(push[1]).toMatchObject({ timeout: 60000 });
+  });
+});
+
+// A PR title a few characters over budget used to be a hard schema reject, and
+// the reject landed here — after preflight, build and the version bump had
+// already committed. The ship died with the version raised and no PR to show
+// for it, which reads as a crash rather than as "your title was too long".
+describe("ship_release — over-long PR title is clamped, never fatal", () => {
+  const LONG = "fix(ship): clamp over-long PR titles on a word boundary instead of aborting the entire release pipeline";
+
+  test("an over-long title still ships and reports what was cut", async () => {
+    const res = await handler(params({ title: LONG }));
+
+    expect(res.success).toBe(true);
+    expect(res.titleClamped).toEqual({
+      original: LONG,
+      applied: expect.any(String),
+      max: PR_TITLE_MAX,
+    });
+    expect(res.titleClamped.applied.length).toBeLessThanOrEqual(PR_TITLE_MAX);
+  });
+
+  test("the PR is created with the clamped title, not the raw one", async () => {
+    await handler(params({ title: LONG }));
+
+    const [prArgs] = ghLib.createPR.mock.calls.at(-1);
+    expect(prArgs.title.length).toBeLessThanOrEqual(PR_TITLE_MAX);
+    expect(prArgs.title).not.toBe(LONG);
+    // Word boundary, so the conventional-commit prefix survives intact.
+    expect(prArgs.title.startsWith("fix(ship): clamp over-long PR titles")).toBe(true);
+  });
+
+  test("a title within budget is passed through untouched and not reported", async () => {
+    const res = await handler(params({ title: "fix(ship): short enough" }));
+
+    expect(res.titleClamped).toBeUndefined();
+    expect(ghLib.createPR.mock.calls.at(-1)[0].title).toBe("fix(ship): short enough");
   });
 });

--- a/plugins/devops/skills/ship/SKILL.md
+++ b/plugins/devops/skills/ship/SKILL.md
@@ -370,7 +370,9 @@ the tool automatically skips tag/release creation when `base` is not `main`.
 
 The tool handles: commit (optional), rebase verification, push (explicit force-with-lease after rebase), PR create (or reuse with mergeability check), **pre-merge CI checks gate (waits for green)**, **pre-merge rebase re-check (closes the checks-window race)**, merge (squash or merge commit), **post-merge tree guard**, **alpha channel tag** (main only), GitHub release deferred to promotion.
 
-Returns: `{ branch, commit, rebased, pushed, pr: {number, url}, checks: {status, passed, failed, pending}, merged, mergeStrategy, intermediate, tag, channel, tagVerified, releaseDeferred, postMergeTreeMatch, postMergeWarning }`.
+Returns: `{ branch, commit, rebased, pushed, pr: {number, url}, checks: {status, passed, failed, pending}, merged, mergeStrategy, intermediate, tag, channel, tagVerified, releaseDeferred, postMergeTreeMatch, postMergeWarning, titleClamped }`.
+
+**If `titleClamped` is set**: the PR title exceeded the 70-char budget and was cut on a word boundary — the ship proceeded, it is not an error. The field carries `{ original, applied, max }`. Aim for a shorter title next time; surface it only if the clamped subject reads badly.
 
 **Ring model (channels):** the tag is `alpha/vX.Y.Z` — every ship publishes to
 the EARLIEST channel autonomously. beta/stable tags and GitHub Releases are

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.133.5",
+  "version": "0.133.6",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

A PR title a few characters past the 70-char budget was enforced as a hard `z.string().max(70)`, so the MCP call was rejected outright instead of the title being shortened. The reject lands at the worst possible point: by the time `ship_release` runs, preflight has passed, the build is green, and the version bump plus CHANGELOG are already committed. The ship then died with the version raised and no PR to show for it — which reads as a crash, not as "your title was too long". Recurring across several projects over the past weeks.

The completion card carried the same defect on `summary` (80 chars) and on the `changes` / `tests` / `validation` arrays (3/3/4). There it is worse than cosmetic: the stop hook requires a card before a turn may end, so one surplus bullet could reject the only call able to satisfy that requirement.

## Changes

- New `mcp-server/lib/soft-limits.js` — `clampText` cuts on a word boundary (no ellipsis: a squash merge turns the PR title into the commit subject) and `clampList` slices, both reporting what was cut. Dependency-free, so it stays testable from the repo root where zod does not resolve.
- `ship_release` clamps the title in the handler and reports `titleClamped` (`{ original, applied, max }`), so a shortened title is visible rather than silent. `PR_TITLE_MAX` is exported; the budget survives as guidance in `.describe()`.
- The card's four hard caps become clamps.
- Ship skill documents the new `titleClamped` return field.

## Verification

- Full suite green: 76 files, 1918 tests.
- `npm run lint` clean.
- New regression tests cover the handler end to end: an over-long title still ships, the PR is created with the clamped title (conventional-commit prefix intact), and a title within budget passes through untouched and is not reported.

## Note

The Codex review gate could not run — the CLI returned a usage-limit error (rc=1). Per the gate's failure-tolerance rule the pipeline continued; this change has not had an independent Codex review.
