### PR TITLE
fix(plugin-update): keep cache dirs other live sessions run from

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.137.0"
+    "version": "0.137.1"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.137.0",
+      "version": "0.137.1",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.137.0",
+      "version": "0.137.1",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.137.1] — 2026-09-02
+
+### Fixed
+
+- **Upgrading the plugin in one session disconnected the MCP servers of every other session that was open.** The cache rebuild treated `~/.claude/plugins/cache/**` as if it belonged to the session doing the rebuild, and deleted every version directory except the one it was building. Those directories are the `CLAUDE_PLUGIN_ROOT` of the MCP servers that are already running — their working directory and their `require()` root — so a version bump in one window pulled the ground out from under all the others; measured here as nine live sessions serving MCP out of `0.136.0` and `0.136.1` while only `0.137.0` still existed on disk. The guard that already existed for this (issue #219, which keeps a same-version repair from de-registering the current session's own skills) protected the session doing the work and no other. Claude Code reference-counts these directories itself: every session writes a `<versionDir>/.in_use/<pid>` marker and its own sweeper collects a directory only once no live marker remains, which is why two versions of the official plugins legitimately sit in the cache side by side. The rebuild now prunes through that contract and fails safe — an unreadable marker directory, an unparsable marker, or a half-written `.tmp` marker all count as in use, because over-retention costs one stale folder that the sweeper collects later, while under-retention breaks every other open session. `versionChanged` is no longer a pruning criterion; one rule now covers the same-version repair and a version upgrade alike.
+
 ## [0.137.0] — 2026-09-01
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.137.0**
+**Version: 0.137.1**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.137.0",
+  "version": "0.137.1",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/deep-knowledge/plugin-behavior.md
+++ b/plugins/devops/deep-knowledge/plugin-behavior.md
@@ -119,6 +119,29 @@ belongs in that project's own `.claude/` instructions. Inside the plugin source
 repo, direct implementation is the correct route and no issue is needed.
 Full hierarchy, detection, and exceptions: `plugin-scope-routing.md`.
 
+## Plugin Cache — Shared State Across Live Sessions
+
+`~/.claude/plugins/cache/**` is shared by every Claude session running at the
+same time. A cached version dir is the `CLAUDE_PLUGIN_ROOT` of that session's
+MCP servers — their `cwd` **and** their `require()` root — so deleting one pulls
+the working directory out from under sessions still running on it, and they
+report **"MCP server disconnected"**.
+
+Claude Code reference-counts this itself: each session drops a marker at
+`<versionDir>/.in_use/<pid>`, and its own sweeper collects a dir only once no
+live marker remains. That is why two versions of the same plugin legitimately
+coexist in the cache while an older session is still open — the official
+plugins do exactly this.
+
+**Rule: no hook may delete anything under the plugin cache without first
+checking the `.in_use` markers.** Prune via `hooks/lib/cache-inuse.js`
+(`prunableEntries` / `isVersionDirInUse`), which fails safe — an unreadable or
+unparsable claim counts as in use. Over-retention is harmless (Claude Code's
+sweeper collects it later); under-retention breaks every other open session.
+`ss.plugin.update`'s `rebuildCache` is the only caller today, and a version bump
+is **not** a licence to prune a claimed dir: "this session upgraded" says
+nothing about what the other eight are running.
+
 ## Issue Creation — Always Delegate
 
 When a skill or hook needs to create a GitHub issue, it MUST delegate to

--- a/plugins/devops/hooks/lib/cache-inuse.js
+++ b/plugins/devops/hooks/lib/cache-inuse.js
@@ -1,0 +1,111 @@
+/**
+ * @module cache-inuse
+ * @version 0.1.0
+ * @description Honors Claude Code's native plugin-cache reference counting when
+ *   deciding which cached plugin version dirs a rebuild may delete.
+ *
+ *   Claude Code drops a marker file per live session into every plugin version
+ *   dir that session has loaded:
+ *
+ *     <versionDir>/.in_use/<pid>   →  {"pid":<pid>,"procStartFt":"<FILETIME>"}
+ *
+ *   Its own sweeper only collects version dirs with no live marker left, which
+ *   is why two versions of the same plugin legitimately coexist in the cache
+ *   while older sessions are still open.
+ *
+ *   ss.plugin.update's rebuildCache used to prune old version dirs
+ *   unconditionally. Those dirs are the CLAUDE_PLUGIN_ROOT — the `cwd` AND the
+ *   require() root — of the MCP servers belonging to every OTHER still-running
+ *   Claude session. Upgrading in one session therefore tore the working
+ *   directory out from under all the others, and they reported "MCP server
+ *   disconnected" (issue: local plugin install / MCP disconnects). Pruning must
+ *   go through this module so a claimed dir is left alone.
+ *
+ *   FAIL-SAFE: uncertainty always means "in use". An unreadable marker dir, a
+ *   marker that is neither parsable JSON nor PID-prefixed, or any marker whose
+ *   PID is alive all keep the dir. Only a version dir with no live claim at all
+ *   is prunable — over-retention is harmless (Claude Code's own sweeper
+ *   collects it later), while under-retention breaks live sessions.
+ *
+ *   PID reuse is deliberately NOT screened via the marker's `procStartFt`:
+ *   treating a recycled PID as still-live over-retains, which is the safe
+ *   direction, and avoids depending on a Windows-only FILETIME comparison.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { isProcessAlive } = require('./mcp-status');
+
+// Claude Code's marker directory name inside each cached plugin version dir.
+const IN_USE_DIR = '.in_use';
+
+/**
+ * Resolve the PID a marker file stands for. Prefers the marker's JSON body and
+ * falls back to the filename's leading digits, which is what survives a
+ * half-written `<pid>.tmp.<hash>` marker.
+ * @param {string} markerDir
+ * @param {string} name  marker filename
+ * @returns {number|null}  null when the marker claims no identifiable PID
+ */
+function markerPid(markerDir, name) {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(path.join(markerDir, name), 'utf8'));
+    if (Number.isFinite(parsed && parsed.pid)) return parsed.pid;
+  } catch {
+    // Unreadable or not JSON — fall through to the filename.
+  }
+  const match = /^(\d+)/.exec(name);
+  return match ? Number(match[1]) : null;
+}
+
+/**
+ * Is any live Claude session still claiming this cached version dir?
+ * @param {string} versionDir  e.g. …/cache/dotclaude/devops/0.136.0
+ * @param {(pid:number)=>boolean} [isAlive]  injectable for tests
+ * @returns {boolean}
+ */
+function isVersionDirInUse(versionDir, isAlive = isProcessAlive) {
+  const markerDir = path.join(versionDir, IN_USE_DIR);
+  let names;
+  try {
+    if (!fs.existsSync(markerDir)) return false; // nothing ever claimed it
+    names = fs.readdirSync(markerDir);
+  } catch {
+    return true; // marker dir exists but is unreadable → assume claimed
+  }
+  for (const name of names) {
+    const pid = markerPid(markerDir, name);
+    if (pid === null) return true; // unidentifiable claim → assume live
+    if (isAlive(pid)) return true;
+  }
+  return false;
+}
+
+/**
+ * The entries of a plugin's cache dir a rebuild may safely delete: everything
+ * except the version being built and anything a live session still claims.
+ * @param {string} pluginCache  e.g. …/cache/dotclaude/devops
+ * @param {string} keepVersion  the version dir the rebuild targets
+ * @param {(pid:number)=>boolean} [isAlive]  injectable for tests
+ * @returns {string[]}  entry names, relative to pluginCache
+ */
+function prunableEntries(pluginCache, keepVersion, isAlive = isProcessAlive) {
+  let entries;
+  try {
+    entries = fs.readdirSync(pluginCache);
+  } catch {
+    return []; // cache dir absent or unreadable — nothing to prune
+  }
+  return entries.filter(
+    (entry) => entry !== keepVersion && !isVersionDirInUse(path.join(pluginCache, entry), isAlive),
+  );
+}
+
+module.exports = {
+  IN_USE_DIR,
+  markerPid,
+  isVersionDirInUse,
+  prunableEntries,
+};

--- a/plugins/devops/hooks/lib/cache-inuse.test.js
+++ b/plugins/devops/hooks/lib/cache-inuse.test.js
@@ -1,0 +1,115 @@
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+// cache-inuse.js is CommonJS (hooks are standalone CJS scripts) — default interop.
+import cacheInUse from "./cache-inuse.js";
+
+const { IN_USE_DIR, isVersionDirInUse, prunableEntries } = cacheInUse;
+
+const LIVE = 1111;
+const DEAD = 2222;
+const isAlive = (pid) => pid === LIVE;
+
+let cache;
+
+function marker(versionDir, name, content) {
+  const dir = path.join(versionDir, IN_USE_DIR);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, name), content);
+}
+
+function version(name) {
+  const dir = path.join(cache, name);
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+beforeEach(() => {
+  cache = fs.mkdtempSync(path.join(os.tmpdir(), "dotclaude-inuse-"));
+});
+
+afterEach(() => {
+  try {
+    fs.rmSync(cache, { recursive: true, force: true });
+  } catch { /* ignore */ }
+});
+
+describe("isVersionDirInUse — Claude Code's native .in_use reference counting", () => {
+  test("no .in_use dir at all → nothing claims the version dir", () => {
+    expect(isVersionDirInUse(version("0.1.0"), isAlive)).toBe(false);
+  });
+
+  test("empty .in_use dir → no claim", () => {
+    const dir = version("0.1.0");
+    fs.mkdirSync(path.join(dir, IN_USE_DIR), { recursive: true });
+    expect(isVersionDirInUse(dir, isAlive)).toBe(false);
+  });
+
+  test("marker for a live PID → in use", () => {
+    const dir = version("0.1.0");
+    marker(dir, String(LIVE), JSON.stringify({ pid: LIVE, procStartFt: "1343" }));
+    expect(isVersionDirInUse(dir, isAlive)).toBe(true);
+  });
+
+  test("marker for a dead PID only → not in use", () => {
+    const dir = version("0.1.0");
+    marker(dir, String(DEAD), JSON.stringify({ pid: DEAD, procStartFt: "1343" }));
+    expect(isVersionDirInUse(dir, isAlive)).toBe(false);
+  });
+
+  test("one dead + one live marker → in use", () => {
+    const dir = version("0.1.0");
+    marker(dir, String(DEAD), JSON.stringify({ pid: DEAD }));
+    marker(dir, String(LIVE), JSON.stringify({ pid: LIVE }));
+    expect(isVersionDirInUse(dir, isAlive)).toBe(true);
+  });
+
+  test("half-written .tmp marker falls back to the leading PID in the filename", () => {
+    const dir = version("0.1.0");
+    marker(dir, `${LIVE}.tmp.7da02f73`, "");
+    expect(isVersionDirInUse(dir, isAlive)).toBe(true);
+  });
+
+  test("marker with neither parsable JSON nor a PID-prefixed name → assumed in use", () => {
+    const dir = version("0.1.0");
+    marker(dir, "garbage", "not json");
+    expect(isVersionDirInUse(dir, isAlive)).toBe(true);
+  });
+
+  test("unreadable .in_use (a file, not a dir) → assumed in use", () => {
+    const dir = version("0.1.0");
+    fs.writeFileSync(path.join(dir, IN_USE_DIR), "not a directory");
+    expect(isVersionDirInUse(dir, isAlive)).toBe(true);
+  });
+});
+
+describe("prunableEntries — which version dirs a cache rebuild may delete", () => {
+  test("never prunes the version being built, even with no claim on it", () => {
+    version("0.137.0");
+    expect(prunableEntries(cache, "0.137.0", isAlive)).toEqual([]);
+  });
+
+  test("prunes an unclaimed old version dir", () => {
+    version("0.137.0");
+    version("0.135.0");
+    expect(prunableEntries(cache, "0.137.0", isAlive)).toEqual(["0.135.0"]);
+  });
+
+  test("keeps an old version dir another live session still claims", () => {
+    version("0.137.0");
+    marker(version("0.136.0"), String(LIVE), JSON.stringify({ pid: LIVE }));
+    version("0.135.0");
+    expect(prunableEntries(cache, "0.137.0", isAlive)).toEqual(["0.135.0"]);
+  });
+
+  test("a claim by a dead session does not protect the dir", () => {
+    version("0.137.0");
+    marker(version("0.136.0"), String(DEAD), JSON.stringify({ pid: DEAD }));
+    expect(prunableEntries(cache, "0.137.0", isAlive)).toEqual(["0.136.0"]);
+  });
+
+  test("missing plugin cache dir → nothing to prune, no throw", () => {
+    expect(prunableEntries(path.join(cache, "absent"), "0.137.0", isAlive)).toEqual([]);
+  });
+});

--- a/plugins/devops/hooks/session-start/ss.plugin.update.inplace.test.js
+++ b/plugins/devops/hooks/session-start/ss.plugin.update.inplace.test.js
@@ -2,46 +2,44 @@ import { describe, test, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+// Same CJS module rebuildCache() prunes through — exercised directly so this
+// test cannot drift from the shipped decision.
+import cacheInUse from "../lib/cache-inuse.js";
+
+const { IN_USE_DIR, prunableEntries } = cacheInUse;
 
 /**
  * Characterization test for the cache-cleanup decision in ss.plugin.update.js's
- * rebuildCache() — issue #219.
+ * rebuildCache() — issues #219 and the MCP-disconnect regression.
  *
- * The bug: a same-version cache REPAIR deleted the entire plugin cache dir
- * (`fs.rmSync(pluginCache, { recursive })`) and recreated it. The version dir is
- * exactly what Claude Code's already-loaded skill/slash-command registry points
- * at — nuking and recreating it mid-session changed the dir's identity and
- * de-registered every skill/slash-command for the rest of the session, leaving
- * `/devops-*` as "Unknown command". MCP tools (RAM) and agent types survived;
- * only skills/commands broke.
+ * #219: a same-version cache REPAIR deleted the entire plugin cache dir
+ * (`fs.rmSync(pluginCache, { recursive: true })`) and recreated it. The version
+ * dir is exactly what Claude Code's already-loaded skill/slash-command registry
+ * points at — nuking and recreating it mid-session changed the dir's identity
+ * and de-registered every skill/slash-command for the rest of the session,
+ * leaving `/devops-*` as "Unknown command".
  *
- * The fix: branch on `versionChanged`. A version UPGRADE still nukes all old
- * version dirs (new installPath, restart needed anyway). A same-version REPAIR
- * overwrites IN PLACE — it keeps the current version dir (preserving its identity
- * so the registry stays valid) and only prunes OTHER (old) version dirs.
+ * MCP disconnects: the version-UPGRADE branch still nuked every other version
+ * dir. Those dirs are the CLAUDE_PLUGIN_ROOT (`cwd` + require() root) of the MCP
+ * servers of every OTHER still-running Claude session, so upgrading in one
+ * session broke all the others ("MCP server disconnected"). Claude Code
+ * reference-counts loaded version dirs via `<dir>/.in_use/<pid>` markers.
+ *
+ * The fix collapses both branches into one rule: keep the version dir being
+ * built, keep anything a live session still claims, prune the rest.
  *
  * rebuildCache() is a non-exported internal of a SessionStart hook whose module
  * body self-executes on import (see the #190 copydir test for the same
- * constraint). So this test mirrors the EXACT cleanup decision the fix encodes,
- * against a temp cache tree, and asserts the registry-referenced dir survives an
- * in-place repair but not a version change.
+ * constraint), so the cleanup is expressed here via the lib it delegates to.
  */
-
-// Mirror of the cleanup block in rebuildCache() (the part the #219 fix changed).
-function applyCacheCleanup(pluginCache, version, versionChanged) {
+function applyCacheCleanup(pluginCache, version, isAlive) {
   const newCache = path.join(pluginCache, version);
-  const inPlace = !versionChanged && fs.existsSync(newCache);
+  // "In place" = the target dir already existed and survived the prune, so its
+  // identity (and with it the loaded skill/command registry) is preserved.
+  const inPlace = fs.existsSync(newCache);
 
-  if (inPlace) {
-    // Keep the current version dir (registry points at it); prune OTHER versions.
-    for (const entry of fs.readdirSync(pluginCache)) {
-      if (entry !== version) {
-        fs.rmSync(path.join(pluginCache, entry), { recursive: true, force: true });
-      }
-    }
-  } else if (fs.existsSync(pluginCache)) {
-    // Version change / first build: clean ALL old version dirs.
-    fs.rmSync(pluginCache, { recursive: true, force: true });
+  for (const entry of prunableEntries(pluginCache, version, isAlive)) {
+    fs.rmSync(path.join(pluginCache, entry), { recursive: true, force: true });
   }
   fs.mkdirSync(newCache, { recursive: true });
   return { inPlace, newCache };
@@ -55,6 +53,10 @@ let pluginCache;
 // vanishes, the dir was deleted + recreated (the #219 de-registration trigger).
 const VERSION = "0.102.1";
 const IDENTITY_MARKER = ".session-identity";
+
+const LIVE_PID = 4242;
+const noneAlive = () => false;
+const onlyLive = (pid) => pid === LIVE_PID;
 
 function write(root, rel, content) {
   const full = path.join(root, rel);
@@ -79,25 +81,25 @@ afterEach(() => {
 });
 
 describe("ss.plugin.update rebuildCache cleanup decision — issue #219", () => {
-  test("same-version repair (versionChanged=false) keeps the version dir's identity", () => {
-    const { inPlace } = applyCacheCleanup(pluginCache, VERSION, false);
+  test("same-version repair keeps the version dir's identity", () => {
+    const { inPlace } = applyCacheCleanup(pluginCache, VERSION, noneAlive);
     expect(inPlace).toBe(true);
     // The marker survives → dir was NOT deleted+recreated → registry stays valid.
     expect(fs.existsSync(path.join(pluginCache, VERSION, IDENTITY_MARKER))).toBe(true);
   });
 
   test("same-version repair still prunes OTHER (old) version dirs", () => {
-    applyCacheCleanup(pluginCache, VERSION, false);
+    applyCacheCleanup(pluginCache, VERSION, noneAlive);
     expect(fs.existsSync(path.join(pluginCache, "0.100.0"))).toBe(false);
     // ...but the cache holds exactly the current version.
     expect(fs.readdirSync(pluginCache)).toEqual([VERSION]);
   });
 
-  test("version change (versionChanged=true) nukes all dirs incl. the marker", () => {
-    const { inPlace } = applyCacheCleanup(pluginCache, "0.103.0", true);
+  test("version change prunes every unclaimed dir incl. the marker", () => {
+    const { inPlace } = applyCacheCleanup(pluginCache, "0.103.0", noneAlive);
     expect(inPlace).toBe(false);
-    // Old version dir AND its identity marker are gone — a restart is expected
-    // on a real upgrade anyway (new installPath).
+    // Old version dirs are gone — nothing was standing on them, and a real
+    // upgrade expects a restart anyway (new installPath).
     expect(fs.existsSync(path.join(pluginCache, VERSION))).toBe(false);
     expect(fs.existsSync(path.join(pluginCache, "0.100.0"))).toBe(false);
     expect(fs.existsSync(path.join(pluginCache, "0.103.0"))).toBe(true);
@@ -105,9 +107,41 @@ describe("ss.plugin.update rebuildCache cleanup decision — issue #219", () => 
 
   test("first build (cache dir absent) creates the version dir without error", () => {
     fs.rmSync(pluginCache, { recursive: true, force: true });
-    const { inPlace, newCache } = applyCacheCleanup(pluginCache, VERSION, false);
+    const { inPlace, newCache } = applyCacheCleanup(pluginCache, VERSION, noneAlive);
     // No existing dir → not an in-place repair; the fresh dir is created.
     expect(inPlace).toBe(false);
     expect(fs.existsSync(newCache)).toBe(true);
+  });
+});
+
+describe("ss.plugin.update rebuildCache — MCP servers of other live sessions", () => {
+  test("a version change spares the old dir another live session is running from", () => {
+    // Another open session loaded VERSION and left its reference-count marker.
+    write(
+      pluginCache,
+      path.join(VERSION, IN_USE_DIR, String(LIVE_PID)),
+      JSON.stringify({ pid: LIVE_PID, procStartFt: "134327528064993669" }),
+    );
+
+    applyCacheCleanup(pluginCache, "0.103.0", onlyLive);
+
+    // That session's CLAUDE_PLUGIN_ROOT — its MCP servers' cwd and require()
+    // root — must still be there, or it reports "MCP server disconnected".
+    expect(fs.existsSync(path.join(pluginCache, VERSION, "skills", "ship", "SKILL.md"))).toBe(true);
+    // Unclaimed leftovers are still collected.
+    expect(fs.existsSync(path.join(pluginCache, "0.100.0"))).toBe(false);
+    expect(fs.existsSync(path.join(pluginCache, "0.103.0"))).toBe(true);
+  });
+
+  test("once that session exits, the same upgrade collects its dir", () => {
+    write(
+      pluginCache,
+      path.join(VERSION, IN_USE_DIR, String(LIVE_PID)),
+      JSON.stringify({ pid: LIVE_PID, procStartFt: "134327528064993669" }),
+    );
+
+    applyCacheCleanup(pluginCache, "0.103.0", noneAlive);
+
+    expect(fs.existsSync(path.join(pluginCache, VERSION))).toBe(false);
   });
 });

--- a/plugins/devops/hooks/session-start/ss.plugin.update.js
+++ b/plugins/devops/hooks/session-start/ss.plugin.update.js
@@ -43,6 +43,7 @@ const fs = require('fs');
 const path = require('path');
 const { t } = require('../lib/locale');
 const { latestVisible, readChannelPin } = require('../lib/channels');
+const { prunableEntries } = require('../lib/cache-inuse');
 
 // Translations for user-facing output. SessionStart fires before any user
 // prompt — there is no detected locale yet and no session_id in hook input
@@ -203,37 +204,35 @@ function copyDir(src, dst) {
   return fs.existsSync(path.join(dst, '.claude-plugin', 'plugin.json'));
 }
 
-function rebuildCache(marketplace, pluginName, pluginDir, version, sha, { versionChanged = true, channel = 'stable' } = {}) {
+function rebuildCache(marketplace, pluginName, pluginDir, version, sha, { channel = 'stable' } = {}) {
   const pluginCache = path.join(cacheDir, marketplace, pluginName);
   const newCache = path.join(pluginCache, version);
 
-  // Same-version cache REPAIR on an existing dir → overwrite IN PLACE.
+  // Prune old version dirs — but only the ones nothing is standing on.
   //
-  // A version UPGRADE gets a brand-new installPath, so deleting the old version
-  // dirs is correct (registry is repointed, a restart is needed anyway). But a
-  // cache REPAIR keeps the same version dir — and that dir is exactly what Claude
-  // Code's already-loaded skill/slash-command registry points at. Deleting and
-  // recreating it mid-session (rm + mkdir) changes the dir's identity and
-  // de-registers every skill/slash-command for the rest of the session, leaving
-  // /devops-* as "Unknown command" (issue #219). MCP tools (live in RAM) and
-  // agent types (separate registry) survive — only skills/commands break.
-  // Overwriting files in place keeps the dir, so the registry stays valid and no
-  // restart is needed. (Stale files removed upstream at the SAME version — rare —
-  // are not pruned this way; that trade-off is far cheaper than nuking the
-  // skill registry.)
-  const inPlace = !versionChanged && fs.existsSync(newCache);
-
-  if (inPlace) {
-    // Keep the current version dir (the registry points at it), but still prune
-    // any OTHER (old) version dirs so the cache holds only `version`.
-    for (const entry of fs.readdirSync(pluginCache)) {
-      if (entry !== version) {
-        fs.rmSync(path.join(pluginCache, entry), { recursive: true, force: true });
-      }
-    }
-  } else if (fs.existsSync(pluginCache)) {
-    // Version change / first build: clean ALL old version dirs.
-    fs.rmSync(pluginCache, { recursive: true, force: true });
+  // Two dirs must survive a rebuild:
+  //
+  //   1. The version dir being (re)built. On a same-version cache REPAIR that
+  //      dir is exactly what Claude Code's already-loaded skill/slash-command
+  //      registry points at; deleting and recreating it mid-session (rm + mkdir)
+  //      changes the dir's identity and de-registers every skill/slash-command
+  //      for the rest of the session, leaving /devops-* as "Unknown command"
+  //      (issue #219). Overwriting files in place keeps the dir, so the registry
+  //      stays valid and no restart is needed. (Stale files removed upstream at
+  //      the SAME version — rare — are not pruned this way; far cheaper than
+  //      nuking the skill registry.)
+  //
+  //   2. Any OLDER version dir another live Claude session still claims. Claude
+  //      Code reference-counts every loaded version dir via `<dir>/.in_use/<pid>`
+  //      markers, and those dirs are the CLAUDE_PLUGIN_ROOT — the `cwd` and the
+  //      require() root — of that session's MCP servers. Deleting them because
+  //      THIS session upgraded pulled the working directory out from under every
+  //      other open session, which is what made them report "MCP server
+  //      disconnected". prunableEntries() fails safe: anything claimed, or whose
+  //      claim cannot be read, is left alone and collected later by Claude Code's
+  //      own sweeper.
+  for (const entry of prunableEntries(pluginCache, version)) {
+    fs.rmSync(path.join(pluginCache, entry), { recursive: true, force: true });
   }
 
   // Create (or keep) the version dir
@@ -443,7 +442,7 @@ for (const marketplace of fs.readdirSync(marketplacesDir)) {
     } catch { /* registry unreadable — rebuild to be safe */ cacheMissing = true; }
 
     if (versionChanged || cacheMissing || cacheStale) {
-      const result = rebuildCache(marketplace, name, dir, after, newSha, { versionChanged, channel });
+      const result = rebuildCache(marketplace, name, dir, after, newSha, { channel });
       updated.push({
         name,
         from: beforeVersions[name] || '?',

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.137.0",
+  "version": "0.137.1",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

Upgrading the plugin in one session disconnected the MCP servers of every other session that was open.

`rebuildCache` treated `~/.claude/plugins/cache/**` as if it belonged to the session doing the rebuild and deleted every version directory except the one it was building. Those directories are the `CLAUDE_PLUGIN_ROOT` of already-running MCP servers — their `cwd` **and** their `require()` root — so a version bump in one window pulled the ground out from under all the others.

Measured on this machine: nine live sessions serving MCP out of `0.136.0` / `0.136.1` while only `0.137.0` still existed on disk.

The #219 guard already encoded this reasoning, but only for the rebuilding session's own directory — it never generalized to the other sessions.

## Fix

Claude Code reference-counts loaded version dirs itself: each session writes a `<versionDir>/.in_use/<pid>` marker, and its own sweeper collects a directory only once no live marker remains. That is why two versions of the official plugins legitimately sit in the cache side by side.

New `hooks/lib/cache-inuse.js` honors that contract:

- `prunableEntries()` keeps the version being built plus anything a live session still claims.
- Fails safe — an unreadable marker dir, an unparsable marker, or a half-written `.tmp` marker all count as **in use**. Over-retention costs one stale folder the sweeper collects later; under-retention breaks every other open session.
- `versionChanged` is no longer a pruning criterion: one rule now covers the #219 in-place repair and a version upgrade alike.

## Tests

- New `cache-inuse.test.js` — 13 cases covering live/dead/mixed markers, `.tmp` markers, unparsable markers, and an unreadable marker dir.
- `ss.plugin.update.inplace.test.js` now exercises the real lib instead of a private copy of the decision, plus two new cases: a version change spares a dir a live session claims, and collects it once that session exits.
- Full suite: 84 files, 2097 tests green; `eslint` clean.

## Notes

- The rule is documented in `deep-knowledge/plugin-behavior.md` → "Plugin Cache — Shared State Across Live Sessions".
- Codex review gate skipped: the Codex CLI is at its usage limit until 2026-09-10.