### PR TITLE
feat(concept): frozen-iteration floating bar + relock veil on tab

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.139.1"
+    "version": "0.140.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.139.1",
+      "version": "0.140.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.139.1",
+      "version": "0.140.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.140.0] — 2026-09-04
+
+### Added
+
+- **A `/concept` page now says, on the page itself, when you are reading an earlier iteration — and relocks every past round you leave.** Switching to a past tab used to show it behind the post-submit dimmer, which is click-to-dismiss: users lifted it by reflex and then read history as the live page, because after the lift nothing on screen said "earlier round" except the chip highlight in the panel, and the live chip is not always the last one once a final report exists. The lifted veil also stayed lifted across tab switches, so several past rounds could be unlocked at the same time.
+
+  Every non-live tab now shows a fixed top-centre pill — "🕘 Iteration N · frühere Runde, schreibgeschützt" with a "Zur aktuellen Runde" button — that survives the click on the veil, and `showIteration()` re-arms the shared dimmer on every entry into a past round while hiding it on the live one: at most the one past round on screen is unlocked, none while the live round is shown. On design pages the pill drops into the row below the design switcher and keeps to its width band, so it never collides with the screen indicator or the ☰ FAB. Gate entry 30b pins the bar and the relock call as engine entries, so an existing page picks both up on its next iteration append.
+
 ## [0.139.1] — 2026-09-04
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.139.1**
+**Version: 0.140.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.139.1",
+  "version": "0.140.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/skills/concept/SKILL.md
+++ b/plugins/devops/skills/concept/SKILL.md
@@ -517,7 +517,10 @@ signal Claude monitors.
    reveal `#content-dimmer` so the content area visually fades. The decision
    panel + FABs sit at higher z-index and stay clear + interactive. The
    dimmer is click-to-dismiss; otherwise it auto-clears on the next page
-   reload (next iteration / final report).
+   reload (next iteration / final report). The same dimmer doubles as the
+   **frozen veil**: `showIteration()` re-arms it on every non-live tab and
+   shows the `#frozen-bar` floating pill with a back-to-live button (see
+   `deep-knowledge/iteration-rules.md` § Rules, "Veil + floating bar").
 5. Switch the decision panel from "ready" to "submitted" state — showing a
    clear "Entscheidungen übermittelt" indicator with a hint to switch to the
    Claude chat (see `deep-knowledge/templates.md` § Submit Handler)

--- a/plugins/devops/skills/concept/deep-knowledge/iteration-rules.md
+++ b/plugins/devops/skills/concept/deep-knowledge/iteration-rules.md
@@ -25,6 +25,20 @@ selections, read-only comments).
   which state the user submitted, read-only comment fields with the text
   the user entered. Users can click back to earlier tabs to review their
   own past feedback at any time.
+- **Veil + floating bar on every past tab (all templates).** Entering a
+  non-live tab locks it behind the shared `#content-dimmer` (the "veil";
+  `showIteration()` → `lockFrozenView()`) and unhides `#frozen-bar`, a fixed
+  top-centre pill reading "🕘 Iteration N · frühere Runde, schreibgeschützt"
+  with a `#frozen-bar-back` button to the live round. The veil is
+  click/Escape-to-lift so the round can be read in full; the bar stays up
+  after the lift — it is the signal that survives the reflex click. Lock
+  discipline: **every** tab switch relocks (another past round → that one is
+  veiled, the previous one is veiled again the next time it is opened; the
+  live round → the dimmer is hidden and every past round is locked). So at
+  most ONE past round is unlocked at any time, and zero while the live round
+  is shown. The bar is page-level chrome outside `section[data-iteration]`
+  and must be copied verbatim into every template skeleton (see templates.md
+  § Common Structure; gate entry 30b).
   - **Exemption for `design` iterations:** freezing must NOT disable
     navigation — the user still has to be able to revisit the mockups. The
     `disabled`-everything sweep MUST skip `.design-switch-item`,

--- a/plugins/devops/skills/concept/deep-knowledge/templates.md
+++ b/plugins/devops/skills/concept/deep-knowledge/templates.md
@@ -67,6 +67,8 @@ must see their own language. The locale hint is authoritative.
 | `panel.frozen`                 | Frozen iteration               | Eingefrorene Iteration |
 | `panel.frozen_hint`            | You are reading an earlier round. It is read-only — its decisions were already submitted. | Du liest eine frühere Runde. Sie ist schreibgeschützt — ihre Entscheidungen wurden bereits übermittelt. |
 | `panel.frozen_back`            | Back to the current round      | Zurück zur aktuellen Runde |
+| `frozen.bar_hint`              | · earlier round, read-only     | · frühere Runde, schreibgeschützt |
+| `frozen.bar_back`              | Go to current round            | Zur aktuellen Runde |
 | `panel.connecting_title`       | Claude is connecting           | Claude verbindet sich |
 | `panel.connected_title`        | Claude connected               | Claude verbunden |
 | `panel.disconnected_title`     | Claude not connected           | Claude nicht verbunden |
@@ -519,17 +521,33 @@ the `[ui-locale: ...]` hint produced.
     </aside>
   </div>
 
-  <!-- Submitted-state content dimmer (all templates).
-       After a submit, body.content-dimmed flips this on. The dimmer covers
-       the content area and directs focus to the decision panel / FAB. The
-       panel + FABs are above z-index 50 so they paint over the dimmer and
-       stay visually clear and clickable. The dimmer itself is click-to-
-       dismiss; otherwise it auto-clears on the next page reload (new
-       iteration / final report) because `content-dimmed` is not persisted. -->
+  <!-- Content dimmer (all templates) — two jobs, one element.
+       (1) Submitted-state focus shifter: after a submit, body.content-dimmed
+       flips this on so the user's focus lands on the decision panel / FAB.
+       (2) Frozen veil: showIteration() re-arms it on EVERY entry into a
+       non-live tab, locking the past round behind the same overlay. In both
+       roles the panel + FABs sit above z-index 50 and stay clickable, and the
+       dimmer is click/Escape-to-dismiss. The submit role auto-clears on the
+       next reload (`content-dimmed` is not persisted); the veil role comes
+       back on the next tab switch, so at most the one past round on screen is
+       ever unlocked. -->
   <div class="content-dimmer" id="content-dimmer"
        role="button" tabindex="-1"
        aria-label="{{panel.dim_dismiss}}"
        title="{{panel.dim_dismiss}}" hidden></div>
+
+  <!-- Frozen-iteration floating bar (all templates). Page-level chrome, so it
+       lives OUTSIDE section[data-iteration], next to the dimmer. showIteration()
+       unhides it on every non-live tab and fills [data-frozen-bar-title] with
+       that tab's chip label. It exists because the veil is lifted by reflex:
+       once the dimmer is clicked away, nothing on the page says "this is an
+       earlier round" except the small chip highlight in the panel — and the
+       live chip is not always the last one. Its button is the second way back
+       to the live round (#back-to-live-btn in #panel-frozen is the first). -->
+  <div class="frozen-bar" id="frozen-bar" role="status" hidden>
+    <span class="frozen-bar-text">🕘 <strong data-frozen-bar-title>Iteration 1</strong> {{frozen.bar_hint}}</span>
+    <button type="button" id="frozen-bar-back">{{frozen.bar_back}}</button>
+  </div>
 
   <script type="application/json" id="concept-decisions">
     {"submitted": false, "decisions": [], "comments": []}
@@ -1907,11 +1925,17 @@ it today.
     </aside>
   </div>
 
-  <!-- Shared content dimmer — see Common Structure for behavior + CSS. -->
+  <!-- Shared content dimmer + frozen bar — see Common Structure for
+       behavior + CSS. Both are page-level chrome and MUST be copied verbatim:
+       showIteration() drives them regardless of template. -->
   <div class="content-dimmer" id="content-dimmer"
        role="button" tabindex="-1"
        aria-label="{{panel.dim_dismiss}}"
        title="{{panel.dim_dismiss}}" hidden></div>
+  <div class="frozen-bar" id="frozen-bar" role="status" hidden>
+    <span class="frozen-bar-text">🕘 <strong data-frozen-bar-title>Iteration 1</strong> {{frozen.bar_hint}}</span>
+    <button type="button" id="frozen-bar-back">{{frozen.bar_back}}</button>
+  </div>
 </body>
 </html>
 ```
@@ -5175,11 +5199,17 @@ bi-state. Claude chooses the structure that fits the content.
     </aside>
   </div>
 
-  <!-- Shared content dimmer — see Common Structure for behavior + CSS. -->
+  <!-- Shared content dimmer + frozen bar — see Common Structure for
+       behavior + CSS. Both are page-level chrome and MUST be copied verbatim:
+       showIteration() drives them regardless of template. -->
   <div class="content-dimmer" id="content-dimmer"
        role="button" tabindex="-1"
        aria-label="{{panel.dim_dismiss}}"
        title="{{panel.dim_dismiss}}" hidden></div>
+  <div class="frozen-bar" id="frozen-bar" role="status" hidden>
+    <span class="frozen-bar-text">🕘 <strong data-frozen-bar-title>Iteration 1</strong> {{frozen.bar_hint}}</span>
+    <button type="button" id="frozen-bar-back">{{frozen.bar_back}}</button>
+  </div>
 </body>
 </html>
 ```
@@ -5581,6 +5611,58 @@ body.content-dimmed .content-dimmer:not([hidden]) {
 .content-dimmer:focus-visible {
   outline: 2px solid var(--accent-color, #58a6ff);
   outline-offset: -4px;
+}
+
+/* Frozen-iteration floating bar — shown by showIteration() on every non-live
+   tab, together with the re-armed dimmer (the "veil"). The veil is what gets
+   clicked away by reflex; the bar is what still says "you are in history"
+   afterwards, so it deliberately uses the WARNING tint rather than the muted
+   history colour of .frozen-indicator — being overlooked is the failure mode
+   it exists to fix. Sits above the dimmer (50) and the design chrome sharing
+   its band (switcher 95, anno pill 96), below the FABs (100), the panel
+   backdrop (150) and the panel itself. */
+.frozen-bar {
+  position: fixed; top: 0.75rem; left: 50%; transform: translateX(-50%);
+  z-index: 97;
+  box-sizing: border-box;
+  display: flex; align-items: center; gap: 0.6rem;
+  max-width: min(560px, calc(100vw - 2rem));
+  padding: 0.4rem 0.45rem 0.4rem 0.85rem;
+  border-radius: 999px;
+  border: 1px solid var(--warning-color, #d29922);
+  background: color-mix(in srgb, var(--warning-color, #d29922) 16%, var(--panel-bg, #161b22));
+  color: var(--text-color, #c9d1d9);
+  font-size: 0.82rem;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+}
+.frozen-bar[hidden] { display: none; }
+.frozen-bar-text {
+  min-width: 0;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.frozen-bar-text strong { color: var(--text-color, #c9d1d9); }
+.frozen-bar button {
+  flex-shrink: 0;
+  padding: 0.3rem 0.75rem; border-radius: 999px; border: none;
+  background: var(--accent-color, #58a6ff); color: #fff;
+  font-size: 0.8rem; font-weight: 600; cursor: pointer;
+  transition: filter 0.15s ease;
+}
+.frozen-bar button:hover { filter: brightness(1.12); }
+.frozen-bar button:focus-visible {
+  outline: 2px solid var(--accent-color, #58a6ff);
+  outline-offset: 2px;
+}
+/* Design template: the top-centre band at 0.75rem belongs to .design-switcher.
+   Drop into the row below it (same 3.75rem derivation as .anno-toggle-fab)
+   and stay inside the switcher's 34vw width band, so the bar can never run
+   into the screen-indicator column on the left or the ☰ FAB on the right —
+   the same geometry contract every other piece of design chrome follows. */
+html[data-template="design"] .frozen-bar {
+  top: 3.75rem;
+  max-width: min(34vw, 560px);
 }
 
 /* Submitted state */
@@ -7374,6 +7456,16 @@ function hideContentDimmer() {
   if (dim) dim.hidden = true;
   document.body.classList.remove('content-dimmed');
 }
+// Frozen veil — the same overlay doubles as the lock over a past iteration.
+// showIteration() calls this on EVERY entry into a non-live tab, so a veil the
+// user lifted (click / Escape) comes back the moment they switch tabs: at most
+// the one past round currently on screen is ever unlocked, and switching to
+// the live tab hides the dimmer instead (see showIteration), so from the live
+// round every past round is locked again.
+function lockFrozenView() {
+  document.body.classList.add('content-dimmed');
+  showContentDimmer();
+}
 document.getElementById('content-dimmer')
   ?.addEventListener('click', hideContentDimmer);
 // Keyboard escape — keyboard-only users can't click the dimmer, so let
@@ -8322,6 +8414,21 @@ function showIteration(n) {
   }
   if (panelFinal) panelFinal.style.display = isFinal ? 'block' : 'none';
   if (panelFrozen) panelFrozen.style.display = isLive ? 'none' : 'block';
+  // Frozen veil + floating bar. Every entry into a non-live tab RE-LOCKS the
+  // round behind the shared content dimmer (lockFrozenView), so at most the
+  // one past round on screen can be unlocked and any tab switch — to another
+  // past round or back to the live one — relocks it. The bar stays up after
+  // the user lifts the veil: the veil is clicked away by reflex, the bar is
+  // what still tells them they are in history. On the live tab the dimmer is
+  // hidden (a veil lifted on a past round must not reappear over the live one).
+  const frozenBar = document.getElementById('frozen-bar');
+  if (frozenBar) {
+    frozenBar.hidden = !!isLive;
+    const title = frozenBar.querySelector('[data-frozen-bar-title]');
+    const tab = document.querySelector('.iteration-tab[data-iteration="' + n + '"]');
+    if (title) title.textContent = tab ? tab.textContent.trim() : String(n);
+  }
+  if (isLive) hideContentDimmer(); else lockFrozenView();
   if (typeof buildSectionNav === 'function') buildSectionNav();
   if (typeof refreshFinalizeWizard === 'function') refreshFinalizeWizard({ reset: true });
   document.dispatchEvent(new CustomEvent('iteration:changed'));
@@ -8331,13 +8438,18 @@ document.querySelectorAll('.iteration-tab').forEach(tab => {
   tab.addEventListener('click', () => showIteration(tab.dataset.iteration));
 });
 
-// The frozen panel's way back. Without it the only exit from a past tab is to
-// spot which chip is the live one — and the live tab is not always the last
-// chip (the final report is), so guessing is a real failure mode.
-document.getElementById('back-to-live-btn')?.addEventListener('click', () => {
+// The way back to the live round. Without it the only exit from a past tab is
+// to spot which chip is the live one — and the live tab is not always the last
+// chip (the final report is), so guessing is a real failure mode. Two entry
+// points, one target: the panel's #back-to-live-btn and the floating
+// #frozen-bar-back (the bar sits over the content, where the user's eyes are
+// after they lift the veil — the panel link alone was too easy to miss).
+function goToLiveIteration() {
   const live = document.querySelector('section[data-iteration][data-active]');
   if (live) showIteration(live.dataset.iteration);
-});
+}
+document.getElementById('back-to-live-btn')?.addEventListener('click', goToLiveIteration);
+document.getElementById('frozen-bar-back')?.addEventListener('click', goToLiveIteration);
 
 document.addEventListener('DOMContentLoaded', () => {
   const active = document.querySelector('section[data-iteration][data-active]');

--- a/plugins/devops/skills/concept/deep-knowledge/validation-gate.md
+++ b/plugins/devops/skills/concept/deep-knowledge/validation-gate.md
@@ -37,7 +37,7 @@ no legitimate matches — do not "keep it as a convenience". The decision panel
 
 ## Phase 1 — Shared patterns (ALL templates)
 
-Every concept page must contain these 52 patterns, regardless of template
+Every concept page must contain these 53 patterns, regardless of template
 (the numbering carries `b` suffixes where a pattern was added next to a
 related one — count the rows, not the highest number):
 
@@ -75,7 +75,8 @@ related one — count the rows, not the highest number):
 | 28 | `panel-final-report` | Final-report panel element. Auto-shown by `showIteration()` when the active section carries `data-final-report`; replaces `panel-ready` (no iterate/implement buttons). |
 | 28b | `panel-frozen` | Frozen panel state, shown on every non-live iteration tab. `showIteration()` switches to it unconditionally, so a page without it loses the panel's whole lower half whenever the user reviews an earlier round — no controls, no explanation, and no way back to the live tab except guessing which chip it is. Must include the `#back-to-live-btn`. |
 | 29 | `refreshFinalizeWizard({ reset: true })` — grep the CALL, not the symbol | Recomputes the close-out wizard's step list (the issues step exists only while the active section has un-routed `[data-open-questions]` checkboxes) and re-renders. The call must appear inside `showIteration()` so a tab switch restarts the flow at step 1. A page that defines the function but never calls it passes a symbol-only grep and renders a wizard that never updates. |
-| 30 | `content-dimmer` | Shared post-submit focus overlay. After a submit, `body.content-dimmed` flips it on; the decision panel + FABs sit at higher z-index and paint above it. Click-to-dismiss; auto-clears on page reload. See `templates.md` § Common Structure (HTML) and § Decision Panel State CSS for the reference implementation. |
+| 30 | `content-dimmer` | Shared post-submit focus overlay AND frozen veil. After a submit, `body.content-dimmed` flips it on; `showIteration()` re-arms it via `lockFrozenView()` on every entry into a non-live tab (so at most the one past round on screen is ever unlocked, and every tab switch relocks). The decision panel + FABs sit at higher z-index and paint above it. Click/Escape-to-dismiss; the submit role auto-clears on page reload. See `templates.md` § Common Structure (HTML) and § Decision Panel State CSS for the reference implementation. |
+| 30b | `frozen-bar` (the element) AND `lockFrozenView` (the CALL inside `showIteration()`) | Frozen-iteration floating bar + veil relock. The bar is page-level chrome (outside `section[data-iteration]`, next to the dimmer) that `showIteration()` unhides on every non-live tab with the tab's chip label in `[data-frozen-bar-title]` and a `#frozen-bar-back` button to the live round. Without it, lifting the veil leaves nothing on screen that says "this is an earlier round" — users click the veil away by reflex and then read history as the live page. Without the `lockFrozenView()` call, a lifted veil stays lifted across tab switches and several past rounds end up unlocked at once. Both halves ENGINE entries — see § Engine drift on iteration append. |
 | 31 | `ensureCommentSlots` | Auto-injects an adjacent `<textarea data-comment="$decisionId-note">` for every `[data-decision]` bi-state group that lacks one. MUST be called from `DOMContentLoaded` BEFORE `restoreState` so the restore step rehydrates the typed values onto real nodes. See templates.md § Comment Slot Injection. |
 | 32 | `panel-dispose-concept` | Disposition fieldset — the wizard's `files` step. Carries the discard / keep / gitignore radio group + optional `moveTo` input. See templates.md § Disposition Control. |
 | 33 | `renderWizard` | Renders exactly one wizard step, the `Schritt n/m` counter, and the back/next/execute button set. Missing → every step renders at once and the flow is back to the wall of buttons the wizard replaced. |
@@ -157,8 +158,9 @@ keeps the old defect through every later round, and the user reports "still
 to twice since.
 
 Before appending, run the gate over the existing HTML. When any ENGINE entry
-fails — 44 (attachments), 46 / 47 (design-mode chrome), 48 (scroll boxes),
-or the tab-switch patterns — re-sync that whole shared block **verbatim from
+fails — 30b (frozen bar + veil relock), 44 (attachments), 46 / 47
+(design-mode chrome), 48 (scroll boxes), or the tab-switch patterns —
+re-sync that whole shared block **verbatim from
 templates.md** BEFORE the new section goes in. Re-sync the block, not the one
 line the grep flagged: these blocks fail in halves, and a page missing one
 literal is a page carrying a stale copy of everything around it. Appending

--- a/plugins/devops/skills/concept/frozen-veil-bar.test.js
+++ b/plugins/devops/skills/concept/frozen-veil-bar.test.js
@@ -1,0 +1,270 @@
+import { describe, test, expect } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import vm from "node:vm";
+import { fileURLToPath } from "node:url";
+
+// Two UX defects observed on a real multi-iteration concept page:
+//
+//   1. The post-submit dimmer was the only thing veiling a past round, and it
+//      is click-to-dismiss. Users lift it by reflex the moment they open an
+//      old tab, and then read history as the live page — after the lift,
+//      nothing on screen says "earlier round" except the chip highlight in
+//      the panel, and the live chip is not always the last one.
+//   2. Once lifted, the veil stayed lifted across tab switches, so several
+//      past rounds could be unlocked at the same time.
+//
+// Contract pinned here: showIteration() re-arms the dimmer (lockFrozenView)
+// on EVERY entry into a non-live tab and unhides a fixed #frozen-bar with a
+// back-to-live button; the live tab hides the dimmer. So at most the one past
+// round on screen is unlocked, and none while the live round is shown.
+//
+// templates.md is a REFERENCE Claude copies verbatim into generated pages, so
+// a defect here ships silently into every concept produced afterwards.
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DK = path.join(__dirname, "deep-knowledge");
+const md = fs.readFileSync(path.join(DK, "templates.md"), "utf8");
+const gate = fs.readFileSync(path.join(DK, "validation-gate.md"), "utf8");
+const iterRules = fs.readFileSync(path.join(DK, "iteration-rules.md"), "utf8");
+
+// Line-based scanner (same reason as panel-chrome.test.js): a lazy regex
+// desynchronises on the first block whose body contains a fence.
+function scanBlocks(src) {
+  const lines = src.split("\n");
+  const out = [];
+  let open = null, body = [];
+  for (let i = 0; i < lines.length; i++) {
+    const m = /^```(.*)$/.exec(lines[i]);
+    if (m) {
+      if (open === null) { open = { info: m[1].trim(), start: i + 2 }; body = []; }
+      else { out.push({ info: open.info, line: open.start, code: body.join("\n") }); open = null; }
+      continue;
+    }
+    if (open) body.push(lines[i]);
+  }
+  return out;
+}
+const BLOCKS = scanBlocks(md);
+const HTML_BLOCKS = BLOCKS.filter((b) => b.info === "html");
+const cssSource = BLOCKS.filter((b) => b.info === "css").map((b) => b.code).join("\n");
+
+function fnSource(name) {
+  const m = md.match(new RegExp("function " + name + "\\([^)]*\\) \\{[\\s\\S]*?\\n\\}"));
+  if (!m) throw new Error("function " + name + " not found in templates.md");
+  return m[0];
+}
+
+describe("frozen veil + floating bar — markup", () => {
+  // Every template skeleton (Common Structure, design, free) ships the
+  // dimmer; each MUST ship the bar right next to it, outside any iteration
+  // section, because showIteration() drives both regardless of template.
+  test("every skeleton that declares #content-dimmer also declares #frozen-bar outside the iteration sections", () => {
+    const skeletons = HTML_BLOCKS.filter((b) => b.code.includes('id="content-dimmer"'));
+    expect(skeletons.length).toBe(3);
+    for (const b of skeletons) {
+      const where = `html block at line ${b.line}`;
+      expect(b.code, where).toContain('id="frozen-bar"');
+      expect(b.code, where).toContain("data-frozen-bar-title");
+      expect(b.code, where).toContain('id="frozen-bar-back"');
+      expect(b.code, where).toContain("{{frozen.bar_hint}}");
+      expect(b.code, where).toContain("{{frozen.bar_back}}");
+      // Page-level chrome: after the last closed section, never inside one.
+      const barAt = b.code.indexOf('id="frozen-bar"');
+      expect(barAt, where).toBeGreaterThan(b.code.lastIndexOf("</section>"));
+      // Hidden by default — only showIteration() unhides it on a past tab.
+      expect(b.code, where).toMatch(/id="frozen-bar" role="status" hidden/);
+    }
+  });
+
+  test("locale table carries the bar strings in en and de", () => {
+    for (const key of ["frozen.bar_hint", "frozen.bar_back"]) {
+      const row = md.split("\n").find((l) => l.startsWith("| `" + key + "`"));
+      expect(row, key).toBeDefined();
+      const cells = row.split("|").map((s) => s.trim()).filter(Boolean);
+      expect(cells.length, key).toBe(3);
+    }
+  });
+});
+
+describe("frozen veil + floating bar — CSS", () => {
+  test("bar is fixed chrome above the dimmer and below the FABs", () => {
+    const dimmer = cssSource.match(/\.content-dimmer \{([\s\S]*?)\}/);
+    const bar = cssSource.match(/\n\.frozen-bar \{([\s\S]*?)\}/);
+    expect(dimmer).not.toBeNull();
+    expect(bar).not.toBeNull();
+    const z = (rule) => Number(/z-index:\s*(\d+)/.exec(rule[1])[1]);
+    expect(bar[1]).toContain("position: fixed");
+    expect(z(bar)).toBeGreaterThan(z(dimmer));
+    // FABs (100) and the panel must keep painting over the bar.
+    expect(z(bar)).toBeLessThan(100);
+    expect(cssSource).toContain(".frozen-bar[hidden] { display: none; }");
+  });
+
+  // On design pages the 0.75rem top-centre band belongs to .design-switcher.
+  // The bar drops into the row below it and stays inside the switcher's
+  // width band — the same geometry contract as the rest of the chrome.
+  test("design template moves the bar below the switcher and caps it to the switcher's band", () => {
+    const rule = cssSource.match(/html\[data-template="design"\] \.frozen-bar \{([\s\S]*?)\}/);
+    expect(rule).not.toBeNull();
+    expect(rule[1]).toContain("top: 3.75rem");
+    expect(rule[1]).toMatch(/max-width:\s*min\(34vw/);
+  });
+});
+
+describe("frozen veil + floating bar — JS contract", () => {
+  test("showIteration relocks past rounds, hides the dimmer on the live one, and drives the bar", () => {
+    const fn = fnSource("showIteration");
+    expect(fn).toContain("if (isLive) hideContentDimmer(); else lockFrozenView();");
+    expect(fn).toContain("frozenBar.hidden = !!isLive");
+    expect(fn).toContain("[data-frozen-bar-title]");
+  });
+
+  test("lockFrozenView re-arms the shared dimmer", () => {
+    const fn = fnSource("lockFrozenView");
+    expect(fn).toContain("classList.add('content-dimmed')");
+    expect(fn).toContain("showContentDimmer()");
+  });
+
+  test("both back-to-live entry points share one target", () => {
+    expect(md).toContain("getElementById('back-to-live-btn')?.addEventListener('click', goToLiveIteration)");
+    expect(md).toContain("getElementById('frozen-bar-back')?.addEventListener('click', goToLiveIteration)");
+  });
+
+  test("gate and iteration rules carry the contract", () => {
+    expect(gate).toMatch(/\| 30b \| `frozen-bar`/);
+    expect(gate).toContain("lockFrozenView");
+    expect(iterRules).toContain("lockFrozenView");
+    expect(iterRules).toContain("#frozen-bar");
+  });
+});
+
+// ── Behavioural run of the reference functions against a minimal DOM stub ──
+// No jsdom in this repo, and the functions only touch a handful of DOM
+// surfaces, so a hand-rolled stub is enough to exercise the lock discipline
+// end to end: 3 sections (3 is live), tabs, dimmer, bar.
+
+function makeStub() {
+  const mkClassList = (owner) => ({
+    add: (...c) => c.forEach((x) => owner._classes.add(x)),
+    remove: (...c) => c.forEach((x) => owner._classes.delete(x)),
+    toggle: (c, force) => { force ? owner._classes.add(c) : owner._classes.delete(c); },
+    contains: (c) => owner._classes.has(c),
+  });
+  const mkEl = (attrs = {}, extra = {}) => {
+    const el = {
+      hidden: false, dataset: {}, style: {}, textContent: "", _attrs: {}, _classes: new Set(),
+      hasAttribute: (a) => a in el._attrs,
+      setAttribute: (a, v) => { el._attrs[a] = v; },
+      addEventListener: () => {},
+      ...extra,
+    };
+    el.classList = mkClassList(el);
+    for (const [k, v] of Object.entries(attrs)) {
+      el._attrs[k] = v;
+      if (k.startsWith("data-")) el.dataset[k.slice(5).replace(/-([a-z])/g, (_, c) => c.toUpperCase())] = v;
+    }
+    return el;
+  };
+  const sections = [1, 2, 3].map((n) => mkEl({ "data-iteration": String(n), "data-iteration-template": "decision" }));
+  sections[2]._attrs["data-active"] = "";
+  const tabs = [1, 2, 3].map((n) => mkEl({ "data-iteration": String(n) }, { textContent: `  Iteration ${n}  ` }));
+  const dimmer = mkEl(); dimmer.hidden = true;
+  const title = mkEl();
+  const bar = mkEl(); bar.hidden = true;
+  bar.querySelector = (sel) => (sel === "[data-frozen-bar-title]" ? title : null);
+  const byId = { "content-dimmer": dimmer, "frozen-bar": bar };
+  const body = mkEl();
+  const documentElement = mkEl();
+  const document = {
+    body, documentElement,
+    getElementById: (id) => byId[id] || null,
+    querySelectorAll: (sel) => (sel === "section[data-iteration]" ? sections : sel === ".iteration-tab" ? tabs : []),
+    querySelector: (sel) => {
+      if (sel === "section[data-iteration][data-active]") return sections.find((s) => "data-active" in s._attrs) || null;
+      const m = /^\.iteration-tab\[data-iteration="(\d+)"\]$/.exec(sel);
+      if (m) return tabs.find((t) => t.dataset.iteration === m[1]) || null;
+      return null;
+    },
+    dispatchEvent: () => true,
+    addEventListener: () => {},
+  };
+  return { document, sections, tabs, dimmer, bar, title, body };
+}
+
+function loadRuntime() {
+  const stub = makeStub();
+  const ctx = {
+    document: stub.document,
+    CustomEvent: function CustomEvent(type) { this.type = type; },
+    console,
+  };
+  vm.createContext(ctx);
+  const src = [
+    fnSource("showContentDimmer"),
+    fnSource("hideContentDimmer"),
+    fnSource("lockFrozenView"),
+    fnSource("resolveIterationTemplate"),
+    fnSource("applyIterationTemplate"),
+    fnSource("showIteration"),
+    "globalThis.showIteration = showIteration;",
+  ].join("\n");
+  new vm.Script(src, { filename: "templates.md#tab-switch" }).runInContext(ctx);
+  return { ...stub, showIteration: ctx.showIteration };
+}
+
+describe("frozen veil + floating bar — behaviour (reference JS on a DOM stub)", () => {
+  const veiled = (r) => !r.dimmer.hidden && r.body.classList.contains("content-dimmed");
+
+  test("live tab: bar hidden, no veil", () => {
+    const r = loadRuntime();
+    r.showIteration("3");
+    expect(r.bar.hidden).toBe(true);
+    expect(veiled(r)).toBe(false);
+    expect(r.body.classList.contains("viewing-frozen")).toBe(false);
+  });
+
+  test("entering a past tab veils it and shows the bar with that tab's label", () => {
+    const r = loadRuntime();
+    r.showIteration("3");
+    r.showIteration("1");
+    expect(veiled(r)).toBe(true);
+    expect(r.bar.hidden).toBe(false);
+    expect(r.title.textContent).toBe("Iteration 1");
+    expect(r.body.classList.contains("viewing-frozen")).toBe(true);
+  });
+
+  test("lifting the veil then switching to another past tab relocks — at most one unlocked", () => {
+    const r = loadRuntime();
+    r.showIteration("1");
+    // user clicks the dimmer away (hideContentDimmer is what the click does)
+    r.dimmer.hidden = true; r.body.classList.remove("content-dimmed");
+    expect(veiled(r)).toBe(false);
+    r.showIteration("2");
+    expect(veiled(r)).toBe(true);
+    expect(r.title.textContent).toBe("Iteration 2");
+    // and going back to the first past round veils it again too
+    r.dimmer.hidden = true; r.body.classList.remove("content-dimmed");
+    r.showIteration("1");
+    expect(veiled(r)).toBe(true);
+  });
+
+  test("returning to the live tab hides the veil and the bar", () => {
+    const r = loadRuntime();
+    r.showIteration("2");
+    expect(veiled(r)).toBe(true);
+    r.showIteration("3");
+    expect(veiled(r)).toBe(false);
+    expect(r.bar.hidden).toBe(true);
+  });
+
+  test("a final-report live tab behaves like any live tab", () => {
+    const r = loadRuntime();
+    r.sections[2]._attrs["data-final-report"] = "";
+    r.showIteration("1");
+    r.showIteration("3");
+    expect(r.body.classList.contains("viewing-final")).toBe(true);
+    expect(veiled(r)).toBe(false);
+    expect(r.bar.hidden).toBe(true);
+  });
+});

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.139.1",
+  "version": "0.140.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

Reviewing a past `/concept` iteration was easy to mistake for the live page. The only veil over it was the post-submit content dimmer, which is click-to-dismiss — users lift it by reflex the moment they open an old tab, and after the lift nothing on screen says "earlier round" except the chip highlight in the panel (and the live chip is not always the last one once a final report exists). The lifted veil also stayed lifted across tab switches, so several past rounds could be unlocked at once.

## Changes

- **Floating bar on every non-live tab.** `showIteration()` unhides a fixed top-centre `#frozen-bar` pill — "🕘 Iteration N · frühere Runde, schreibgeschützt" + "Zur aktuellen Runde" button — filled with the tab's chip label. Warning tint on purpose: being overlooked is the failure mode it fixes. On design pages it drops into the row below the design switcher and keeps to the switcher's 34vw band (no collision with screen indicator / ☰ FAB).
- **Relock discipline.** `lockFrozenView()` re-arms the shared dimmer on every entry into a past round; the live tab hides it. At most one past round is unlocked at any time, none while the live round is shown. The veil stays click/Escape-to-lift.
- **One target, two entry points.** `goToLiveIteration()` backs both the panel's `#back-to-live-btn` and the bar's `#frozen-bar-back`.
- **Validation gate** entry 30b (`frozen-bar` element + `lockFrozenView` call) added to the engine-drift list, so existing pages pick the bar up on their next iteration append. `iteration-rules.md` / `SKILL.md` document the rule; locale strings `frozen.bar_hint` / `frozen.bar_back` (en/de).
- **Tests:** `frozen-veil-bar.test.js` — markup in all three skeletons, CSS z-order/geometry, JS contract, and a behavioural run of the reference tab-switch JS on a DOM stub (relock alt→alt, unveil →live, final-report live tab).

## Verification

- `npm run lint` clean; `npm test` 95 files / 2240 tests green (13 new)
- Browser preview (sidebar layout, dark): bar visible above the dimmer; after clicking the veil the dimmer is gone and the bar stays
- Codex review gate: skipped (Codex usage limit reached — provider error, not a finding)

🤖 Generated with [Claude Code](https://claude.com/claude-code)