### PR TITLE
fix(concept): keep the panel TOC, unstack the overlays, clear the

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.135.0"
+    "version": "0.135.1"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.135.0",
+      "version": "0.135.1",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.135.0",
+      "version": "0.135.1",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.135.1] — 2026-08-29
+
+### Fixed
+
+- **Switching design in a concept emptied the menu and stranded you there.** The ☰ panel's table of contents lists every design of the round, each entry doubling as the control that switches to it — but the whole container was hidden whenever the design *currently on the canvas* happened to hold a single screen. So on a round with five designs, opening the one with one screen blanked all five entries at once, and the only way back was a floating switcher sitting at 18% opacity. The collapse now happens per design row instead of on the shared container, decided once per design when the panel is built, so it no longer changes under you when you switch. The container itself only disappears when there is genuinely nothing left to navigate — one design, one screen, and no questions attached to the round; that last condition matters because the question entries live in the same container and the only other route to them is the switcher, which a single-design round already hides.
+
+- **The ☰ menu and the 💬 feedback dock sat on top of each other.** Both open against the right edge and neither knew about the other, so opening one over the other left two panels stacked with 326×445 pixels of overlap. Opening either now minimises the other; dismissing one never resurrects the other. If the cursor was in a feedback field when the menu opened, focus moves into the menu rather than onto the 💬 button — that button paints above the menu's backdrop, so focus parked there would have been sitting on a control that closes what you just opened.
+
+- **Design mockups were painted under the floating chrome.** The canvas runs edge to edge while the page counter, the design switcher and the ☰ button float over it, so the first lines of any screen tall enough to fill the window were unreadable — 18 pixels of overlap on every screen of every round. The canvas now reserves that band. The reserve is deliberately not symmetric: the top edge is occupied across its whole width, the bottom only in its two corners, so mirroring it would have cost another 60 pixels of artefact height on an edge that is empty in the middle — and in a device view that height is what the phone and tablet frames are scaled against.
+
+- **A decision round could show the previous design round's table of contents.** The panel builder returns early when the visible round has no design, before it clears the list, so the stale entries survived the switch and offered to jump to a design nobody was looking at.
+
 ## [0.135.0] — 2026-08-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.135.0**
+**Version: 0.135.1**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.135.0",
+  "version": "0.135.1",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/skills/concept/deep-knowledge/templates.md
+++ b/plugins/devops/skills/concept/deep-knowledge/templates.md
@@ -1012,19 +1012,31 @@ buttons:
   wiring with `data-screen-link` handles the transition like any other
   screen switch.
 - **Single-screen design (exactly one `<section data-screen>`):**
-  - No screen-nav rendered inside the ☰ panel
+  - Only THAT design's row collapses in the ☰ panel: its
+    `.screen-nav-group` keeps the heading that switches to it, and just the
+    one redundant screen entry goes. `#screen-nav` itself must NOT be
+    gated on this — it lists every design in the iteration, so hiding the
+    container on the active design's screen count blanks the whole table
+    of contents and strands the user (see § Layout CSS). The container
+    disappears only when the iteration ALSO has a single design, i.e.
+    when there is genuinely nothing left to navigate.
   - Feedback dock shows ONLY the general-notes textarea (no
     per-screen section, no "Aktueller Screen" label)
   - No click-dummy wiring required — nothing to navigate to
   - The screen-indicator overlay can be hidden or simplified
-  - `updateScreenScope()` detects `screens.length === 1` and sets
-    `document.body.dataset.singleScreen = 'true'` so CSS can hide the
-    per-screen UI. CSS adds: `body[data-single-screen="true"] #screen-nav,
-    body[data-single-screen="true"] .feedback-section:has(#screen-textareas)
-    { display: none }`.
+  - Two flags, two scopes, deliberately: `updateScreenScope()` sets
+    `document.body.dataset.singleScreen` from the design currently on the
+    canvas — that is the right scope for the DOCK, which always talks about
+    the active screen. `buildDesignUI()` stamps
+    `group.dataset.singleScreen` per design — the right scope for the
+    PANEL, which shows all of them at once and must stay stable when the
+    active design changes. Never drive one from the other's flag.
 - **Single-design iteration (exactly one `<section data-design>`):**
   degenerates to today's behaviour — no design switcher, no per-design
-  feedback row, `#screen-nav` renders as a flat list (no design heading).
+  feedback row, `#screen-nav` renders the screens as a flat list (the
+  design heading collapses). A views group, if the iteration has one, still
+  renders WITH its heading — `body[data-single-design]` hides
+  `.screen-nav-design-heading`, not `.screen-nav-views-heading`.
   `buildDesignUI()` detects `designs.length === 1` and sets
   `document.body.dataset.singleDesign = 'true'`, the sibling of
   `data-single-screen` above, so CSS hides the same way. The `data-design`
@@ -1184,8 +1196,13 @@ decoration on every screen.
   (`data-open="true"`), it shows the full question, an answer textarea and
   an attachment drop area.
 - **Positioned in percentages, not pixels.** `--anno-x` / `--anno-y` on the
-  wrapping `.anno` element place the pin as a percentage of the screen box,
-  so it survives any viewport size. `data-anno-side="right|left|top|bottom"`
+  wrapping `.anno` element place the pin as a percentage of the screen box —
+  `.anno-layer` is `inset: 0`, so that box is the FULL section including the
+  chrome safe area (§ Layout CSS), not the padded content box the mock is
+  drawn in. Hand-picked coordinates must be read off the whole viewport, not
+  off the artefact. `anchorToTarget()` measures live rects and is unaffected;
+  this only matters for coordinates authored by hand. They survive any
+  viewport size either way. `data-anno-side="right|left|top|bottom"`
   picks which side the bubble opens on — Claude chooses this at generation
   time from the element's position in the mock; there is no runtime
   collision math.
@@ -1890,6 +1907,53 @@ html[data-template="design"] body { height: 100%; overflow: hidden; }
 [data-template="design"] .concept-layout.design.fullscreen { display: block; width: 100vw; height: 100vh; overflow: hidden; }
 [data-template="design"] .concept-layout.design .concept-content { position: absolute; inset: 0; overflow: hidden; }
 
+/* ── Chrome safe area ───────────────────────────────────────────────────
+   Every fixed control in design mode sits on the viewport's top or bottom
+   edge while the canvas beneath runs edge to edge (inset: 0). A flat 2rem
+   padding therefore starts the content at 32px where the chrome reaches
+   92px, so the first rows of any screen tall enough to fill the viewport
+   are painted UNDER the indicator, the design switcher and the ☰ FAB
+   (measured in Edge at 921x873: content top 32px, indicator bottom 50px —
+   18px of unreadable overlap on every screen of the page).
+
+   The § Layout CSS top-edge partition above solves the chrome-vs-chrome
+   collisions; this is the missing chrome-vs-CONTENT one. Two tokens, derived
+   from the geometry already fixed there, so the reserve can never drift from
+   the chrome that caused it:
+     TOP     .panel-fab        2rem offset + 60px circle   = 92px  (right)
+             .anno-toggle-fab  3.75rem offset + ~2rem pill = 92px  (left)
+             .screen-indicator 1rem offset + ~2.1rem pill  = 50px  (left)
+             .design-switcher  0.75rem offset + ~2.3rem    = 49px  (centre)
+     BOTTOM  .feedback-fab     2rem offset + 60px circle   = 92px  (right)
+             .viewport-toggle  2rem offset + 34px pill     = 66px  (left)
+
+   The reserve is deliberately NOT symmetric, because the two edges are not.
+   The top edge is occupied across its whole width — indicator on the left,
+   switcher in the centre, ☰ on the right — so content must clear its
+   deepest element everywhere: 92px = 5.75rem. The bottom edge carries two
+   CORNER controls and nothing in between, so the ordinary 2rem gutter is
+   the honest reserve there; a 60px FAB floating over a canvas corner is the
+   normal pattern, and mirroring the top would have spent another 60px of
+   artefact height on an edge that is empty across ~96% of its width. In
+   device mode that height is multiplicative — fitDeviceStage() scales the
+   frame pair to the box — so it is the most expensive space on the page.
+   The cost of the asymmetry is that `align-items: center` now centres the
+   artefact 30px below the true optical centre at 873px height (3.4%), which
+   is well under the threshold where anyone reads it as misaligned.
+   Chromium keeps centred overflow reachable in a scroll container (verified:
+   a 2000px probe in a 560px box still scrolls to its first row), so the
+   smaller content box this creates needs no `safe center` companion.
+
+   Every consumer repeats the value as a var() fallback. That is not
+   belt-and-braces: this file is a REFERENCE that gets copied in pieces, and
+   a page that takes the section rules without this declaration would have
+   the whole `padding` shorthand invalidated at computed-value time — losing
+   the horizontal gutter too, silently, with no chrome reserve either. */
+html[data-template="design"] {
+  --chrome-safe-top: 5.75rem;
+  --chrome-safe-bottom: 2rem;
+}
+
 /* Iteration sections fill the viewport. Screens inside do too —
    only the active one is visible (hidden attribute on the others).
    Outside design mode iterations stay in normal document flow. */
@@ -1898,7 +1962,9 @@ section[data-iteration][hidden] { display: none; }
 [data-template="design"] section[data-screen] {
   position: absolute; inset: 0;
   display: flex; align-items: center; justify-content: center;
-  padding: 2rem; overflow-y: auto;
+  /* Chrome safe area top, plain gutter sides and bottom. */
+  padding: var(--chrome-safe-top, 5.75rem) 2rem var(--chrome-safe-bottom, 2rem);
+  overflow-y: auto;
   animation: screen-in 0.25s ease;
 }
 section[data-screen][hidden] { display: none; }
@@ -1913,7 +1979,10 @@ section[data-screen][hidden] { display: none; }
    chrome (indicator/switcher/FABs stay put). */
 [data-template="design"] section[data-view] {
   position: absolute; inset: 0;
-  padding: 2rem; overflow-y: auto;
+  /* Same chrome safe area as a screen — a view is the other thing that can
+     be full-height, and it is the one that always scrolls. */
+  padding: var(--chrome-safe-top, 5.75rem) 2rem var(--chrome-safe-bottom, 2rem);
+  overflow-y: auto;
   animation: screen-in 0.25s ease;
 }
 section[data-view][hidden] { display: none; }
@@ -1969,6 +2038,17 @@ html:not([data-template="design"]) .viewport-toggle,
 html:not([data-template="design"]) .design-switcher,
 html:not([data-template="design"]) .anno-toggle-fab,
 html:not([data-template="design"]) .anno-layer { display: none !important; }
+
+/* The panel carries BOTH navs because a page may mix iteration templates:
+   #screen-nav for design iterations, #section-nav for decision/free ones
+   (incl. the final report). Exactly one may render at a time, and the swap
+   must be driven by the template, never by JS: buildDesignUI() returns early
+   when the visible iteration has no design (`if (!active) return`), BEFORE it
+   clears nav.innerHTML — so on a decision tab the previous design's entries
+   are still sitting in #screen-nav. Without this rule they render as a dead
+   TOC whose headings switch to a design nobody is looking at. */
+html:not([data-template="design"]) #screen-nav,
+html[data-template="design"] #section-nav { display: none !important; }
 
 /* Minimal screen counter — NOT a header bar.
    Left-anchored at 1rem and content-sized, so its natural width grows with
@@ -2511,15 +2591,43 @@ body.panel-open .design-switcher { opacity: 0; pointer-events: none; }
 #screen-textareas textarea[hidden],
 #design-textareas textarea[hidden] { display: none; }
 
-/* Single-screen design: hide screen-nav + per-screen feedback section +
-   its own leading divider. Order is general -> design -> page, so the
-   divider that must disappear with the page row is the one immediately
-   BEFORE it, not the one before general (which is always first, no
-   leading divider). Only general (and, if >=2 designs, per-design) notes
-   remain visible. */
-body[data-single-screen="true"] #screen-nav,
+/* Single-screen design: hide the per-screen feedback section + its own
+   leading divider. Order is general -> design -> page, so the divider that
+   must disappear with the page row is the one immediately BEFORE it, not
+   the one before general (which is always first, no leading divider). Only
+   general (and, if >=2 designs, per-design) notes remain visible.
+   body[data-single-screen] is the correct scope HERE: the dock always talks
+   about the screen currently on the canvas, so an active-design flag is
+   exactly what it needs. */
 body[data-single-screen="true"] .feedback-section:has(#screen-textareas),
 body[data-single-screen="true"] .feedback-divider:has(+ .feedback-section #screen-textareas) {
+  display: none;
+}
+
+/* The panel TOC collapses PER GROUP, never per body. #screen-nav is a
+   CROSS-design container: one .screen-nav-group per design, each led by the
+   heading that switches to it. body[data-single-screen] is written by
+   updateScreenScope() from the ACTIVE design's screen count, so gating the
+   container on it blanked the entire table of contents — every other
+   design's entry, and the only in-panel way back — the moment the user
+   switched to a design that happened to hold one screen. The flag belongs
+   on the group, stamped once per design by buildDesignUI(), where it is
+   also stable across switches instead of flipping under the user. */
+.screen-nav-group[data-single-screen="true"] .screen-nav-item { display: none; }
+
+/* Only when there is genuinely nothing left to navigate — one design, that
+   one design holds one screen, AND the iteration has no views — may the
+   container itself go. Without this the emptied flex box keeps its
+   border-bottom and paints a stray divider under the iteration tabs.
+   The :has() guard is load-bearing, not defensive: the views group lives
+   inside THIS container, and the only other route to a view is the
+   .view-switch-item row inside .design-switcher — which
+   body[data-single-design="true"] hides two rules down. Drop the guard and a
+   single-design, single-screen iteration with views has no route to any of
+   them at all, in either surface. "Nothing left to navigate" has to mean
+   nothing, views included. */
+body[data-single-design="true"][data-single-screen="true"]
+  #screen-nav:not(:has(.screen-nav-view-item)) {
   display: none;
 }
 
@@ -2668,7 +2776,7 @@ body.panel-open .viewport-toggle { opacity: 0; pointer-events: none; }
    overflow-y: auto here makes the scrollbar's appearance shrink clientWidth,
    which lowers the fit scale, which removes the scrollbar again — a visible
    oscillation, and a "ResizeObserver loop" warning in Chromium. */
-[data-template="design"] section[data-screen][data-device-mode] { overflow: hidden; padding: 1.5rem; }
+[data-template="design"] section[data-screen][data-device-mode] { overflow: hidden; padding: var(--chrome-safe-top, 5.75rem) 1.5rem var(--chrome-safe-bottom, 2rem); }
 .device-stage {
   align-self: stretch;             /* the section centres its children; the
                                       stage must instead fill it, or the
@@ -2942,6 +3050,12 @@ change) via `harvestDockValues()`.
       group.appendChild(heading);
 
       const screens = [...d.querySelectorAll('section[data-screen][id]')];
+      // Per-design collapse flag for the TOC (§ Layout CSS,
+      // .screen-nav-group[data-single-screen]). Derived from THIS design's
+      // own screens — body[data-single-screen] tracks only the design on the
+      // canvas, and using it here would hide every other design's rows too,
+      // flipping the whole TOC on every switch.
+      group.dataset.singleScreen = String(screens.length <= 1);
       screens.forEach((sec, idx) => {
         const btn = document.createElement('button');
         btn.className = 'screen-nav-item';
@@ -3106,8 +3220,11 @@ change) via `harvestDockValues()`.
     // choice into a boot-time TypeError.
     const totalEl = document.getElementById('total-screens');
     if (totalEl) totalEl.textContent = screens.length;
-    // Single-screen designs: hide screen-nav + per-screen feedback.
-    // CSS keys off body[data-single-screen="true"].
+    // Single-screen designs: hide the per-screen FEEDBACK row (and, combined
+    // with body[data-single-design], the now-empty #screen-nav). This flag
+    // describes the design currently on the canvas, so it must never gate the
+    // panel's per-design rows on its own — buildDesignUI() stamps
+    // group.dataset.singleScreen for those. See § Layout CSS.
     document.body.dataset.singleScreen = screens.length <= 1 ? 'true' : 'false';
   }
 
@@ -3734,7 +3851,26 @@ change) via `harvestDockValues()`.
   }
   // The switcher auto-hides while the panel is open (the panel carries the
   // same navigation) — driven by body.panel-open, see Layout CSS.
-  window.openPanel = () => { panel?.classList.add('open'); backdrop?.classList.add('visible'); panelToggle?.classList.add('hidden'); document.body.classList.add('panel-open'); };
+  // The ☰ panel and the 💬 dock are both right-edge overlays and are
+  // therefore mutually exclusive: opening one minimises the other, so they
+  // can never sit expanded on top of each other. The reciprocal call belongs
+  // in the OPEN paths only — a close path must never touch the other
+  // overlay, or dismissing one would resurrect the other.
+  // The call goes through `window.` and is optional on purpose: the dock
+  // wiring below has its own markup preconditions, and a page missing them
+  // must not take the panel down with it (same failure mode the guard above
+  // documents).
+  window.openPanel = () => {
+    const fromDock = dock?.contains(document.activeElement);
+    window.closeDock?.(true);
+    panel?.classList.add('open');
+    backdrop?.classList.add('visible');
+    panelToggle?.classList.add('hidden');
+    document.body.classList.add('panel-open');
+    // Only re-home focus that the dock just lost — never steal it from a
+    // pointer user who was not typing anywhere.
+    if (fromDock) panelCloseBtn?.focus();
+  };
   window.closePanel = () => { panel?.classList.remove('open'); backdrop?.classList.remove('visible'); panelToggle?.classList.remove('hidden'); document.body.classList.remove('panel-open'); };
   panelToggle?.addEventListener('click', openPanel);
   panelCloseBtn?.addEventListener('click', closePanel);
@@ -3758,12 +3894,19 @@ change) via `harvestDockValues()`.
   const LABEL_OPEN = dockToggle.dataset.labelOpen || dockToggle.getAttribute('aria-label');
   const LABEL_CLOSE = dockToggle.dataset.labelClose || LABEL_OPEN;
   function openDock() {
+    window.closePanel?.();   // mutually exclusive overlays, see openPanel above
     dock.dataset.open = 'true';
     dockToggle.setAttribute('aria-expanded', 'true');
     dockToggle.setAttribute('aria-label', LABEL_CLOSE);
   }
-  function closeDock() {
-    const focusWasInside = dock.contains(document.activeElement);
+  // `handOff` = the dock is closing because the panel is taking over. Then
+  // the FAB must NOT be focused: it sits at z-index 220, above the panel
+  // backdrop, so a keyboard user would be left standing on a control that
+  // dismisses the overlay that just opened. openPanel() moves focus into the
+  // panel instead. Every other close still restores the FAB, or focus would
+  // be orphaned inside a display:none dock.
+  function closeDock(handOff) {
+    const focusWasInside = !handOff && dock.contains(document.activeElement);
     dock.dataset.open = 'false';
     dockToggle.setAttribute('aria-expanded', 'false');
     dockToggle.setAttribute('aria-label', LABEL_OPEN);

--- a/plugins/devops/skills/concept/panel-chrome.test.js
+++ b/plugins/devops/skills/concept/panel-chrome.test.js
@@ -1,0 +1,514 @@
+import { describe, test, expect } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// The ☰ decision panel is the only navigation a design concept has that is
+// not a floating overlay: it lists every design and every screen, and it is
+// where the user switches between them. Two defects made it unusable, both
+// found in a real generated page rather than by reading the template:
+//
+//   1. `#screen-nav` — the panel's whole table of contents — was hidden by
+//      `body[data-single-screen="true"]`. That flag is written by
+//      updateScreenScope() from the ACTIVE design's screen count, but the
+//      container it hid is CROSS-design: one group per design, each with the
+//      heading that switches to it. So in a multi-design iteration, switching
+//      to any design that happens to have a single screen blanked the entire
+//      TOC — every other design's entry with it — and left no way back except
+//      the dimmed floating switcher. A per-design count must never gate a
+//      cross-design container.
+//   2. The ☰ panel and the 💬 feedback dock opened independently. Both are
+//      right-edge overlays, so opening one over the other left them stacked
+//      (measured: 326x445px of overlap at a 921px viewport).
+//
+// templates.md is a REFERENCE Claude copies verbatim into generated pages, so
+// a defect here ships silently into every concept produced afterwards.
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DK = path.join(__dirname, "deep-knowledge");
+const md = fs.readFileSync(path.join(DK, "templates.md"), "utf8");
+
+// Line-based scanner (same reason as viewport-switcher.test.js): a lazy
+// `\`\`\`css\n([\s\S]*?)\`\`\`` regex desynchronises on the first block whose
+// body contains a fence and silently stops seeing everything after it.
+function scanBlocks(src) {
+  const lines = src.split("\n");
+  const out = [];
+  let open = null, body = [];
+  for (let i = 0; i < lines.length; i++) {
+    const m = /^```(.*)$/.exec(lines[i]);
+    if (m) {
+      if (open === null) { open = { info: m[1].trim(), start: i + 2 }; body = []; }
+      else { out.push({ info: open.info, line: open.start, code: body.join("\n") }); open = null; }
+      continue;
+    }
+    if (open) body.push(lines[i]);
+  }
+  return out;
+}
+const BLOCKS = scanBlocks(md);
+const cssSource = BLOCKS.filter((b) => b.info === "css").map((b) => b.code).join("\n");
+const jsSource = BLOCKS.filter((b) => /^(javascript|js)$/.test(b.info)).map((b) => b.code).join("\n");
+
+/** Splits a selector list on top-level commas only — `:has(a, b)` and
+ *  `[attr="x,y"]` must stay one selector. */
+function splitSelectors(list) {
+  const out = [];
+  let depth = 0, buf = "";
+  for (const ch of list) {
+    if (ch === "(" || ch === "[") depth++;
+    else if (ch === ")" || ch === "]") depth--;
+    if (ch === "," && depth === 0) { out.push(buf.trim()); buf = ""; continue; }
+    buf += ch;
+  }
+  if (buf.trim()) out.push(buf.trim());
+  return out;
+}
+
+// Comments have to go before the walker runs: it accumulates everything
+// between two braces as the selector, so a rule preceded by a `/* … */`
+// block would carry that whole comment in its selector text and never match
+// an anchored pattern.
+const stripComments = (s) => s.replace(/\/\*[\s\S]*?\*\//g, "");
+
+/** Brace-balanced rule walker. Recurses into at-rules so a declaration
+ *  nested in `@media` is not invisible to the assertions below. */
+function cssRules(src) {
+  const out = [];
+  let i = 0, sel = "";
+  while (i < src.length) {
+    if (src[i] === "}") { sel = ""; i++; continue; }
+    if (src[i] !== "{") { sel += src[i]; i++; continue; }
+    let depth = 1, j = i + 1;
+    while (j < src.length && depth > 0) {
+      if (src[j] === "{") depth++;
+      else if (src[j] === "}") { depth--; if (!depth) break; }
+      j++;
+    }
+    const body = src.slice(i + 1, j);
+    const head = sel.trim();
+    if (head.startsWith("@")) out.push(...cssRules(body));
+    else if (head) out.push({ selectors: splitSelectors(head), body });
+    sel = "";
+    i = j + 1;
+  }
+  return out;
+}
+
+const RULES = cssRules(stripComments(cssSource));
+
+// "Hidden" has to mean every way a rule can take an element off the page, not
+// just the one the bug happened to use. Keying on `display: none` alone would
+// let the identical regression back in through `visibility: hidden` or a
+// zero-height clip, and the offender scan below would still report clean.
+const HIDES = [
+  /display\s*:\s*none/,
+  /visibility\s*:\s*hidden/,
+  /opacity\s*:\s*0(?![.\d])/,
+  /max-height\s*:\s*0(?![.\d])/,
+  /(?<!max-|min-)height\s*:\s*0(?![.\d])/,
+];
+const hidden = RULES.filter((r) => HIDES.some((re) => re.test(r.body)));
+
+/** Slices a brace-balanced function body starting at `marker`. */
+function slice(src, marker) {
+  const start = src.indexOf(marker);
+  expect(start, marker).toBeGreaterThan(-1);
+  let i = src.indexOf("{", start), depth = 0;
+  for (; i < src.length; i++) {
+    if (src[i] === "{") depth++;
+    else if (src[i] === "}" && --depth === 0) return src.slice(start, i + 1);
+  }
+  throw new Error("unbalanced braces after " + marker);
+}
+
+describe("panel TOC — a design switch must not blank #screen-nav", () => {
+  test("nothing hides #screen-nav on the active design's screen count alone", () => {
+    // `body[data-single-screen="true"] #screen-nav` is the exact rule that
+    // shipped the bug: true whenever the design currently on the canvas has
+    // one screen, regardless of how many designs the iteration holds.
+    // The prohibition is specifically about THAT flag — hiding the container
+    // for an unrelated reason (e.g. a non-design iteration is showing) is
+    // legitimate and must not be reported here.
+    const offenders = [];
+    for (const rule of hidden) {
+      for (const sel of rule.selectors) {
+        if (!/#screen-nav\b[^,]*$/.test(sel)) continue;   // subject must BE the container
+        if (!/\[data-single-screen/.test(sel)) continue;  // unrelated condition — fine
+        if (!/\[data-single-design\s*=\s*"true"\]/.test(sel)) offenders.push(sel);
+      }
+    }
+    expect(offenders, "selectors hiding the whole TOC on a per-design condition").toEqual([]);
+  });
+
+  test("a non-design iteration never shows the previous design's TOC", () => {
+    // buildDesignUI() returns early when the visible iteration has no design,
+    // BEFORE it clears nav.innerHTML — so the entries survive the switch and
+    // only CSS can keep them off a decision / free / final-report tab.
+    const build = slice(jsSource, "function buildDesignUI(");
+    const clear = build.indexOf("nav.innerHTML");
+    const early = build.indexOf("if (!active) return");
+    expect(early, "the early return this rule compensates for").toBeGreaterThan(-1);
+    expect(early, "early return still precedes the nav clear").toBeLessThan(clear);
+    const swapped = hidden.some((r) => r.selectors.some((s) =>
+      /^html:not\(\[data-template="design"\]\)\s+#screen-nav$/.test(s.trim())));
+    expect(swapped, 'html:not([data-template="design"]) #screen-nav').toBe(true);
+  });
+
+  test("views keep a route when everything else collapses", () => {
+    // The views group lives INSIDE #screen-nav, and the only other route to a
+    // view is .view-switch-item inside .design-switcher — which
+    // body[data-single-design="true"] hides. Collapsing the container on a
+    // single-design, single-screen iteration that HAS views therefore strands
+    // them with no reachable surface at all.
+    const container = hidden.filter((r) => r.selectors.some((s) =>
+      /#screen-nav/.test(s) && /\[data-single-screen/.test(s)));
+    expect(container.length, "the container-collapse rule").toBeGreaterThan(0);
+    for (const rule of container) {
+      for (const sel of rule.selectors.filter((s) => /#screen-nav/.test(s))) {
+        expect(sel.replace(/\s+/g, " "), "must exempt iterations that hold views")
+          .toMatch(/#screen-nav:not\(:has\(\.screen-nav-view-item\)\)/);
+      }
+    }
+    // and the switcher half of the claim — the reason the guard is needed
+    const switcherHidden = hidden.some((r) => r.selectors.some((s) =>
+      /^body\[data-single-design="true"\]\s+\.design-switcher$/.test(s.trim())));
+    expect(switcherHidden, "body[data-single-design] .design-switcher").toBe(true);
+    expect(jsSource, "view segments live in the design switcher")
+      .toMatch(/btn\.className = 'view-switch-item'/);
+  });
+
+  test("the whole TOC may still collapse when one design holds one screen", () => {
+    // The legitimate case the original rule was written for must survive the
+    // fix — otherwise an empty flex container leaves a stray divider line.
+    const collapses = hidden.some((r) => r.selectors.some((sel) =>
+      /#screen-nav\b/.test(sel)
+      && /\[data-single-design\s*=\s*"true"\]/.test(sel)
+      && /\[data-single-screen\s*=\s*"true"\]/.test(sel)));
+    expect(collapses, "body[data-single-design][data-single-screen] #screen-nav").toBe(true);
+  });
+
+  test("a single-screen design collapses its OWN group's screen row", () => {
+    // Per-design granularity: the flag lives on .screen-nav-group, so the
+    // other designs' rows are untouched and the state does not change when
+    // the active design does.
+    const perGroup = hidden.some((r) => r.selectors.some((sel) =>
+      /\.screen-nav-group\[data-single-screen\s*=\s*"true"\]/.test(sel)
+      && /\.screen-nav-item\s*$/.test(sel)));
+    expect(perGroup, ".screen-nav-group[data-single-screen=true] .screen-nav-item").toBe(true);
+  });
+
+  test("buildDesignUI stamps each group from that design's own screen count", () => {
+    const build = slice(jsSource, "function buildDesignUI(");
+    // The count must come from the design being rendered (`d`), not from the
+    // active one — that is the whole point of moving the flag off <body>.
+    expect(build).toMatch(/group\.dataset\.singleScreen\s*=/);
+    const stamp = /group\.dataset\.singleScreen\s*=\s*String\(\s*screens\.length\s*<=\s*1\s*\)/;
+    expect(build, "group flag derived from this group's screens").toMatch(stamp);
+    // and it must be stamped from the same array the items are built from
+    expect(build).toMatch(/const screens = \[\.\.\.d\.querySelectorAll\('section\[data-screen\]\[id\]'\)\]/);
+  });
+
+  test("the CSS reads the very attribute the JS writes", () => {
+    // The bug this file guards was a MISMATCH between what the JS sets and
+    // what the CSS reads, so checking each side's existence separately is not
+    // enough: a rename on either side leaves both isolated assertions green.
+    // Both halves are derived from the source here, then required to meet.
+    const build = slice(jsSource, "function buildDesignUI(");
+    const kebab = (s) => s.replace(/[A-Z]/g, (c) => "-" + c.toLowerCase());
+
+    const groupClass = /group\.className\s*=\s*'([^']+)'/.exec(build);
+    expect(groupClass, "group.className in buildDesignUI").toBeTruthy();
+    const flagKey = /group\.dataset\.(\w+)\s*=/.exec(build);
+    expect(flagKey, "group.dataset.<flag> in buildDesignUI").toBeTruthy();
+    // The item class must come from the screens loop, not from the design
+    // switcher or the view list, which also assign a className in here.
+    const loop = slice(build, "screens.forEach(");
+    const itemClass = /btn\.className\s*=\s*'([^']+)'/.exec(loop);
+    expect(itemClass, "btn.className inside screens.forEach").toBeTruthy();
+
+    const want = `.${groupClass[1]}[data-${kebab(flagKey[1])}="true"] .${itemClass[1]}`;
+    const wired = hidden.some((r) => r.selectors.some((s) => s.trim() === want));
+    expect(wired, `CSS must hide exactly: ${want}`).toBe(true);
+  });
+
+  test("the container rule reads the very body flag updateScreenScope writes", () => {
+    const scope = slice(jsSource, "function updateScreenScope(");
+    const kebab = (s) => s.replace(/[A-Z]/g, (c) => "-" + c.toLowerCase());
+    const bodyKey = /document\.body\.dataset\.(\w+)\s*=/.exec(scope);
+    expect(bodyKey, "document.body.dataset.<flag> in updateScreenScope").toBeTruthy();
+    const attr = `[data-${kebab(bodyKey[1])}="true"]`;
+    // That flag may reach #screen-nav ONLY together with the single-design
+    // one — on its own it describes just the design on the canvas.
+    const container = hidden.filter((r) => r.selectors.some((s) => /#screen-nav\s*$/.test(s)));
+    expect(container.length, "a rule hiding #screen-nav").toBeGreaterThan(0);
+    for (const rule of container) {
+      for (const sel of rule.selectors.filter((s) => /#screen-nav\s*$/.test(s))) {
+        if (!sel.includes(attr)) continue;
+        expect(sel, "active-design flag must be paired with single-design")
+          .toMatch(/\[data-single-design\s*=\s*"true"\]/);
+      }
+    }
+  });
+
+  test("the dock's per-screen row keeps the active-design body flag", () => {
+    // Guard against over-correcting: the dock IS about the screen currently
+    // on the canvas, so body[data-single-screen] is the right scope there.
+    const dockRow = hidden.some((r) => r.selectors.some((sel) =>
+      /^body\[data-single-screen\s*=\s*"true"\]/.test(sel)
+      && /#screen-textareas/.test(sel)));
+    expect(dockRow, "body[data-single-screen] .feedback-section:has(#screen-textareas)").toBe(true);
+  });
+});
+
+describe("chrome safe area — the canvas must not paint under fixed chrome", () => {
+  // Design mode floats the indicator, the design switcher and two 60px FABs
+  // over a canvas that runs edge to edge (inset: 0). A flat `padding: 2rem`
+  // put the content's first row 32px down while the chrome reached 92px, so
+  // every screen tall enough to fill the viewport had its opening lines
+  // painted underneath it (measured at 921x873: 18px of overlap).
+  const CONTAINERS = [
+    ['screens', /^\[data-template="design"\] section\[data-screen\]$/],
+    ['views', /^\[data-template="design"\] section\[data-view\]$/],
+    ['device frames', /section\[data-screen\]\[data-device-mode\]$/],
+  ];
+
+  function ruleFor(re) {
+    const hit = RULES.find((r) => r.selectors.some((s) => re.test(s.trim())));
+    expect(hit, "rule for " + re).toBeTruthy();
+    return hit.body;
+  }
+
+  test("the reserve is declared as tokens, not a number per call site", () => {
+    const root = RULES.find((r) => r.selectors.some((s) => /^html\[data-template="design"\]$/.test(s.trim()))
+      && /--chrome-safe-top\s*:/.test(r.body));
+    expect(root, "html[data-template=design] { --chrome-safe-* }").toBeTruthy();
+    expect(root.body).toMatch(/--chrome-safe-top\s*:\s*[\d.]+rem/);
+    expect(root.body).toMatch(/--chrome-safe-bottom\s*:\s*[\d.]+rem/);
+  });
+
+  test.each(CONTAINERS)("%s reserve the top band", (_name, re) => {
+    const body = ruleFor(re);
+    const padding = /padding\s*:\s*([^;]+);/.exec(body);
+    expect(padding, "padding declaration").toBeTruthy();
+    // The TOP component must be the token; a bare length here is the bug.
+    expect(padding[1].trim(), "top padding").toMatch(/^var\(--chrome-safe-top,\s*[\d.]+rem\)\s/);
+    // and the bottom must be declared too, so the shorthand cannot silently
+    // mirror the top back onto an edge that does not need it.
+    expect(padding[1].trim(), "bottom padding").toMatch(/ var\(--chrome-safe-bottom,\s*[\d.]+rem\)$/);
+  });
+
+  test("the top token clears the deepest chrome the file itself positions", () => {
+    // Derived from the CSS, not from a copy of the number in the comment —
+    // moving a FAB without moving the reserve must fail here.
+    const rem = (v) => (/rem$/.test(v) ? parseFloat(v) * 16 : parseFloat(v));
+    const rootBody = RULES.find((r) => /--chrome-safe-top\s*:/.test(r.body)).body;
+    const top = rem(/--chrome-safe-top\s*:\s*([\d.]+rem)/.exec(rootBody)[1]);
+    const css = stripComments(cssSource);
+    const fabTop = rem(/\.panel-fab\s*\{[^}]*top:\s*([\d.]+rem)/.exec(css)[1]);
+    const fabBox = RULES.find((r) => r.selectors.some((s) => /\.panel-fab$/.test(s.trim()))
+      && /height:\s*\d+px/.test(r.body));
+    const fabH = parseFloat(/height:\s*(\d+)px/.exec(fabBox.body)[1]);
+    expect(top, `--chrome-safe-top must cover .panel-fab (${fabTop}px + ${fabH}px)`)
+      .toBeGreaterThanOrEqual(fabTop + fabH);
+    // The annotation eye pill shares the top-left column and sits BELOW the
+    // indicator, so it is the other candidate for deepest.
+    const anno = rem(/\.anno-toggle-fab\s*\{[^}]*top:\s*([\d.]+rem)/.exec(css)[1]);
+    expect(top, "--chrome-safe-top must clear #anno-toggle's row").toBeGreaterThan(anno);
+  });
+
+  test("the reserve does not push device frames past the readability floor", () => {
+    // The safe area costs the .device-stage box real height, and fitDeviceStage
+    // scales the frame pair to that box. Below MIN_DEVICE_SCALE the stage flips
+    // to a scrolling, top-aligned layout — a whole layout-mode change caused
+    // only by padding. bestFit is pure, so the interaction can be computed here
+    // instead of asserted by eye.
+    const js = jsSource;
+    const rem = (v) => (/rem$/.test(v) ? parseFloat(v) * 16 : parseFloat(v));
+    const consts = ["DEVICE_SIZES", "MIN_DEVICE_SCALE"]
+      .map((n) => new RegExp("^\\s*const " + n + " = .*$", "m").exec(js)?.[0])
+      .filter(Boolean).join("\n");
+    expect(consts, "device constants").toContain("MIN_DEVICE_SCALE");
+    const bestFit = new Function(consts + "\n" + slice(js, "function bestFit(")
+      + "\nreturn { bestFit, DEVICE_SIZES, MIN_DEVICE_SCALE };")();
+
+    const rootBody = RULES.find((r) => /--chrome-safe-top\s*:/.test(r.body)).body;
+    const top = rem(/--chrome-safe-top\s*:\s*([\d.]+rem)/.exec(rootBody)[1]);
+    const bottom = rem(/--chrome-safe-bottom\s*:\s*([\d.]+rem)/.exec(rootBody)[1]);
+    const side = rem(/padding:[^;]*?\s([\d.]+rem)\s+var\(--chrome-safe-bottom/
+      .exec(stripComments(cssSource).replace(/\s+/g, " "))?.[1] || "1.5rem");
+
+    // A 13" laptop window is the smallest canvas these pages target.
+    const VW = 1280, VH = 700, GAP = 32;
+    const availW = VW - 2 * side, availH = VH - top - bottom;
+    const { bestFit: fit, DEVICE_SIZES, MIN_DEVICE_SCALE } = bestFit;
+    for (const [name, size] of Object.entries(DEVICE_SIZES)) {
+      // worst realistic case: portrait + landscape of the same device
+      const pair = [size, [size[1], size[0]]];
+      const res = fit(pair, availW, availH, GAP);
+      expect(res.clamped, `${name} pair clamps at ${VW}x${VH} — the safe area `
+        + `left only ${availH}px of height`).toBe(false);
+      expect(res.scale, `${name} pair scale`).toBeGreaterThan(MIN_DEVICE_SCALE);
+    }
+  });
+
+  test("the bottom reserve stays a plain gutter — the edge is corner-only", () => {
+    // Asymmetry is the point: mirroring the top would spend another 60px of
+    // artefact height on an edge whose centre holds nothing. If a future
+    // change puts chrome in the bottom CENTRE, this is the test to revisit.
+    const css = stripComments(cssSource);
+    const rem = (v) => (/rem$/.test(v) ? parseFloat(v) * 16 : parseFloat(v));
+    const rootBody = RULES.find((r) => /--chrome-safe-bottom\s*:/.test(r.body)).body;
+    const bottom = rem(/--chrome-safe-bottom\s*:\s*([\d.]+rem)/.exec(rootBody)[1]);
+    expect(bottom, "bottom gutter").toBeLessThan(
+      rem(/--chrome-safe-top\s*:\s*([\d.]+rem)/.exec(rootBody)[1]));
+    // Both bottom-edge controls must be corner-anchored for that to hold.
+    for (const sel of ['.feedback-fab', '.viewport-toggle']) {
+      const rule = RULES.find((r) => r.selectors.some((x) => x.trim() === sel)
+        && /(left|right):/.test(r.body));
+      expect(rule, sel + " must be corner-anchored").toBeTruthy();
+      expect(rule.body, sel + " anchor").toMatch(/(left|right):\s*[\d.]+rem/);
+    }
+    expect(css).not.toMatch(/\.[\w-]+\s*\{[^}]*bottom:\s*[\d.]+rem;[^}]*left:\s*50%/);
+  });
+});
+
+describe("panel and dock are mutually exclusive overlays", () => {
+  // Executed, not pattern-matched: the four functions are lifted out of
+  // templates.md and run against stub elements, so this pins the state
+  // machine rather than the wording of it.
+  function harness() {
+    const focusLog = [];
+    const el = (name) => {
+      const cls = new Set();
+      const node = {
+        name,
+        classList: {
+          add: (c) => cls.add(c), remove: (c) => cls.delete(c), contains: (c) => cls.has(c),
+        },
+        dataset: {},
+        setAttribute() {}, getAttribute() { return null; },
+        // `holds` lets a test say "the caret is inside me right now"
+        holds: false,
+        contains() { return node.holds; },
+        focus() { focusLog.push(name); },
+      };
+      return node;
+    };
+    // The reciprocal calls go through `window.`, so the harness has to make
+    // the same export templates.md makes — asserted below, not assumed.
+    expect(jsSource, "window.closeDock export").toMatch(/window\.closeDock\s*=\s*closeDock\s*;/);
+    const src = [
+      slice(jsSource, "window.openPanel ="),
+      slice(jsSource, "window.closePanel ="),
+      slice(jsSource, "function openDock("),
+      slice(jsSource, "function closeDock("),
+      "window.closeDock = closeDock",
+    ].join(";\n");
+    const make = new Function("panel", "panelToggle", "panelCloseBtn", "backdrop",
+      "dock", "dockToggle", "document", "window", "LABEL_OPEN", "LABEL_CLOSE",
+      // openPanel/closePanel are assigned onto `window`, never declared
+      src + "; return { openPanel: window.openPanel, closePanel: window.closePanel,"
+          + " openDock, closeDock };");
+    const panel = el("panel"), dock = el("dock"), panelToggle = el("panelToggle"),
+      panelCloseBtn = el("panelCloseBtn"), backdrop = el("backdrop"),
+      dockToggle = el("dockToggle");
+    const doc = { body: el("body"), activeElement: null };
+    const api = make(panel, panelToggle, panelCloseBtn, backdrop, dock, dockToggle,
+      doc, {}, "open", "close");
+    return {
+      ...api,
+      panelOpen: () => panel.classList.contains("open"),
+      dockOpen: () => dock.dataset.open === "true",
+      // simulate the caret sitting in a dock textarea
+      caretInDock: (on) => { dock.holds = on; doc.activeElement = on ? el("textarea") : null; },
+      focusLog,
+    };
+  }
+
+  test("opening the panel minimises the dock", () => {
+    const h = harness();
+    h.openDock();
+    expect(h.dockOpen()).toBe(true);
+    h.openPanel();
+    expect(h.panelOpen(), "panel opened").toBe(true);
+    expect(h.dockOpen(), "dock still open behind the panel").toBe(false);
+  });
+
+  test("opening the dock closes the panel", () => {
+    const h = harness();
+    h.openPanel();
+    expect(h.panelOpen()).toBe(true);
+    h.openDock();
+    expect(h.dockOpen(), "dock opened").toBe(true);
+    expect(h.panelOpen(), "panel still open under the dock").toBe(false);
+  });
+
+  test("the FABs are actually bound to the functions under test", () => {
+    // The harness above proves the state machine; it cannot prove the buttons
+    // reach it. Without this, renaming the handler at the addEventListener
+    // call site leaves every behavioural test green and the page dead.
+    expect(jsSource, "☰ bound to openPanel")
+      .toMatch(/panelToggle\?\.addEventListener\('click',\s*openPanel\)/);
+    expect(jsSource, "💬 toggles the dock")
+      .toMatch(/dockToggle\.addEventListener\('click',[\s\S]{0,160}?closeDock\(\)[\s\S]{0,80}?openDock\(\)/);
+  });
+
+  test("a hand-off close does not park focus on the dock FAB", () => {
+    // The 💬 FAB outranks the panel backdrop, so focusing it while the panel
+    // opens leaves a keyboard user on a control that dismisses the panel.
+    const close = slice(jsSource, "function closeDock(");
+    expect(close, "closeDock takes a hand-off flag").toMatch(/function closeDock\(\s*\w+\s*\)/);
+    expect(close, "the flag suppresses the focus restore")
+      .toMatch(/const focusWasInside\s*=\s*!\w+\s*&&\s*dock\.contains/);
+    const open = slice(jsSource, "window.openPanel =");
+    expect(open, "openPanel closes the dock as a hand-off").toMatch(/closeDock\?\.\(\s*true\s*\)/);
+    expect(open, "and re-homes the focus it took").toMatch(/panelCloseBtn\?\.focus\(\)/);
+  });
+
+  test("☰ from inside the dock moves focus into the panel, not onto the FAB", () => {
+    // The 💬 FAB paints above the panel backdrop, so parking focus there would
+    // leave a keyboard user on a control that dismisses the panel they just
+    // opened. Executed, not pattern-matched — the source-shape assertions
+    // above cannot see where focus actually lands.
+    const h = harness();
+    h.openDock();
+    h.caretInDock(true);
+    h.openPanel();
+    expect(h.panelOpen()).toBe(true);
+    expect(h.dockOpen()).toBe(false);
+    expect(h.focusLog, "focus must not land on the dock FAB").not.toContain("dockToggle");
+    expect(h.focusLog, "focus is re-homed into the panel").toContain("panelCloseBtn");
+  });
+
+  test("a normal dock dismissal still restores the FAB", () => {
+    // The hand-off must not cost the ordinary close its focus restore, or
+    // focus is orphaned inside a display:none dock.
+    const h = harness();
+    h.openDock();
+    h.caretInDock(true);
+    h.closeDock();
+    expect(h.focusLog, "plain close returns focus to the FAB").toContain("dockToggle");
+  });
+
+  test("a pointer user is not robbed of focus", () => {
+    const h = harness();
+    h.openDock();          // caret NOT in the dock
+    h.openPanel();
+    expect(h.focusLog, "nothing was focused").toEqual([]);
+  });
+
+  test("closing one never re-opens the other", () => {
+    // The reciprocal calls live in the OPEN paths only; a close that also
+    // opened would ping-pong the two overlays on every dismissal.
+    const h = harness();
+    h.openPanel();
+    h.closePanel();
+    expect(h.panelOpen()).toBe(false);
+    expect(h.dockOpen(), "closing the panel opened the dock").toBe(false);
+    h.openDock();
+    h.closeDock();
+    expect(h.dockOpen()).toBe(false);
+    expect(h.panelOpen(), "closing the dock opened the panel").toBe(false);
+  });
+});

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.135.0",
+  "version": "0.135.1",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

Three defects in the `design` template reference, all found in a real generated page rather than by reading the file.

**The ☰ panel's table of contents blanked on a design switch.** `#screen-nav` is a cross-design container — one group per design, each led by the heading that switches to it — but it was hidden by `body[data-single-screen="true"]`, a flag `updateScreenScope()` writes from the *active* design's screen count. Switching to any design that happened to hold one screen erased every other design's entry with it. Measured on the reported page: nav `display: flex → none`, height `535px → 0`, five groups still in the DOM, none visible.

The collapse now lives on the group (`.screen-nav-group[data-single-screen]`), stamped per design in `buildDesignUI()` — so it is decided from that design's own screens and does not change when the active design does. The container itself only goes when a single design holds a single screen **and** the iteration has no views: the views group lives inside that container, and the only other route to a view is the `.view-switch-item` row inside `.design-switcher`, which `body[data-single-design]` already hides.

**The ☰ panel and the 💬 dock stacked.** Both are right-edge overlays and opened independently — measured 326×445px of overlap at a 921px viewport. Opening one now minimises the other, in the open paths only, so a dismissal never resurrects the other. A hand-off close skips the FAB focus restore and `openPanel()` re-homes focus into the panel: the FAB outranks the backdrop, so focus parked there would sit on a control that dismisses the panel it just opened.

**Canvas content painted under the fixed chrome.** Content top 32px against a chrome bottom of 50px — 18px unreadable on every screen. Two derived tokens now reserve the band. The reserve is deliberately asymmetric: the top edge is occupied across its whole width (indicator left, switcher centre, ☰ right), the bottom only in two corners, so mirroring it would have spent another 60px of artefact height on an edge that is empty across ~96% of its width — multiplicatively so in device mode, where `fitDeviceStage()` scales the frame pair to that box.

Also adds the design/non-design nav swap the template never had (`buildDesignUI()` returns before clearing `nav.innerHTML`, so a decision tab kept a dead TOC), and corrects three comment blocks that still documented the old rules. In a file Claude copies verbatim, a stale comment is a wrong instruction — one of them sat directly on the line that writes the flag.

## Verification

- Reproduced and re-verified in a real browser against a generated page: TOC visible in every state across both iterations, all design headings clickable, list stable across switches; 0px panel/dock overlap over seven click states; 0 chrome overlaps over 9 screens (top **and** bottom).
- `panel-chrome.test.js` — 24 tests. Six were red before the fix. The panel/dock state machine and the focus hand-off are *executed*, not pattern-matched: the four functions are lifted out of the reference and run against stub nodes.
- The wiring test derives the group class, the dataset key and the item class from the JS source and requires exact coverage by a CSS rule — mutation-checked: renaming either side, or the class, turns it red.
- Full suite: 81 files / 2004 tests, lint clean.

## Notes

- Codex review gate: skipped — the CLI reported its usage limit. Non-blocking per the gate's failure-tolerance rule.
- The `ship_build` test step needs `--maxWorkers=2` in this environment; at full concurrency the vitest worker RPC times out reporting task updates and the run is marked failed even though all 2004 tests pass (verified separately, exit 0). Pre-existing flake, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)