### PR TITLE
fix(ship-verify): resolve abandoned watchers instead of nagging

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.138.0"
+    "version": "0.138.1"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.138.0",
+      "version": "0.138.1",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.138.0",
+      "version": "0.138.1",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.138.1] — 2026-09-02
+
+### Fixed
+
+- **A post-merge watcher that died took its result with it, and announced itself as still running for a day afterwards.** The watcher is spawned detached, so a machine shutdown or a killed session ends it without any of its terminal writes ever happening, and its state file stays on `status: "watching"` with `finishedAt: null` forever. The only defence was a flat twenty-four hour staleness constant in the SessionStart reader — a number with no relationship to the watcher's own lifetime, which is at most five minutes of run detection plus `--max-wait` plus the deploy probe. For the whole of that day the reader greeted every session with "Ship verify still running", counting up: the reported figure had reached 1205 minutes for a process that had been dead since minute forty. Then, on expiry, it set `acknowledged: true` while leaving `status: "watching"` — so the entry was never reported at all, the outcome of that ship was silently lost, and because the status never changed the branch was re-entered at every subsequent session, re-stamping `staleAt` with a fresh timestamp each time. Eight entries were sitting in that state here, the oldest since 2026-08-17, all carrying the same current-day `staleAt`.
+
+  Every state file now carries `maxWaitSec` and `deadlineAt`, so a reader decides "working" or "died" from the run's own numbers rather than a constant. Past that instant the entry is treated as abandoned and reconciled against `gh run list --commit <merge-sha>`, which answers the counterfactual the watcher can no longer answer itself; the result is written as a terminal state, surfaced exactly once, and cannot re-enter the watching branch. Reconciliation trusts only the per-commit query — the branch-scoped fallback misses tag-triggered runs entirely, so an empty result there yields `inconclusive` with a `gh pr checks` hint rather than a fabricated "no workflow ran". Matches are further restricted to runs created before the deadline, because in this repo the Release workflow fires on the bare `vX.Y.Z` tag that `/promote` later adds to the already-merged commit: without that restriction a promotion's CI would be reported as the ship's own. The watcher additionally writes a terminal `inconclusive` when it is terminated gracefully; a hard kill remains the reader's problem, which is what the deadline is for.
+
 ## [0.138.0] — 2026-09-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.138.0**
+**Version: 0.138.1**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.138.0",
+  "version": "0.138.1",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/hooks/session-start/ss.ship.verify.js
+++ b/plugins/devops/hooks/session-start/ss.ship.verify.js
@@ -1,14 +1,16 @@
 #!/usr/bin/env node
 /**
  * @hook ss.ship.verify
- * @version 0.1.0
+ * @version 0.2.0
  * @event SessionStart
  * @plugin devops
  * @description Surface results from the post-merge watcher (post-ship CI +
  *   optional deploy verify). Reads <cwd>/.claude/.ship-watcher/*.json and:
  *
  *     - reports completed runs that have not yet been acknowledged
- *     - flags watcher state files older than 24h as stale (auto-acknowledged)
+ *     - resolves ABANDONED watchers (process died without writing a terminal
+ *       state) by reconciling against GitHub, reports them once, and writes a
+ *       terminal state so they can never nag again
  *     - mentions in-flight watchers ("ship verify still running")
  *
  *   Acknowledged entries are marked in-place (no deletion) so the user can
@@ -17,67 +19,164 @@
  *   Silent when there are no watcher files at all.
  */
 
-require('../lib/plugin-guard');
-
 const fs = require('fs');
 const path = require('path');
+const { execFileSync } = require('node:child_process');
 
-const cwd = process.cwd();
-const watcherDir = path.join(cwd, '.claude', '.ship-watcher');
-const STALE_MS = 24 * 60 * 60 * 1000;
+// The watcher is spawned detached (`Start-Process -WindowStyle Hidden` /
+// `nohup`); a machine shutdown or a killed session ends it without running its
+// own fatal handler, so `status: "watching"` is NOT self-limiting. These mirror
+// post-merge-watcher.js's timing so "how long could it legitimately still be
+// alive?" is answered from the watcher's real lifetime rather than a flat
+// constant. Legacy entries predate `deadlineAt` and fall back to these.
+const DETECT_WINDOW_MS = 5 * 60_000; // POLL_INITIAL_RUN_DETECT_MAX_MS
+const DEFAULT_MAX_WAIT_MS = 1800 * 1_000; // --max-wait default
+const DEFAULT_VERIFY_TIMEOUT_MS = 600 * 1_000; // verify timeout_seconds default
+const GRACE_MS = 5 * 60_000;
 
-if (!fs.existsSync(watcherDir)) process.exit(0);
+const GH_TIMEOUT_MS = 15_000;
+const GIT_TIMEOUT_MS = 5_000;
 
-let entries;
-try {
-  entries = fs.readdirSync(watcherDir).filter((f) => f.endsWith('.json'));
-} catch {
-  process.exit(0);
-}
-if (entries.length === 0) process.exit(0);
+/**
+ * Latest instant at which the watcher for `data` could still legitimately be
+ * working. An explicit `deadlineAt` (written by post-merge-watcher >= 0.2.0)
+ * wins; otherwise reconstruct it from the watcher's phases.
+ *
+ * @param {object} data parsed watcher state file
+ * @returns {number|null} epoch ms, or null when `startedAt` is unusable
+ */
+function resolveDeadlineMs(data) {
+  const started = data?.startedAt ? Date.parse(data.startedAt) : NaN;
+  if (!Number.isFinite(started)) return null;
 
-const reports = [];
-const inflight = [];
+  const explicit = data.deadlineAt ? Date.parse(data.deadlineAt) : NaN;
+  if (Number.isFinite(explicit)) return explicit;
 
-for (const file of entries) {
-  const full = path.join(watcherDir, file);
-  let data;
-  try {
-    data = JSON.parse(fs.readFileSync(full, 'utf8'));
-  } catch {
-    continue;
-  }
-
-  const startedMs = data.startedAt ? new Date(data.startedAt).getTime() : 0;
-  const age = Date.now() - startedMs;
-
-  if (data.status === 'watching') {
-    if (age > STALE_MS) {
-      // Mark stale-acknowledged so it does not nag forever
-      data.acknowledged = true;
-      data.staleAt = new Date().toISOString();
-      try { fs.writeFileSync(full, JSON.stringify(data, null, 2)); } catch {}
-      continue;
-    }
-    inflight.push(data);
-    continue;
-  }
-
-  if (data.status === 'complete' && !data.acknowledged) {
-    reports.push({ file: full, data });
-  }
+  const declared = Number(data.maxWaitSec);
+  const maxWaitMs = Number.isFinite(declared) && declared > 0 ? declared * 1_000 : DEFAULT_MAX_WAIT_MS;
+  const verifyMs = data.hasVerifyConfig ? DEFAULT_VERIFY_TIMEOUT_MS : 0;
+  return started + DETECT_WINDOW_MS + maxWaitMs + verifyMs + GRACE_MS;
 }
 
-if (reports.length === 0 && inflight.length === 0) process.exit(0);
+/**
+ * A `watching` entry whose watcher can no longer be alive. An entry with an
+ * unusable `startedAt` counts as abandoned: an unjudgeable entry must resolve,
+ * never linger.
+ *
+ * @param {object} data
+ * @param {number} now epoch ms
+ * @returns {boolean}
+ */
+function isAbandoned(data, now = Date.now()) {
+  if (data?.status !== 'watching') return false;
+  const deadline = resolveDeadlineMs(data);
+  if (deadline === null) return true;
+  return now > deadline;
+}
 
-const out = [];
-out.push('Post-ship deploy verification — surface this summary AS-IS to the user as the FIRST action of this turn (Lang: user-preference):');
-out.push('');
+/**
+ * The workflow run belonging to this merge, restricted to the watcher's own
+ * window. A run created after the deadline is a LATER event on the same commit
+ * — in this repo the Release workflow fires on the bare `vX.Y.Z` tag that
+ * `/promote` adds to the already-merged commit days afterwards — and must not
+ * be reported as the ship's CI.
+ *
+ * @param {Array|null} runs `gh run list --json ...` output
+ * @param {{ mergeSha: string, deadlineMs: number|null }} opts
+ * @returns {object|null}
+ */
+function findRun(runs, { mergeSha, deadlineMs }) {
+  if (!Array.isArray(runs) || !mergeSha) return null;
+  return (
+    runs.find((r) => {
+      if (!r?.headSha) return false;
+      if (r.headSha !== mergeSha && !r.headSha.startsWith(mergeSha)) return false;
+      if (deadlineMs !== null && r.createdAt) {
+        const created = Date.parse(r.createdAt);
+        if (Number.isFinite(created) && created > deadlineMs) return false;
+      }
+      return true;
+    }) || null
+  );
+}
 
-for (const { data } of reports) {
-  const prRef = data.pr ? `PR #${data.pr}` : `commit ${data.mergeSha?.slice(0, 7) || '?'}`;
-  const icon = data.overall === 'success' ? '✓' : (data.overall === 'timeout' ? '⏱' : '✗');
-  out.push(`${icon} **Ship verify — ${prRef} on \`${data.base}\`**`);
+/**
+ * Turn an abandoned entry into a terminal one. Answers the counterfactual
+ * "what would the watcher have concluded had it survived?" — never invents a
+ * verdict it cannot support.
+ *
+ * `lookup.authoritative` is true only for the per-commit query. The
+ * branch-scoped fallback misses tag-triggered runs entirely, so an empty
+ * result there proves nothing and yields `inconclusive`, not `no-run`.
+ *
+ * @param {object} data
+ * @param {{ runs: Array|null, authoritative: boolean }} lookup
+ * @param {number} now epoch ms
+ * @returns {object} new terminal state (input is not mutated)
+ */
+function reconcile(data, lookup, now = Date.now()) {
+  const ts = new Date(now).toISOString();
+  const next = { ...data, status: 'complete', finishedAt: ts, abandonedAt: ts };
+  const run = findRun(lookup?.runs, { mergeSha: data.mergeSha, deadlineMs: resolveDeadlineMs(data) });
+
+  if (run) {
+    const finished = run.status === 'completed';
+    const passed = finished && run.conclusion === 'success';
+    next.ci = {
+      status: finished ? (passed ? 'success' : 'failed') : 'watching',
+      runId: run.databaseId ?? null,
+      runUrl: run.url ?? null,
+      workflowName: run.workflowName ?? null,
+      conclusion: run.conclusion ?? null,
+    };
+    next.overall = finished ? (passed ? 'success' : 'failed') : 'inconclusive';
+    next.resolution = finished ? (passed ? 'ci-passed' : 'ci-failed') : 'ci-unfinished';
+  } else if (Array.isArray(lookup?.runs) && lookup.authoritative) {
+    next.ci = {
+      status: 'no-run',
+      note: 'No GitHub Actions workflow triggered by this merge — repo may not have CI configured for push events.',
+    };
+    next.overall = 'success';
+    next.resolution = 'no-run';
+  } else {
+    next.ci = data.ci || null;
+    next.overall = 'inconclusive';
+    next.resolution = 'unreconciled';
+  }
+
+  // A configured deploy probe that never ran is an unknown, not a pass — the
+  // watcher only reaches Phase 2 after CI, and it died before that.
+  if (next.overall === 'success' && data.hasVerifyConfig && !data.verify) {
+    next.overall = 'inconclusive';
+    next.resolution = 'verify-never-ran';
+  }
+
+  return next;
+}
+
+/** `PR #318` / `commit abc1234` label for an entry. */
+function prRef(data) {
+  return data.pr ? `PR #${data.pr}` : `commit ${data.mergeSha?.slice(0, 7) || '?'}`;
+}
+
+/**
+ * Render one completed (or reconciled-abandoned) entry.
+ *
+ * @param {object} data
+ * @returns {string[]} lines
+ */
+function renderReport(data) {
+  const out = [];
+  const icon = data.overall === 'success' ? '✓'
+    : data.overall === 'timeout' ? '⏱'
+      : data.overall === 'inconclusive' ? '⚠' : '✗';
+
+  const suffix = data.abandonedAt
+    ? (data.resolution === 'unreconciled'
+      ? ' — watcher process died, result unknown'
+      : ' — watcher process died, reconciled from GitHub')
+    : '';
+  out.push(`${icon} **Ship verify — ${prRef(data)} on \`${data.base}\`**${suffix}`);
 
   if (data.ci) {
     if (data.ci.status === 'success') {
@@ -96,28 +195,144 @@ for (const { data } of reports) {
     } else {
       out.push(`  - Deploy verify (${data.verify.mode}): **${data.verify.status}** after ${data.verify.attempts} attempt(s) — ${data.verify.lastError || 'no error detail'}`);
     }
-  } else if (data.hasVerifyConfig === false) {
-    // not configured — no line needed
+  } else if (data.resolution === 'verify-never-ran') {
+    out.push('  - Deploy verify: never ran (watcher died before the probe phase)');
+  }
+
+  if (data.resolution === 'unreconciled') {
+    const hint = data.pr ? `gh pr checks ${data.pr}` : `gh run list --commit ${data.mergeSha}`;
+    out.push(`  - Could not reach GitHub to reconcile — check manually: \`${hint}\``);
   }
 
   out.push('');
+  return out;
 }
 
-for (const data of inflight) {
-  const prRef = data.pr ? `PR #${data.pr}` : `commit ${data.mergeSha?.slice(0, 7) || '?'}`;
-  const mins = Math.round((Date.now() - new Date(data.startedAt).getTime()) / 60_000);
-  out.push(`◷ **Ship verify still running** — ${prRef} on \`${data.base}\` (${mins}m elapsed)`);
+/**
+ * Render one watcher that is still inside its own window.
+ *
+ * @param {object} data
+ * @param {number} now epoch ms
+ * @returns {string[]} lines
+ */
+function renderInflight(data, now = Date.now()) {
+  const out = [];
+  const mins = Math.round((now - Date.parse(data.startedAt)) / 60_000);
+  out.push(`◷ **Ship verify still running** — ${prRef(data)} on \`${data.base}\` (${mins}m elapsed)`);
   if (data.ci?.runUrl) out.push(`  - Run: ${data.ci.runUrl}`);
   out.push('');
+  return out;
 }
 
-// Mark surfaced reports as acknowledged in-place so they don't nag next session.
-// History stays on disk for `gh run view` reference.
-for (const { file, data } of reports) {
-  data.acknowledged = true;
-  data.acknowledgedAt = new Date().toISOString();
-  try { fs.writeFileSync(file, JSON.stringify(data, null, 2)); } catch {}
+/**
+ * Ask GitHub what actually happened on `mergeSha`. Per-commit is the only
+ * authoritative query, and it needs a FULL sha (the API ignores abbreviations),
+ * so expand the recorded short sha locally first.
+ *
+ * @param {{ cwd: string, mergeSha: string, base: string }} opts
+ * @returns {{ runs: Array|null, authoritative: boolean }}
+ */
+function lookupRuns({ cwd, mergeSha, base }) {
+  const exec = (cmd, args, timeout) =>
+    execFileSync(cmd, args, { cwd, encoding: 'utf8', timeout, stdio: ['ignore', 'pipe', 'ignore'], windowsHide: true }).trim();
+  const fields = 'databaseId,headSha,status,conclusion,workflowName,url,createdAt';
+
+  let fullSha = null;
+  try {
+    const resolved = exec('git', ['rev-parse', `${mergeSha}^{commit}`], GIT_TIMEOUT_MS);
+    if (/^[0-9a-f]{40}$/i.test(resolved)) fullSha = resolved;
+  } catch { /* commit not fetched locally, or not a repo */ }
+
+  if (fullSha) {
+    try {
+      return { runs: JSON.parse(exec('gh', ['run', 'list', '--commit', fullSha, '--limit', '20', '--json', fields], GH_TIMEOUT_MS)), authoritative: true };
+    } catch { /* gh missing, unauthenticated, offline */ }
+  }
+
+  try {
+    return { runs: JSON.parse(exec('gh', ['run', 'list', '--branch', base, '--limit', '50', '--json', fields], GH_TIMEOUT_MS)), authoritative: false };
+  } catch {
+    return { runs: null, authoritative: false };
+  }
 }
 
-process.stdout.write(out.join('\n') + '\n');
-process.exit(0);
+module.exports = {
+  resolveDeadlineMs,
+  isAbandoned,
+  findRun,
+  reconcile,
+  renderReport,
+  renderInflight,
+  lookupRuns,
+};
+
+if (require.main === module) {
+  require('../lib/plugin-guard');
+
+  const cwd = process.cwd();
+  const watcherDir = path.join(cwd, '.claude', '.ship-watcher');
+
+  if (!fs.existsSync(watcherDir)) process.exit(0);
+
+  let entries;
+  try {
+    entries = fs.readdirSync(watcherDir).filter((f) => f.endsWith('.json'));
+  } catch {
+    process.exit(0);
+  }
+  if (entries.length === 0) process.exit(0);
+
+  const now = Date.now();
+  const reports = [];
+  const inflight = [];
+
+  for (const file of entries) {
+    const full = path.join(watcherDir, file);
+    let data;
+    try {
+      data = JSON.parse(fs.readFileSync(full, 'utf8'));
+    } catch {
+      continue;
+    }
+
+    if (data.status === 'watching') {
+      if (!isAbandoned(data, now)) {
+        inflight.push(data);
+        continue;
+      }
+      // Resolve it: report the real outcome once, then never again. The old
+      // code left `status: "watching"` here, so the entry re-entered this
+      // branch every session and was never reported at all.
+      let lookup = { runs: null, authoritative: false };
+      try {
+        lookup = lookupRuns({ cwd, mergeSha: data.mergeSha, base: data.base });
+      } catch { /* stay inconclusive */ }
+      reports.push({ file: full, data: reconcile(data, lookup, now) });
+      continue;
+    }
+
+    if (data.status === 'complete' && !data.acknowledged) {
+      reports.push({ file: full, data });
+    }
+  }
+
+  if (reports.length === 0 && inflight.length === 0) process.exit(0);
+
+  const out = [];
+  out.push('Post-ship deploy verification — surface this summary AS-IS to the user as the FIRST action of this turn (Lang: user-preference):');
+  out.push('');
+
+  for (const { data } of reports) out.push(...renderReport(data));
+  for (const data of inflight) out.push(...renderInflight(data, now));
+
+  // Mark surfaced reports as acknowledged in-place so they don't nag next
+  // session. History stays on disk for `gh run view` reference.
+  for (const { file, data } of reports) {
+    data.acknowledged = true;
+    data.acknowledgedAt = new Date(now).toISOString();
+    try { fs.writeFileSync(file, JSON.stringify(data, null, 2)); } catch { /* read-only dir */ }
+  }
+
+  process.stdout.write(out.join('\n') + '\n');
+  process.exit(0);
+}

--- a/plugins/devops/hooks/session-start/ss.ship.verify.test.js
+++ b/plugins/devops/hooks/session-start/ss.ship.verify.test.js
@@ -1,0 +1,250 @@
+import { describe, test, expect } from "vitest";
+import {
+  resolveDeadlineMs,
+  isAbandoned,
+  findRun,
+  reconcile,
+  renderReport,
+  renderInflight,
+} from "./ss.ship.verify.js";
+
+/**
+ * The bug: a watcher process that dies before writing a terminal state leaves
+ * `status: "watching"` / `finishedAt: null` on disk forever. The hook's only
+ * defence was a flat 24h `STALE_MS` that (a) kept announcing "still running"
+ * for a process dead for hours — observed as "PR #318 … (1205m elapsed)" at
+ * every SessionStart — and (b) on expiry set `acknowledged: true` while
+ * LEAVING `status: "watching"`, so the entry was never reported at all and the
+ * branch was re-entered every session, re-stamping `staleAt` with a fresh
+ * timestamp (all stuck entries carried the same current-day value).
+ *
+ * The invariant these tests pin: an abandoned entry is resolved into a
+ * TERMINAL state exactly once, so it can be reported once and never re-enter
+ * the watching branch.
+ */
+
+const MIN = 60_000;
+const T0 = Date.parse("2026-09-01T20:22:54.314Z");
+const iso = (ms) => new Date(ms).toISOString();
+
+/** Entry as post-merge-watcher writes it on its very first state write. */
+const watching = (over = {}) => ({
+  status: "watching",
+  pr: 318,
+  base: "main",
+  mergeSha: "84a34a2",
+  startedAt: iso(T0),
+  finishedAt: null,
+  ci: null,
+  verify: null,
+  overall: "pending",
+  acknowledged: false,
+  hasVerifyConfig: false,
+  ...over,
+});
+
+const run = (over = {}) => ({
+  databaseId: 33555118598,
+  headSha: "84a34a2dd8e4ce97da832edbf8a92d6a5e377897",
+  status: "completed",
+  conclusion: "success",
+  workflowName: "Release",
+  url: "https://github.com/o/r/actions/runs/33555118598",
+  createdAt: iso(T0 + 2 * MIN),
+  ...over,
+});
+
+describe("resolveDeadlineMs — the watcher's own lifetime, not a flat 24h", () => {
+  test("no verify config: 5m detect + 30m max-wait + 5m grace", () => {
+    expect(resolveDeadlineMs(watching())).toBe(T0 + 40 * MIN);
+  });
+
+  test("verify config adds its 10m default probe window", () => {
+    expect(resolveDeadlineMs(watching({ hasVerifyConfig: true }))).toBe(T0 + 50 * MIN);
+  });
+
+  test("an explicit maxWaitSec from the watcher replaces the default", () => {
+    expect(resolveDeadlineMs(watching({ maxWaitSec: 600 }))).toBe(T0 + 20 * MIN);
+  });
+
+  test("an explicit deadlineAt written by the watcher wins outright", () => {
+    const d = iso(T0 + 3 * MIN);
+    expect(resolveDeadlineMs(watching({ deadlineAt: d, maxWaitSec: 600 }))).toBe(T0 + 3 * MIN);
+  });
+
+  test("unusable startedAt → null (caller must treat as abandoned, not eternal)", () => {
+    expect(resolveDeadlineMs(watching({ startedAt: null }))).toBeNull();
+    expect(resolveDeadlineMs(watching({ startedAt: "not a date" }))).toBeNull();
+  });
+});
+
+describe("isAbandoned", () => {
+  test("a genuinely in-flight watcher is left alone", () => {
+    expect(isAbandoned(watching(), T0 + 5 * MIN)).toBe(false);
+  });
+
+  test("still not abandoned one minute before its own deadline", () => {
+    expect(isAbandoned(watching(), T0 + 39 * MIN)).toBe(false);
+  });
+
+  test("abandoned once past its own deadline", () => {
+    expect(isAbandoned(watching(), T0 + 41 * MIN)).toBe(true);
+  });
+
+  test("REGRESSION: 20.5h old is abandoned — the old 24h rule called it 'still running'", () => {
+    expect(isAbandoned(watching(), T0 + 1230 * MIN)).toBe(true);
+  });
+
+  test("a malformed entry resolves instead of nagging forever", () => {
+    expect(isAbandoned(watching({ startedAt: null }), T0)).toBe(true);
+  });
+
+  test("terminal entries are never re-judged", () => {
+    expect(isAbandoned({ status: "complete", startedAt: iso(T0) }, T0 + 99 * MIN)).toBe(false);
+  });
+});
+
+describe("findRun — SHA prefix match inside the watcher's window", () => {
+  const deadline = T0 + 40 * MIN;
+
+  test("matches the recorded short SHA against the run's full headSha", () => {
+    expect(findRun([run()], { mergeSha: "84a34a2", deadlineMs: deadline })).toBeTruthy();
+  });
+
+  test("ignores a run for a different commit", () => {
+    expect(findRun([run({ headSha: "deadbee" + "0".repeat(33) })], { mergeSha: "84a34a2", deadlineMs: deadline })).toBeNull();
+  });
+
+  test("a promotion-tag run created days later is NOT the ship's CI", () => {
+    // The Release workflow triggers on the bare vX.Y.Z tag that /promote adds
+    // to the SAME commit later. Attributing it to the ship would invent a CI
+    // result the watcher never saw.
+    const later = run({ createdAt: iso(T0 + 3 * 24 * 60 * MIN) });
+    expect(findRun([later], { mergeSha: "84a34a2", deadlineMs: deadline })).toBeNull();
+  });
+
+  test("a run without createdAt is kept — absence of proof is not proof", () => {
+    expect(findRun([run({ createdAt: undefined })], { mergeSha: "84a34a2", deadlineMs: deadline })).toBeTruthy();
+  });
+
+  test("null/empty run lists yield no match", () => {
+    expect(findRun(null, { mergeSha: "84a34a2", deadlineMs: deadline })).toBeNull();
+    expect(findRun([], { mergeSha: "84a34a2", deadlineMs: deadline })).toBeNull();
+  });
+});
+
+describe("reconcile — every path ends terminal", () => {
+  const NOW = T0 + 1230 * MIN;
+  const terminal = (r) => {
+    expect(r.status).toBe("complete");
+    expect(r.finishedAt).not.toBeNull();
+    expect(r.abandonedAt).not.toBeNull();
+    expect(isAbandoned(r, NOW + 10 * 24 * 60 * MIN)).toBe(false);
+  };
+
+  test("authoritative empty list → no-run, success (the healthy outcome here)", () => {
+    const r = reconcile(watching(), { runs: [], authoritative: true }, NOW);
+    terminal(r);
+    expect(r.ci.status).toBe("no-run");
+    expect(r.overall).toBe("success");
+    expect(r.resolution).toBe("no-run");
+  });
+
+  test("in-window run that passed → CI success", () => {
+    const r = reconcile(watching(), { runs: [run()], authoritative: true }, NOW);
+    terminal(r);
+    expect(r.ci.status).toBe("success");
+    expect(r.ci.runUrl).toContain("/actions/runs/");
+    expect(r.overall).toBe("success");
+  });
+
+  test("in-window run that failed → CI failed, conclusion kept for triage", () => {
+    const r = reconcile(watching(), { runs: [run({ conclusion: "failure" })], authoritative: true }, NOW);
+    terminal(r);
+    expect(r.ci.status).toBe("failed");
+    expect(r.ci.conclusion).toBe("failure");
+    expect(r.overall).toBe("failed");
+  });
+
+  test("in-window run still unfinished → inconclusive, not a fabricated verdict", () => {
+    const r = reconcile(watching(), { runs: [run({ status: "in_progress", conclusion: null })], authoritative: true }, NOW);
+    terminal(r);
+    expect(r.overall).toBe("inconclusive");
+    expect(r.resolution).toBe("ci-unfinished");
+  });
+
+  test("gh could not answer → inconclusive, never a silent 'success'", () => {
+    const r = reconcile(watching(), { runs: null, authoritative: false }, NOW);
+    terminal(r);
+    expect(r.overall).toBe("inconclusive");
+    expect(r.resolution).toBe("unreconciled");
+  });
+
+  test("non-authoritative empty list → inconclusive, NOT no-run", () => {
+    // The branch-scoped fallback query misses tag-triggered runs entirely, so
+    // an empty result there does not prove no run existed.
+    const r = reconcile(watching(), { runs: [], authoritative: false }, NOW);
+    terminal(r);
+    expect(r.overall).toBe("inconclusive");
+    expect(r.resolution).toBe("unreconciled");
+  });
+
+  test("verify was configured but never ran → success is downgraded", () => {
+    const r = reconcile(watching({ hasVerifyConfig: true }), { runs: [], authoritative: true }, NOW);
+    terminal(r);
+    expect(r.ci.status).toBe("no-run");
+    expect(r.overall).toBe("inconclusive");
+    expect(r.resolution).toBe("verify-never-ran");
+  });
+
+  test("a verify result the watcher already recorded is preserved", () => {
+    const r = reconcile(
+      watching({ hasVerifyConfig: true, verify: { status: "success", mode: "http", target: "https://x" } }),
+      { runs: [], authoritative: true },
+      NOW,
+    );
+    expect(r.overall).toBe("success");
+    expect(r.verify.status).toBe("success");
+  });
+
+  test("reconcile does not mutate the entry it was handed", () => {
+    const input = watching();
+    reconcile(input, { runs: [], authoritative: true }, NOW);
+    expect(input.status).toBe("watching");
+  });
+});
+
+describe("renderReport — an abandoned entry reads as abandoned", () => {
+  const NOW = T0 + 1230 * MIN;
+
+  test("reconciled no-run says the watcher died and what was found", () => {
+    const lines = renderReport(reconcile(watching(), { runs: [], authoritative: true }, NOW)).join("\n");
+    expect(lines).toContain("PR #318");
+    expect(lines).toMatch(/watcher/i);
+    expect(lines).toContain("no workflow triggered");
+    expect(lines).not.toMatch(/still running/i);
+  });
+
+  test("unreconciled entries carry a manual-check hint, not a verdict", () => {
+    const lines = renderReport(reconcile(watching(), { runs: null, authoritative: false }, NOW)).join("\n");
+    expect(lines).toContain("⚠");
+    expect(lines).toContain("gh pr checks 318");
+  });
+
+  test("an ordinary completed entry is unchanged by the abandonment work", () => {
+    const lines = renderReport({
+      status: "complete", pr: 269, base: "main", overall: "success",
+      ci: { status: "no-run" }, verify: null, hasVerifyConfig: false,
+    }).join("\n");
+    expect(lines).toContain("✓ **Ship verify — PR #269 on `main`**");
+    expect(lines).not.toMatch(/watcher/i);
+  });
+});
+
+describe("renderInflight", () => {
+  test("reports elapsed minutes for a watcher still inside its window", () => {
+    const lines = renderInflight(watching(), T0 + 5 * MIN).join("\n");
+    expect(lines).toContain("still running");
+    expect(lines).toContain("(5m elapsed)");
+  });
+});

--- a/plugins/devops/scripts/post-merge-watcher.js
+++ b/plugins/devops/scripts/post-merge-watcher.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * @script post-merge-watcher
- * @version 0.1.1
+ * @version 0.2.0
  * @plugin devops
  * @description Background watcher that runs after ship_release succeeds.
  *   Waits for the GitHub Actions run on the merge commit, optionally probes
@@ -22,10 +22,17 @@
  * State file: <state-dir>/<merge-sha>.json
  *   { status: "watching" | "complete",
  *     pr, base, mergeSha, startedAt, finishedAt,
+ *     maxWaitSec, deadlineAt,        // latest instant this watcher can still be alive
  *     ci: { status, runId, runUrl, workflowName, conclusion },
  *     verify: { status, mode, target, attempts, lastError } | null,
- *     overall: "pending" | "success" | "failed" | "timeout",
+ *     overall: "pending" | "success" | "failed" | "timeout" | "inconclusive",
  *     acknowledged: false }
+ *
+ * `deadlineAt` is what lets ss.ship.verify tell "still working" from
+ * "abandoned": this process is spawned detached, so a machine shutdown or a
+ * killed session ends it without any of the terminal writes below ever
+ * running. The signal/exit handlers cover graceful termination; `deadlineAt`
+ * covers the rest.
  */
 
 const { spawnSync, execFileSync } = require("node:child_process");
@@ -35,6 +42,8 @@ const { join, dirname } = require("node:path");
 const POLL_INITIAL_RUN_DETECT_MS = 5_000;
 const POLL_INITIAL_RUN_DETECT_MAX_MS = 5 * 60_000;
 const DEFAULT_MAX_WAIT_SEC = 1800;
+const VERIFY_DEFAULT_TIMEOUT_SEC = 600;
+const ABANDON_GRACE_MS = 5 * 60_000;
 
 function parseArgs(argv) {
   const out = {};
@@ -276,6 +285,40 @@ function notifyToast(title, message) {
 let activeState = null;
 let activeStateFile = null;
 
+/**
+ * Flip an in-flight state file to a terminal "inconclusive" result. Terminal
+ * writes always set `status: "complete"`, so that doubles as the guard: a run
+ * that already reached a verdict is never overwritten.
+ *
+ * @param {string} reason
+ */
+function markAbandoned(reason) {
+  if (!activeState || !activeStateFile) return;
+  if (activeState.status === "complete") return;
+  try {
+    activeState.status = "complete";
+    activeState.overall = "inconclusive";
+    activeState.resolution = "watcher-terminated";
+    activeState.finishedAt = new Date().toISOString();
+    activeState.abandonedAt = activeState.finishedAt;
+    activeState.abandonReason = reason;
+    writeState(activeStateFile, activeState);
+  } catch { /* best-effort */ }
+}
+
+// Graceful termination (session teardown, Ctrl-C, logoff) still gets a verdict
+// on disk. A hard kill or power loss cannot be caught here — that is what
+// `deadlineAt` plus the reader's reconciliation are for.
+for (const sig of ["SIGTERM", "SIGINT", "SIGHUP", "SIGBREAK"]) {
+  try {
+    process.on(sig, () => {
+      markAbandoned(`received ${sig}`);
+      process.exit(143);
+    });
+  } catch { /* signal not supported on this platform */ }
+}
+process.on("exit", () => markAbandoned("process exited before reaching a verdict"));
+
 async function main() {
   const args = parseArgs(process.argv);
   const cwd = args.cwd;
@@ -296,13 +339,30 @@ async function main() {
   const stateFile = join(stateDir, `${mergeSha}.json`);
   const verifyConfig = parseVerifyConfig(verifyConfigPath);
 
+  // Publish the watcher's own outside-limit so a reader can decide whether a
+  // still-"watching" file means "working" or "died"; without it the reader is
+  // left guessing with a constant that has nothing to do with this run.
+  const startedAt = new Date();
+  const verifyTimeoutSec = verifyConfig
+    ? Number(verifyConfig.timeout_seconds) || VERIFY_DEFAULT_TIMEOUT_SEC
+    : 0;
+  const deadlineAt = new Date(
+    startedAt.getTime() +
+      POLL_INITIAL_RUN_DETECT_MAX_MS +
+      maxWaitSec * 1000 +
+      verifyTimeoutSec * 1000 +
+      ABANDON_GRACE_MS,
+  ).toISOString();
+
   const state = {
     status: "watching",
     pr,
     base,
     mergeSha,
-    startedAt: new Date().toISOString(),
+    startedAt: startedAt.toISOString(),
     finishedAt: null,
+    maxWaitSec,
+    deadlineAt,
     ci: null,
     verify: null,
     overall: "pending",

--- a/plugins/devops/skills/ship/deep-knowledge/post-merge-verify.md
+++ b/plugins/devops/skills/ship/deep-knowledge/post-merge-verify.md
@@ -111,9 +111,17 @@ Notes:
 - **CI does not exist** → `ci: { status: "no-run" }`, verify still runs if
   configured. Pure-frontend repos without CI but with a deploy hook can use
   this pattern.
-- **Watcher process killed before completion** → state file stays in
-  `status: "watching"`. The SessionStart hook auto-acknowledges entries
-  older than 24h.
+- **Watcher process killed before completion** → the watcher writes
+  `overall: "inconclusive"` on graceful termination (SIGTERM/SIGINT/logoff).
+  A hard kill (machine shutdown, power loss) cannot be caught, so the state
+  file stays in `status: "watching"`; every state file therefore carries a
+  `deadlineAt` (detect window + `--max-wait` + verify timeout + 5 min grace).
+  Past that instant `ss.ship.verify` treats the entry as **abandoned**,
+  reconciles it against `gh run list --commit <merge-sha>` — restricted to
+  runs created before `deadlineAt`, so a later `/promote` tag run on the same
+  commit is not misreported as the ship's CI — and writes a terminal state.
+  It is surfaced **once** (`⚠` when GitHub could not be reached) and never
+  nags again.
 
 ## Example: SPA on Vercel
 

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.138.0",
+  "version": "0.138.1",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

A post-merge watcher that dies takes its result with it — and then announces itself as still running for a day.

The watcher is spawned detached, so a machine shutdown or a killed session ends it without any of its terminal writes ever happening. Its state file stays on `status: "watching"` / `finishedAt: null` forever, and the only defence was a flat 24h `STALE_MS` in `ss.ship.verify` — a number with no relationship to the watcher's own lifetime (5 min run-detect + `--max-wait` + the deploy probe, ~40–50 min at most).

Two distinct failures came out of that:

- For a whole day the reader greeted every session with **"Ship verify still running"**, counting up. The reported figure had reached **1205 minutes** for a process dead since minute forty.
- On expiry it set `acknowledged: true` while **leaving `status: "watching"`**. So the entry was never reported at all — the outcome of that ship was silently lost — and because the status never changed, the branch was re-entered every session, re-stamping `staleAt` with a fresh timestamp each time.

Eight entries were sitting in that state in this repo, the oldest since 2026-08-17, all carrying the same current-day `staleAt`.

## Fix

Every state file now carries `maxWaitSec` + `deadlineAt` (detect window + `--max-wait` + verify timeout + 5 min grace), so a reader decides *working* vs *died* from the run's own numbers rather than a constant. Past that instant the entry is **abandoned**: reconciled against `gh run list --commit <merge-sha>`, written as a terminal state, surfaced exactly once, and structurally unable to re-enter the watching branch.

Two things it deliberately refuses to do:

- **Fabricate a verdict.** Only the per-commit query is authoritative. The branch-scoped fallback misses tag-triggered runs entirely, so an empty result there yields `inconclusive` with a `gh pr checks` hint — never "no workflow ran".
- **Credit a promotion's CI to the ship.** Matches are restricted to runs created before the deadline. In this repo the Release workflow fires on the bare `vX.Y.Z` tag that `/promote` adds to the already-merged commit later; without that restriction the promotion run would be reported as the merge's own CI.

The watcher additionally writes a terminal `inconclusive` on graceful termination (SIGTERM/SIGINT/logoff). A hard kill remains the reader's problem — that is what the deadline is for.

## Verification

- 29 new tests for `ss.ship.verify` (deadline resolution, abandonment, window-restricted run matching, every reconcile path ends terminal). Full suite: 85 files / 2128 tests green, lint clean — re-run after rebasing onto #320.
- Run against the real `.claude/.ship-watcher/`: all 8 stuck entries resolved — PRs #305/#310/#314/#318 to `CI (Release): passed`, the rest to `no-run`. A second run reports only the genuinely in-flight watcher, proving the entries cannot nag again.

Codex review gate: skipped — `ERROR: You've hit your usage limit` (rc=1), per the skill's failure-tolerance rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)