### PR TITLE
fix(concept): stop attachment stacking, bleed-through, raw scrollbars

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.139.0"
+    "version": "0.139.1"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.139.0",
+      "version": "0.139.1",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.139.0",
+      "version": "0.139.1",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.139.1] — 2026-09-04
+
+### Fixed
+
+- **A `/concept` page still stacked one 📎 attachment bar per hidden dock field after the fix that was meant to end it, scrolled the dock behind a raw platform scrollbar, and let the page header shine through frozen design iterations.** Measured on a real four-iteration page: twelve visible attachment bars for three visible textareas, 1062px of dock content in a 430px box, and the document `<h1>` plus the iteration intro painted through the mockup right under the screen indicator after every ☰ switch. Three causes. The page's attachment engine predated the earlier fix (`parentElement.appendChild(bar)`, no `.attach-bar` half in the hiding rule) and still *passed* the validation gate, because entry 44 grepped a single literal that the page happened to contain; and an iteration append re-uses the page's existing engine forever, so the defect survived every later round of the same concept. In design mode a page that started as a decision round keeps its document header and each iteration's intro in normal flow while the design section paints over them `position: absolute; inset: 0` — and the generic frozen-iteration `opacity: 0.85` turned that into bleed-through.
+
+  The attachment engine now injects its own visibility CSS once (`#attach-visibility-styles`), so a page that copies the JavaScript without the layout rule still hides a bar with its field. Gate entry 44 requires both hiding literals, the `afterend` mount and the injected style, and rejects the legacy `parentElement.appendChild(bar)` and `attach-hint` shapes; new entries 46 and 47 pin the design-mode rules that hide the document header and intro and keep a frozen design iteration fully opaque, and entry 48 warns on a missing scrollbar skin. The three scroll boxes (`.feedback-dock`, `.concept-decision-panel`, `section[data-screen]`) carry a thin border-coloured scrollbar in every template. Step 5c of the skill gains an **engine drift check** before every append: the gate runs over the whole existing page and any failing shared block is re-synced from the reference before the new iteration lands — so a page generated before a template fix picks the fix up on its next round instead of never.
+
 ## [0.139.0] — 2026-09-04
 
 Backlog run 2026-09-03/04 (PR #325, eight issues). The plugin's own ship server was unreachable while this work was made — the very defect fixed first below — so the eight fixes landed as one integration PR and this entry versions them.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.139.0**
+**Version: 0.139.1**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.139.0",
+  "version": "0.139.1",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/skills/concept/SKILL.md
+++ b/plugins/devops/skills/concept/SKILL.md
@@ -1064,6 +1064,16 @@ iteration must be live in the browser BEFORE the server signals "processed".
    `deep-knowledge/iteration-rules.md` § Procedure on every iteration —
    coverage gate and `deep-knowledge/validation-gate.md` § Generic Form
    Collection for the required pattern.
+2.6. **Engine drift check.** Run `deep-knowledge/validation-gate.md` over
+   the EXISTING page — the gate applies to the whole file on every append,
+   not only at first generation. The page's shared engine (Attachments
+   JS/CSS, § Layout CSS chrome rules, tab-switch JS) is whatever
+   templates.md said on the day it was generated, and every later round
+   re-uses it. If any engine entry fails (44, 46, 47, 48, tab-switch),
+   re-sync that whole block **verbatim from templates.md NOW**, before
+   appending — otherwise the new iteration inherits the old defect and the
+   user sees the same bug after updating the plugin. See
+   `deep-knowledge/validation-gate.md` § Engine drift on iteration append.
 3. Append a new `<section data-iteration="{N+1}" data-active>` with the
    updated / next-round content (new variants, refined options, whatever
    the feedback produced). Set `submitted: false` in `#concept-decisions`,

--- a/plugins/devops/skills/concept/deep-knowledge/iteration-rules.md
+++ b/plugins/devops/skills/concept/deep-knowledge/iteration-rules.md
@@ -201,3 +201,17 @@ This gate exists because hand-listed selectors written for iteration N
 will not pick up new fields introduced in iteration N+1, and the failure
 is silent: the user sees the panel turn green, but Claude receives a
 truncated payload.
+
+**2.6. Engine drift check.** Run `validation-gate.md` over the existing
+page before appending. The page's shared engine — Attachments JS/CSS,
+§ Layout CSS chrome rules, tab-switch JS — is a copy of whatever
+templates.md said on generation day, and every later round re-uses it
+unchanged. If any engine entry fails (44 attachments, 46 / 47 design-mode
+chrome, 48 scroll boxes, tab-switch), re-sync that whole block verbatim
+from templates.md FIRST, then append.
+
+Same shape of failure as 2.5, one level down: the defect is not in the
+iteration being added, it is in the machinery the iteration is being added
+to. Left alone it survives every update to the plugin, because nothing
+re-reads templates.md for an existing page unless this step does. See
+`validation-gate.md` § Engine drift on iteration append.

--- a/plugins/devops/skills/concept/deep-knowledge/templates.md
+++ b/plugins/devops/skills/concept/deep-knowledge/templates.md
@@ -570,6 +570,15 @@ Rules:
 - The `<html data-template>` value written at generation time MUST already
   equal the active iteration's (normalised) template — otherwise the first
   paint shows the wrong layout.
+- **A page that started as `decision` or `free` keeps its document header**
+  (`<h1>`, subtitle, `#theme-toggle` inside `.concept-content > header`) and
+  its per-iteration `<header class="iteration-intro">` for the rest of its
+  life — a later `design` iteration must never delete them, or switching
+  back to an earlier round loses its own title. Design mode is
+  `position: absolute; inset: 0` and would paint straight over both, so it
+  HIDES them in CSS instead: see § Layout CSS → "Document chrome vs. the
+  fullscreen canvas" and the frozen-opacity exemption next to it. Both rules
+  are mandatory on any page that mixes design with decision/free.
 
 ---
 
@@ -1910,6 +1919,38 @@ it today.
 ## Layout CSS
 
 ```css
+/* ── Scroll boxes ───────────────────────────────────────────────────────
+   Deliberately UNSCOPED (the only rules in this section that are): these
+   three are the page's scrolling surfaces in EVERY template, and a
+   scrollbar skin changes no geometry, so scoping it to design mode would
+   only mean the decision/free iterations of the same page keep the raw
+   platform bar. The boxes need `overflow-y: auto` for legitimate reasons
+   (a dock taller than its max-height, a long panel TOC, a screen taller
+   than the safe area), but the default Windows/Chromium bar is an opaque
+   16px slab against a dark panel — measured on a real page as the single
+   loudest piece of chrome in a 430px dock. Thin + border-coloured thumb on
+   a transparent track reads as part of the panel instead. Both syntaxes:
+   `scrollbar-*` covers Firefox and modern Chromium, the `::-webkit-*`
+   pseudo-elements cover the older Chromium/WebKit that ignore it. */
+.feedback-dock,
+.concept-decision-panel,
+section[data-screen] {
+  scrollbar-width: thin;
+  scrollbar-color: var(--border-color, #30363d) transparent;
+}
+.feedback-dock::-webkit-scrollbar,
+.concept-decision-panel::-webkit-scrollbar,
+section[data-screen]::-webkit-scrollbar { width: 8px; }
+.feedback-dock::-webkit-scrollbar-thumb,
+.concept-decision-panel::-webkit-scrollbar-thumb,
+section[data-screen]::-webkit-scrollbar-thumb {
+  background: var(--border-color, #30363d);
+  border-radius: 4px;
+}
+.feedback-dock::-webkit-scrollbar-track,
+.concept-decision-panel::-webkit-scrollbar-track,
+section[data-screen]::-webkit-scrollbar-track { background: transparent; }
+
 /* EVERY rule below is scoped to html[data-template="design"]. That attribute
    is a projection of the ACTIVE iteration (see § Per-Iteration Templates), so
    flipping it flips the whole layout: a decision/free iteration on the same
@@ -1922,6 +1963,38 @@ html[data-template="design"],
 html[data-template="design"] body { height: 100%; overflow: hidden; }
 [data-template="design"] .concept-layout.design.fullscreen { display: block; width: 100vw; height: 100vh; overflow: hidden; }
 [data-template="design"] .concept-layout.design .concept-content { position: absolute; inset: 0; overflow: hidden; }
+
+/* ── Document chrome vs. the fullscreen canvas ──────────────────────────
+   A page may START as decision or free (§ Per-Iteration Templates), and
+   those templates put a `<header>` with the <h1>, the subtitle and the
+   #theme-toggle directly inside .concept-content, plus a
+   `<header class="iteration-intro">` at the top of every iteration section.
+   Both stay in NORMAL FLOW. Design mode then makes the iteration section
+   `position: absolute; inset: 0` — it paints OVER them instead of pushing
+   them aside, and the frozen-iteration opacity below let the h1 and the
+   intro shine through the mockup right under the fixed screen indicator
+   (measured at 1280x720: h1 at y=32, intro at y=0, indicator top-left, all
+   three overlapping and the page reading as "empty" after a ☰ switch).
+   Design mode owns the whole viewport, so the document header and the
+   per-iteration intro are hidden while it is active; flipping
+   `<html data-template>` back to decision/free brings both back, unchanged.
+   The theme toggle lives only in that header and is therefore gone in
+   design mode — accepted: the design template never had one of its own,
+   and the theme is a page-level preference set from any non-design
+   iteration (and persisted). Do NOT "solve" this by re-homing the toggle
+   into the design chrome: that reopens the FAB geometry rules (P13). */
+html[data-template="design"] .concept-content > header,
+html[data-template="design"] section[data-iteration] > .iteration-intro { display: none; }
+
+/* Frozen design iterations stay FULLY opaque. The generic
+   `section[data-iteration]:not([data-active]) { opacity: 0.85 }`
+   (§ Tab Bar CSS) is a legible "this round is history" cue for a sidebar
+   iteration in normal flow. On an absolute/inset:0 design section it is a
+   bleed-through instead: whatever is behind the canvas — the document
+   header, a sibling iteration's intro — shows through the mockup. Frozen
+   state is already communicated here by the panel's frozen state and the
+   read-only dock (applyDockFreezeState), so the opacity buys nothing. */
+html[data-template="design"] section[data-iteration]:not([data-active]) { opacity: 1; }
 
 /* ── Chrome safe area ───────────────────────────────────────────────────
    Every fixed control in design mode sits on the viewport's top or bottom
@@ -6368,7 +6441,21 @@ emitted directly after the textarea it belongs to. **Emit it that way** — a
 mount separated from its field, or one nested somewhere else in the row,
 silently reintroduces the stack. The same rule names `.attach-bar` for the
 mountless path, where `_mountAttachmentBar()` inserts the bar itself
-`afterend` of the textarea for exactly this reason. Hiding the bar is deliberately CSS-only:
+`afterend` of the textarea for exactly this reason.
+`ta.parentElement.appendChild(bar)` is the **forbidden legacy shape**: it
+drops the bar after everything else in the row, so it is no longer an
+adjacent sibling and no rule reaches it. A page that still contains it is
+stacking bars today and must have this whole block re-synced (§ Engine drift
+on iteration append in `validation-gate.md`).
+
+**The engine carries its own visibility CSS.** `initCommentAttachments()`
+calls `_ensureAttachStyles()` once, which injects
+`<style id="attach-visibility-styles">` with the two `textarea[hidden] + …`
+rules and `.attach-slot:empty` if that element is not on the page yet. The
+§ Layout CSS copy stays as well — belt and braces, the same argument as the
+`var()` fallbacks around `--chrome-safe-top`: this file is a REFERENCE that
+is copied in PIECES, and a page that took the JS without the Layout CSS rule
+would mount bars nothing ever hides. Hiding the bar is deliberately CSS-only:
 `showScreen()`/`showDesign()`/`showView()` must stay free to toggle nothing
 but `ta.hidden`, and the bar has to keep existing (and stay wired) while
 hidden so the attachments already on an inactive field are still there when
@@ -6591,6 +6678,24 @@ function _barFor(slotKey) {
   return document.querySelector('.attach-bar[data-attach-for="' + CSS.escape(slotKey) + '"]');
 }
 
+// The engine ships its own visibility CSS. § Layout CSS declares the same two
+// rules, and that copy stays — but this file is a REFERENCE that gets copied
+// in PIECES (same argument as the `var()` fallbacks on --chrome-safe-top): a
+// page that took the Attachments JS without the Layout CSS rule mounts bars
+// that nothing ever hides, and the dock renders one 📎 row per hidden field
+// stacked under the single visible textarea. Injected once, idempotent by id,
+// so an iteration append that re-runs the engine adds nothing.
+function _ensureAttachStyles() {
+  if (document.getElementById('attach-visibility-styles')) return;
+  const style = document.createElement('style');
+  style.id = 'attach-visibility-styles';
+  style.textContent =
+    'textarea[hidden] + .attach-slot,' +
+    'textarea[hidden] + .attach-bar { display: none; }' +
+    '.attach-slot:empty { display: none; }';
+  (document.head || document.documentElement).appendChild(style);
+}
+
 // Resolves where a slot's bar lives: a dedicated .attach-slot mount when the
 // markup declares one (annotation answers, every dock-built textarea — see
 // § Layout JS), otherwise appended straight after the textarea (decision
@@ -6603,6 +6708,8 @@ function _mountAttachmentBar(ta, slotKey) {
   const dedicated = document.querySelector('.attach-slot[data-attach-slot="' + CSS.escape(slotKey) + '"]');
   if (dedicated) dedicated.appendChild(bar);
   // `afterend`, not parentElement.appendChild: the bar belongs to ITS field,
+  // and appending the bar onto `ta.parentElement` is the FORBIDDEN legacy
+  // shape — a page still carrying it stacks bars and must be re-synced here,
   // and appending to the container drops it after whatever else the row holds
   // — far from the textarea, and out of reach of the
   // `textarea[hidden] + .attach-bar` rule that hides it with its field.
@@ -6633,6 +6740,7 @@ function attachFileIcon(mime, name) {
 }
 
 function initCommentAttachments() {
+  _ensureAttachStyles();
   document.querySelectorAll('textarea[data-attachable]').forEach(ta => {
     const slotKey = _slotKeyOf(ta);
     if (!slotKey) return;

--- a/plugins/devops/skills/concept/deep-knowledge/validation-gate.md
+++ b/plugins/devops/skills/concept/deep-knowledge/validation-gate.md
@@ -37,7 +37,7 @@ no legitimate matches — do not "keep it as a convenience". The decision panel
 
 ## Phase 1 — Shared patterns (ALL templates)
 
-Every concept page must contain these 49 patterns, regardless of template
+Every concept page must contain these 52 patterns, regardless of template
 (the numbering carries `b` suffixes where a pattern was added next to a
 related one — count the rows, not the highest number):
 
@@ -90,7 +90,10 @@ related one — count the rows, not the highest number):
 | 41 | `data-attachable` | The ONE marker `initCommentAttachments()` matches to decide which fields get an attachment bar. MUST NOT be `data-comment` — several fields carry `data-comment` without being attachable (plain text-only comments), and several carry both (annotation answers, decision notes); matching on `data-comment` wires a bar onto every one of those a second time or onto fields that were never meant to take a file. See templates.md § Attachments. |
 | 42 | `initCommentAttachments` | Wires the 📎 button, drag & drop, and Ctrl/Cmd+V paste onto every `textarea[data-attachable]`. Missing → attachment bars render (if emitted inline) but do nothing. |
 | 43 | `_guardedSetItem` | Every `localStorage.setItem` call site (state persistence + both `-pending` submit-queue writes) MUST go through this wrapper, never a bare `localStorage.setItem`. A `QuotaExceededError` thrown out of an unguarded call kills ALL further persistence for the rest of the page with nothing telling the user — see templates.md § State Persistence. |
-| 44 | `textarea[hidden] + .attach-slot` | The CSS rule that takes an inactive field's 📎 bar off the page. The dock builds one textarea per screen / design / view and hides all but the active one, but a `.attach-slot` mount is that textarea's SIBLING — and `.attach-slot:empty` stops covering it the moment `initCommentAttachments()` mounts a bar into it. Missing → the page renders one 📎 row per hidden field, stacked under the single visible textarea. See templates.md § Attachments. |
+| 44 | ALL FOUR of `textarea[hidden] + .attach-slot`, `textarea[hidden] + .attach-bar`, `insertAdjacentElement('afterend', bar)` (inside `_mountAttachmentBar`), `attach-visibility-styles` — AND NEITHER of `parentElement.appendChild(bar)` NOR `attach-hint` | The attachment engine's four halves; any one missing puts the 📎 stack back. The dock builds one textarea per screen / design / view and hides all but the active one, but a `.attach-slot` mount is that textarea's SIBLING — and `.attach-slot:empty` stops covering it the moment `initCommentAttachments()` mounts a bar into it. `.attach-bar` covers the mountless path, `afterend` is what makes that path an adjacent sibling at all, and `attach-visibility-styles` is the JS-injected copy of both rules (`_ensureAttachStyles()`) for a page that took the engine without the Layout CSS. The two negatives are the legacy shapes: `parentElement.appendChild(bar)` mounts the bar out of reach of every rule above, `attach-hint` is the removed per-field shortcut label. See templates.md § Attachments. |
+| 46 | `html[data-template="design"] .concept-content > header` AND `.iteration-intro { display: none` in the same rule | Design mode's iteration sections are `position: absolute; inset: 0`, but a page that started as `decision` or `free` keeps a `<header>` (h1 + subtitle + `#theme-toggle`) in `.concept-content` and an `<header class="iteration-intro">` per iteration, both in normal flow. Without this rule the canvas paints straight over them and their text bleeds through the mockup under the fixed screen indicator (measured at 1280x720: h1 at y=32, intro at y=0, both overlapping the artefact). Mandatory on every page that mixes `design` with `decision`/`free`. See templates.md § Layout CSS → "Document chrome vs. the fullscreen canvas". |
+| 47 | `html[data-template="design"] section[data-iteration]:not([data-active])` with `opacity: 1` | The exemption from § Tab Bar CSS's generic `opacity: 0.85` frozen-iteration cue. On an absolute/inset:0 design section that cue is not a dim, it is a see-through: the document header and sibling content show through the mockup, which is what makes a ☰ switch to a frozen design round look like an empty, doubled-up page. Frozen state is already carried by the panel's frozen state and the read-only dock (`applyDockFreezeState`). Missing → hard fail, same as 46: the two defects only ever appear together. |
+| 48 | `scrollbar-width: thin` + `::-webkit-scrollbar` covering `.feedback-dock`, `.concept-decision-panel`, `section[data-screen]` | **Warning, not a hard fail** — the page is usable without it. All three legitimately carry `overflow-y: auto`, and the default Chromium/Windows bar is an opaque 16px slab inside a 430px dark dock. Skinned thin with a `var(--border-color)` thumb on a transparent track. Both syntaxes required (`scrollbar-*` for Firefox/modern Chromium, `::-webkit-scrollbar*` for older WebKit). See templates.md § Layout CSS → "Scroll boxes". |
 | 45 | `section[data-design]:not([data-design-active="true"])` | The CSS backstop for "exactly one design and one screen paint". Designs and screens are `position:absolute; inset:0`, so a single inactive section that ships without `hidden` does not sit somewhere wrong — it paints on top of the active one. Measured on a real page: three designs, five screens, all stacked on the same square, headings and mockups interleaved. `hidden` cannot be the only guard because the markup is merely ASKED to emit it. Must be `:has()`-guarded, together with the matching `section[data-screen]:not([data-screen-active="true"])` rule and `body:not([data-view-active="true"]) section[data-view]`. See templates.md § Layout CSS. |
 
 **Failure for 21 / 22:** if either pattern is missing, the page is rejected
@@ -127,6 +130,40 @@ presence is only half the check — every `.attach-slot` in the page must also
 sit directly after the textarea it belongs to. Grep the mounts: any one
 separated from its field by another element is hidden by nothing and puts a
 duplicate bar back on screen.
+
+The four-literal form of 44 is deliberate. The entry used to grep for
+`textarea[hidden] + .attach-slot` alone, and a real page with 18 attachable
+fields PASSED it while rendering 12 stacked 📎 bars for 3 visible textareas
+(dock content 1062px inside a 430px box): it had the `.attach-slot` half of
+the CSS but not the `.attach-bar` half, its `_mountAttachmentBar()` still did
+`ta.parentElement.appendChild(bar)`, and its bars still carried
+`.attach-hint`. One literal out of an engine with four moving parts is not a
+check, it is a coincidence — a page can satisfy it and be maximally broken.
+Grep for all four positives and both negatives, every time.
+
+**Failure for 46 / 47:** both are hard fails, and they are one defect —
+patch both rules together. 48 is a warning: note it, add the rule, but do
+not block on it.
+
+## Engine drift on iteration append
+
+**This gate runs against the WHOLE existing file on every append, not only
+on first generation.** A concept page carries its shared engine — the
+Attachments JS + CSS, the § Layout CSS chrome rules, the tab-switch JS —
+from the day it was generated, and an iteration append (SKILL.md Step 5c)
+re-uses that engine forever. So a page generated before a templates.md fix
+keeps the old defect through every later round, and the user reports "still
+4 attachment bars" *after* updating the plugin, on a page that was appended
+to twice since.
+
+Before appending, run the gate over the existing HTML. When any ENGINE entry
+fails — 44 (attachments), 46 / 47 (design-mode chrome), 48 (scroll boxes),
+or the tab-switch patterns — re-sync that whole shared block **verbatim from
+templates.md** BEFORE the new section goes in. Re-sync the block, not the one
+line the grep flagged: these blocks fail in halves, and a page missing one
+literal is a page carrying a stale copy of everything around it. Appending
+first and patching after leaves the freshly appended iteration wired to the
+old engine.
 
 ## Generic Form Collection (mandatory for all templates)
 

--- a/plugins/devops/skills/concept/design-chrome-overlap.test.js
+++ b/plugins/devops/skills/concept/design-chrome-overlap.test.js
@@ -1,0 +1,366 @@
+import { describe, test, expect } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Three defects measured on ONE real generated page (4 iterations, 18
+// textarea[data-attachable], 1280x720). All three share a root cause shape:
+// the page is a COPY of templates.md taken on generation day, so a reference
+// that is only correct in one place ships broken pages forever after.
+//
+//   1. Stacked 📎 bars — 12 visible for 3 visible textareas, dock content
+//      1062px inside a 430px box. The page had the `.attach-slot` half of the
+//      hide rule and not the `.attach-bar` half, mounted via
+//      `parentElement.appendChild(bar)`, and still rendered `.attach-hint`.
+//      Gate entry 44 grepped ONE literal, so it passed. Fix: the engine
+//      injects its own visibility CSS (`attach-visibility-styles`), so a page
+//      that copies the JS without the Layout CSS is still correct.
+//   2. The raw platform scrollbar in the feedback dock: three boxes carry a
+//      legitimate `overflow-y: auto` and nothing skinned the bar.
+//   3. Header/intro bleed-through on a ☰ switch to a frozen design round.
+//      Design iterations are `position: absolute; inset: 0` and paint over the
+//      document `<header>` and the `.iteration-intro`, which stay in normal
+//      flow — and `:not([data-active]) { opacity: 0.85 }` made the section
+//      see-through, so both showed straight through the mockup (h1 at y=32,
+//      intro at y=0, under the fixed screen indicator).
+//
+// templates.md is a REFERENCE Claude copies verbatim into generated pages, so
+// a defect here ships silently into every concept produced afterwards.
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DK = path.join(__dirname, "deep-knowledge");
+const md = fs.readFileSync(path.join(DK, "templates.md"), "utf8");
+const gate = fs.readFileSync(path.join(DK, "validation-gate.md"), "utf8");
+const skill = fs.readFileSync(path.join(__dirname, "SKILL.md"), "utf8");
+const iterRules = fs.readFileSync(path.join(DK, "iteration-rules.md"), "utf8");
+
+// Line-based scanner (same reason as panel-chrome.test.js): a lazy
+// ```css\n([\s\S]*?)``` regex desynchronises on the first block whose body
+// contains a fence and silently stops seeing everything after it.
+function scanBlocks(src) {
+  const lines = src.split("\n");
+  const out = [];
+  let open = null, body = [];
+  for (let i = 0; i < lines.length; i++) {
+    const m = /^```(.*)$/.exec(lines[i]);
+    if (m) {
+      if (open === null) { open = { info: m[1].trim(), start: i + 2 }; body = []; }
+      else { out.push({ info: open.info, line: open.start, code: body.join("\n") }); open = null; }
+      continue;
+    }
+    if (open) body.push(lines[i]);
+  }
+  return out;
+}
+const BLOCKS = scanBlocks(md);
+const CSS_BLOCKS = BLOCKS.filter((b) => b.info === "css");
+const JS_BLOCKS = BLOCKS.filter((b) => /^(javascript|js)$/.test(b.info));
+const cssSource = CSS_BLOCKS.map((b) => b.code).join("\n");
+const jsSource = JS_BLOCKS.map((b) => b.code).join("\n");
+
+const stripComments = (s) => s.replace(/\/\*[\s\S]*?\*\//g, "");
+const stripJsComments = (s) => s.replace(/^\s*\/\/.*$/gm, "");
+
+function splitSelectors(list) {
+  const out = [];
+  let depth = 0, buf = "";
+  for (const ch of list) {
+    if (ch === "(" || ch === "[") depth++;
+    else if (ch === ")" || ch === "]") depth--;
+    if (ch === "," && depth === 0) { out.push(buf.trim()); buf = ""; continue; }
+    buf += ch;
+  }
+  if (buf.trim()) out.push(buf.trim());
+  return out;
+}
+
+/** Brace-balanced rule walker; recurses into at-rules. */
+function cssRules(src) {
+  const out = [];
+  let i = 0, sel = "";
+  while (i < src.length) {
+    if (src[i] === "}") { sel = ""; i++; continue; }
+    if (src[i] !== "{") { sel += src[i]; i++; continue; }
+    let depth = 1, j = i + 1;
+    while (j < src.length && depth > 0) {
+      if (src[j] === "{") depth++;
+      else if (src[j] === "}") { depth--; if (!depth) break; }
+      j++;
+    }
+    out.push({ selectors: splitSelectors(sel.trim()), body: src.slice(i + 1, j) });
+    if (sel.trim().startsWith("@")) out.push(...cssRules(src.slice(i + 1, j)));
+    sel = "";
+    i = j + 1;
+  }
+  return out.filter((r) => r.selectors.length && !r.selectors[0].startsWith("@"));
+}
+const RULES = cssRules(stripComments(cssSource));
+const norm = (s) => s.replace(/\s+/g, " ").trim();
+
+/** Slices a brace-balanced function body starting at `marker`. */
+function slice(src, marker) {
+  const start = src.indexOf(marker);
+  expect(start, marker).toBeGreaterThan(-1);
+  let i = src.indexOf("{", start), depth = 0;
+  for (; i < src.length; i++) {
+    if (src[i] === "{") depth++;
+    else if (src[i] === "}" && --depth === 0) return src.slice(start, i + 1);
+  }
+  throw new Error("unbalanced braces after " + marker);
+}
+
+/** Every rule whose selector list contains one matching `re`. */
+function rulesFor(re) {
+  return RULES.filter((r) => r.selectors.some((s) => re.test(norm(s))));
+}
+
+describe("design mode hides the document chrome it would paint over", () => {
+  test("the document header is hidden while design mode is active", () => {
+    // The decision and free templates put <h1> + subtitle + #theme-toggle in
+    // `.concept-content > header`; the design template's .concept-content
+    // holds only <main>. A mixed page (§ Per-Iteration Templates allows any
+    // order) therefore carries a header the design canvas paints over.
+    const hits = rulesFor(/^html\[data-template="design"\] \.concept-content > header$/);
+    expect(hits.length, 'html[data-template="design"] .concept-content > header').toBeGreaterThan(0);
+    for (const r of hits) expect(r.body).toMatch(/display\s*:\s*none/);
+  });
+
+  test("the per-iteration intro is hidden too", () => {
+    // Both decision/free and design iterations may open with
+    // <header class="iteration-intro">. It sits INSIDE the absolutely
+    // positioned section, so it bleeds through the mockup from y=0.
+    const hits = rulesFor(/^html\[data-template="design"\] section\[data-iteration\] > \.iteration-intro$/);
+    expect(hits.length, "design mode must hide .iteration-intro").toBeGreaterThan(0);
+    for (const r of hits) expect(r.body).toMatch(/display\s*:\s*none/);
+  });
+
+  test("the markup shape the rules key on is the one the templates emit", () => {
+    // Anchoring on a selector nobody emits is the failure mode these two
+    // assertions exist to prevent: both halves are read back out of the
+    // template markup rather than assumed.
+    const html = BLOCKS.filter((b) => b.info === "html").map((b) => b.code).join("\n");
+    expect(html, ".concept-content > header in the decision/free skeleton")
+      .toMatch(/<div class="concept-content">\s*(<!--[\s\S]*?-->\s*)*<header>/);
+    expect(html, '<header class="iteration-intro"> inside an iteration section')
+      .toMatch(/<header class="iteration-intro">/);
+  });
+
+  test("the theme toggle's only home is that header — hiding it is a decision, not an oversight", () => {
+    // If a future change gives design mode its own toggle, this test is the
+    // one to revisit: the rule above would then be hiding a live control.
+    const html = BLOCKS.filter((b) => b.info === "html").map((b) => b.code).join("\n");
+    const toggles = html.match(/id="theme-toggle"/g) || [];
+    expect(toggles.length, "#theme-toggle occurrences in template markup").toBeGreaterThan(0);
+    expect(md, "the trade-off must be written down where the rule lives")
+      .toMatch(/theme toggle lives only in that header/);
+  });
+
+  test("a frozen DESIGN iteration stays fully opaque", () => {
+    // § Tab Bar CSS dims every frozen iteration to 0.85 — legible for a
+    // sidebar section in normal flow, a see-through hole for an
+    // absolute/inset:0 canvas. Frozen-ness is carried by the panel state and
+    // the read-only dock (applyDockFreezeState) instead.
+    const dim = rulesFor(/^section\[data-iteration\]:not\(\[data-active\]\)$/)
+      .filter((r) => /opacity\s*:\s*0?\.\d/.test(r.body));
+    expect(dim.length, "the generic frozen dimmer this exempts").toBeGreaterThan(0);
+
+    const exempt = rulesFor(/^html\[data-template="design"\] section\[data-iteration\]:not\(\[data-active\]\)$/)
+      .filter((r) => /opacity\s*:\s*1(?![.\d])/.test(r.body));
+    expect(exempt.length, 'html[data-template="design"] …:not([data-active]) { opacity: 1 }')
+      .toBeGreaterThan(0);
+
+    // Source order cannot be relied on — the two rules live in different
+    // sections of this reference and a generated page inlines them in
+    // whatever order it assembles the <style>. The exemption must therefore
+    // win on SPECIFICITY: it is the dimmer's own selector with an extra
+    // `html[data-template="design"]` in front, which outranks it wherever it
+    // lands. A same-specificity variant (e.g. dropping the html prefix for a
+    // `[data-template="design"]` one on the section itself) would be a
+    // coin-flip on order, so pin the shape.
+    for (const r of exempt) {
+      for (const sel of r.selectors) {
+        expect(norm(sel), "exemption must outrank the dimmer by specificity")
+          .toBe('html[data-template="design"] '
+            + dim[0].selectors.map(norm).find((s) => /^section\[data-iteration\]/.test(s)));
+      }
+    }
+  });
+
+  test("§ Per-Iteration Templates says a decision/free page keeps its header", () => {
+    // The CSS only works if the markup is still there to hide; a later design
+    // round deleting the header would strand every earlier iteration.
+    const section = md.slice(md.indexOf("## Per-Iteration Templates"),
+      md.indexOf("# Template: decision"));
+    expect(section, "the keep-the-header rule").toMatch(/keeps its document header/i);
+    // The prose is hard-wrapped, so the pointer may straddle a newline.
+    expect(norm(section), "and the pointer to the CSS that hides it")
+      .toMatch(/Document chrome vs\. the fullscreen canvas/);
+  });
+});
+
+describe("scroll boxes are skinned, not raw", () => {
+  const BOXES = [".feedback-dock", ".concept-decision-panel", "section[data-screen]"];
+
+  test.each(BOXES)("%s declares the thin scrollbar", (box) => {
+    const hit = RULES.find((r) => r.selectors.some((s) => norm(s) === box)
+      && /scrollbar-width\s*:\s*thin/.test(r.body));
+    expect(hit, box + " { scrollbar-width: thin }").toBeTruthy();
+    expect(hit.body, box + " thumb colour on a transparent track")
+      .toMatch(/scrollbar-color\s*:\s*var\(--border-color[^)]*\)\s+transparent/);
+  });
+
+  test.each(BOXES)("%s ships the ::-webkit fallback too", (box) => {
+    // scrollbar-* is Firefox + modern Chromium only; older WebKit ignores it
+    // entirely and keeps the 16px slab. Both syntaxes or neither.
+    const want = {
+      "::-webkit-scrollbar": /width\s*:\s*8px/,
+      "::-webkit-scrollbar-thumb": /background\s*:\s*var\(--border-color/,
+      "::-webkit-scrollbar-track": /background\s*:\s*transparent/,
+    };
+    for (const [pseudo, body] of Object.entries(want)) {
+      const hit = RULES.find((r) => r.selectors.some((s) => norm(s) === box + pseudo)
+        && body.test(r.body));
+      expect(hit, box + pseudo).toBeTruthy();
+    }
+    const thumb = RULES.find((r) => r.selectors.some((s) => norm(s) === box + "::-webkit-scrollbar-thumb"));
+    expect(thumb.body, "thumb is rounded").toMatch(/border-radius\s*:\s*4px/);
+  });
+
+  test("the skin stays unscoped — every template has these boxes", () => {
+    // Scoping it to html[data-template="design"] would leave the decision and
+    // free iterations of the SAME page with the raw bar.
+    for (const box of BOXES) {
+      const hit = RULES.find((r) => r.selectors.some((s) => norm(s) === box)
+        && /scrollbar-width/.test(r.body));
+      for (const sel of hit.selectors) {
+        expect(norm(sel), "scrollbar skin must not be template-scoped")
+          .not.toMatch(/data-template/);
+      }
+    }
+  });
+
+  test("the boxes it skins are the ones that actually scroll", () => {
+    // Derived, not copied: a box that stops scrolling should drop out of the
+    // list rather than keep a dead rule, and one that STARTS scrolling should
+    // fail here until it is added.
+    const scrolling = new Set();
+    for (const r of RULES) {
+      if (!/overflow(-y)?\s*:\s*(auto|scroll)/.test(r.body)) continue;
+      for (const s of r.selectors) {
+        for (const box of BOXES) if (norm(s).includes(box)) scrolling.add(box);
+      }
+    }
+    expect([...scrolling].sort(), "skinned boxes must all be scroll containers")
+      .toEqual([...BOXES].sort());
+  });
+});
+
+describe("the attachment engine carries its own visibility CSS", () => {
+  test("_ensureAttachStyles injects the id the gate greps for", () => {
+    const fn = slice(jsSource, "function _ensureAttachStyles(");
+    expect(fn, "idempotent by id").toMatch(/getElementById\('attach-visibility-styles'\)/);
+    expect(fn, "and stamps that id on the node it creates")
+      .toMatch(/\.id\s*=\s*'attach-visibility-styles'/);
+    // Both halves of the hide rule, plus the :empty mount rule.
+    expect(fn).toMatch(/textarea\[hidden\] \+ \.attach-slot/);
+    expect(fn).toMatch(/textarea\[hidden\] \+ \.attach-bar/);
+    expect(fn).toMatch(/\.attach-slot:empty/);
+  });
+
+  test("it is called from initCommentAttachments, in the same block", () => {
+    // A helper defined in one copied block and called from another is exactly
+    // the partial-copy failure it exists to prevent, so pin both to ONE fence.
+    const block = JS_BLOCKS.find((b) => /function initCommentAttachments\(/.test(b.code));
+    expect(block, "the block defining initCommentAttachments").toBeTruthy();
+    expect(block.code, "_ensureAttachStyles must live in the same block")
+      .toMatch(/function _ensureAttachStyles\(/);
+    const init = slice(block.code, "function initCommentAttachments(");
+    expect(init, "engine styles are ensured before any bar is mounted")
+      .toMatch(/^\s*function initCommentAttachments\([^)]*\)\s*\{\s*_ensureAttachStyles\(\);/);
+  });
+
+  test("the Layout CSS copy stays — belt and braces, both directions", () => {
+    // The injected style covers "took the JS, not the CSS"; the static rule
+    // covers first paint before any script runs.
+    for (const sub of [".attach-slot", ".attach-bar"]) {
+      const hit = RULES.find((r) => r.selectors.some((s) =>
+        norm(s) === "textarea[hidden] + " + sub) && /display\s*:\s*none/.test(r.body));
+      expect(hit, "textarea[hidden] + " + sub + " in the CSS blocks").toBeTruthy();
+    }
+  });
+
+  test("the mountless path inserts afterend, never onto the container", () => {
+    const mount = slice(jsSource, "function _mountAttachmentBar(");
+    expect(mount, "adjacent-sibling mount").toMatch(/insertAdjacentElement\('afterend', bar\)/);
+    // Scanned across EVERY js block, not just this function: the forbidden
+    // shape reappearing anywhere means some copy path can still emit it.
+    expect(stripJsComments(jsSource), "parentElement.appendChild(bar) is the legacy stacking shape")
+      .not.toMatch(/parentElement\.appendChild\(bar\)/);
+    expect(md, "…and it must be named as forbidden in the prose")
+      .toMatch(/forbidden legacy shape/i);
+  });
+});
+
+describe("the gate can no longer pass a stacking page", () => {
+  const entry = (n) => {
+    const line = gate.split("\n").find((l) => l.startsWith("| " + n + " |"));
+    expect(line, "gate entry " + n).toBeTruthy();
+    return line;
+  };
+
+  test("entry 44 requires all four engine literals and both negatives", () => {
+    const e = entry(44);
+    for (const lit of [
+      "textarea[hidden] + .attach-slot",
+      "textarea[hidden] + .attach-bar",
+      "insertAdjacentElement('afterend', bar)",
+      "attach-visibility-styles",
+      "parentElement.appendChild(bar)",
+      "attach-hint",
+    ]) expect(e, "entry 44 must name " + lit).toContain(lit);
+    expect(gate, "…and explain why one literal was not enough")
+      .toMatch(/PASSED it while rendering/);
+  });
+
+  test("entries 46 / 47 pin the design-mode chrome rules", () => {
+    expect(entry(46)).toContain('html[data-template="design"] .concept-content > header');
+    expect(entry(46)).toContain(".iteration-intro");
+    expect(entry(47)).toContain('html[data-template="design"] section[data-iteration]:not([data-active])');
+    expect(entry(47)).toMatch(/opacity:\s*1/);
+  });
+
+  test("entry 48 is the scrollbar warning", () => {
+    const e = entry(48);
+    expect(e).toContain("scrollbar-width: thin");
+    expect(e).toContain("::-webkit-scrollbar");
+    for (const box of [".feedback-dock", ".concept-decision-panel", "section[data-screen]"]) {
+      expect(e, "entry 48 must name " + box).toContain(box);
+    }
+    expect(e, "explicitly a warning, unlike 46/47").toMatch(/[Ww]arning, not a hard fail/);
+  });
+
+  test("the gate says it applies to existing pages on every append", () => {
+    expect(gate, "§ Engine drift on iteration append")
+      .toMatch(/## Engine drift on iteration append/);
+    expect(gate, "the whole-file claim").toMatch(/WHOLE existing file on every append/);
+  });
+});
+
+describe("iteration append re-syncs a drifted engine before appending", () => {
+  test("SKILL.md Step 5c gains the drift check between 2.5 and 3", () => {
+    const proc = skill.slice(skill.indexOf("2.5. **Verify form collection coverage"));
+    const drift = proc.indexOf("2.6. **Engine drift check");
+    const append = proc.indexOf("3. Append a new `<section data-iteration=");
+    expect(drift, "step 2.6").toBeGreaterThan(-1);
+    expect(append, "the append step").toBeGreaterThan(-1);
+    expect(drift, "the drift check must run BEFORE the append").toBeLessThan(append);
+    expect(proc.slice(drift, append), "…and point at the gate section")
+      .toMatch(/Engine drift on iteration append/);
+  });
+
+  test("iteration-rules.md carries the same step", () => {
+    expect(iterRules).toMatch(/\*\*2\.6\. Engine drift check\.\*\*/);
+    expect(iterRules, "re-sync verbatim, then append")
+      .toMatch(/re-sync that whole block verbatim\s+from templates\.md FIRST, then append/);
+  });
+});

--- a/plugins/devops/skills/concept/templates-reference.test.js
+++ b/plugins/devops/skills/concept/templates-reference.test.js
@@ -123,8 +123,20 @@ describe("concept templates reference — embedded code integrity", () => {
     while ((m = re.exec(md))) used.add(m[1]);
     expect(used.size).toBeGreaterThan(0);
 
+    // Ids the JS CREATES are exempt, and derived rather than listed: a
+    // `getElementById(x)` paired with a `node.id = x` in the same reference is
+    // an idempotence guard ("inject this once"), not a lookup of a mount the
+    // markup owes. Deriving it keeps the exemption honest — delete the
+    // creating assignment and the id lands back in `undeclared`.
+    const created = new Set();
+    const jsSource = jsBlocks.map((b) => b.code).join("\n");
+    const idRe = /\.id\s*=\s*['"]([A-Za-z0-9_-]+)['"]/g;
+    let c;
+    while ((c = idRe.exec(jsSource))) created.add(c[1]);
+
     const undeclared = [...used]
       .filter((id) => !(id in OPTIONAL_IDS))
+      .filter((id) => !created.has(id))
       .filter((id) => !htmlSource.includes(`id="${id}"`));
 
     // A missing mount point does not throw — the JS null-guards its lookups —

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.139.0",
+  "version": "0.139.1",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

Three `/concept` defects measured on a real four-iteration page (decision → design → design → final report):

- **12 visible 📎 attachment bars for 3 visible dock textareas.** The page's attachment engine predated #317 (`parentElement.appendChild(bar)`, hiding rule without the `.attach-bar` half) and still passed the validation gate because entry 44 grepped a single literal. Iteration appends never refreshed the engine, so the defect survived every later round.
- **Raw platform scrollbar in the feedback dock** (1062px content in a 430px box, no scrollbar skin anywhere in the reference).
- **Header/intro bleed-through after ☰ switches.** A page that starts as a decision round keeps its document `<header>` and each `.iteration-intro` in normal flow; design-mode sections paint over them `position:absolute; inset:0`, and the generic frozen-iteration `opacity: 0.85` let both shine through the mockup under the screen indicator.

## Changes

- `templates.md` § Attachments: `_ensureAttachStyles()` injects `#attach-visibility-styles` once, so the JS hides bars with their fields even when copied without the layout rule; legacy mount shape called out as forbidden.
- `templates.md` § Layout CSS: thin border-coloured scrollbars for `.feedback-dock`, `.concept-decision-panel`, `section[data-screen]` (deliberately unscoped); `html[data-template="design"]` hides `.concept-content > header` and `.iteration-intro` and keeps frozen design iterations at `opacity: 1`.
- `validation-gate.md`: entry 44 rewritten (4 required literals + 2 negatives), new entries 46/47 (hard) and 48 (warning), new section "Engine drift on iteration append".
- `SKILL.md` Step 5c + `iteration-rules.md`: step 2.6 engine drift check — the gate runs over the whole existing page before every append and failing shared blocks are re-synced from the reference.
- New `design-chrome-overlap.test.js` (24 tests) pins all of it; `templates-reference.test.js` derives the injection-guard id exemption from source.

## Verification

- `npm test`: 94 files / 2227 passed, 3 skipped; `npm run lint` clean.
- Committed template blocks patched into the real page and re-measured in a browser: 3 bars for 3 textareas across iterations, style element injected exactly once, header/intro `display: none` and section `opacity: 1` in design mode, header back on the free-template report, `scrollbar-width: thin` on dock and panel.
- Independent QA pass: 7/7 checks (gate literals verbatim, negatives absent, specificity (0,3,2) beats (0,2,1) regardless of source order).

🤖 Generated with [Claude Code](https://claude.com/claude-code)