### PR TITLE
fix(git-sync): merge origin/main, not the ref git cannot update

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.133.6"
+    "version": "0.133.7"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.133.6",
+      "version": "0.133.7",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.133.6",
+      "version": "0.133.7",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.133.7] — 2026-08-24
+
+### Fixed
+
+- **The background git sync was doing nothing at all, and said so by staying quiet.** It merged the *local* `main` ref and kept that ref current with `git fetch origin main:main` — a fetch git refuses outright whenever `main` is checked out in any worktree, which is the standard layout here: the primary worktree parked on main, feature work in linked worktrees. The refusal went into the script's catch-all and vanished, so every run compared `HEAD` against a ref frozen at whatever was last pulled by hand, `rev-list --count HEAD..main` answered 0, and the sync correctly reported that there was nothing to do. Measured before the fix: across 96 sessions in three days it delivered exactly one result, and none at all in this repo, while `main` advanced six times a day. The local ref in this checkout had not moved in a week. The sync now merges `refs/remotes/<origin>/<parent>` — refs that are never checked out and can always be updated — and the default branch is asked for via `origin/HEAD` instead of assumed to be `main`, so a `master` repo is no longer a silent no-op either.
+
+- **A sync that actually runs needed guards a no-op never did.** It now refuses to touch the index when HEAD is detached (these worktrees sit detached between tasks, where a merge writes a commit nothing points at), when another operation owns the index — including a conflicted `git stash pop`, which leaves unmerged entries but no marker file and would otherwise have had its conflicts resolved and committed by the sync — and while a `/ship` is in flight, checked both when the sync is spawned and again immediately before the merge. It never touches a path with uncommitted work, untracked files and renames included, and a probe that fails reads as "busy", never as "clean".
+
+- **Repo commit hooks no longer turn every sync into a recurring failure report.** The sync commits from a detached, console-less process: a hook that prompts cannot be answered, and a commitlint `commit-msg` rejecting git's auto-generated "Merge remote-tracking branch …" subject would have produced a `✗` every thirty minutes for as long as `main` stayed ahead. Its own git calls now run with `core.hooksPath` pointed at a directory that cannot exist — deliberately not `--no-verify`, which `git merge` only accepts from Git 2.36 and which on an older git would have recreated the same loop through an unknown-option error.
+
+- **A failed merge can no longer wedge the sync shut.** When the auto-resolve commit fails, the merge is rolled back before the failure is reported; leaving `MERGE_HEAD` in place would have made the new quiescence gate read the worktree as busy and silence every future sync in it. The report names the leftover state when the rollback itself does not take.
+
+- **The three report shapes stopped being interchangeable.** A merge git refused without producing a single conflicted file used to be reported as a conflict with an empty file list, which handed the assistant the full semantic-resolution procedure for nothing; it is now an error. In the other direction, a genuine conflict was downgraded to an error whenever any unrelated scratch file sat in the worktree — and only the conflict shape carries the resolution procedure, so the one case the feature exists for was the one that never reached anyone.
+
 ## [0.133.6] — 2026-08-23
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.133.6**
+**Version: 0.133.7**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.133.6",
+  "version": "0.133.7",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/deep-knowledge/merge-safety.md
+++ b/plugins/devops/deep-knowledge/merge-safety.md
@@ -188,9 +188,36 @@ git add <resolved-files>
 git commit --no-edit
 ```
 
-## How git-sync.js Handles Conflicts
+## What git-sync.js Merges, and When It Refuses
 
-As of v0.3.0, `git-sync.js` resolves conflicts in two tiers:
+The sync merges **remote-tracking refs** (`origin/main`, and `origin/<parent>`
+for a hierarchical branch), never the local branch ref. That is not a
+preference: `git fetch origin main:main` is refused by git whenever `main` is
+checked out in any worktree — the standard layout here — so a sync built on the
+local ref compares HEAD against a frozen ref and silently reports nothing. It
+did exactly that, for weeks, until v0.4.0.
+
+Before touching the index, the sync refuses to run at all when:
+
+- **HEAD is detached** — worktrees sit detached between tasks, and a merge there
+  writes a commit nothing points at.
+- **Another operation owns the index** — an unfinished merge, rebase,
+  cherry-pick, revert or bisect, or *any* unmerged index entry. The last one
+  matters on its own: a conflicted `git stash pop` leaves no marker file, and a
+  merge attempted on top of it would pick up that operation's conflicted files
+  and commit them.
+- **A `/ship` is in flight** — checked at spawn time by the hooks and again
+  immediately before the merge, so a ship started mid-fetch is still caught.
+- **The incoming change touches a path with uncommitted work** — untracked files
+  and renames included. The sync stays silent and merges at a later window.
+
+Its own git calls run with `core.hooksPath` pointed at a non-existent directory:
+the process is detached and console-less, so a repo hook that prompts cannot be
+answered and one that rejects (commitlint refusing git's auto-generated merge
+subject) would turn every sync into a recurring failure report. `--no-verify` is
+deliberately NOT used — `git merge` only accepts it from Git 2.36.
+
+Conflicts are then resolved in two tiers:
 
 1. **Trivial conflicts** — resolved automatically without user intervention:
    - One side unchanged from base → take the other side
@@ -205,6 +232,13 @@ As of v0.3.0, `git-sync.js` resolves conflicts in two tiers:
      result file that `prompt.git.sync` injects as turn context. Conflicts
      therefore surface inside a turn the user is already in — there is no
      cron waking Claude up in a turn of its own.
+
+The three report shapes are not interchangeable. Only `⚠` carries the
+resolution procedure to the assistant; `✗` is classified as an error and stops
+there. A merge git refused without producing a single conflicted file is
+therefore reported as `✗`, never as a `⚠` with an empty file list, and a real
+conflict is never downgraded to `✗` because unrelated scratch files happen to
+sit in the worktree.
 
 ## How ship_release Prevents Overwrites
 

--- a/plugins/devops/hooks/session-start/ss.git.sync.js
+++ b/plugins/devops/hooks/session-start/ss.git.sync.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * @hook ss.git.sync
- * @version 1.0.0
+ * @version 1.1.0
  * @event SessionStart
  * @plugin devops
  * @description Starts ONE detached background git sync for this worktree.
@@ -42,8 +42,19 @@ function git(cmd) {
 if (git('rev-parse --is-inside-work-tree') !== 'true') process.exit(0);
 if (!git('remote')) process.exit(0);
 
-const branch = git('rev-parse --abbrev-ref HEAD');
+// symbolic-ref, not rev-parse --abbrev-ref: the latter answers the literal
+// 'HEAD' on a detached HEAD, which passes the !== 'main' test and burns the
+// 30-minute throttle slot on a sync the child then refuses outright. These
+// worktrees sit detached between tasks, so that is the common state.
+const branch = git('symbolic-ref --quiet --short HEAD');
 if (!branch || branch === 'main') process.exit(0);
+
+// A session resumed in the middle of a ship must not merge under the pipeline:
+// ship rebases and releases what it just tested, and a background merge commit
+// arriving in between changes the tree out from under it.
+try {
+  if (require('../lib/ship-sentinel').isActive(cwd)) process.exit(0);
+} catch { /* sentinel unreadable — proceed */ }
 
 // Throttle is worktree-scoped, so reopening Claude five times in ten minutes
 // (or running two sessions on the same worktree) still yields one sync.

--- a/plugins/devops/hooks/stop/stop.git.sync.js
+++ b/plugins/devops/hooks/stop/stop.git.sync.js
@@ -1,15 +1,19 @@
 #!/usr/bin/env node
 /**
  * @hook stop.git.sync
- * @version 0.1.0
+ * @version 0.2.0
  * @event Stop
  * @plugin devops
  * @description Throttled background git sync at turn end. Replaces the former
  *   ten-minute git-sync cron as the in-session recurrence mechanism.
  *
- *   Stop is the right moment: the turn is over, so a merge cannot land under a
- *   file the assistant is mid-edit on — the cron could fire at any instant,
- *   including inside a tool call. The child is detached and this hook returns
+ *   Stop is the better moment: the turn is over, so the merge does not land in
+ *   the middle of a tool call the way the ten-minute cron could. It is not a
+ *   guarantee — the child is detached and takes a second or two, so a merge can
+ *   still overlap the START of the next turn. What keeps that safe is in
+ *   scripts/git-sync.js, not here: it refuses to touch any path with
+ *   uncommitted changes, and bails outright on a repo that is mid-merge,
+ *   mid-rebase or detached. The child is detached and this hook returns
  *   immediately, so turn end is never delayed by a fetch.
  *
  *   Always exits 0 with no output. A sync that finds something writes a result
@@ -43,10 +47,21 @@ function maybeSync() {
   // pure waste while the window is closed.
   if (!claimSyncSlot(cwd, { peek: true })) return;
 
+  // A ship spans several turns (approval questions, CI wait), so Stop fires
+  // INSIDE the pipeline. A merge commit landing between ship's rebase and its
+  // release would mean the tree that was tested is not the tree being shipped.
+  try {
+    if (require('../lib/ship-sentinel').isActive(cwd)) return;
+  } catch { /* sentinel unreadable — a sync is not worth failing turn end over */ }
+
   if (git('rev-parse --is-inside-work-tree') !== 'true') return;
   if (!git('remote')) return;
 
-  const branch = git('rev-parse --abbrev-ref HEAD');
+  // symbolic-ref, not rev-parse --abbrev-ref: the latter answers the literal
+  // 'HEAD' on a detached HEAD, which passes the !== 'main' test and burns the
+  // 30-minute throttle slot on a sync the child then refuses outright. These
+  // worktrees sit detached between tasks, so that is the common state.
+  const branch = git('symbolic-ref --quiet --short HEAD');
   if (!branch || branch === 'main') return;
 
   // Claim only now that a sync will actually happen.

--- a/plugins/devops/scripts/__fixtures__/git-sync-world.js
+++ b/plugins/devops/scripts/__fixtures__/git-sync-world.js
@@ -1,0 +1,143 @@
+/**
+ * @module git-sync-world
+ * @description Test-only harness for the git-sync integration suites.
+ *
+ *   git-sync's defining bug was invisible to unit tests — it merged the LOCAL
+ *   `main` ref and refreshed it with `git fetch origin main:main`, a command
+ *   git refuses whenever main is checked out in some worktree. Nothing short of
+ *   a real repository in that exact layout catches it, so every suite built on
+ *   this harness runs against real git: a bare origin, a primary worktree
+ *   parked on main, and feature work in a linked worktree.
+ *
+ *   The suites are split across several files on purpose. Each world costs two
+ *   real clones, and one file holding all of them ran long enough that vitest's
+ *   reporter RPC timed out mid-run ("Timeout calling onTaskUpdate") — reported
+ *   as an error next to a fully green suite. Separate files land in separate
+ *   workers and stay short enough for that not to happen.
+ */
+
+import { execFileSync } from "child_process";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { fileURLToPath } from "url";
+
+export const SCRIPT = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "git-sync.js"
+);
+
+/** Every world this process created, for the suite's afterAll sweep. */
+const worlds = [];
+
+/**
+ * Identity comes from the environment rather than three `git config` calls per
+ * repository: a process spawn costs ~200ms on Windows and each test builds a
+ * fresh world. gpg signing is off deliberately — the sync commits from a
+ * detached, console-less child that cannot drive pinentry, so the machine's
+ * global signing config would otherwise hang the test on nothing to do with
+ * the script under test.
+ */
+const GIT_ENV = {
+  ...process.env,
+  GIT_AUTHOR_NAME: "Test",
+  GIT_AUTHOR_EMAIL: "test@example.com",
+  GIT_COMMITTER_NAME: "Test",
+  GIT_COMMITTER_EMAIL: "test@example.com",
+  GIT_CONFIG_COUNT: "1",
+  GIT_CONFIG_KEY_0: "commit.gpgsign",
+  GIT_CONFIG_VALUE_0: "false",
+};
+
+export function git(cwd, args) {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    stdio: ["pipe", "pipe", "pipe"],
+    windowsHide: true,
+    env: GIT_ENV,
+  }).trim();
+}
+
+/** Run git-sync.js the way the background spawner does. Returns its report or "". */
+export function runSync(cwd, resultFile, envOverride = {}) {
+  execFileSync(process.execPath, [SCRIPT], {
+    cwd,
+    encoding: "utf8",
+    stdio: ["pipe", "pipe", "pipe"],
+    windowsHide: true,
+    env: { ...GIT_ENV, ...envOverride, DEVOPS_GIT_SYNC_RESULT_FILE: resultFile },
+  });
+  try {
+    return fs.readFileSync(resultFile, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+export function write(repo, file, content) {
+  fs.writeFileSync(path.join(repo, file), content, "utf8");
+}
+
+/** Read back a working-tree file, normalising the CRLF git checks out on Windows. */
+export function read(repo, file) {
+  return fs.readFileSync(path.join(repo, file), "utf8").replace(/\r\n/g, "\n");
+}
+
+export function commitAll(repo, message) {
+  git(repo, ["add", "-A"]);
+  git(repo, ["commit", "-m", message, "--no-verify"]);
+}
+
+/** A scratch directory tracked for cleanup, for suites that build their own world. */
+export function makeRoot() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "git-sync-int-"));
+  worlds.push(root);
+  return root;
+}
+
+/**
+ * origin (bare) ← primary (on main) + linked worktree on `feature`.
+ * `other` is a second clone used to move origin/main behind everyone's back,
+ * the way a merged PR does — it must not be primary, because advancing
+ * primary's local main would destroy the very precondition under test.
+ */
+export function makeWorld() {
+  const root = makeRoot();
+  const originPath = path.join(root, "origin.git");
+  git(root, ["init", "--bare", "--initial-branch=main", originPath]);
+
+  const primary = path.join(root, "primary");
+  git(root, ["clone", "--quiet", originPath, primary]);
+  write(primary, "base.txt", "base\n");
+  write(primary, "untouched.txt", "untouched\n");
+  commitAll(primary, "base");
+  git(primary, ["push", "--quiet", "origin", "main"]);
+
+  // Linked worktree on a feature branch — primary STAYS on main.
+  const wt = path.join(root, "wt");
+  git(primary, ["worktree", "add", "--quiet", "-b", "feature", wt, "main"]);
+
+  const other = path.join(root, "other");
+  git(root, ["clone", "--quiet", originPath, other]);
+
+  return { root, originPath, primary, wt, other };
+}
+
+/** Land a commit on origin/main, as a merged PR would. Expects `other` on main. */
+export function advanceOrigin(other, file, content, message) {
+  git(other, ["pull", "--quiet", "--ff-only", "origin", "main"]);
+  write(other, file, content);
+  commitAll(other, message);
+  git(other, ["push", "--quiet", "origin", "main"]);
+}
+
+/** Register as the suite's afterAll. */
+export function cleanupWorlds() {
+  for (const dir of worlds) {
+    try {
+      fs.rmSync(dir, { recursive: true, force: true, maxRetries: 3 });
+    } catch { /* Windows may still hold a handle — the temp dir is disposable */ }
+  }
+}

--- a/plugins/devops/scripts/git-sync.conflicts.test.js
+++ b/plugins/devops/scripts/git-sync.conflicts.test.js
@@ -1,0 +1,204 @@
+import { describe, test, expect, afterAll } from "vitest";
+import fs from "fs";
+import path from "path";
+import {
+  git,
+  runSync,
+  write,
+  read,
+  commitAll,
+  makeWorld,
+  advanceOrigin,
+  cleanupWorlds,
+} from "./__fixtures__/git-sync-world.js";
+
+/**
+ * What git-sync reports when the merge is not clean, and how it walks a
+ * branch's parent chain. The reporting shape matters as much as the merge:
+ * only a ⚠ carries the resolution procedure to the assistant, while a ✗ is
+ * classified as an error and stops there.
+ */
+
+afterAll(cleanupWorlds);
+
+describe.concurrent("conflict reporting", () => {
+  test("auto-resolves a whitespace-only conflict instead of asking for help", () => {
+    const { root, wt, other } = makeWorld();
+    // Same line touched on both sides, but the worktree only re-indented it —
+    // that is the "one side is whitespace-identical to base" trivial case.
+    advanceOrigin(other, "base.txt", "BASE\n", "main rewrites the line");
+
+    write(wt, "base.txt", "  base\n");
+    commitAll(wt, "worktree only re-indents the line");
+
+    const report = runSync(wt, path.join(root, "result"));
+
+    expect(report).toContain("✓ origin/main → feature");
+    expect(report).toContain("auto-resolved");
+    expect(report).not.toContain("⚠");
+    // main's content won, and the merge is committed — no markers left behind.
+    expect(read(wt, "base.txt")).toContain("BASE");
+    expect(git(wt, ["status", "--porcelain"])).toBe("");
+  });
+
+  test("rolls the merge back when the auto-resolved commit cannot be made", () => {
+    const { root, wt, other } = makeWorld();
+    advanceOrigin(other, "base.txt", "BASE\n", "main rewrites the line");
+
+    write(wt, "base.txt", "  base\n");
+    commitAll(wt, "worktree only re-indents the line");
+
+    // Same whitespace conflict as above, but the commit at the end of the
+    // auto-resolve path cannot be made: signing is demanded and the signing
+    // program does not exist. Pure git, no mocks, and it fails at exactly the
+    // right moment — a conflicting merge creates no commit, so it proceeds and
+    // resolves normally, and only `git commit` hits the missing signer.
+    // (Withholding the committer identity instead fails the merge itself, too
+    // early to exercise this path at all.)
+    const report = runSync(wt, path.join(root, "result"), {
+      GIT_CONFIG_COUNT: "2",
+      GIT_CONFIG_KEY_0: "commit.gpgsign",
+      GIT_CONFIG_VALUE_0: "true",
+      GIT_CONFIG_KEY_1: "gpg.program",
+      GIT_CONFIG_VALUE_1: path.join(root, "no-such-gpg"),
+    });
+
+    expect(report).toContain("✗ origin/main → feature");
+    expect(report).toContain("the merge was rolled back");
+    // The point of the rollback: no MERGE_HEAD survives, so the quiescence
+    // gate does not read this worktree as busy and mute every future sync.
+    expect(fs.existsSync(git(wt, ["rev-parse", "--path-format=absolute", "--git-path", "MERGE_HEAD"]))).toBe(false);
+    expect(git(wt, ["status", "--porcelain"])).toBe("");
+    expect(read(wt, "base.txt")).toBe("  base\n");
+  });
+
+  test("an ambiguous conflict is reported with its file list and aborted cleanly", () => {
+    const { root, wt, other } = makeWorld();
+    advanceOrigin(other, "base.txt", "written by main\n", "main rewrites base.txt");
+
+    write(wt, "base.txt", "written by the feature branch\n");
+    commitAll(wt, "feature rewrites base.txt");
+
+    const report = runSync(wt, path.join(root, "result"));
+
+    expect(report).toContain("⚠ origin/main → feature: 1 file(s) with ambiguous conflicts");
+    expect(report).toContain("base.txt");
+    // Aborted cleanly: no merge in progress, no conflict markers left behind.
+    expect(git(wt, ["status", "--porcelain"])).toBe("");
+    expect(read(wt, "base.txt")).toBe("written by the feature branch\n");
+  });
+
+  test("an ambiguous conflict survives unrelated dirt in the worktree", () => {
+    const { root, wt, other } = makeWorld();
+    advanceOrigin(other, "base.txt", "written by main\n", "main rewrites base.txt");
+
+    write(wt, "base.txt", "written by the feature branch\n");
+    commitAll(wt, "feature rewrites base.txt");
+    // Scratch files sitting around are the normal state of a working session.
+    write(wt, "scratch.log", "debug output\n");
+    write(wt, "untouched.txt", "unrelated work in progress\n");
+
+    const report = runSync(wt, path.join(root, "result"));
+
+    // The ⚠ must NOT be downgraded to ✗: only ⚠ carries the resolution
+    // procedure to the assistant, and ✗ is classified as an error instead.
+    expect(report).toContain("⚠ origin/main → feature: 1 file(s) with ambiguous conflicts");
+    expect(report).not.toContain("✗");
+    expect(read(wt, "scratch.log")).toBe("debug output\n");
+  });
+
+  test("stays silent when the merge would overwrite an untracked file", () => {
+    const { root, wt, other } = makeWorld();
+    advanceOrigin(other, "generated.txt", "from main\n", "main adds generated.txt");
+
+    // Same path exists locally, untracked — git refuses the merge without
+    // producing a single conflicted file. That is the `files.length === 0`
+    // path, and it must not turn into a ✗ repeating every sync window.
+    write(wt, "generated.txt", "built locally\n");
+
+    const resultFile = path.join(root, "result");
+    expect(runSync(wt, resultFile)).toBe("");
+    expect(fs.existsSync(resultFile)).toBe(false);
+    expect(read(wt, "generated.txt")).toBe("built locally\n");
+  });
+
+  test("detects an overlap when main renamed a file the worktree is editing", () => {
+    const { root, wt, other } = makeWorld();
+    git(other, ["mv", "base.txt", "renamed.txt"]);
+    commitAll(other, "main renames base.txt");
+    git(other, ["push", "--quiet", "origin", "main"]);
+
+    // Dirty on the OLD path — visible only because the incoming diff is asked
+    // for with --no-renames.
+    write(wt, "base.txt", "work in progress\n");
+
+    const resultFile = path.join(root, "result");
+    expect(runSync(wt, resultFile)).toBe("");
+    expect(fs.existsSync(resultFile)).toBe(false);
+    expect(read(wt, "base.txt")).toBe("work in progress\n");
+  });
+});
+
+describe.concurrent("branch hierarchy", () => {
+  test("merges the whole parent chain from remote-tracking refs", () => {
+    const { root, primary, other, originPath } = makeWorld();
+
+    // origin gets a `feat` branch, and a worktree sits on feat/auth.
+    //
+    // The worktree is cut from origin/feat, NOT from a local `feat` branch, and
+    // that is not a test convenience: git cannot hold refs/heads/feat and
+    // refs/heads/feat/auth at the same time ("cannot lock ref ... 'feat'
+    // exists"). v0.3.x created exactly that local ref via `fetch origin
+    // feat:feat` — so the hierarchy feature could not work even with a healthy
+    // main.
+    //
+    // Note the shape this test pins down, because it is the ONLY one git
+    // allows: the parent is pushed, the child is local-only. Pushing feat/auth
+    // while origin has feat is rejected at the remote with the same D/F error,
+    // so a stacked pair cannot coexist upstream at all. The parent chain is
+    // therefore usable up to the moment the child branch is pushed — a
+    // pre-existing limit of the naming scheme, not of the sync.
+    git(other, ["checkout", "--quiet", "-b", "feat"]);
+    write(other, "feat.txt", "feat\n");
+    commitAll(other, "feat base");
+    git(other, ["push", "--quiet", "origin", "feat"]);
+    git(other, ["checkout", "--quiet", "main"]);
+
+    const sub = path.join(root, "sub");
+    git(primary, ["fetch", "--quiet", "origin", "feat"]);
+    git(primary, ["worktree", "add", "--quiet", "-b", "feat/auth", sub, "origin/feat"]);
+
+    // Both parents move on afterwards. advanceOrigin needs `other` on main.
+    advanceOrigin(other, "from-main.txt", "main\n", "main moves");
+    git(other, ["checkout", "--quiet", "feat"]);
+    write(other, "from-feat.txt", "feat\n");
+    commitAll(other, "feat moves");
+    git(other, ["push", "--quiet", "origin", "feat"]);
+    git(other, ["checkout", "--quiet", "main"]);
+    void originPath;
+
+    const report = runSync(sub, path.join(root, "result"));
+
+    expect(report).toContain("origin/main → feat/auth");
+    expect(report).toContain("origin/feat → feat/auth");
+    expect(fs.existsSync(path.join(sub, "from-main.txt"))).toBe(true);
+    expect(fs.existsSync(path.join(sub, "from-feat.txt"))).toBe(true);
+    expect(report).not.toContain("⚠");
+    expect(report).not.toContain("✗");
+  });
+
+  test("ignores a parent segment that does not exist upstream", () => {
+    const { root, primary, other } = makeWorld();
+
+    // `claude/x` — the everyday layout here. There is no `claude` branch.
+    const sub = path.join(root, "claude-wt");
+    git(primary, ["worktree", "add", "--quiet", "-b", "claude/x", sub, "main"]);
+    advanceOrigin(other, "from-main.txt", "main\n", "main moves");
+
+    const report = runSync(sub, path.join(root, "result"));
+
+    expect(report).toContain("✓ origin/main → claude/x: 1 commit(s)");
+    expect(report).not.toContain("claude →");
+    expect(report).not.toContain("✗");
+  });
+});

--- a/plugins/devops/scripts/git-sync.guards.test.js
+++ b/plugins/devops/scripts/git-sync.guards.test.js
@@ -1,0 +1,191 @@
+import { describe, test, expect, afterAll } from "vitest";
+import fs from "fs";
+import path from "path";
+import {
+  git,
+  runSync,
+  write,
+  read,
+  commitAll,
+  makeRoot,
+  makeWorld,
+  advanceOrigin,
+  cleanupWorlds,
+} from "./__fixtures__/git-sync-world.js";
+
+/**
+ * The preconditions git-sync refuses to run without. Every one of these became
+ * load-bearing the moment the sync stopped being a silent no-op: a merge that
+ * actually happens can damage a repo that is mid-operation, on a detached
+ * HEAD, or governed by commit hooks a detached child cannot answer.
+ */
+
+afterAll(cleanupWorlds);
+
+describe.concurrent("refuses to run unless the repo is quiescent", () => {
+  test("does nothing on a detached HEAD", () => {
+    const { root, wt, other } = makeWorld();
+    advanceOrigin(other, "from-main.txt", "main\n", "main moves");
+
+    // The state every worktree here sits in between tasks.
+    git(wt, ["checkout", "--quiet", "--detach", "HEAD"]);
+    const head = git(wt, ["rev-parse", "HEAD"]);
+
+    const resultFile = path.join(root, "result");
+    expect(runSync(wt, resultFile)).toBe("");
+    expect(fs.existsSync(resultFile)).toBe(false);
+    // No commit written that nothing points at, no working tree rewritten.
+    expect(git(wt, ["rev-parse", "HEAD"])).toBe(head);
+    expect(fs.existsSync(path.join(wt, "from-main.txt"))).toBe(false);
+  });
+
+  test("does nothing while a merge is unfinished", () => {
+    const { root, wt, other } = makeWorld();
+
+    // Park the worktree in a conflicted merge, the way a /ship rebase would.
+    git(wt, ["checkout", "--quiet", "-b", "side"]);
+    write(wt, "base.txt", "side\n");
+    commitAll(wt, "side edits base.txt");
+    git(wt, ["checkout", "--quiet", "feature"]);
+    write(wt, "base.txt", "feature\n");
+    commitAll(wt, "feature edits base.txt");
+    try {
+      git(wt, ["merge", "side", "--no-edit"]);
+    } catch { /* conflict is the point */ }
+    expect(git(wt, ["rev-parse", "--verify", "MERGE_HEAD"])).toBeTruthy();
+
+    advanceOrigin(other, "from-main.txt", "main\n", "main moves");
+    const before = git(wt, ["rev-parse", "HEAD"]);
+
+    const resultFile = path.join(root, "result");
+    expect(runSync(wt, resultFile)).toBe("");
+    expect(fs.existsSync(resultFile)).toBe(false);
+    // The user's conflict is left exactly as it was — not resolved, not committed.
+    expect(git(wt, ["rev-parse", "HEAD"])).toBe(before);
+    expect(git(wt, ["rev-parse", "--verify", "MERGE_HEAD"])).toBeTruthy();
+    expect(read(wt, "base.txt")).toContain("<<<<<<<");
+  });
+});
+
+describe.concurrent("repo hooks and unmarked conflicts", () => {
+  test("a rejecting commit-msg hook does not turn every sync into a failure", () => {
+    const { root, wt, other } = makeWorld();
+    // A commitlint-style gate: git's own "Merge remote-tracking branch …"
+    // subject does not match a conventional-commit pattern, so without
+    // --no-verify this hook rejects every single background merge.
+    const hookDir = path.join(wt, ".git-hooks");
+    fs.mkdirSync(hookDir);
+    fs.writeFileSync(
+      path.join(hookDir, "commit-msg"),
+      "#!/bin/sh\ngrep -qE '^(feat|fix|chore)' \"$1\" || { echo 'commit-msg: rejected'; exit 1; }\n",
+      { mode: 0o755 }
+    );
+    git(wt, ["config", "core.hooksPath", hookDir]);
+    advanceOrigin(other, "a.txt", "a\n", "one");
+    advanceOrigin(other, "b.txt", "b\n", "two");
+    // Two diverging commits so the merge needs a real merge commit, not a
+    // fast-forward — a fast-forward writes no message and would prove nothing.
+    write(wt, "own.txt", "own\n");
+    commitAll(wt, "feat: own work");
+
+    const report = runSync(wt, path.join(root, "result"));
+
+    expect(report).toContain("✓ origin/main → feature: 2 commit(s)");
+    expect(report).not.toContain("✗");
+    expect(git(wt, ["rev-list", "--count", "HEAD..origin/main"])).toBe("0");
+  });
+
+  test("does nothing while a conflicted stash pop is unresolved", () => {
+    const { root, wt, other } = makeWorld();
+    // A conflicted `git stash pop` leaves unmerged index entries but NO
+    // MERGE_HEAD — invisible to a marker-file check, which is why the gate
+    // asks the index directly.
+    write(wt, "base.txt", "stashed edit\n");
+    git(wt, ["stash", "push", "--quiet"]);
+    write(wt, "base.txt", "committed edit\n");
+    commitAll(wt, "feature edits base.txt");
+    try {
+      git(wt, ["stash", "pop"]);
+    } catch { /* the conflict is the point */ }
+    expect(git(wt, ["ls-files", "--unmerged"])).not.toBe("");
+    // No marker file anywhere — a linked worktree keeps its git dir elsewhere,
+    // so ask git for the path rather than guessing at <wt>/.git.
+    expect(fs.existsSync(git(wt, ["rev-parse", "--path-format=absolute", "--git-path", "MERGE_HEAD"]))).toBe(false);
+
+    advanceOrigin(other, "from-main.txt", "main\n", "main moves");
+    const before = git(wt, ["rev-parse", "HEAD"]);
+
+    const resultFile = path.join(root, "result");
+    expect(runSync(wt, resultFile)).toBe("");
+    expect(fs.existsSync(resultFile)).toBe(false);
+    // Nothing committed, and the user's half-resolved state left alone.
+    expect(git(wt, ["rev-parse", "HEAD"])).toBe(before);
+    expect(git(wt, ["ls-files", "--unmerged"])).not.toBe("");
+  });
+
+  test("resumes as soon as the blocking state is cleared", () => {
+    const { root, wt, other } = makeWorld();
+    write(wt, "base.txt", "stashed edit\n");
+    git(wt, ["stash", "push", "--quiet"]);
+    write(wt, "base.txt", "committed edit\n");
+    commitAll(wt, "feature edits base.txt");
+    try {
+      git(wt, ["stash", "pop"]);
+    } catch { /* the conflict is the point */ }
+    advanceOrigin(other, "from-main.txt", "main\n", "main moves");
+
+    // Positive control: the silence above must come from the gate, not from
+    // the world being unable to produce a sync at all.
+    expect(runSync(wt, path.join(root, "result"))).toBe("");
+
+    git(wt, ["checkout", "--theirs", "--", "base.txt"]);
+    git(wt, ["add", "--", "base.txt"]);
+    git(wt, ["stash", "drop", "--quiet"]);
+    commitAll(wt, "resolve the stash pop");
+
+    const report = runSync(wt, path.join(root, "result2"));
+    expect(report).toContain("✓ origin/main → feature: 1 commit(s)");
+  });
+});
+
+describe.concurrent("default branch", () => {
+  test("syncs a repo whose default branch is master", () => {
+    // Built by hand rather than via makeWorld — the point is the branch name.
+    const root = makeRoot();
+    const originPath = path.join(root, "origin.git");
+    git(root, ["init", "--bare", "--initial-branch=master", originPath]);
+
+    const primary = path.join(root, "primary");
+    git(root, ["clone", "--quiet", originPath, primary]);
+    write(primary, "base.txt", "base\n");
+    commitAll(primary, "base");
+    git(primary, ["push", "--quiet", "origin", "master"]);
+
+    const wt = path.join(root, "wt");
+    git(primary, ["worktree", "add", "--quiet", "-b", "feature", wt, "master"]);
+
+    const other = path.join(root, "other");
+    git(root, ["clone", "--quiet", originPath, other]);
+    write(other, "from-master.txt", "master\n");
+    commitAll(other, "master moves");
+    git(other, ["push", "--quiet", "origin", "master"]);
+
+    const report = runSync(wt, path.join(root, "result"));
+
+    expect(report).toContain("✓ origin/master → feature: 1 commit(s)");
+    expect(fs.existsSync(path.join(wt, "from-master.txt"))).toBe(true);
+  });
+
+  test("survives an origin/HEAD pointing at a branch that no longer exists", () => {
+    const { root, wt, other } = makeWorld();
+    // A clone-time symlink left behind by a renamed default branch.
+    git(wt, ["symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/trunk"]);
+    advanceOrigin(other, "from-main.txt", "main\n", "main moves");
+
+    const report = runSync(wt, path.join(root, "result"));
+
+    // Falls through to the real default branch instead of syncing nothing.
+    expect(report).toContain("✓ origin/main → feature: 1 commit(s)");
+    expect(fs.existsSync(path.join(wt, "from-main.txt"))).toBe(true);
+  });
+});

--- a/plugins/devops/scripts/git-sync.js
+++ b/plugins/devops/scripts/git-sync.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * @script git-sync
- * @version 0.3.1
+ * @version 0.4.0
  * @plugin devops
  * @description Core git sync logic — fetch remote, merge parent chain into
  *   current branch. Supports branch hierarchy (feat/auth/login merges
@@ -12,11 +12,10 @@
  */
 
 const { execFileSync } = require('child_process');
-const { readFileSync, writeFileSync } = require('fs');
+const { existsSync, readFileSync, writeFileSync } = require('fs');
 const { join } = require('path');
 
 const cwd = process.cwd();
-const MAIN = 'main';
 
 // argv-form + windowsHide, NEVER a shell string: this script runs as a DETACHED,
 // console-less child (git-sync-bg.js). From such a parent every execSync string
@@ -43,12 +42,101 @@ if (git(['rev-parse', '--is-inside-work-tree']) !== 'true') {
   process.exit(0);
 }
 
-const remote = git(['remote']);
-if (!remote) process.exit(0);
-const origin = remote.split('\n')[0];
+const remotes = (git(['remote']) || '').split('\n').filter(Boolean);
+if (!remotes.length) process.exit(0);
+// A fork checkout has both `origin` and `upstream`; picking the first line
+// alphabetically would sync a branch against somebody else's default branch.
+const origin = remotes.includes('origin') ? 'origin' : remotes[0];
 
-const branch = git(['rev-parse', '--abbrev-ref', 'HEAD']);
+// The default branch is asked for, not assumed. A hardcoded 'main' makes the
+// whole sync a silent no-op in a `master` repo — the same class of quiet
+// nothing-happens this version exists to remove.
+const MAIN = (() => {
+  const head = git(['symbolic-ref', '--quiet', '--short', `refs/remotes/${origin}/HEAD`]);
+  const candidates = [];
+  // origin/HEAD is a local symlink written at clone time. It happily keeps
+  // pointing at a branch that has since been renamed or deleted, so it is a
+  // hint to be verified, not an answer.
+  if (head && head.startsWith(`${origin}/`)) candidates.push(head.slice(origin.length + 1));
+  candidates.push('main', 'master');
+  for (const candidate of candidates) {
+    if (git(['rev-parse', '--verify', '--quiet', `refs/remotes/${origin}/${candidate}`])) return candidate;
+  }
+  return 'main';
+})();
+
+// Detached HEAD → `rev-parse --abbrev-ref HEAD` answers the literal "HEAD",
+// which is not MAIN and used to sail straight through. Merging onto a detached
+// HEAD writes a commit nothing points at (lost at the next checkout) and
+// rewrites the working tree of someone who is inspecting an old commit. The
+// worktrees here sit detached between tasks, so this is the common state, not
+// an exotic one.
+const branch = git(['symbolic-ref', '--quiet', '--short', 'HEAD']);
 if (!branch || branch === MAIN) process.exit(0);
+
+// An unfinished merge/rebase/cherry-pick/revert/bisect owns the index. A merge
+// attempted on top of one fails without conflicts of its own, and the recovery
+// path below would then pick up THAT operation's conflicted files, rewrite them
+// and commit them — turning a background convenience into data loss. Wait.
+const gitDir = git(['rev-parse', '--absolute-git-dir']);
+if (!gitDir) process.exit(0);
+
+/**
+ * git, with the repo's commit hooks switched off.
+ *
+ * Deliberately `core.hooksPath` rather than `--no-verify`: `git merge` only
+ * learned `--no-verify` in 2.36 (Apr 2022), and on an older git — Ubuntu 20.04
+ * ships 2.25, Debian bullseye 2.30 — the flag is an "unknown option" that
+ * fails the merge, lands in the no-conflicted-files branch, and reports
+ * `✗ merge refused` every window forever. Pointing hooksPath at a directory
+ * that cannot exist works back to 2.9 and covers `pre-merge-commit` too.
+ */
+const NO_HOOKS = ['-c', `core.hooksPath=${join(gitDir, 'devops-git-sync-no-hooks')}`];
+function gitNoHooks(args) {
+  return git([...NO_HOOKS, ...args]);
+}
+
+const IN_PROGRESS = ['MERGE_HEAD', 'CHERRY_PICK_HEAD', 'REVERT_HEAD', 'BISECT_LOG', 'rebase-merge', 'rebase-apply'];
+
+/**
+ * True while some other operation owns the index.
+ *
+ * The marker files alone are only a proxy. `git stash pop` — the everyday case
+ * — leaves conflicts with NO marker at all, and so do `merge --squash`,
+ * `checkout -m` and `revert -n`. The invariant that actually matters is
+ * "the index holds unmerged entries", so ask for that directly and keep the
+ * markers for the states that have a clean index (a paused rebase, a bisect).
+ */
+function repoBusy() {
+  if (IN_PROGRESS.some(marker => existsSync(join(gitDir, marker)))) return true;
+  const unmerged = git(['ls-files', '--unmerged']);
+  return unmerged === null || unmerged !== '';
+}
+
+/**
+ * True while /ship owns this worktree.
+ *
+ * The spawning hooks check this too, but they check it at spawn time — and the
+ * dangerous child is the one spawned by the Stop just BEFORE the user types
+ * /ship: its gates have already passed and its merge would land inside the
+ * pipeline's rebase. Asking again here, immediately before the index is
+ * written, closes that window.
+ */
+function shipInFlight() {
+  try {
+    return require('../hooks/lib/ship-sentinel').isActive(cwd);
+  } catch {
+    // Fails OPEN, unlike repoBusy() which fails closed — and the asymmetry is
+    // deliberate. A failed repo probe means "I cannot see the state", and
+    // writing the index blind is unsafe. A require() throw means the helper is
+    // not installed: a static packaging condition, not an unknown state.
+    // Failing closed here would let a partial plugin cache silence the sync in
+    // every repo, permanently and invisibly.
+    return false;
+  }
+}
+
+if (repoBusy() || shipInFlight()) process.exit(0);
 
 // Ensure diff3 is set for meaningful conflict markers
 const conflictStyle = git(['config', '--get', 'merge.conflictstyle']);
@@ -203,6 +291,53 @@ function resolveFile(filePath) {
   return { resolved: true, content: result };
 }
 
+/**
+ * Uncommitted paths that the incoming merge would also touch.
+ *
+ * A background merge must never fight the user's work in progress. git refuses
+ * such a merge anyway ("Your local changes to the following files would be
+ * overwritten by merge"), but it refuses BEFORE producing any conflicted file
+ * — landing in the same no-conflicted-files branch as a genuine failure, where
+ * it is indistinguishable from one. Detecting the overlap up front keeps that
+ * case silent: the tree is dirty right now, the next sync window finds the same
+ * commits and merges them once the work is committed.
+ */
+function dirtyOverlap(source) {
+  // Three plain path lists — worktree-vs-index, index-vs-HEAD, and untracked.
+  // Deliberately NOT `status --porcelain`: its "XY path" columns start with a
+  // space for unstaged changes, and git() trims its output, so any fixed-offset
+  // parse of it silently reads the path one character short.
+  //
+  // Untracked files count: a merge that ADDS a file which already exists
+  // untracked is refused by git without producing a single conflicted file —
+  // the one shape that reaches the "merge refused" branch and would then repeat
+  // its ✗ every thirty minutes until the user happens to delete the file.
+  const probes = [
+    git(['diff', '--name-only']),
+    git(['diff', '--name-only', '--cached']),
+    git(['ls-files', '--others', '--exclude-standard']),
+  ];
+  // A probe that THREW (null) is not the same as one that found nothing (''),
+  // and "unknown" must read as "busy, not now" rather than "clean" — a guard
+  // that fails open is not a guard. In practice the case this catches is the
+  // 15s timeout above (a slow or network-mounted repo), NOT a contended
+  // index.lock: `git diff` skips its opportunistic index refresh when the lock
+  // is held and still exits 0.
+  if (probes.some(p => p === null)) return ['<unreadable worktree state>'];
+
+  const dirty = new Set(probes.flatMap(p => p.split('\n')).filter(Boolean));
+  if (!dirty.size) return [];
+
+  // --no-renames so a rename lists BOTH paths: with rename detection on, git
+  // prints only the destination, and a dirty copy of the *old* path would slip
+  // past the guard straight into a refused merge.
+  // Also null when the two sides share no merge base (an orphan branch) — a
+  // merge there would be a surprise, so treating it as "not now" is right.
+  const incoming = git(['diff', '--name-only', '--no-renames', `HEAD...${source}`]);
+  if (incoming === null) return ['<unreadable incoming diff>'];
+  return incoming.split('\n').filter(Boolean).filter(f => dirty.has(f));
+}
+
 // Try merging source into HEAD. Resolve trivial conflicts automatically,
 // warn only for genuinely ambiguous conflicts that need semantic resolution.
 // See deep-knowledge/merge-safety.md for the full resolution protocol.
@@ -212,8 +347,23 @@ function tryMerge(source) {
 
   const count = parseInt(behind);
 
-  // Normal merge (clean — no conflicts)
-  if (git(['merge', source, '--no-edit', '--quiet']) !== null) {
+  // Work in progress on a file the merge would rewrite → not now, and silently.
+  if (dirtyOverlap(source).length > 0) return null;
+
+  // The gates at the top of this file ran before a fetch per parent, and a
+  // fetch takes seconds. A /ship or a rebase started in that window would be
+  // invisible to them, so ask again with the index about to be written.
+  if (repoBusy() || shipInFlight()) return null;
+
+  // Both git calls that write run with hooks disabled: this process is
+  // detached and has no console, so a repo hook that prompts cannot be
+  // answered, and one that rejects — a commitlint `commit-msg` refusing git's
+  // auto-generated "Merge remote-tracking branch …" subject is the obvious
+  // case in a repo with this plugin's own conventions — would turn every clean
+  // sync into a ✗ repeating for as long as main stays ahead. Hook policy
+  // belongs to the commits the user makes, not to a background fast-forward of
+  // their own default branch.
+  if (gitNoHooks(['merge', source, '--no-edit', '--quiet']) !== null) {
     return { source, commits: count };
   }
 
@@ -222,8 +372,21 @@ function tryMerge(source) {
   const files = conflictOutput ? conflictOutput.split('\n').filter(Boolean) : [];
 
   if (files.length === 0) {
+    // git refused the merge without leaving a single conflicted file. That is
+    // a FAILURE, not a conflict — reporting it as ⚠ used to hand the assistant
+    // the full semantic-resolution procedure for an empty file list.
     git(['merge', '--abort']);
-    return { source, commits: count, conflict: true, files: [] };
+    // Same check as the other two abort sites: an abort that did not unwind
+    // leaves the worktree mid-merge, which the quiescence gate then reads as
+    // "busy" and silences every future sync in this worktree.
+    return {
+      source,
+      commits: count,
+      failed: true,
+      reason: existsSync(join(gitDir, 'MERGE_HEAD'))
+        ? 'merge refused with no conflicted files, and the worktree is still mid-merge — run `git merge --abort`'
+        : 'merge refused, no conflicted files',
+    };
   }
 
   let totalAmbiguous = 0;
@@ -241,10 +404,14 @@ function tryMerge(source) {
     // Some conflicts couldn't be resolved — abort and warn
     git(['merge', '--abort']);
 
-    // Verify abort succeeded — if tree is still dirty, the abort failed
-    const postAbort = git(['status', '--porcelain']);
-    if (postAbort) {
-      return { source, commits: count, failed: true };
+    // Verify the abort actually unwound the merge. Deliberately NOT
+    // `status --porcelain`: that reports untracked files and any unrelated
+    // work in progress, so a single scratch file next to a real conflict used
+    // to downgrade the ⚠ to ✗ — and ✗ is classified as an error, which means
+    // the conflict procedure never reached the assistant for the one case this
+    // whole feature exists to handle.
+    if (existsSync(join(gitDir, 'MERGE_HEAD'))) {
+      return { source, commits: count, failed: true, reason: 'merge --abort did not unwind the merge' };
     }
 
     return {
@@ -256,33 +423,68 @@ function tryMerge(source) {
     };
   }
 
-  // All conflicts resolved — complete the merge
-  git(['commit', '--no-edit']);
+  // All conflicts resolved — complete the merge. The commit is checked, not
+  // assumed: a consumer repo's pre-commit hook runs here too, in a detached,
+  // console-less process, and a hook that fails (or blocks on a prompt until
+  // the 15s timeout) leaves MERGE_HEAD in place. Reporting ✓ then would hand
+  // the user's next `git commit` a merge commit they never made.
+  if (gitNoHooks(['commit', '--no-edit']) === null || existsSync(join(gitDir, 'MERGE_HEAD'))) {
+    // Unwind before giving up. Returning with MERGE_HEAD still in place would
+    // leave the worktree mid-merge, and the quiescence gate at the top of this
+    // file would then silence every future sync in it — the failure path
+    // wedging the whole feature shut, in the one place nobody looks.
+    git(['merge', '--abort']);
+    const stuck = existsSync(join(gitDir, 'MERGE_HEAD'));
+    return {
+      source,
+      commits: count,
+      failed: true,
+      reason: stuck
+        ? 'conflicts resolved but the merge commit failed — the worktree is still mid-merge, run `git merge --abort`'
+        : 'conflicts resolved but the merge commit failed — the merge was rolled back',
+    };
+  }
   return { source, commits: count, autoResolved: files.length };
 }
 
-// Fetch main
-if (git(['fetch', origin, MAIN, '--quiet']) === null) {
-  process.exit(0);
+// Fetch each parent of this branch into its REMOTE-TRACKING ref, and merge
+// from that ref — never from the local branch.
+//
+// v0.3.x merged the local `main` and kept it current with `git fetch origin
+// main:main`. git refuses that fetch whenever `main` is checked out in ANY
+// worktree:
+//   fatal: refusing to fetch into branch 'refs/heads/main' checked out at '...'
+// which is exactly the standard layout here — primary worktree parked on main,
+// feature work in linked worktrees. git() swallows the error, so the sync went
+// on to compare HEAD against a local `main` frozen at whatever was last pulled
+// by hand, `rev-list --count HEAD..main` answered 0, and the sync stayed silent
+// for weeks while origin/main moved. refs/remotes/<origin>/<x> is never checked
+// out and can therefore always be updated.
+const sources = [];
+for (const p of getParentChain(branch)) {
+  const tracking = `refs/remotes/${origin}/${p}`;
+  git(['fetch', origin, `+refs/heads/${p}:${tracking}`, '--quiet']);
+  // Skips parents that do not exist upstream (e.g. the "claude" segment of
+  // claude/some-branch). A failed fetch with a tracking ref left from an
+  // earlier run is fine: those commits are real, merging them is the job.
+  if (git(['rev-parse', '--verify', '--quiet', tracking]) === null) continue;
+  sources.push(`${origin}/${p}`);
 }
-git(['fetch', origin, `${MAIN}:${MAIN}`, '--quiet']);
 
-// Build parent chain, fetch each from origin, keep only existing branches
-const parents = getParentChain(branch).filter(p => {
-  if (p === MAIN) return true;
-  // Fetch and update local ref from origin (fast-forward)
-  git(['fetch', origin, `${p}:${p}`, '--quiet']);
-  return git(['rev-parse', '--verify', p]) !== null;
-});
+if (!sources.length) process.exit(0);
+
+// Best effort, never load-bearing: keep the local main ref in step for repos
+// where nothing has it checked out. Fails silently in the layout above.
+git(['fetch', origin, `${MAIN}:${MAIN}`, '--quiet']);
 
 // Merge each parent into current branch (root → closest parent)
 const messages = [];
-for (const parent of parents) {
+for (const parent of sources) {
   const result = tryMerge(parent);
   if (!result) continue;
 
   if (result.failed) {
-    messages.push(`✗ ${parent} → ${branch}: merge failed (unknown error)`);
+    messages.push(`✗ ${parent} → ${branch}: ${result.reason || 'merge failed (unknown error)'}`);
   } else if (result.conflict) {
     const partialNote = result.partialResolve
       ? ` (${result.partialResolve} conflict(s) auto-resolved)`

--- a/plugins/devops/scripts/git-sync.test.js
+++ b/plugins/devops/scripts/git-sync.test.js
@@ -1,0 +1,114 @@
+import { describe, test, expect, afterAll } from "vitest";
+import fs from "fs";
+import path from "path";
+import {
+  git,
+  runSync,
+  write,
+  read,
+  commitAll,
+  makeWorld,
+  advanceOrigin,
+  cleanupWorlds,
+} from "./__fixtures__/git-sync-world.js";
+
+/**
+ * The core contract: git-sync must actually move commits from the default
+ * branch into the current one, in the worktree layout where v0.3.x could not
+ * — and never at the cost of uncommitted work.
+ */
+
+afterAll(cleanupWorlds);
+
+describe.concurrent("merge source — the regression that made the sync a silent no-op", () => {
+  test("merges origin/main even though main is checked out in the primary worktree", () => {
+    const { root, primary, wt, other } = makeWorld();
+    advanceOrigin(other, "feature-of-main.txt", "from main\n", "main moves on");
+
+    const report = runSync(wt, path.join(root, "result"));
+
+    expect(report).toContain("✓ origin/main → feature: 1 commit(s)");
+    expect(fs.existsSync(path.join(wt, "feature-of-main.txt"))).toBe(true);
+
+    // The precondition that used to defeat the sync is still in force: the
+    // local main ref could NOT be advanced, because primary has it checked out.
+    expect(git(primary, ["rev-parse", "--abbrev-ref", "HEAD"])).toBe("main");
+    expect(git(wt, ["rev-parse", "main"])).not.toBe(git(wt, ["rev-parse", "origin/main"]));
+  });
+
+  test("the local main ref being stale does not suppress the merge", () => {
+    const { root, wt, other } = makeWorld();
+    const staleMain = git(wt, ["rev-parse", "main"]);
+    advanceOrigin(other, "a.txt", "a\n", "one");
+    advanceOrigin(other, "b.txt", "b\n", "two");
+
+    const report = runSync(wt, path.join(root, "result"));
+
+    expect(report).toContain("✓ origin/main → feature: 2 commit(s)");
+    expect(git(wt, ["rev-parse", "main"])).toBe(staleMain);
+    expect(git(wt, ["rev-list", "--count", "HEAD..origin/main"])).toBe("0");
+  });
+
+  test("stays silent and writes no result file when already up to date", () => {
+    const { root, wt } = makeWorld();
+    const resultFile = path.join(root, "result");
+
+    expect(runSync(wt, resultFile)).toBe("");
+    expect(fs.existsSync(resultFile)).toBe(false);
+  });
+
+  test("does nothing on main itself", () => {
+    const { root, primary, wt, other } = makeWorld();
+    advanceOrigin(other, "x.txt", "x\n", "main moves on");
+    void wt;
+
+    const resultFile = path.join(root, "result");
+    expect(runSync(primary, resultFile)).toBe("");
+    expect(fs.existsSync(resultFile)).toBe(false);
+  });
+});
+
+describe.concurrent("uncommitted work", () => {
+  test("skips silently while a dirty file overlaps the incoming change", () => {
+    const { root, wt, other } = makeWorld();
+    advanceOrigin(other, "base.txt", "base, edited on main\n", "main edits base.txt");
+
+    write(wt, "base.txt", "base, edited in the worktree\n");
+    const resultFile = path.join(root, "result");
+
+    expect(runSync(wt, resultFile)).toBe("");
+    expect(fs.existsSync(resultFile)).toBe(false);
+    // The user's work in progress is untouched and still uncommitted.
+    expect(read(wt, "base.txt")).toBe("base, edited in the worktree\n");
+    expect(git(wt, ["status", "--porcelain"])).toContain("base.txt");
+  });
+
+  test("merges anyway when the dirty file is not part of the incoming change", () => {
+    const { root, wt, other } = makeWorld();
+    advanceOrigin(other, "elsewhere.txt", "elsewhere\n", "main touches another file");
+
+    write(wt, "untouched.txt", "work in progress\n");
+
+    const report = runSync(wt, path.join(root, "result"));
+
+    expect(report).toContain("✓ origin/main → feature: 1 commit(s)");
+    expect(fs.existsSync(path.join(wt, "elsewhere.txt"))).toBe(true);
+    expect(read(wt, "untouched.txt")).toBe("work in progress\n");
+  });
+
+  test("picks the commits up on the next run once the work is committed", () => {
+    const { root, wt, other } = makeWorld();
+    advanceOrigin(other, "base.txt", "base, edited on main\n", "main edits base.txt");
+
+    write(wt, "base.txt", "base, edited in the worktree\n");
+    expect(runSync(wt, path.join(root, "result"))).toBe("");
+
+    commitAll(wt, "worktree edits base.txt");
+
+    // Now genuinely conflicting: both sides changed the same line.
+    const report = runSync(wt, path.join(root, "result2"));
+    expect(report).toContain("⚠ origin/main → feature");
+    expect(report).toContain("base.txt");
+    expect(report).not.toContain("0 file(s)");
+  });
+});

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.133.6",
+  "version": "0.133.7",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

The background git sync had been a silent no-op for weeks. It merged the **local** `main` ref and kept that ref current with `git fetch origin main:main` — a fetch git refuses whenever `main` is checked out in any worktree:

```
fatal: refusing to fetch into branch 'refs/heads/main' checked out at '...'
```

That is the standard layout here (primary worktree parked on main, feature work in linked worktrees). The error was swallowed by the script's catch-all `git()` wrapper, so every run compared `HEAD` against a ref frozen at whatever was last pulled by hand, `rev-list --count HEAD..main` answered 0, and the sync truthfully reported nothing to do.

**Measured before the fix:** across 96 sessions in three days it delivered exactly one result, and none at all in this repo, while `main` advanced six times a day. The local `main` ref in this checkout had not moved in a week.

The sync now merges `refs/remotes/<origin>/<parent>` — refs that are never checked out and can always be updated — and derives the default branch from `origin/HEAD` instead of assuming `main`.

## Guards a no-op never needed

A sync that actually merges can damage a repo, so it now refuses to run when:

- **HEAD is detached** — worktrees here sit detached between tasks, and a merge there writes a commit nothing points at
- **another operation owns the index** — an unfinished merge/rebase/cherry-pick/revert/bisect, or *any* unmerged index entry. A conflicted `git stash pop` leaves no marker file, and the old recovery path would have resolved and committed *its* conflicts
- **a `/ship` is in flight** — checked at spawn time and again immediately before the merge
- **the incoming change touches a path with uncommitted work** — untracked files and renames included; a probe that fails reads as "busy", never as "clean"

Its own git calls disable repo commit hooks via `core.hooksPath`, not `--no-verify`: `git merge` only accepts that flag from Git 2.36, and on an older git the unknown option would have turned every sync into a recurring failure report. A failed auto-resolve commit now rolls the merge back, so the failure path cannot leave the worktree mid-merge and wedge the new quiescence gate shut.

## Reporting

Only `⚠` carries the resolution procedure to the assistant; `✗` is classified as an error and stops there. A merge git refused without conflicted files is now `✗` rather than a conflict with an empty file list, and a genuine conflict is no longer downgraded to `✗` by unrelated scratch files in the worktree.

## Verification

- **22 integration tests** against real repositories in the layout that triggered the bug (`git-sync.test.js`, `git-sync.guards.test.js`, `git-sync.conflicts.test.js`, sharing `__fixtures__/git-sync-world.js`). 14 of them fail against the previous version.
- **Mutation-tested** the two load-bearing claims: removing the hook-disabling reproduces the predicted `✗` loop, removing the rollback leaves the worktree mid-merge. Both tests go red.
- **QA sandbox over the real Stop hook**: baseline sync, quiescence gate, and ship gate each confirmed end to end; with a real rejecting `commit-msg` hook installed the sync produced `✓ origin/main → feature: 2 commit(s)` with a genuine two-parent merge commit, and the hook stayed live for the user's own commits.
- Full suite: 79 files / 1940 tests, lint clean.
- The test file is split across three suites because a single one ran long enough to trip vitest's reporter RPC timeout — reported as an error next to a fully green suite.

Three adversarial review rounds informed the guards above. The Codex review gate could not run: the CLI reported its usage limit was exhausted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)