### PR TITLE
fix(completion): render the card offline when MCP never connects

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.136.1"
+    "version": "0.137.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.136.1",
+      "version": "0.137.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.136.1",
+      "version": "0.137.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.137.0] — 2026-09-01
+
+### Fixed
+
+- **A session whose MCP servers never connected lost its completion card entirely — for every turn, and quietly.** The card existed only as an MCP tool, so when the servers timed out while starting (thirty seconds, and under heavy parallel load it took all of them down at once, the unrelated ones included) the tool was simply not in the session. The Stop gate still fired and still demanded a card; the fallback it named, ToolSearch, cannot load a tool from a server that never came up; and because the gate deliberately blocks only once per turn, it then yielded. The turn ended with an explanation instead of a card, and so did every turn after it, for the rest of the session. Over the three hours in which this was measured, five of six enforced cards were never rendered — against a baseline of virtually none in the weeks before.
+
+### Added
+
+- **The card renders without MCP at all.** The completion server takes a second entry point, `--render-card <payload.json>`: the same renderer, the same field names, the same coercions, the same flags that satisfy the Stop gate, with the card markdown on stdout. The MCP SDK and its schema library moved behind that branch as lazy imports, so the fallback runs on a bare node with no third-party module in its graph — the situation it exists for is precisely the one where the MCP stack is unavailable. Both places that enforce the card, the Stop gate's block reason and the reminder injected after every tool call, now name that path, so "no card was possible" is no longer a reachable answer.
+
 ## [0.136.1] — 2026-09-01
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.136.1**
+**Version: 0.137.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.136.1",
+  "version": "0.137.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/deep-knowledge/plugin-behavior.md
+++ b/plugins/devops/deep-knowledge/plugin-behavior.md
@@ -36,6 +36,19 @@ It fires whenever a task is fully completed and Claude is waiting for the next u
 - `render_completion_card` (MCP tool) — writes `card-rendered` flag after successful
   render so `stop.flow.guard` knows the card was produced.
 
+**When the MCP server is not there:** if the servers failed to connect for a
+session (`CONNECT_TIMEOUT`, "failed to connect" — it happens under heavy parallel
+load), the tool is absent and ToolSearch cannot load it either. The card is still
+required. Render it offline through the same renderer:
+
+```bash
+node "$CLAUDE_PLUGIN_ROOT/mcp-server/index.js" --render-card <payload.json>
+```
+
+Same field names as the tool (including `session_id`), card markdown on stdout,
+same `card-rendered` / `validation-attested` flags written. Relay stdout VERBATIM.
+"No card possible" is never the answer — that path exists for exactly this case.
+
 **Desktop App visibility:** The `render_completion_card` MCP tool result is hidden
 inside a collapsed "Hat ein Tool verwendet" element. All hooks instruct Claude to
 copy the returned markdown and output it VERBATIM as direct text response.

--- a/plugins/devops/hooks/lib/card-guard.js
+++ b/plugins/devops/hooks/lib/card-guard.js
@@ -83,11 +83,13 @@ function lastAssistantContainsCard(transcriptContent) {
  *                                     not the user. Never enforce the card.
  * @param {boolean} [s.validationPending]  — a code change owes a validation attestation
  * @param {boolean} [s.validationAttested] — the card was rendered with a `validation` field
+ * @param {string}  [s.pluginRoot]   — active install root, so the block reason can name
+ *                                     the offline renderer path for this install
  * @returns {{ action: 'block' | 'pass', resetFlags: boolean, reason?: string }}
  */
 function decideAction({
   workHappened, cardRendered, stopHookActive, substantial, silent,
-  validationPending, validationAttested,
+  validationPending, validationAttested, pluginRoot,
 }) {
   if (silent) {
     // Background tick (cron git-sync, concept bridge poll, autonomous loop).
@@ -110,7 +112,7 @@ function decideAction({
     return {
       action: 'block',
       resetFlags: false, // keep flags so the post-render stop hook sees consistent state
-      reason: buildBlockReason(),
+      reason: buildBlockReason(pluginRoot),
     };
   }
 
@@ -127,13 +129,31 @@ function decideAction({
   return { action: 'pass', resetFlags: true };
 }
 
-function buildBlockReason() {
+/**
+ * Path of the offline card renderer for this install, in a form Bash accepts on
+ * Windows too (forward slashes). Falls back to the env placeholder when the
+ * caller could not resolve a root — a named variable still beats no instruction.
+ */
+function offlineRendererPath(pluginRoot) {
+  const root = pluginRoot ? String(pluginRoot).replace(/\\/g, '/') : '$CLAUDE_PLUGIN_ROOT';
+  return `${root}/mcp-server/index.js`;
+}
+
+function buildBlockReason(pluginRoot) {
   return [
     '[stop.flow.guard] Completion card required — not yet rendered this turn.',
     '',
     'Call `mcp__plugin_devops_dotclaude-completion__render_completion_card` NOW as the FIRST action.',
     'If the direct call fails with "tool not found", fall back to ToolSearch:',
     '  select:mcp__plugin_devops_dotclaude-completion__render_completion_card',
+    '',
+    'If ToolSearch ALSO cannot find it because the MCP server never connected this',
+    'session (CONNECT_TIMEOUT / "failed to connect"), the card is still required —',
+    'render it offline through the same renderer, via Bash:',
+    `  node "${offlineRendererPath(pluginRoot)}" --render-card <payload.json>`,
+    'Write the exact arguments you would have passed to the tool into payload.json',
+    '(same field names, including "session_id"), then relay stdout VERBATIM. Do not',
+    'report "no card possible" — that path exists precisely for a dead MCP server.',
     '',
     'Variant decision (pick exactly one):',
     '  ship pipeline ran + merged → ship-successful  (ONLY after /ship + merge)',

--- a/plugins/devops/hooks/lib/card-guard.test.js
+++ b/plugins/devops/hooks/lib/card-guard.test.js
@@ -424,4 +424,33 @@ describe("buildBlockReason", () => {
     expect(r).toMatch(/VERBATIM/);
     expect(r).toMatch(/LAST/);
   });
+
+  // A session whose MCP servers never connected (CONNECT_TIMEOUT under load)
+  // used to end with no card at all: the tool is absent, ToolSearch cannot load
+  // it, the gate blocks once and then yields. The reason must name the offline
+  // renderer so that session still produces a card.
+  test("names the offline renderer under the given plugin root", () => {
+    const r = buildBlockReason("C:\\Users\\x\\.claude\\plugins\\cache\\dotclaude\\devops\\0.1.0");
+    expect(r).toMatch(/CONNECT_TIMEOUT/);
+    expect(r).toContain(
+      'node "C:/Users/x/.claude/plugins/cache/dotclaude/devops/0.1.0/mcp-server/index.js" --render-card',
+    );
+  });
+
+  test("falls back to the env placeholder when no plugin root is known", () => {
+    const r = buildBlockReason();
+    expect(r).toContain('node "$CLAUDE_PLUGIN_ROOT/mcp-server/index.js" --render-card');
+  });
+
+  test("decideAction threads the plugin root into the card block reason", () => {
+    const d = decideAction({
+      workHappened: true,
+      cardRendered: false,
+      stopHookActive: false,
+      substantial: false,
+      pluginRoot: "/opt/devops",
+    });
+    expect(d.action).toBe("block");
+    expect(d.reason).toContain('node "/opt/devops/mcp-server/index.js" --render-card');
+  });
 });

--- a/plugins/devops/hooks/post-tool-use/post.flow.completion.js
+++ b/plugins/devops/hooks/post-tool-use/post.flow.completion.js
@@ -41,6 +41,13 @@ const {
   testRunOutcome,
 } = require('../lib/browsertest-guard');
 
+// Offline card renderer — the same module that backs the MCP tool, invoked as a
+// CLI. Named in the reminder so a session whose MCP servers never connected
+// still knows how to produce a card. Forward slashes: the reminder is a Bash
+// command line, and Windows paths must survive it.
+const OFFLINE_RENDERER = (process.env.CLAUDE_PLUGIN_ROOT || path.resolve(__dirname, '..', '..'))
+  .replace(/\\/g, '/') + '/mcp-server/index.js';
+
 /**
  * Read the pinned $TEST_PROFILE for this session (cache written per
  * deep-knowledge/test-plan.md) plus the project's no-runtime static carve-outs
@@ -244,6 +251,7 @@ process.stdin.on('end', () => {
     'COMPLETION CARD — when ALL work is done:',
     'Call `mcp__plugin_devops_dotclaude-completion__render_completion_card` directly (already loaded MCP tool).',
     'Only if the direct call fails with "tool not found", fall back to ToolSearch: select:mcp__plugin_devops_dotclaude-completion__render_completion_card',
+    `If the MCP server never connected this session (CONNECT_TIMEOUT), render offline instead — never skip the card: node "${OFFLINE_RENDERER}" --render-card <payload.json> (same JSON args, relay stdout verbatim).`,
     `Pass: variant, summary (max ~10 words, user language), lang:(use "de" if user writes German, "en" otherwise), session_id:"${hook.session_id || ''}",`,
     '  plus changes, tests, state, cta, userTest, userFinalTest as applicable.',
     `  cwd:"${hook.cwd || ''}" — without it PR/commit/branch render as dead text, not links.`,

--- a/plugins/devops/hooks/stop/stop.flow.guard.js
+++ b/plugins/devops/hooks/stop/stop.flow.guard.js
@@ -21,6 +21,7 @@
 require('../lib/plugin-guard');
 
 const fs = require('fs');
+const path = require('path');
 const { readSessionFile } = require('../lib/session-id');
 const {
   decideAction,
@@ -76,6 +77,9 @@ process.stdin.on('end', () => {
     silent,
     validationPending,
     validationAttested,
+    // Active install root — the block reason names the offline renderer under it
+    // for the case where the MCP server never connected this session.
+    pluginRoot: process.env.CLAUDE_PLUGIN_ROOT || path.resolve(__dirname, '..', '..'),
   });
 
   if (decision.resetFlags) {

--- a/plugins/devops/mcp-server/index.cli.test.js
+++ b/plugins/devops/mcp-server/index.cli.test.js
@@ -1,5 +1,6 @@
-import { describe, test, expect, beforeAll, afterAll } from "vitest";
-import { execFileSync } from "node:child_process";
+import { describe, test, expect, beforeAll, afterAll, vi } from "vitest";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 import { existsSync, mkdtempSync, rmSync, writeFileSync, unlinkSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { tmpdir } from "node:os";
@@ -11,20 +12,32 @@ import { fileURLToPath } from "node:url";
 // bare node. That also pins the property that makes it a fallback at all — the
 // repo checkout has no node_modules under mcp-server/, so if the entry file ever
 // pulls the MCP SDK or zod in before the CLI branch, this test fails to spawn.
+//
+// Async execFile, never execFileSync: a sync spawn blocks the vitest worker's
+// event loop for the child's whole lifetime, which starves the worker's RPC and
+// fails the RUN with `[vitest-worker]: Timeout calling "onTaskUpdate"` even
+// though every test passed.
+const run = promisify(execFile);
 
 const ENTRY = join(dirname(fileURLToPath(import.meta.url)), "index.js");
 
+// Each case spawns node and shells out to git for the build-ID. Under full
+// parallel suite load that comfortably exceeds the 5s default.
+vi.setConfig({ testTimeout: 30_000 });
+
+// Never spawn the headless usage scraper (Edge) from a unit test.
+const CHILD_ENV = { ...process.env, DEVOPS_COMPLETION_NO_USAGE: "1" };
+
 let workDir;
 
-function renderCard(payload) {
+async function renderCard(payload) {
   const file = join(workDir, `payload-${Math.random().toString(36).slice(2)}.json`);
   writeFileSync(file, JSON.stringify(payload));
-  return execFileSync(process.execPath, [ENTRY, "--render-card", file], {
+  const { stdout } = await run(process.execPath, [ENTRY, "--render-card", file], {
     encoding: "utf8",
-    // Never spawn the headless usage scraper (Edge) from a unit test.
-    env: { ...process.env, DEVOPS_COMPLETION_NO_USAGE: "1" },
-    timeout: 30_000,
+    env: CHILD_ENV,
   });
+  return stdout;
 }
 
 function flagFile(sessionId) {
@@ -44,8 +57,8 @@ afterAll(() => {
 });
 
 describe("--render-card CLI fallback", () => {
-  test("renders the same card markdown the MCP tool returns", () => {
-    const out = renderCard({
+  test("renders the same card markdown the MCP tool returns", async () => {
+    const out = await renderCard({
       variant: "analysis",
       summary: "Karte ohne MCP-Server",
       lang: "de",
@@ -57,35 +70,35 @@ describe("--render-card CLI fallback", () => {
     expect(out).toContain("Completion card → Rendert auch ohne MCP");
   });
 
-  test("stdout carries the card only — no relay-instruction preamble to strip", () => {
-    const out = renderCard({ variant: "analysis", summary: "Nur die Karte", session_id: "cli-test-clean" });
+  test("stdout carries the card only — no relay-instruction preamble to strip", async () => {
+    const out = await renderCard({ variant: "analysis", summary: "Nur die Karte", session_id: "cli-test-clean" });
     expect(out).not.toContain("DO NOT OUTPUT THIS BLOCK");
   });
 
-  test("satisfies the Stop gate by writing the card-rendered flag", () => {
+  test("satisfies the Stop gate by writing the card-rendered flag", async () => {
     const sessionId = "cli-test-flag";
     try { unlinkSync(flagFile(sessionId)); } catch { /* not there yet */ }
 
-    renderCard({ variant: "analysis", summary: "Flag-Test", session_id: sessionId });
+    await renderCard({ variant: "analysis", summary: "Flag-Test", session_id: sessionId });
 
     expect(existsSync(flagFile(sessionId))).toBe(true);
     unlinkSync(flagFile(sessionId));
   });
 
-  test("attests validation only when the field is populated", () => {
+  test("attests validation only when the field is populated", async () => {
     const withItems = "cli-test-attested";
     const without = "cli-test-unattested";
     for (const s of [withItems, without]) {
       try { unlinkSync(attestedFile(s)); } catch { /* not there yet */ }
     }
 
-    renderCard({
+    await renderCard({
       variant: "ready",
       summary: "Mit Validierung",
       session_id: withItems,
       validation: [{ requirement: "Karte ohne MCP", status: "met", evidence: "CLI-Test" }],
     });
-    renderCard({ variant: "ready", summary: "Ohne Validierung", session_id: without });
+    await renderCard({ variant: "ready", summary: "Ohne Validierung", session_id: without });
 
     expect(existsSync(attestedFile(withItems))).toBe(true);
     expect(existsSync(attestedFile(without))).toBe(false);
@@ -95,8 +108,8 @@ describe("--render-card CLI fallback", () => {
     try { unlinkSync(flagFile(without)); } catch { /* best effort */ }
   });
 
-  test("applies the schema's coercions: JSON strings, lang default, soft clamps", () => {
-    const out = renderCard({
+  test("applies the schema's coercions: JSON strings, lang default, soft clamps", async () => {
+    const out = await renderCard({
       variant: "analysis",
       summary: "x".repeat(120),
       session_id: "cli-test-coercions",
@@ -115,24 +128,18 @@ describe("--render-card CLI fallback", () => {
     expect(out).not.toContain("dropped by the clamp");
   });
 
-  test("an unknown variant still yields a card instead of an error", () => {
-    const out = renderCard({ variant: "not-a-variant", summary: "Unbekannte Variante", session_id: "cli-test-variant" });
+  test("an unknown variant still yields a card instead of an error", async () => {
+    const out = await renderCard({ variant: "not-a-variant", summary: "Unbekannte Variante", session_id: "cli-test-variant" });
     expect(out).toMatch(/✨✨✨ Unbekannte Variante ✨✨✨/);
   });
 
-  test("exits 2 with a diagnostic when the payload is unreadable", () => {
-    let err;
-    try {
-      execFileSync(process.execPath, [ENTRY, "--render-card", join(workDir, "does-not-exist.json")], {
-        encoding: "utf8",
-        env: { ...process.env, DEVOPS_COMPLETION_NO_USAGE: "1" },
-        timeout: 30_000,
-      });
-    } catch (e) {
-      err = e;
-    }
-    expect(err).toBeDefined();
-    expect(err.status).toBe(2);
+  test("exits 2 with a diagnostic when the payload is unreadable", async () => {
+    const missing = join(workDir, "does-not-exist.json");
+    const err = await run(process.execPath, [ENTRY, "--render-card", missing], { encoding: "utf8", env: CHILD_ENV })
+      .then(() => null, (e) => e);
+
+    expect(err).not.toBeNull();
+    expect(err.code).toBe(2);
     expect(err.stderr).toMatch(/cannot read payload/);
   });
 });

--- a/plugins/devops/mcp-server/index.cli.test.js
+++ b/plugins/devops/mcp-server/index.cli.test.js
@@ -1,0 +1,138 @@
+import { describe, test, expect, beforeAll, afterAll } from "vitest";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync, writeFileSync, unlinkSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+
+// The CLI fallback exists for the session where the MCP server never connected
+// (CONNECT_TIMEOUT under load, mid-session cache rebuild, crashed spawn). It is
+// therefore exercised the way it is actually used: as a real child process, on a
+// bare node. That also pins the property that makes it a fallback at all — the
+// repo checkout has no node_modules under mcp-server/, so if the entry file ever
+// pulls the MCP SDK or zod in before the CLI branch, this test fails to spawn.
+
+const ENTRY = join(dirname(fileURLToPath(import.meta.url)), "index.js");
+
+let workDir;
+
+function renderCard(payload) {
+  const file = join(workDir, `payload-${Math.random().toString(36).slice(2)}.json`);
+  writeFileSync(file, JSON.stringify(payload));
+  return execFileSync(process.execPath, [ENTRY, "--render-card", file], {
+    encoding: "utf8",
+    // Never spawn the headless usage scraper (Edge) from a unit test.
+    env: { ...process.env, DEVOPS_COMPLETION_NO_USAGE: "1" },
+    timeout: 30_000,
+  });
+}
+
+function flagFile(sessionId) {
+  return join(tmpdir(), `dotclaude-devops-card-rendered-${sessionId}`);
+}
+
+function attestedFile(sessionId) {
+  return join(tmpdir(), `dotclaude-devops-validation-attested-${sessionId}`);
+}
+
+beforeAll(() => {
+  workDir = mkdtempSync(join(tmpdir(), "devops-card-cli-"));
+});
+
+afterAll(() => {
+  try { rmSync(workDir, { recursive: true, force: true }); } catch { /* best effort */ }
+});
+
+describe("--render-card CLI fallback", () => {
+  test("renders the same card markdown the MCP tool returns", () => {
+    const out = renderCard({
+      variant: "analysis",
+      summary: "Karte ohne MCP-Server",
+      lang: "de",
+      session_id: "cli-test-basic",
+      changes: [{ area: "Completion card", description: "Rendert auch ohne MCP" }],
+    });
+
+    expect(out).toMatch(/^### \*\*✨✨✨ Karte ohne MCP-Server ✨✨✨\*\*/m);
+    expect(out).toContain("Completion card → Rendert auch ohne MCP");
+  });
+
+  test("stdout carries the card only — no relay-instruction preamble to strip", () => {
+    const out = renderCard({ variant: "analysis", summary: "Nur die Karte", session_id: "cli-test-clean" });
+    expect(out).not.toContain("DO NOT OUTPUT THIS BLOCK");
+  });
+
+  test("satisfies the Stop gate by writing the card-rendered flag", () => {
+    const sessionId = "cli-test-flag";
+    try { unlinkSync(flagFile(sessionId)); } catch { /* not there yet */ }
+
+    renderCard({ variant: "analysis", summary: "Flag-Test", session_id: sessionId });
+
+    expect(existsSync(flagFile(sessionId))).toBe(true);
+    unlinkSync(flagFile(sessionId));
+  });
+
+  test("attests validation only when the field is populated", () => {
+    const withItems = "cli-test-attested";
+    const without = "cli-test-unattested";
+    for (const s of [withItems, without]) {
+      try { unlinkSync(attestedFile(s)); } catch { /* not there yet */ }
+    }
+
+    renderCard({
+      variant: "ready",
+      summary: "Mit Validierung",
+      session_id: withItems,
+      validation: [{ requirement: "Karte ohne MCP", status: "met", evidence: "CLI-Test" }],
+    });
+    renderCard({ variant: "ready", summary: "Ohne Validierung", session_id: without });
+
+    expect(existsSync(attestedFile(withItems))).toBe(true);
+    expect(existsSync(attestedFile(without))).toBe(false);
+
+    unlinkSync(attestedFile(withItems));
+    try { unlinkSync(flagFile(withItems)); } catch { /* best effort */ }
+    try { unlinkSync(flagFile(without)); } catch { /* best effort */ }
+  });
+
+  test("applies the schema's coercions: JSON strings, lang default, soft clamps", () => {
+    const out = renderCard({
+      variant: "analysis",
+      summary: "x".repeat(120),
+      session_id: "cli-test-coercions",
+      // The MCP schema accepts these as JSON strings; the CLI must too.
+      changes: JSON.stringify([
+        { area: "A", description: "first" },
+        { area: "B", description: "second" },
+        { area: "C", description: "third" },
+        { area: "D", description: "dropped by the clamp" },
+      ]),
+    });
+
+    expect(out).toContain("x".repeat(80));
+    expect(out).not.toContain("x".repeat(81));
+    expect(out).toContain("C → third");
+    expect(out).not.toContain("dropped by the clamp");
+  });
+
+  test("an unknown variant still yields a card instead of an error", () => {
+    const out = renderCard({ variant: "not-a-variant", summary: "Unbekannte Variante", session_id: "cli-test-variant" });
+    expect(out).toMatch(/✨✨✨ Unbekannte Variante ✨✨✨/);
+  });
+
+  test("exits 2 with a diagnostic when the payload is unreadable", () => {
+    let err;
+    try {
+      execFileSync(process.execPath, [ENTRY, "--render-card", join(workDir, "does-not-exist.json")], {
+        encoding: "utf8",
+        env: { ...process.env, DEVOPS_COMPLETION_NO_USAGE: "1" },
+        timeout: 30_000,
+      });
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeDefined();
+    expect(err.status).toBe(2);
+    expect(err.stderr).toMatch(/cannot read payload/);
+  });
+});

--- a/plugins/devops/mcp-server/index.js
+++ b/plugins/devops/mcp-server/index.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * @module dotclaude-completion-mcp
- * @version 0.7.0
+ * @version 0.8.0
  * @plugin devops
  * @description MCP server with two tools:
  *   - `get_usage`              — live usage via the claude.ai internal API
@@ -14,11 +14,30 @@
  *
  *   Registered in plugin.json → started automatically by Claude Code.
  *   Stdout is the JSON-RPC wire — all logging goes to stderr.
+ *
+ *   SECOND ENTRY POINT — offline card renderer:
+ *
+ *     node mcp-server/index.js --render-card <payload.json>   (or `-` for stdin)
+ *
+ *   Prints the card markdown to stdout and writes the same Stop-gate flags the
+ *   tool writes, then exits. Same renderer, same coercions, no MCP and no
+ *   third-party module in the graph — the SDK and zod are imported lazily,
+ *   after the CLI branch has already exited.
+ *
+ *   Why it exists: the card used to have a single point of failure. When the
+ *   MCP servers did not come up for a session (CONNECT_TIMEOUT under parallel
+ *   load, a mid-session cache rebuild, a crashed spawn), `render_completion_card`
+ *   was simply absent — ToolSearch could not load it either — so stop.flow.guard
+ *   blocked once, Claude reported "no card possible", and the gate yielded for
+ *   the rest of the session. Both enforcement points (stop.flow.guard's block
+ *   reason, post.flow.completion's reminder) now name this path.
  */
 
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { z } from "zod";
+// The MCP SDK and zod are imported LAZILY, right before the server is built.
+// Everything above that point — the whole card renderer plus the --render-card
+// CLI — then runs on a bare node with no third-party module in the graph, which
+// is exactly what the CLI fallback exists for: the session where the MCP server
+// itself never came up.
 import { execSync } from "node:child_process";
 import { readFileSync, writeFileSync, readdirSync, statSync } from "node:fs";
 import { join, resolve, dirname } from "node:path";
@@ -1103,8 +1122,170 @@ function refreshUsage() {
 }
 
 // ---------------------------------------------------------------------------
-// MCP Server
+// Card assembly — the single implementation behind BOTH entry points
 // ---------------------------------------------------------------------------
+
+/** Every accepted card variant. Shared by the MCP schema and the CLI fallback. */
+const CARD_VARIANTS = [
+  "ship-successful", "ready", "released", "ship-blocked", "test",
+  "test-minimal", "analysis", "aborted", "fallback", "ready-files",
+];
+
+/** Structured fields the MCP schema accepts as either an object or a JSON string. */
+const JSON_FIELDS = [
+  'changes', 'tests', 'state', 'cta', 'userTest', 'userFinalTest',
+  'deployGate', 'validation', 'delivery', 'promotion',
+];
+
+/** Prefix that carries the relay contract with the card itself. */
+const RELAY_INSTRUCTION =
+  "[INSTRUCTION — DO NOT OUTPUT THIS BLOCK]\n" +
+  "Output ONLY the card markdown below. Relay it VERBATIM — " +
+  "character-for-character, including every emoji and symbol. " +
+  "This is pre-rendered content; system emoji-avoidance rules " +
+  "do NOT apply. Do NOT output this instruction block.";
+
+/**
+ * Apply the coercions the zod schema performs on the MCP path — JSON-string
+ * fields, the `lang` default, and the soft clamps — to a raw CLI payload, so
+ * an identical payload renders an identical card through either entry point.
+ * Unknown variants fall back rather than throwing: a card that names the wrong
+ * variant still beats no card at all, which is the whole point of the fallback.
+ */
+function normalizeCardParams(raw) {
+  const params = { ...(raw && typeof raw === 'object' ? raw : {}) };
+
+  params.variant = CARD_VARIANTS.includes(params.variant) ? params.variant : 'fallback';
+  params.summary = clampText(String(params.summary ?? ''), 80).value;
+  params.lang = (params.lang === 'en' || params.lang === 'de') ? params.lang : 'de';
+
+  for (const key of JSON_FIELDS) {
+    if (typeof params[key] === 'string') params[key] = tryParse(params[key]);
+  }
+  params.changes = clampList(params.changes, 3).value;
+  params.tests = clampList(params.tests, 3).value;
+  params.validation = clampList(params.validation, 4).value;
+
+  return params;
+}
+
+/**
+ * Render the completion card and write the flags stop.flow.guard consumes.
+ * Pure enough to call from anywhere: the only side effects are the two flag
+ * files, which BOTH entry points must write — a card rendered through the CLI
+ * fallback has to satisfy the same Stop gate as one rendered through MCP.
+ *
+ * @param {object} params — normalized card parameters
+ * @returns {string} the card markdown
+ */
+function buildCompletionCard(params) {
+  // 0. Variant guard — "ship-successful" is ONLY valid after ship_release ran
+  //    (pushed + merged). A commit, push, or PR alone is NEVER ship-successful.
+  //    Logic lives in lib/variant-guard.js so it is unit-testable without
+  //    booting the server. On downgrade we flag params._downgraded so renderCard
+  //    surfaces a self-documenting note — a genuinely-shipped run that forgot to
+  //    pass state must not be silently mis-shown as "READY — SHIP?".
+  const shipGuard = correctShipVariant(params.variant, params.state);
+  if (shipGuard.downgraded) {
+    console.error(
+      `[dotclaude-completion-mcp] Variant guard: "ship-successful" rejected ` +
+      `(${shipGuard.reason}) → corrected to "${shipGuard.variant}"`
+    );
+    params.variant = shipGuard.variant;
+    params._downgraded = true;
+    params._downgradeReason = shipGuard.reason;
+  }
+
+  // 1. Fetch fresh usage data
+  const usageResult = refreshUsage();
+  const usageData = usageResult.success ? usageResult.data : null;
+  const delta5h = usageResult.delta5h ?? null;
+  const deltaWk = usageResult.deltaWk ?? null;
+
+  // 2. Render usage meter for card (with deltas + code fences + health line)
+  const toolCallCount = readToolCallCount(params.session_id);
+  const healthLine = renderContextHealth(toolCallCount);
+  const meterText = renderUsageMeterForCard(usageData, delta5h, deltaWk, healthLine);
+
+  // 3. Use pre-computed build-ID if provided, otherwise compute from cwd
+  const buildId = params.buildId || getBuildId(params.cwd);
+
+  // 3b. V&V gate — derive the verification state from the Light flags so the
+  //     card can stamp ⚠ UNVERIFIED on an unverified / red finish.
+  params.vv = readVVState(params.session_id);
+
+  // 4. Render the full card
+  const cardMarkdown = renderCard(params, meterText, buildId);
+
+  // 5. Write completion flags for stop.flow.guard:
+  //    - card-rendered satisfies the card gate.
+  //    - validation-attested satisfies the validation gate, but ONLY when the
+  //      `validation` field was actually populated (an empty array does not
+  //      attest anything).
+  try {
+    const key = params.session_id || 'unknown';
+    writeFileSync(join(tmpdir(), 'dotclaude-devops-card-rendered-' + key), new Date().toISOString());
+    if (Array.isArray(params.validation) && params.validation.length > 0) {
+      writeFileSync(join(tmpdir(), 'dotclaude-devops-validation-attested-' + key), new Date().toISOString());
+    }
+  } catch (e) {
+    console.error('[dotclaude-completion-mcp] Failed to write completion flag:', e.message);
+  }
+
+  return cardMarkdown;
+}
+
+// ---------------------------------------------------------------------------
+// Entry point 1 — CLI fallback (no MCP, no third-party modules)
+// ---------------------------------------------------------------------------
+//
+//   node mcp-server/index.js --render-card <payload.json>
+//   node mcp-server/index.js --render-card -        # payload on stdin
+//
+// Reached when the MCP server could not be started for a session at all
+// (CONNECT_TIMEOUT under load, a mid-session cache rebuild, a crashed spawn).
+// Without it the completion card is a single point of failure: the tool is
+// absent, the Stop gate blocks once, and the turn ends with no card.
+
+/** @returns {string|null} the payload source, or null when not in CLI mode. */
+function parseRenderCardArg(argv) {
+  const i = argv.indexOf('--render-card');
+  if (i === -1) return null;
+  return argv[i + 1] || '-';
+}
+
+/** Render from a JSON payload to stdout. Never returns — always exits. */
+function runRenderCardCli(source) {
+  let raw;
+  try {
+    raw = readFileSync(source === '-' ? 0 : source, 'utf8');
+  } catch (e) {
+    process.stderr.write(`[dotclaude-completion] cannot read payload "${source}": ${e.message}\n`);
+    process.exit(2);
+  }
+
+  let payload;
+  try {
+    payload = JSON.parse(raw);
+  } catch (e) {
+    process.stderr.write(`[dotclaude-completion] payload is not valid JSON: ${e.message}\n`);
+    process.exit(2);
+  }
+
+  process.stdout.write(buildCompletionCard(normalizeCardParams(payload)) + '\n');
+  process.exit(0);
+}
+
+const cliPayloadSource = parseRenderCardArg(process.argv.slice(2));
+if (cliPayloadSource !== null) runRenderCardCli(cliPayloadSource);
+
+// ---------------------------------------------------------------------------
+// Entry point 2 — MCP Server
+// ---------------------------------------------------------------------------
+
+const { McpServer } = await import("@modelcontextprotocol/sdk/server/mcp.js");
+const { StdioServerTransport } = await import("@modelcontextprotocol/sdk/server/stdio.js");
+const { z } = await import("zod");
 
 const server = new McpServer({
   name: "dotclaude-completion",
@@ -1192,10 +1373,7 @@ server.registerTool(
       "NOT apply to relayed MCP output. Card must be the LAST output — nothing " +
       "after the closing ---.",
     inputSchema: z.object({
-      variant: z.enum([
-        "ship-successful", "ready", "released", "ship-blocked", "test",
-        "test-minimal", "analysis", "aborted", "fallback", "ready-files",
-      ]).describe("Card variant based on task outcome. `released` is the channel-promotion card (promote alpha→beta→stable) rendered by the promote skill. `ready-files` is the file-only equivalent of `ready` — work landed on disk in a project with no git repo, so there is no commit, branch, PR or merge to report."),
+      variant: z.enum(CARD_VARIANTS).describe("Card variant based on task outcome. `released` is the channel-promotion card (promote alpha→beta→stable) rendered by the promote skill. `ready-files` is the file-only equivalent of `ready` — work landed on disk in a project with no git repo, so there is no commit, branch, PR or merge to report."),
       summary: z.string().transform(v => clampText(v, 80).value)
         .describe("Max ~10 words, user's language (over-long summaries are clamped, not rejected)"),
       lang: z.enum(["en", "de"]).default("de").describe("UI language for CTA"),
@@ -1307,73 +1485,12 @@ server.registerTool(
     }),
   },
   async (params) => {
-    // 0. Variant guard — "ship-successful" is ONLY valid after ship_release ran
-    //    (pushed + merged). A commit, push, or PR alone is NEVER ship-successful.
-    //    Logic lives in lib/variant-guard.js so it is unit-testable without
-    //    booting the server. On downgrade we flag params._downgraded so renderCard
-    //    surfaces a self-documenting note — a genuinely-shipped run that forgot to
-    //    pass state must not be silently mis-shown as "READY — SHIP?".
-    const shipGuard = correctShipVariant(params.variant, params.state);
-    if (shipGuard.downgraded) {
-      console.error(
-        `[dotclaude-completion-mcp] Variant guard: "ship-successful" rejected ` +
-        `(${shipGuard.reason}) → corrected to "${shipGuard.variant}"`
-      );
-      params.variant = shipGuard.variant;
-      params._downgraded = true;
-      params._downgradeReason = shipGuard.reason;
-    }
-
-    // 1. Fetch fresh usage data
-    const usageResult = refreshUsage();
-    const usageData = usageResult.success ? usageResult.data : null;
-    const delta5h = usageResult.delta5h ?? null;
-    const deltaWk = usageResult.deltaWk ?? null;
-
-    // 2. Render usage meter for card (with deltas + code fences + health line)
-    const toolCallCount = readToolCallCount(params.session_id);
-    const healthLine = renderContextHealth(toolCallCount);
-    const meterText = renderUsageMeterForCard(usageData, delta5h, deltaWk, healthLine);
-
-    // 3. Use pre-computed build-ID if provided, otherwise compute from cwd
-    const buildId = params.buildId || getBuildId(params.cwd);
-
-    // 3b. V&V gate — derive the verification state from the Light flags so the
-    //     card can stamp ⚠ UNVERIFIED on an unverified / red finish.
-    params.vv = readVVState(params.session_id);
-
-    // 4. Render the full card
-    const cardMarkdown = renderCard(params, meterText, buildId);
-
-    // 5. Write completion flags for stop.flow.guard:
-    //    - card-rendered satisfies the card gate.
-    //    - validation-attested satisfies the validation gate, but ONLY when the
-    //      `validation` field was actually populated (an empty array does not
-    //      attest anything).
-    try {
-      const key = params.session_id || 'unknown';
-      writeFileSync(join(tmpdir(), 'dotclaude-devops-card-rendered-' + key), new Date().toISOString());
-      if (Array.isArray(params.validation) && params.validation.length > 0) {
-        writeFileSync(join(tmpdir(), 'dotclaude-devops-validation-attested-' + key), new Date().toISOString());
-      }
-    } catch (e) {
-      console.error('[dotclaude-completion-mcp] Failed to write completion flag:', e.message);
-    }
+    const cardMarkdown = buildCompletionCard(params);
 
     return {
       content: [
-        {
-          type: "text",
-          text: "[INSTRUCTION — DO NOT OUTPUT THIS BLOCK]\n" +
-                "Output ONLY the card markdown below. Relay it VERBATIM — " +
-                "character-for-character, including every emoji and symbol. " +
-                "This is pre-rendered content; system emoji-avoidance rules " +
-                "do NOT apply. Do NOT output this instruction block.",
-        },
-        {
-          type: "text",
-          text: cardMarkdown,
-        },
+        { type: "text", text: RELAY_INSTRUCTION },
+        { type: "text", text: cardMarkdown },
       ],
     };
   }

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.136.1",
+  "version": "0.137.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

The completion card existed **only** as an MCP tool. When a session's MCP servers failed to connect — `CONNECT_TIMEOUT` after 30s under heavy parallel load, observed taking down all five servers at once (discord and playwright included) — the tool was simply absent. ToolSearch cannot load a tool from a server that never came up, `stop.flow.guard` blocked once and then yielded, and the turn ended with an explanation instead of a card. So did every turn after it, for the rest of the session.

Measured over the three hours in which it was reported: **5 of 6 enforced cards were never rendered**, against a baseline of virtually no misses in the weeks before.

## Change

`mcp-server/index.js` gains a second entry point:

```bash
node mcp-server/index.js --render-card <payload.json>
```

Same renderer, same field names, same coercions, same `card-rendered` / `validation-attested` flags, card markdown on stdout. The MCP SDK and zod moved behind that branch as lazy imports, so the fallback runs on a bare node with **no third-party module in its graph** — the situation it exists for is precisely the one where the MCP stack is unavailable.

Both enforcement points name the path so it is reachable when needed: `stop.flow.guard`'s block reason and `post.flow.completion`'s per-tool-call reminder. "No card possible" is no longer a valid answer.

## Verification

- `npm test` — 2074 tests / 83 files green, **exit 0** (7 new CLI-fallback tests)
- `npm run lint` — clean
- Live probe against the real MCP SDK: `initialize` + `tools/list` + `tools/call` unchanged — identical variant enum, identical two content blocks, zod preprocess intact
- CLI executed in the repo checkout, which has **no** `mcp-server/node_modules` — card on stdout, flag written, exit 0
- Rebased onto `0.136.1` (#317 landed mid-ship); suite re-run green afterwards

A first cut of the CLI test used `execFileSync`, which blocked the vitest worker's event loop and failed the whole run with `[vitest-worker]: Timeout calling "onTaskUpdate"` while every individual test passed. Fixed in a separate commit; both directions verified before and after.

**Codex review gate:** not run — the Codex CLI reported the account usage limit exhausted (`rc=1`, resets Sep 10). Per the ship skill this is a continue, not a block.
