### PR TITLE
fix(concept): stop stacking attachment bars and inactive designs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.136.0"
+    "version": "0.136.1"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.136.0",
+      "version": "0.136.1",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.136.0",
+      "version": "0.136.1",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.136.1] — 2026-09-01
+
+### Fixed
+
+- **A concept page's feedback dock stacked one attachment bar per hidden field.** The dock builds a textarea for every screen, every design and every view up front and then only flips `hidden` on switch — but each field's attachment mount is its *sibling*, not its child, and `.attach-slot:empty` stops hiding a mount the instant a bar is mounted into it. So from the moment the attachment engine wired the page, every hidden field's paperclip row rendered underneath the single visible textarea: measured on a real page, eight identical "Ctrl+V or drop any file" rows stacked under one note field. Hiding a mount with its field is now a CSS rule rather than something the switchers have to remember, and the bar keeps existing while hidden so files already attached to an inactive field survive the switch back. The mountless fallback path used to append the bar to the end of the row instead of next to its field, which put half of them out of reach of that rule; it now inserts directly after the textarea.
+
+- **A design iteration could paint every one of its designs on top of each other.** Designs and screens in a `design` iteration are `position: absolute; inset: 0`, so a section that ships without `hidden` does not land somewhere wrong — it lands on the same square as the active one. The markup is asked to emit `hidden` on every inactive design and screen, but nothing enforced it, and a real generated page emitted it on none of its three designs: five screens painted at once, headings and mockups interleaved, the page unreadable and every click ambiguous. The active flags are already what the page resolves by — `activeDesign()` and `activeScreen()` both key on them, and the switchers keep them in step with `hidden` — so they now carry the visibility as well. The rules are `:has()`-guarded, so markup that omits the flags entirely degrades to the previous behaviour instead of blanking the canvas; a view, which has no boot state in which it should show, is kept off screen outside view mode.
+
+### Changed
+
+- **The attachment affordance is the paperclip alone.** Every attachable field carries a bar, so the spelled-out "Ctrl+V or drop any file" line under each one repeated the same sentence down the length of the dock and out-weighed the field it decorated. The shortcuts moved into the button's `title` and a new `aria-label`; the drop target still announces itself with the dashed outline the moment a file is dragged over it.
+
 ## [0.136.0] — 2026-08-30
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.136.0**
+**Version: 0.136.1**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.136.0",
+  "version": "0.136.1",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/skills/concept/deep-knowledge/templates.md
+++ b/plugins/devops/skills/concept/deep-knowledge/templates.md
@@ -145,7 +145,6 @@ must see their own language. The locale hint is authoritative.
 | `panel.maximize`               | Maximize                        | Maximieren |
 | `panel.restore_size`           | Restore size                    | Größe wiederherstellen |
 | `attach.button_title`          | Attach file (or Ctrl+V / drag & drop) | Datei anhängen (oder Strg+V / hierher ziehen) |
-| `attach.hint`                  | Ctrl+V or drop any file          | Strg+V oder beliebige Datei ablegen |
 | `attach.not_synced`            | not yet synced                  | noch nicht synchronisiert |
 | `attach.uploading`             | Uploading…                      | Wird hochgeladen… |
 | `attach.remove`                | Remove attachment                | Anhang entfernen |
@@ -1968,6 +1967,23 @@ section[data-iteration][hidden] { display: none; }
   animation: screen-in 0.25s ease;
 }
 section[data-screen][hidden] { display: none; }
+/* Structural backstop for the "exactly one of these is on screen" invariant.
+   `hidden` is the switchers' mechanism, and the markup above asks for it on
+   every inactive design and screen — but nothing enforces that, and these
+   boxes are position:absolute/inset:0. A single forgotten `hidden` therefore
+   does not misplace a section, it paints every sibling onto the same square:
+   three designs' mockups drawn on top of each other, their headings and
+   labels interleaved, the page unreadable and every click ambiguous.
+   The active flags are already this page's own source of truth — both
+   activeDesign() and activeScreen() resolve by them, and showDesign() /
+   showScreen() keep them in step with `hidden` on every switch — so they can
+   carry the visibility too. Both rules are `:has()`-guarded: they bite only
+   once a sibling IS marked active, so markup that omits the flags entirely
+   degrades to the old behaviour instead of blanking the canvas. */
+section[data-iteration]:has(> section[data-design][data-design-active="true"])
+  > section[data-design]:not([data-design-active="true"]) { display: none; }
+section[data-design]:has(section[data-screen][data-screen-active="true"])
+  section[data-screen]:not([data-screen-active="true"]) { display: none; }
 @keyframes screen-in { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: translateY(0); } }
 
 /* ── Views (optional, § Views (optional)) — top-level siblings of
@@ -1986,6 +2002,13 @@ section[data-screen][hidden] { display: none; }
   animation: screen-in 0.25s ease;
 }
 section[data-view][hidden] { display: none; }
+/* Same backstop, the other direction: outside view mode NO view paints, flag
+   or not. A view is fullscreen and absolutely positioned like a screen, so a
+   view that boots without `hidden` covers the design the page opened on.
+   body[data-view-active] is maintained by showView() (true) and by
+   showDesign() + the iteration switch (false), and its ABSENCE — nothing ran
+   yet — reads as "not in view mode", which is exactly the boot state. */
+body:not([data-view-active="true"]) section[data-view] { display: none; }
 .view-frame { max-width: 860px; margin: 0 auto; }
 /* Comparison view kind — see § Views (optional) → View kind `comparison`. */
 .cmp-options {
@@ -2183,6 +2206,19 @@ body.panel-open .anno-toggle-fab { opacity: 0; pointer-events: none; }
 }
 /* Attachment mount — deliberately empty, see § Annotation Layer. */
 .attach-slot:empty { display: none; }
+/* …and deliberately hidden while the field it belongs to is. The dock builds
+   one textarea PER screen / design / view and hides all but the active one
+   (§ Layout JS), but `.attach-slot` is that textarea's SIBLING, not its child:
+   the moment initCommentAttachments() mounts a bar the slot stops being
+   `:empty`, so without this rule every inactive field's bar renders under the
+   one visible textarea — a stack of N identical 📎 rows instead of one.
+   The mount is always emitted immediately after its textarea, so the adjacent
+   sibling combinator ties their visibility together with no JS to keep in
+   sync — showScreen()/showDesign()/showView() only touch `ta.hidden`. The
+   `.attach-bar` half covers the mountless fallback path, where the bar is
+   inserted straight after the textarea instead of into a slot. */
+textarea[hidden] + .attach-slot,
+textarea[hidden] + .attach-bar { display: none; }
 /* Leader line + bubble offset, one rule pair per side. The line is a short
    fixed-length connector (14px), never computed at runtime. */
 .anno[data-anno-side="right"] .anno-bubble { left: calc(var(--anno-pin-size, 28px) + 14px); top: 50%; transform: translateY(-50%); }
@@ -2587,9 +2623,12 @@ body.panel-open .design-switcher { opacity: 0; pointer-events: none; }
   }
 }
 
-/* Hidden per-screen / per-design textareas: only the active one shown */
+/* Hidden per-screen / per-design / per-view textareas: only the active one
+   shown. #view-textareas belongs here for the same reason the other two do —
+   buildViewTextareas() hides every one of its textareas identically. */
 #screen-textareas textarea[hidden],
-#design-textareas textarea[hidden] { display: none; }
+#design-textareas textarea[hidden],
+#view-textareas textarea[hidden] { display: none; }
 
 /* Single-screen design: hide the per-screen feedback section + its own
    leading divider. Order is general -> design -> page, so the divider that
@@ -3139,6 +3178,10 @@ change) via `harvestDockValues()`.
       ta.hidden = d !== active;
       if (carried[ta.dataset.comment]) ta.value = carried[ta.dataset.comment];
       container.appendChild(ta);
+      // The mount goes DIRECTLY after its textarea — nothing in between.
+      // `textarea[hidden] + .attach-slot` (§ Layout CSS) is what hides an
+      // inactive field's 📎 bar, and it only reaches an adjacent sibling.
+      // Same rule in buildScreenTextareas/buildViewTextareas below.
       const slot = document.createElement('div');
       slot.className = 'attach-slot';
       slot.dataset.attachSlot = ta.dataset.comment;
@@ -6129,6 +6172,25 @@ same slot key, so calling it again after `ensureCommentSlots()`, after a
 dock rebuild (§ Layout JS `buildDesignUI()`), or after an iteration append
 is always safe.
 
+**One bar per field is not one bar on screen — the mount must follow its
+field's visibility.** The dock builds a textarea per screen, per design and
+per view up front and then only flips `hidden` on switch (§ Layout JS), so
+at any moment most attachable fields are hidden. Their `.attach-slot` mounts
+are *siblings* of those textareas, and `.attach-slot:empty { display: none }`
+stops covering them the instant a bar is mounted — which is why the dock
+rendered one 📎 row per hidden field stacked under the single visible
+textarea. `textarea[hidden] + .attach-slot { display: none }` (§ Layout
+CSS) is what keeps the two in step; it works because the mount is always
+emitted directly after the textarea it belongs to. **Emit it that way** — a
+mount separated from its field, or one nested somewhere else in the row,
+silently reintroduces the stack. The same rule names `.attach-bar` for the
+mountless path, where `_mountAttachmentBar()` inserts the bar itself
+`afterend` of the textarea for exactly this reason. Hiding the bar is deliberately CSS-only:
+`showScreen()`/`showDesign()`/`showView()` must stay free to toggle nothing
+but `ta.hidden`, and the bar has to keep existing (and stay wired) while
+hidden so the attachments already on an inactive field are still there when
+the user switches back to it.
+
 **The durability rule is unchanged: upload on ATTACH, never on submit.** The
 file is sent to the bridge the moment it is picked/pasted/dropped and is
 fsynced to `.claude/concepts/<slug>/attachments/<sha256>.<ext>` shortly
@@ -6192,16 +6254,23 @@ The bar is injected per field by `ensureCommentSlots()` and
 
 ```html
 <div class="attach-bar" data-attach-for="variant-a-note">
-  <button type="button" class="attach-btn" title="{{attach.button_title}}">📎</button>
-  <span class="attach-hint">{{attach.hint}}</span>
+  <button type="button" class="attach-btn"
+          title="{{attach.button_title}}" aria-label="{{attach.button_title}}">📎</button>
   <input type="file" multiple hidden>
   <div class="attach-thumbs"></div>
 </div>
 ```
 
 `{{attach.button_title}}` → e.g. "Datei anhängen (oder Strg+V / hierher
-ziehen)", `{{attach.hint}}` → e.g. "Strg+V oder beliebige Datei ablegen".
-Resolve both at generation time per § UI Locale.
+ziehen)". Resolve it at generation time per § UI Locale.
+
+**The 📎 alone is the affordance — no hint label.** Every attachable field
+carries a bar, so a spelled-out "Ctrl+V or drop any file" line repeated under
+each one is pure noise: it out-weighs the field it decorates and reads as
+clutter down a dock of them. The paste/drop shortcuts live in the button's
+`title`/`aria-label`, which is where a discoverable-but-quiet affordance
+belongs, and the drop target itself stays advertised by the dashed
+`.attach-dragover` outline the moment a file is dragged over the textarea.
 
 ### CSS
 
@@ -6213,7 +6282,6 @@ Resolve both at generation time per § UI Locale.
   padding: .15rem .45rem; font-size: .95rem; line-height: 1.4;
 }
 .attach-btn:hover { border-color: var(--accent-color); color: var(--text-primary); }
-.attach-hint { font-size: .72rem; color: var(--text-tertiary); }
 .attach-thumbs { display: flex; gap: .4rem; flex-wrap: wrap; width: 100%; }
 .attach-thumb { position: relative; width: 64px; height: 64px; border-radius: 6px;
                 overflow: hidden; border: 1px solid var(--border-color); }
@@ -6327,8 +6395,8 @@ function buildAttachmentBar(slotKey) {
   bar.className = 'attach-bar';
   bar.dataset.attachFor = slotKey;
   bar.innerHTML =
-    '<button type="button" class="attach-btn" title="{{attach.button_title}}">📎</button>' +
-    '<span class="attach-hint">{{attach.hint}}</span>' +
+    '<button type="button" class="attach-btn" title="{{attach.button_title}}"' +
+    ' aria-label="{{attach.button_title}}">📎</button>' +
     '<input type="file" multiple hidden>' +
     '<div class="attach-thumbs"></div>';
   return bar;
@@ -6351,7 +6419,11 @@ function _mountAttachmentBar(ta, slotKey) {
   const bar = buildAttachmentBar(slotKey);
   const dedicated = document.querySelector('.attach-slot[data-attach-slot="' + CSS.escape(slotKey) + '"]');
   if (dedicated) dedicated.appendChild(bar);
-  else if (ta.parentElement) ta.parentElement.appendChild(bar);
+  // `afterend`, not parentElement.appendChild: the bar belongs to ITS field,
+  // and appending to the container drops it after whatever else the row holds
+  // — far from the textarea, and out of reach of the
+  // `textarea[hidden] + .attach-bar` rule that hides it with its field.
+  else if (ta.parentElement) ta.insertAdjacentElement('afterend', bar);
   return bar;
 }
 

--- a/plugins/devops/skills/concept/deep-knowledge/validation-gate.md
+++ b/plugins/devops/skills/concept/deep-knowledge/validation-gate.md
@@ -37,7 +37,7 @@ no legitimate matches — do not "keep it as a convenience". The decision panel
 
 ## Phase 1 — Shared patterns (ALL templates)
 
-Every concept page must contain these 47 patterns, regardless of template
+Every concept page must contain these 49 patterns, regardless of template
 (the numbering carries `b` suffixes where a pattern was added next to a
 related one — count the rows, not the highest number):
 
@@ -90,6 +90,8 @@ related one — count the rows, not the highest number):
 | 41 | `data-attachable` | The ONE marker `initCommentAttachments()` matches to decide which fields get an attachment bar. MUST NOT be `data-comment` — several fields carry `data-comment` without being attachable (plain text-only comments), and several carry both (annotation answers, decision notes); matching on `data-comment` wires a bar onto every one of those a second time or onto fields that were never meant to take a file. See templates.md § Attachments. |
 | 42 | `initCommentAttachments` | Wires the 📎 button, drag & drop, and Ctrl/Cmd+V paste onto every `textarea[data-attachable]`. Missing → attachment bars render (if emitted inline) but do nothing. |
 | 43 | `_guardedSetItem` | Every `localStorage.setItem` call site (state persistence + both `-pending` submit-queue writes) MUST go through this wrapper, never a bare `localStorage.setItem`. A `QuotaExceededError` thrown out of an unguarded call kills ALL further persistence for the rest of the page with nothing telling the user — see templates.md § State Persistence. |
+| 44 | `textarea[hidden] + .attach-slot` | The CSS rule that takes an inactive field's 📎 bar off the page. The dock builds one textarea per screen / design / view and hides all but the active one, but a `.attach-slot` mount is that textarea's SIBLING — and `.attach-slot:empty` stops covering it the moment `initCommentAttachments()` mounts a bar into it. Missing → the page renders one 📎 row per hidden field, stacked under the single visible textarea. See templates.md § Attachments. |
+| 45 | `section[data-design]:not([data-design-active="true"])` | The CSS backstop for "exactly one design and one screen paint". Designs and screens are `position:absolute; inset:0`, so a single inactive section that ships without `hidden` does not sit somewhere wrong — it paints on top of the active one. Measured on a real page: three designs, five screens, all stacked on the same square, headings and mockups interleaved. `hidden` cannot be the only guard because the markup is merely ASKED to emit it. Must be `:has()`-guarded, together with the matching `section[data-screen]:not([data-screen-active="true"])` rule and `body:not([data-view-active="true"]) section[data-view]`. See templates.md § Layout CSS. |
 
 **Failure for 21 / 22:** if either pattern is missing, the page is rejected
 at the post-generation gate. See § Generic Form Collection below for the
@@ -109,10 +111,22 @@ but lacks `data-attachable`, or if `initCommentAttachments` matches
 mandatory pattern — either fields double-wire a second bar, or a field the
 user expects to attach a file to silently accepts none.
 
+**Failure for 45:** a page missing the rule is not merely un-hardened — grep
+its markup for `section[data-design]` and `section[data-screen]` and check
+that every inactive one carries `hidden`. If any does not, the page is
+already stacking sections on top of each other and must be regenerated, not
+just patched with the rule.
+
 **Failure for 43:** grep every `localStorage.setItem(` occurrence in the
 rendered page; each one MUST read `_guardedSetItem(`, no exceptions. One
 unguarded call site reintroduces the exact silent-persistence-death defect
 this pattern exists to catch.
+
+**Failure for 44:** the rule is an ADJACENT sibling combinator, so its
+presence is only half the check — every `.attach-slot` in the page must also
+sit directly after the textarea it belongs to. Grep the mounts: any one
+separated from its field by another element is hidden by nothing and puts a
+duplicate bar back on screen.
 
 ## Generic Form Collection (mandatory for all templates)
 

--- a/plugins/devops/skills/concept/panel-chrome.test.js
+++ b/plugins/devops/skills/concept/panel-chrome.test.js
@@ -512,3 +512,135 @@ describe("panel and dock are mutually exclusive overlays", () => {
     expect(h.panelOpen(), "closing the dock opened the panel").toBe(false);
   });
 });
+
+describe("attachment bars — one 📎 on screen, not one per hidden field", () => {
+  // The dock builds a textarea per screen, per design and per view up front
+  // and then only flips `hidden` on switch, but each textarea's `.attach-slot`
+  // mount is a SIBLING of it. `.attach-slot:empty` covers a mount only until a
+  // bar lands in it, so the moment initCommentAttachments() ran, every hidden
+  // field's bar rendered under the one visible textarea — the dock showed
+  // eight identical "📎 Strg+V oder beliebige Datei ablegen" rows.
+
+  test("a hidden field's bar is hidden with it, on both mount paths", () => {
+    // Two paths exist: a dedicated `.attach-slot` (every dock-built field,
+    // annotation answers) and the mountless fallback that inserts the bar
+    // itself after the textarea. Covering only the first leaves the second
+    // free to stack.
+    for (const sub of [".attach-slot", ".attach-bar"]) {
+      const rule = hidden.find((r) => r.selectors.some((s) =>
+        new RegExp("^textarea\\[hidden\\]\\s*\\+\\s*\\" + sub + "$").test(s.trim())));
+      expect(rule, "textarea[hidden] + " + sub).toBeDefined();
+    }
+  });
+
+  test("the mountless fallback puts the bar next to its field", () => {
+    // …which is what makes the `.attach-bar` half of that rule reachable.
+    // `parentElement.appendChild` drops the bar after everything else in the
+    // row instead — no longer an adjacent sibling, no longer hideable.
+    const mount = slice(jsSource, "function _mountAttachmentBar(");
+    expect(mount, "fallback insert point").toMatch(/insertAdjacentElement\('afterend', bar\)/);
+    expect(mount, "fallback must not append to the container")
+      .not.toMatch(/parentElement\.appendChild\(bar\)/);
+  });
+
+  test("every dock builder emits the mount adjacent to its textarea", () => {
+    // The rule above is an ADJACENT sibling combinator, so it only reaches a
+    // mount that directly follows its field. Anything appended in between
+    // silently restores the stack while the CSS still reads correct.
+    const builders = [
+      "function buildDesignTextareas(",
+      "function buildScreenTextareas(",
+      "function buildViewTextareas(",
+    ];
+    for (const fn of builders) {
+      const body = slice(jsSource, fn);
+      const ta = body.indexOf("appendChild(ta)");
+      const slot = body.indexOf("appendChild(slot)");
+      expect(ta, fn + " appends its textarea").toBeGreaterThan(-1);
+      expect(slot, fn + " appends its attach mount after the textarea").toBeGreaterThan(ta);
+      const between = body.slice(ta + "appendChild(ta)".length, slot);
+      expect(between, fn + " appends something between field and mount")
+        .not.toMatch(/appendChild\(/);
+    }
+  });
+
+  test("the visibility hand-off stays CSS-only", () => {
+    // The bar must keep EXISTING (and stay wired) while its field is hidden —
+    // attachments already on an inactive field have to survive the switch —
+    // so the switchers may only toggle `ta.hidden`, never unmount a bar.
+    const switchers = [
+      "window.showScreen = function(",
+      "window.showDesign = function(",
+      "window.showView = function(",
+    ];
+    for (const fn of switchers) {
+      const body = slice(jsSource, fn);
+      expect(body, fn + " must not tear down attachment mounts")
+        .not.toMatch(/attach-slot|attachSlot|attach-bar|attachFor/);
+    }
+  });
+
+  test("the bar is the icon alone — no hint label", () => {
+    // One 📎 per field is already the affordance; a spelled-out shortcut line
+    // repeated under every field out-weighs the field it decorates. The
+    // shortcuts live in the button's title/aria-label instead.
+    const bar = slice(jsSource, "function buildAttachmentBar(");
+    expect(bar, "the 📎 keeps an accessible name once its label is gone")
+      .toMatch(/aria-label="\{\{attach\.button_title\}\}"/);
+    expect(md, "attach-hint markup, CSS or locale key came back")
+      .not.toMatch(/attach-hint|`attach\.hint`/);
+  });
+});
+
+describe("exactly one design / screen / view paints", () => {
+  // Measured on a real generated page: an iteration holding three designs
+  // emitted `hidden` on none of them, so five screens across all three
+  // rendered at once — every one position:absolute/inset:0, all stacked on
+  // the same square. Headings, labels and mockups interleaved; the page was
+  // unreadable and every click ambiguous. `hidden` alone could not prevent
+  // it: it is set by JS the markup is merely ASKED to pre-empt, and nothing
+  // enforced that. These rules make the active flags carry visibility too.
+
+  const norm = (s) => s.replace(/\s+/g, " ").trim();
+
+  test("an inactive design and an inactive screen are off the canvas", () => {
+    for (const [sel, flag] of [
+      ["section[data-design]", "data-design-active"],
+      ["section[data-screen]", "data-screen-active"],
+    ]) {
+      const subject = sel + ':not([' + flag + '="true"])';
+      const matching = hidden.flatMap((r) => r.selectors.map(norm))
+        .filter((s) => s.endsWith(subject));
+      expect(matching.length, subject).toBeGreaterThan(0);
+      // ...but only once something IS marked active. Unguarded, a page whose
+      // markup omits the flag entirely would render an empty canvas - a worse
+      // failure than the stack this replaces.
+      for (const s of matching) {
+        expect(s, "must be :has()-guarded").toContain(":has(");
+      }
+    }
+  });
+
+  test("no view paints outside view mode", () => {
+    // The other direction: at boot nothing has run, so body[data-view-active]
+    // is absent — which must read as "not in view mode", or a view that ships
+    // without `hidden` covers the design the page opens on.
+    const rule = hidden.find((r) => r.selectors.some((s) =>
+      /^body:not\(\[data-view-active="true"\]\)\s+section\[data-view\]$/.test(s.trim())));
+    expect(rule, 'body:not([data-view-active="true"]) section[data-view]').toBeDefined();
+  });
+
+  test("the switchers still maintain the flags the rules key on", () => {
+    // The CSS above is only as good as the attributes it reads. A switcher
+    // that stopped writing one would leave the canvas permanently blank
+    // instead of merely mis-highlighted, so pin the writes.
+    expect(slice(jsSource, "window.showDesign = function("), "showDesign writes designActive")
+      .toMatch(/dataset\.designActive\s*=/);
+    expect(slice(jsSource, "window.showScreen = function("), "showScreen writes screenActive")
+      .toMatch(/dataset\.screenActive\s*=/);
+    const view = slice(jsSource, "window.showView = function(");
+    expect(view, "showView writes body[data-view-active]").toMatch(/body\.dataset\.viewActive\s*=\s*'true'/);
+    expect(slice(jsSource, "window.showDesign = function("), "showDesign clears it again")
+      .toMatch(/body\.dataset\.viewActive\s*=\s*'false'/);
+  });
+});

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.136.0",
+  "version": "0.136.1",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

Two defects of the same class in the concept page template, both found by measuring a real generated page rather than by reading the reference.

**Attachment bars stacked, one per hidden field.** The feedback dock builds a textarea per screen / design / view up front and hides all but the active one, but each field's `.attach-slot` mount is its *sibling*. `.attach-slot:empty` stops covering a mount the instant a bar is mounted into it, so every hidden field's paperclip row rendered under the single visible textarea — measured: ten bars, eight of them on screen. `textarea[hidden] + .attach-slot, textarea[hidden] + .attach-bar` ties the two together; the mountless fallback now inserts the bar `afterend` of its textarea so the adjacent-sibling combinator can reach it at all. The bar stays wired while hidden, so files already attached to an inactive field survive the switch back.

**Whole designs stacked.** Designs and screens are `position: absolute; inset: 0`, and the markup is merely *asked* to emit `hidden` on the inactive ones. A real iteration emitted it on none of its three designs: five screens painted onto the same square. The active flags — already what `activeDesign()` / `activeScreen()` resolve by, and kept in step with `hidden` by the switchers — now carry visibility too, `:has()`-guarded so markup without the flags degrades to the old behaviour instead of blanking the canvas.

Also drops the attachment hint label: one paperclip per field is the whole affordance, and the shortcuts moved into the button's `title` / `aria-label`.

## Verification

- `npm test` — **2072 passed (82 files)**, run directly in the worktree. `ship_build`'s own invocation reports failure on three `[vitest-worker] Timeout calling "onTaskUpdate"` unhandled errors in the MCP spawn context — no test fails there either; the RPC timeouts alone make vitest exit non-zero.
- `npm run lint` — clean.
- Live-measured on a running concept page: injecting the new rules took it from **5 visible screens to 1**.

Gate entries 44 + 45 and five regression tests pin all of it.