### PR TITLE
feat(strict): /claude-strict — literal scope, discretionary

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.141.0"
+    "version": "0.142.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.141.0",
+      "version": "0.142.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.141.0",
+      "version": "0.142.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ node_modules/
 .claude/batch-mode.json
 .claude/batch-watchdog.lock
 .claude/batch.md
+.claude/strict-mode.json
 .claude/.ship-in-progress
 .claude/.ship-lockout
 .claude/.ship-watcher/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.142.0] — 2026-09-05
+
+### Added
+
+- **`/claude-strict` — the deliverable is exactly what the prompt names, and only the attributes the prompt leaves open are Claude's call.** "Make the box border thinner" used to invite a padding fix, a doc update and a tidy-up of the two neighbouring borders; nothing in the plugin held the line, and several always-on mandates (docs in the same change, pre-mortem guards, "make reasonable decisions independently") pushed the other way. The new skill fixes the scope in the **vocabulary of the request** — a visual request closes the set of visible things that may change, a technical request closes the set of symbols — while unnamed attributes (colour, pixel value, wording) are chosen and reported in a four-line strict report (`requested / done / chosen / untouched`). Grey zones are settled, not left to mood: a syntactic companion (import, export entry) is in scope, an assertion pinning the exact old value may follow, any other test failure reverts and reports, an ambiguous object is asked about interactively and assumed (and led with) autonomously.
+
+  Two modes, one state file per **worktree**: `/claude-strict <task>` binds the turn and every workflow it starts (a concept session or an autonomous run is auto-bound to its state file and released when that file disappears); `/claude-strict on|off` binds the current worktree + branch, never the whole project — a branch switch deactivates it with a single notice. Enforcement is mechanical: `prompt.strict.enforce` injects the ≤1.4 KB contract once per turn (also on cron and waker turns, so concept iterations stay strict without re-typing), `pre.strict.agent-gate` refuses an Agent spawn whose prompt lacks the block and says how to fix it (recursive — plugin hooks run inside subagents; worktree agents inherit via `<parent>-<role>`), and `stop.strict.release` binds or releases inline modes. `code-defaults.md` § Strict Mode states the precedence over doc-maintenance and pre-mortem outputs; the agent prompt template gains item 9 (forward the block verbatim). Spec: `docs/superpowers/specs/2026-09-04-claude-strict-design.md`.
+
 ## [0.141.0] — 2026-09-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -167,8 +167,8 @@ For the full extension guide with examples per skill, see `deep-knowledge/skill-
 
 ## Features
 
-- **<!--devops:count:hooks-->42<!--/devops:count:hooks--> Hooks** — automated guards and triggers across the full session lifecycle
-- **<!--devops:count:skills-->22<!--/devops:count:skills--> Skills** — ship, promote, commit, fix, setup-issue, setup-project, setup-readme, auto-usage, claude-extend-skill, setup-cleanup, auto-update, concept, run-agents, run-autonomous, run-burn, run-backlog, claude-learn, tune-harden, tune-polish, tune-rethink, auto-graph, claude-batch, web-guide
+- **<!--devops:count:hooks-->45<!--/devops:count:hooks--> Hooks** — automated guards and triggers across the full session lifecycle
+- **<!--devops:count:skills-->23<!--/devops:count:skills--> Skills** — ship, promote, commit, fix, setup-issue, setup-project, setup-readme, auto-usage, claude-extend-skill, setup-cleanup, auto-update, concept, run-agents, run-autonomous, run-burn, run-backlog, claude-learn, tune-harden, tune-polish, tune-rethink, auto-graph, claude-batch, claude-strict, web-guide
 - **<!--devops:count:agents-->12<!--/devops:count:agents--> Agents** — AI, Core, Designer, Feature, Frontend, Gamer, PO, QA, Redteam, Research, Windows
 - **Completion Flow** — mandatory card after every task (8 variants), visual verification, ship recommendation
 - **Ship Enforcement** — intent detection, PR command blocking, automatic /ship skill routing
@@ -178,7 +178,7 @@ For the full extension guide with examples per skill, see `deep-knowledge/skill-
 
 ### Hooks (automatic, no user action needed)
 
-<!--devops:count:hooks-->42<!--/devops:count:hooks--> hooks fire automatically across the session lifecycle — no user action needed.
+<!--devops:count:hooks-->45<!--/devops:count:hooks--> hooks fire automatically across the session lifecycle — no user action needed.
 
 <details>
 <summary><strong>By session lifecycle</strong> — when does it fire?</summary>
@@ -215,6 +215,7 @@ SessionStart  ──>  UserPromptSubmit  ──>  PreToolUse  ──>  PostToolU
 - `prompt.issue.detect` — Detect issue references in user messages.
 - `prompt.plugin.scope` — Inject the scope-routing rule when a consumer project's session starts talking about…
 - `prompt.skill.enforce` — Detects inline skill commands (e.g.
+- `prompt.strict.enforce` — Arms and enforces `/claude-strict` — literal scope, discretionary parameters.
 - `prompt.ship.detect` — Detect ship intent in user prompts and inject Skill('ship') instruction.
 - `prompt.flow.appstart` — Detect app start intent in user prompts.
 - `prompt.worktree.branch-guard` — Prevents working without a dedicated branch inside a linked worktree.
@@ -228,6 +229,7 @@ SessionStart  ──>  UserPromptSubmit  ──>  PreToolUse  ──>  PostToolU
 - `pre.plugin.scope` — Block hand-edits of installed devops plugin artifacts from a consumer project.
 - `pre.edit.branch` — Prevent Edit/Write tool calls while HEAD is on local main/master.
 - `pre.mcp.health` — Detects dead or stale MCP servers before tool calls fail cryptically.
+- `pre.strict.agent-gate` — While `/claude-strict` is active, refuse an Agent spawn whose prompt does not start w…
 
 #### PostToolUse — runs after each tool call
 
@@ -243,6 +245,7 @@ SessionStart  ──>  UserPromptSubmit  ──>  PreToolUse  ──>  PostToolU
 - `stop.flow.browsertest` — Light-verification enforcement gate (the "V" of the V&V gate).
 - `stop.flow.guard` — Per-turn completion card + validation enforcement (the validation half of the V&V gate).
 - `stop.flow.selfcalibration` — Run self-calibration when Claude finishes a response turn.
+- `stop.strict.release` — Settles the lifetime of an inline `/claude-strict` mode at the end of the turn that a…
 - `stop.mcp.reap` — Periodic background reclaim of orphaned Claude Desktop MCP server processes — the "ru…
 <!--/devops:block:hook-lifecycle-->
 
@@ -332,6 +335,7 @@ SessionStart  ──>  UserPromptSubmit  ──>  PreToolUse  ──>  PostToolU
 | `/tune-rethink` | Explicit | Strategic reset for stuck development: code-blind fresh approaches, concept decision, autonomous implementation |
 | `/claude-batch` | Explicit + Hook | Collect mode: batch prompts into `.claude/batch.md` instead of executing them, then merge into one feasibility-checked plan |
 | `/web-guide` | Explicit | Live tutorial in the user's Edge tab: step panel overlay for logins, API keys, and settings Claude cannot do itself |
+| `/claude-strict` | Explicit + Hook | Strict mode: the deliverable is exactly what the prompt names, unnamed attributes are chosen and reported; propagates to agents, skills and concept iterations; `on`/`off` binds it to the current worktree + branch |
 
 #### The `run-*` family — let Claude execute autonomously
 
@@ -695,8 +699,8 @@ Wk  ━━──╏─────────   15% +1%   · 4d 22h left
 devops/
 ├── .claude-plugin/plugin.json     ← Plugin manifest
 ├── CONVENTIONS.md                 ← Naming, versioning, extension rules
-├── hooks/                         ← <!--devops:count:hooks-->42<!--/devops:count:hooks--> hooks (JS) registered in hooks.json
-├── skills/                        ← <!--devops:count:skills-->22<!--/devops:count:skills--> skill definitions (SKILL.md)
+├── hooks/                         ← <!--devops:count:hooks-->45<!--/devops:count:hooks--> hooks (JS) registered in hooks.json
+├── skills/                        ← <!--devops:count:skills-->23<!--/devops:count:skills--> skill definitions (SKILL.md)
 ├── agents/                        ← <!--devops:count:agents-->12<!--/devops:count:agents--> agent definitions
 ├── deep-knowledge/                ← Cross-cutting reference docs
 ├── templates/                     ← Output format templates

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.141.0**
+**Version: 0.142.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/docs/superpowers/plans/2026-09-04-claude-strict.md
+++ b/docs/superpowers/plans/2026-09-04-claude-strict.md
@@ -1,0 +1,190 @@
+# claude-strict Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A `/claude-strict` skill whose scope contract (literal deliverable, discretionary attributes) is persisted per worktree+branch and mechanically propagated to every turn, spawned agent, and concept iteration.
+
+**Architecture:** One state lib (`hooks/lib/strict-state.js`) owns the mode file, mention detection and the canonical contract text. Three thin hooks use it: UserPromptSubmit injects the contract, PreToolUse(Agent) refuses spawns without it, Stop binds or releases inline modes. The skill is prose that mirrors the contract and routes `on|off|status|<task>`.
+
+**Tech Stack:** Node.js (CommonJS hooks), vitest, existing `hooks/lib/batch-state.js` helpers (`isMachinePrompt`, `willBeCollected`), `hooks/lib/plugin-guard.js`.
+
+Spec: `docs/superpowers/specs/2026-09-04-claude-strict-design.md`
+
+## Global Constraints
+
+- All hook code is JavaScript (Node.js), no Bash scripts; paths via `process.cwd()` / `os.homedir()`.
+- Hook file header: `@hook`, `@version`, `@event`, `@plugin devops`, `@description`; first line of logic `require('../lib/plugin-guard')`.
+- Skill frontmatter: folded `description: >-`; `Step 0 — Load Extensions` mandatory.
+- Mode file: `.claude/strict-mode.json` in the worktree, JSON 2-space indent.
+- Contract block ≤ 1 400 chars, opens with `[claude-strict contract]`, closes with `[/claude-strict contract]`; injected once per turn by the UserPromptSubmit hook only.
+- Git calls: `execFileSync` with 5 s timeout, never fatal.
+- `npm test` and `npm run lint` green before every commit; `node plugins/devops/scripts/gen-readme-sections.js --check` green before the final commit.
+
+---
+
+## File structure
+
+| Path | Responsibility |
+|---|---|
+| `plugins/devops/hooks/lib/strict-state.js` | mode file I/O, branch check, bindings, mention detection, contract text, CLI |
+| `plugins/devops/hooks/lib/strict-state.test.js` | unit tests for the lib |
+| `plugins/devops/hooks/user-prompt-submit/prompt.strict.enforce.js` (+ `.test.js`) | arm on mention, inject contract, branch-mismatch notice |
+| `plugins/devops/hooks/pre-tool-use/pre.strict.agent-gate.js` (+ `.test.js`) | refuse Agent spawns lacking the block |
+| `plugins/devops/hooks/stop/stop.strict.release.js` (+ `.test.js`) | bind inline mode to a workflow or release it |
+| `plugins/devops/hooks/hooks.json` | register the three hooks |
+| `plugins/devops/skills/claude-strict/SKILL.md` (+ `skill-text.test.js`) | the skill |
+| `plugins/devops/skills/claude-strict/deep-knowledge/e2e-scenarios.md` | scripted `claude -p` scenarios |
+| `plugins/devops/deep-knowledge/code-defaults.md` | § Strict mode precedence |
+| `plugins/devops/deep-knowledge/agent-orchestration.md` | prompt template item 9 |
+| `plugins/devops/skills/setup-project/SKILL.md`, `.gitignore` | runtime-state gitignore line |
+| `README.md` | skill row + hook rows (generator) |
+
+---
+
+### Task 1: State lib — mode file, branch check, bindings
+
+**Files:**
+- Create: `plugins/devops/hooks/lib/strict-state.js`
+- Test: `plugins/devops/hooks/lib/strict-state.test.js`
+
+**Interfaces (produces):**
+```js
+modePath(cwd) → string
+readMode(cwd) → object|null
+currentBranch(cwd) → string|null            // git symbolic-ref --short HEAD, null outside a repo
+activate(cwd, { reason='inline', branch, sessionId, boundTo=null, now }) → mode
+bind(cwd, reason, boundTo, now) → mode      // inline → concept/autonomous, expiresAt +24h
+deactivate(cwd) → void
+findBinding(cwd) → { reason, file }|null    // first existing of BINDINGS
+evaluate(cwd, { branch, now }) → { active, mode, why }  // why ∈ 'off'|'branch-mismatch'|'binding-gone'|'expired'|null
+isActive(cwd, opts) → boolean
+markBranchNoticed(cwd, branch) / branchNoticed(cwd, branch)
+BINDINGS, MODE_FILE
+```
+
+- [ ] **Step 1: Write the failing tests** (`strict-state.test.js`, vitest ESM, temp dirs with `git init -b <branch>`; helper `repo(branch)` runs `git init -q -b <branch>` in a mkdtemp dir):
+  - `activate` writes `.claude/strict-mode.json` with `active:true`, `reason`, `branch` (defaults to `currentBranch`), `expiresAt:null` for `on`, ISO `expiresAt` for `inline`.
+  - `evaluate` → `active:true, why:null` on the same branch; `why:'branch-mismatch'` after `git checkout -b other`; `why:'off'` when no file; `why:'expired'` when `now` past `expiresAt`; `why:'binding-gone'` for `reason:'concept'` whose `boundTo` file is absent.
+  - `findBinding` returns concept when `.claude/concept-active.json` exists, autonomous when `AUTONOMOUS-LOCKOUT.flag` exists, null otherwise.
+  - `bind` rewrites `reason`/`boundTo`, keeps `branch`.
+  - `currentBranch` returns null in a non-repo dir.
+- [ ] **Step 2: Run** `npx vitest run plugins/devops/hooks/lib/strict-state.test.js` → FAIL (module missing).
+- [ ] **Step 3: Implement** the functions above (git via `execFileSync('git', [...], { cwd, timeout: 5000, stdio: ['ignore','pipe','ignore'] })`, all wrapped in try/catch).
+- [ ] **Step 4: Run tests** → PASS. `npm run lint` clean.
+- [ ] **Step 5: Commit** `feat(strict): state lib — mode file, branch check, bindings`.
+
+### Task 2: State lib — mention detection, contract text, CLI
+
+**Files:**
+- Modify: `plugins/devops/hooks/lib/strict-state.js`
+- Test: `plugins/devops/hooks/lib/strict-state.test.js`
+
+**Interfaces (produces):**
+```js
+detectMention(text) → { mentioned:boolean, route:'on'|'off'|'status'|'task'|null, rest:string }
+contractText({ status }) → string          // status line + block
+hasContract(text) → boolean
+CONTRACT_OPEN, CONTRACT_CLOSE, CONTRACT_BLOCK
+statusLine(mode, branch) → string          // "strict: on · branch feat/x · /claude-strict off"
+CLI: node strict-state.js on|off|status|contract
+```
+
+- [ ] **Step 1: Failing tests:**
+  - mention: `"/claude-strict mach den Rand dünner"` → task, rest = `"mach den Rand dünner"`; `"/devops:claude-strict on"` → on; `"aus"`/`"off"` → off; `"status"` → status; `"/claude-strict /concept X"` → task with rest `"/concept X"`.
+  - not a mention: `` "siehe `/claude-strict` im README" ``; `"docs/claude-strict.md"`; `"strict: true in tsconfig"`; `"be strict about types"`.
+  - expanded command: `"<command-message>…</command-message><command-name>/claude-strict</command-name><command-args>on</command-args>"` → on; `<command-name>/concept</command-name>` → not mentioned.
+  - `contractText()` contains `CONTRACT_OPEN`, `CONTRACT_CLOSE`, `"SCOPE IS LITERAL"`, `"PROPAGATION"`, `"REPORT"`, `"tune-polish"`; `CONTRACT_BLOCK.length <= 1400`.
+  - `hasContract("x\n[claude-strict contract]\n…")` true; false otherwise.
+  - CLI: `spawnSync(node, [lib, 'on'], {cwd})` → mode file exists; `off` → gone; `status` prints JSON with `active`; `contract` prints the block.
+- [ ] **Step 2: Run** → FAIL.
+- [ ] **Step 3: Implement.** Mention regex: `/(^|[\s(\[{"'>])\/(?:devops:)?claude-strict\b/i`; reject when char before `/` is a backtick or the char after the token is a backtick. Route from the first word after the mention: `on|an|start|ein` → on, `off|aus|stop` → off, `status` → status, else task. Expanded form parsed from `<command-name>` + `<command-args>`. CLI guarded by `require.main === module`.
+- [ ] **Step 4: Run** → PASS, lint clean.
+- [ ] **Step 5: Commit** `feat(strict): mention detection, contract text, CLI`.
+
+### Task 3: UserPromptSubmit hook `prompt.strict.enforce`
+
+**Files:**
+- Create: `plugins/devops/hooks/user-prompt-submit/prompt.strict.enforce.js`
+- Test: `plugins/devops/hooks/user-prompt-submit/prompt.strict.enforce.test.js` (stdin-spawn pattern from `prompt.batch.collect.test.js`; temp project with `.claude/settings.json` enabling `devops@dotclaude`, `git init -b feat/x`).
+- Modify: `plugins/devops/hooks/hooks.json` (UserPromptSubmit list, after `prompt.skill.enforce`).
+
+**Consumes:** `detectMention`, `activate`, `deactivate`, `evaluate`, `contractText`, `statusLine`, `markBranchNoticed`, `branchNoticed`; `willBeCollected`, `isMachinePrompt` from `batch-state.js`.
+
+- [ ] **Step 1: Failing tests:**
+  - mode off, no mention → exit 0, empty stdout.
+  - `"/claude-strict mach den Rand dünner"` → mode file with `reason:'inline'`, stdout JSON `additionalContext` contains `[claude-strict contract]`.
+  - `"/claude-strict on"` → `reason:'on'`, `expiresAt:null`, stdout contains the contract and `strict: on`.
+  - `"/claude-strict off"` → file removed, stdout one line containing `off`.
+  - mode on, plain prompt → contract injected, exactly one `[claude-strict contract]`.
+  - mode on, machine prompt `"AUTONOMOUS_RESUME: …"` → still injected.
+  - batch collect active (`batch-state.activate(cwd)`) + `"/claude-strict foo"` → no mode file, no stdout.
+  - mode on for branch `feat/x`, repo now on `other` → stdout notice containing `feat/x` once; second run → silent.
+- [ ] **Step 2: Run** → FAIL.
+- [ ] **Step 3: Implement** per spec § Hooks. Output shape: `{ hookSpecificOutput: { hookEventName: 'UserPromptSubmit', additionalContext } }`.
+- [ ] **Step 4: Register in `hooks.json`**, run tests → PASS, lint clean. Run `npx vitest run plugins/devops/hooks` to confirm no regression (hooks.json roster tests).
+- [ ] **Step 5: Commit** `feat(strict): UserPromptSubmit hook injects the contract`.
+
+### Task 4: PreToolUse gate `pre.strict.agent-gate`
+
+**Files:**
+- Create: `plugins/devops/hooks/pre-tool-use/pre.strict.agent-gate.js`
+- Test: `plugins/devops/hooks/pre-tool-use/pre.strict.agent-gate.test.js`
+- Modify: `plugins/devops/hooks/hooks.json` (new PreToolUse entry, matcher `Agent`).
+- Modify: `plugins/devops/hooks/lib/strict-state.js` — add `resolveInherited(cwd)`.
+
+**Interfaces:** `resolveInherited(cwd) → mode|null` — when no mode in `cwd`: main worktree = parent dir of `git rev-parse --path-format=absolute --git-common-dir`; return its mode when `currentBranch(cwd)` starts with `mode.branch + '-'` or `mode.branch + '/'`.
+
+- [ ] **Step 1: Failing tests:**
+  - inactive → exit 0, no output.
+  - active + `tool_input.prompt` without block → exit 2, stderr contains `[claude-strict]` and `contract`.
+  - active + prompt containing `[claude-strict contract]` → exit 0.
+  - inherited: main repo on `feat/x` with mode `on`; `git worktree add <tmp> -b feat/x-core`; hook run with `cwd` = worktree → exit 2 without block.
+  - `tool_name` not `Agent` → exit 0.
+- [ ] **Step 2: Run** → FAIL.
+- [ ] **Step 3: Implement.** Block message: `[claude-strict] strict mode is active (branch <b>). Agent prompts must start with the contract block. Print it with: node "<lib>" contract — prepend it verbatim and retry.`
+- [ ] **Step 4: Register** `{ "hooks": [ { "type":"command", "command":"node ${CLAUDE_PLUGIN_ROOT}/hooks/pre-tool-use/pre.strict.agent-gate.js" } ], "matcher":"Agent" }`; tests PASS; lint clean.
+- [ ] **Step 5: Commit** `feat(strict): PreToolUse gate refuses Agent spawns without the contract`.
+
+### Task 5: Stop hook `stop.strict.release`
+
+**Files:**
+- Create: `plugins/devops/hooks/stop/stop.strict.release.js`
+- Test: `plugins/devops/hooks/stop/stop.strict.release.test.js`
+- Modify: `plugins/devops/hooks/hooks.json` (Stop list, before `stop.mcp.reap`).
+
+- [ ] **Step 1: Failing tests:**
+  - `reason:'inline'`, no binding file → mode removed.
+  - `reason:'inline'`, `.claude/concept-active.json` present → mode now `reason:'concept'`, `boundTo` set, stderr mentions `concept`.
+  - `reason:'concept'`, bound file gone → removed.
+  - `reason:'on'` → untouched.
+- [ ] **Step 2: Run** → FAIL. **Step 3: Implement.** **Step 4: Register, tests PASS, lint.**
+- [ ] **Step 5: Commit** `feat(strict): Stop hook binds inline mode to a running workflow or releases it`.
+
+### Task 6: The skill
+
+**Files:**
+- Create: `plugins/devops/skills/claude-strict/SKILL.md`
+- Create: `plugins/devops/skills/claude-strict/skill-text.test.js`
+- Create: `plugins/devops/skills/claude-strict/deep-knowledge/e2e-scenarios.md`
+
+- [ ] **Step 1: Failing skill-text tests:** the contract block in SKILL.md between `CONTRACT_OPEN`/`CONTRACT_CLOSE` equals `CONTRACT_BLOCK` from the lib (whitespace-normalised); Step 1 routing table has rows for `on`, `off`, `status`, and a free-text/"anything else" row that says "task"; Step 3 names `Agent`, `Skill`, `concept`, `autonomous`, `--strict`; Step 4 names the four report lines; frontmatter has `argument-hint`.
+- [ ] **Step 2: Run** → FAIL. **Step 3: Write SKILL.md** per spec § Skill (frontmatter: name, version 0.1.0, folded description with triggers `"/claude-strict"`, `"strict"`, `"strikt"`, `"genau so"`, `"nur das"`; `argument-hint: "<task> | on | off | status"`; `allowed-tools: Bash(node *), Bash(git *), Read, Write, Edit, Glob, Grep, Skill, Agent, AskUserQuestion, mcp__plugin_devops_dotclaude-completion__render_completion_card`).
+- [ ] **Step 4: Write e2e-scenarios.md** — four scripted `claude -p` scenarios from spec § Testing with the temp-repo fixture, the exact prompt, the assertion (git diff --stat / grep), and the retry rule.
+- [ ] **Step 5: Tests PASS** incl. `scripts/frontmatter-yaml.test.js`. **Commit** `feat(strict): /claude-strict skill`.
+
+### Task 7: Overlap resolution + docs + roster
+
+**Files:**
+- Modify: `plugins/devops/deep-knowledge/code-defaults.md` — append § "Strict mode" (contract block precedence, pointer to the skill).
+- Modify: `plugins/devops/deep-knowledge/agent-orchestration.md:104-106` — item 9 "Scope contract".
+- Modify: `plugins/devops/skills/setup-project/SKILL.md:107` block and repo `.gitignore` runtime block — add `.claude/strict-mode.json`.
+- Modify: `README.md` skill table (row after `/claude-batch`), run `node plugins/devops/scripts/gen-readme-sections.js`.
+- Run `node plugins/devops/scripts/gen-dk-index.js` if it maintains INDEX.md.
+
+- [ ] **Step 1:** edits above. **Step 2:** `node plugins/devops/scripts/gen-readme-sections.js --check` → exit 0; `npm test`; `npm run lint`.
+- [ ] **Step 3: Commit** `docs(strict): precedence in code-defaults, prompt-template item 9, roster`.
+
+### Task 8: End-to-end runs
+
+- [ ] **Step 1:** Build the temp fixture repo (HTML+CSS box with three borders, one commit), enable the plugin from this worktree via `--plugin-dir` or the installed cache, run scenarios 1–4 from `e2e-scenarios.md` with `claude -p --output-format json` (haiku for 1–2, sonnet for 3), record results.
+- [ ] **Step 2:** Fix whatever the runs reveal (wording in the contract, gate message), re-run, commit `test(strict): e2e scenario results`.

--- a/docs/superpowers/specs/2026-09-04-claude-strict-design.md
+++ b/docs/superpowers/specs/2026-09-04-claude-strict-design.md
@@ -1,0 +1,182 @@
+# claude-strict — Literal Scope, Discretionary Parameters
+
+**Date:** 2026-09-04
+**Status:** Approved for implementation
+**Skill:** `/claude-strict`
+
+## Problem
+
+Some prompts mean exactly what they say. "Make the box border thinner" is a
+request about one border — not about the padding next to it, not about the
+three other borders that "look inconsistent", not about the CSS file's
+formatting, and not about the docs that mention the box. Today nothing in the
+plugin holds that line: `code-defaults.md` says "minimal changes only" but is
+loaded on demand, once per session, and is never forwarded to spawned agents;
+several always-on mandates actively push the other way (agents must update
+docs in the same change, pre-mortem output becomes extra guards and tests,
+autonomous agents "make reasonable decisions independently").
+
+The user wants a mode where the **deliverable is literal** and only the
+**parameters the prompt leaves open** are Claude's call — and where that holds
+for every skill, agent, and concept iteration the prompt sets in motion.
+
+## Non-goals
+
+- A general "be careful" or "ask more" mode. Strict is about *scope*, not
+  about caution. It must not turn into a nag loop.
+- Blocking tool calls on semantic grounds. The hooks enforce the *mechanics*
+  (contract present, mode persisted); the model enforces the *judgment*.
+- Replacing `/tune-harden` / `/tune-polish` scope fences. Those stay.
+
+## The contract
+
+Injected verbatim as one block. Canonical text lives in
+`hooks/lib/strict-state.js` (`contractText()`); `SKILL.md` carries the same
+block and a test asserts they are identical.
+
+```
+[claude-strict contract]
+SCOPE IS LITERAL — measured in the vocabulary of the request.
+- The request names WHAT may change. Nothing else changes: no refactor, no
+  rename, no doc update, no new test, no formatting of untouched lines, no
+  "while I'm here", no new file / dependency / abstraction.
+- Visual request ("the box border") → only that visible element changes; the
+  technical route (import, variable, selector) is yours as long as nothing
+  else visible changes. Technical request ("rename fn X") → only that symbol.
+DISCRETION covers ATTRIBUTES the request leaves open (colour, px, wording),
+never the OBJECT. Ambiguous object: interactive → ask; autonomous → touch the
+single most probable one and lead the report with the assumption.
+TESTS: an assertion that pins the exact old value may be updated. Any other
+failure → apply nothing, revert, report.
+PRECEDENCE (scope axis only): this block overrides doc-maintenance, pre-mortem
+outputs, "make reasonable decisions independently", and the concept
+zero-prompt invariant. Completion card, /ship docs-sync, tune-polish approval
+rule stay in force.
+PROPAGATION: forward this block verbatim at the top of every Agent prompt and
+every skill you invoke; it binds concept iterations and autonomous resumes.
+REPORT (≤4 lines, before the card, omit empty lines):
+  strict — requested: <literal ask>
+  done: <what changed, file:line>
+  chosen: <attribute = value (unspecified)>
+  untouched: <noticed but out of scope>
+[/claude-strict contract]
+```
+
+The block is ≤ 1 400 characters. It is injected **once per turn** by the
+UserPromptSubmit hook; no other hook injects text (cost control, no
+duplication).
+
+## Modes and state
+
+One state file, two ways to arm it: `.claude/strict-mode.json` in the
+**worktree** (each git worktree has its own `.claude/`, so a mode never
+leaks into another worktree of the same repo). Gitignored via the
+`/setup-project` runtime block, same as `batch-mode.json`.
+
+```json
+{
+  "active": true,
+  "branch": "feat/42-box",
+  "reason": "on" | "inline" | "concept" | "autonomous",
+  "boundTo": ".claude/concept-active.json" | "AUTONOMOUS-LOCKOUT.flag" | null,
+  "sessionId": "…",
+  "startedAt": "ISO",
+  "expiresAt": "ISO" | null
+}
+```
+
+| Invocation | reason | Lifetime |
+|---|---|---|
+| `/claude-strict on` | `on` | Until `/claude-strict off`, or the worktree's branch no longer equals `branch` (one-time notice, then inactive). No expiry — the user chose branch scope. |
+| `/claude-strict <task>` or inline mention `/claude-strict …` | `inline` | This turn (all agents spawned in it). At Stop: if a workflow binding file exists → re-bound (`concept` / `autonomous`); else released. |
+| auto-bound | `concept` / `autonomous` | Until the bound file disappears (concept `/shutdown` removes `concept-active.json`; the lockout `clear` removes the flag), or `off`. Safety expiry 24 h. |
+
+**Branch check.** `isActive(cwd)` compares the stored `branch` to
+`git rev-parse --abbrev-ref HEAD` (5 s timeout, `unknown` when not a repo →
+branch check skipped). A `reason: on` mode with a different branch is
+inactive and the next prompt hook reports once: "strict was armed on
+`<branch>`; current branch differs — `/claude-strict on` to re-arm here."
+
+**Worktree agents.** Agents spawned with `isolation: worktree` run in a
+different cwd. The agent gate resolves the mode as: own cwd → else the repo's
+main worktree (`git rev-parse --git-common-dir` → parent) when the current
+branch starts with the stored branch (`<parent>-<role>` / `<parent>/<role>`
+sub-branch conventions). Failing that, the contract in the agent's own prompt
+(enforced by the gate at the parent level) is the carrier.
+
+**Batch interaction.** A prompt that `/claude-batch` will collect (exit 2,
+erased) never arms strict — `willBeCollected()` from `batch-state.js` is
+honoured. At batch merge time the contract, if active, applies per note:
+each note's scope is literal; the merge does not widen it.
+
+## Hooks
+
+| Hook | Event / matcher | Behaviour |
+|---|---|---|
+| `prompt.strict.enforce` | UserPromptSubmit | Detect mention (`/claude-strict` as its own token — not in backticks, not a path segment; or `<command-name>` = claude-strict, args parsed for `on/off/status`). Mention + not collected → arm `inline` (or `on/off` per args). If active or mentioned → emit the contract as `additionalContext`, prefixed by one status line (`strict: on · branch X · /claude-strict off`). Machine prompts (cron, `AUTONOMOUS_*`) get the injection too — they are exactly the turns that must stay strict. |
+| `pre.strict.agent-gate` | PreToolUse `Agent` | Active (own cwd or inherited) and `tool_input.prompt` lacks `[claude-strict contract]` → `permissionDecision: deny` with reason "strict is active — prepend the contract block (print it with `node <lib> contract`) and retry". Present → allow silently. Inactive → silent. Fires recursively inside subagents (plugin hooks run there). |
+| `stop.strict.release` | Stop | `reason: inline` → bind to `concept-active.json` / `AUTONOMOUS-LOCKOUT.flag` if present, else delete the mode. Bound modes whose file is gone → delete. Never touches `reason: on`. |
+
+`updatedInput` is **not** used: Claude Code ignores it for the Agent tool
+(anthropics/claude-code#44412). `additionalContext` on PreToolUse is not
+relied on either.
+
+Verified in-session on 2026-09-04: UserPromptSubmit hooks fire on
+task-notification turns (agent completion and background-Bash completion),
+so the injection reaches concept iterations that arrive via the pickup waker.
+
+## Skill
+
+`skills/claude-strict/SKILL.md` — frontmatter per CONVENTIONS (folded
+description, `argument-hint: "<task> | on | off | status"`, `allowed-tools`
+incl. `Bash(node *)`, `Skill`, `AskUserQuestion`, card renderer).
+
+- Step 0 — extensions (mandatory pattern).
+- Step 1 — route on the first token: `on` / `off` / `status`; anything else
+  (including another slash command) is the task → Step 3.
+- Step 2 — the contract block (verbatim, single source of truth mirrored).
+- Step 3 — execute the task under the contract. If the task invokes another
+  skill (`/claude-strict /concept …`), invoke it with the contract already in
+  context and pass `--strict` where the callee has a flag channel
+  (`tune-harden`, `tune-polish`). Announce auto-binding in one line when a
+  workflow starts.
+- Step 4 — strict report, then the completion card.
+- Step 5 — `on` / `off` / `status` via `node {PLUGIN_ROOT}/hooks/lib/strict-state.js <cmd>`.
+
+## Overlap resolution
+
+| Existing rule | Resolution |
+|---|---|
+| `deep-knowledge/code-defaults.md` § Change Philosophy | Referenced as the always-on base. New § "Strict mode" states that the contract block supersedes doc-maintenance, pre-mortem outputs, and reasonable-defaults directives on scope. |
+| `deep-knowledge/documentation-maintenance.md` + agent doc rules | Overridden per turn under strict; doc debt goes to `untouched`. `/ship` Step 2.6 unchanged. |
+| `deep-knowledge/agent-orchestration.md` § Agent Prompt Template | New item 9: "Scope contract — when the `[claude-strict contract]` block is in context, forward it verbatim at the top of the prompt." |
+| `plugin-behavior.md` § Completion Flow | Unchanged; the card is output, not diff. |
+| `/tune-polish` approval rule, `/tune-harden` no-new-UI | Unchanged; strict is at least as narrow. |
+| `/concept` zero-prompt invariant (finalize) | Unchanged for the wizard; the *implement* action binds "the decisions" to the literally selected items. |
+| `prompt.skill.enforce` | Detects `/claude-strict` mentions and forces the skill load; strict's own hook does the arming, so ordering between the two does not matter. |
+
+## Testing
+
+Mechanical (deterministic, vitest):
+- `hooks/lib/strict-state.test.js` — activate/deactivate, branch mismatch,
+  binding release, expiry, mention detection (backticks, path segment,
+  `strict: true`, expanded command with args), `willBeCollected` guard,
+  contract size cap, CLI subcommands.
+- `hooks/user-prompt-submit/prompt.strict.enforce.test.js` — stdin-spawn per
+  batch-hook pattern: arms on mention, injects when active, silent when off,
+  no arm when batch collects, branch-mismatch notice once, machine prompt
+  still injected.
+- `hooks/pre-tool-use/pre.strict.agent-gate.test.js` — deny without block,
+  allow with block, silent when inactive, inherited worktree case.
+- `hooks/stop/stop.strict.release.test.js` — inline released / re-bound,
+  bound released when file gone, `on` untouched.
+- `skills/claude-strict/skill-text.test.js` — contract block ≡ lib text,
+  routing table rows, propagation clause names Agent/Skill/concept/autonomous.
+- Existing: `frontmatter-yaml.test.js`, `gen-readme-sections --check`.
+
+Semantic (scripted `claude -p` runs against a temp repo, 1 retry allowed,
+documented in `skills/claude-strict/deep-knowledge/e2e-scenarios.md`):
+1. Border request → diff touches only the border declaration.
+2. Unspecified colour → `chosen:` line present; no `chosen:` when nothing was open.
+3. Agent spawn without the block → gate denies, retry carries the block.
+4. `on` in worktree A → prompt in worktree B of the same repo is not strict.

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.141.0",
+  "version": "0.142.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/deep-knowledge/agent-orchestration.md
+++ b/plugins/devops/deep-knowledge/agent-orchestration.md
@@ -104,6 +104,12 @@ Every spawned agent MUST receive:
 8. **Distinct scope boundary** — for parallel agents in the same wave, state what
    each one **owns and does NOT touch**. Vague sub-tasks are the #1 cause of
    duplicate work; two agents must never independently solve the same thing.
+9. **Scope contract** — when a `[claude-strict contract]` block is in context
+   (`/claude-strict` armed for this worktree + branch), it goes **verbatim at
+   the top** of the prompt, before item 1. The `pre.strict.agent-gate` hook
+   refuses a spawn without it. It overrides item 5's "make reasonable decisions
+   independently" on the scope axis: decisions cover unnamed attributes only,
+   never the deliverable. See `code-defaults.md` § Strict Mode.
 
 ### Interaction Directives
 

--- a/plugins/devops/deep-knowledge/code-defaults.md
+++ b/plugins/devops/deep-knowledge/code-defaults.md
@@ -17,3 +17,24 @@ Standard coding conventions enforced across all projects using the devops plugin
 - Don't create helpers or abstractions for one-time operations.
 - Don't design for hypothetical future requirements.
 - Don't add backwards-compatibility hacks for removed code.
+
+## Strict Mode (`/claude-strict`)
+
+The rules above are the always-on baseline. When a `[claude-strict contract]`
+block is in context — injected by `prompt.strict.enforce` while
+`/claude-strict` is armed for this worktree + branch, or carried at the top of
+an agent prompt — it is the **hard, reported, propagated** form of the same
+idea and takes precedence on the scope axis:
+
+- The deliverable is exactly what the request names, measured in the request's
+  own vocabulary (visual request → the visible element; technical request →
+  the symbol). Unnamed attributes are discretionary and are reported.
+- Under the block, documentation-maintenance, pre-mortem outputs (extra guards,
+  tests, narrowed scope) and "make reasonable decisions independently" do not
+  widen the diff; what they would have changed goes to the strict report's
+  `untouched` line instead.
+- Unaffected: the completion card, `/ship` Step 2.6 docs-sync, the
+  `/tune-polish` approval rule.
+
+Every spawned agent inherits the block verbatim (`pre.strict.agent-gate`
+refuses a spawn without it). Skill: `skills/claude-strict/SKILL.md`.

--- a/plugins/devops/docs/architecture.html
+++ b/plugins/devops/docs/architecture.html
@@ -168,7 +168,7 @@
 <section id="overview">
 <h1>Architecture Documentation <small>devops v0.87.0</small></h1>
 <p class="lead">
-  A comprehensive DevOps automation plugin for Claude Code &mdash; <!--devops:count:hooks-->42<!--/devops:count:hooks--> hooks, <!--devops:count:skills-->22<!--/devops:count:skills--> skills, <!--devops:count:agents-->12<!--/devops:count:agents--> agents,
+  A comprehensive DevOps automation plugin for Claude Code &mdash; <!--devops:count:hooks-->45<!--/devops:count:hooks--> hooks, <!--devops:count:skills-->23<!--/devops:count:skills--> skills, <!--devops:count:agents-->12<!--/devops:count:agents--> agents,
   2 MCP servers, a deterministic completion card engine, and a 3-layer extension system.
 </p>
 <div role="note" style="margin:.4rem 0 1.4rem;padding:.6rem .9rem;background:var(--bg2);border-left:3px solid var(--warn);border-radius:4px;color:var(--text2);font-size:.85rem;">
@@ -179,16 +179,16 @@
 
 <div class="card-grid">
   <div class="card">
-    <h4><!--devops:count:hooks-->42<!--/devops:count:hooks--> Hooks</h4>
+    <h4><!--devops:count:hooks-->45<!--/devops:count:hooks--> Hooks</h4>
     <p style="color:var(--text2);font-size:.85rem">Lifecycle guards across SessionStart, UserPromptSubmit, PreToolUse, PostToolUse, Stop</p>
     <span class="badge b-hook">SessionStart &times;<!--devops:count:hooks:ss-->15<!--/devops:count:hooks:ss--></span>
-    <span class="badge b-hook">Prompt &times;<!--devops:count:hooks:prompt-->10<!--/devops:count:hooks:prompt--></span>
-    <span class="badge b-hook">Pre &times;<!--devops:count:hooks:pre-->7<!--/devops:count:hooks:pre--></span>
+    <span class="badge b-hook">Prompt &times;<!--devops:count:hooks:prompt-->11<!--/devops:count:hooks:prompt--></span>
+    <span class="badge b-hook">Pre &times;<!--devops:count:hooks:pre-->8<!--/devops:count:hooks:pre--></span>
     <span class="badge b-hook">Post &times;<!--devops:count:hooks:post-->5<!--/devops:count:hooks:post--></span>
-    <span class="badge b-hook">Stop &times;<!--devops:count:hooks:stop-->5<!--/devops:count:hooks:stop--></span>
+    <span class="badge b-hook">Stop &times;<!--devops:count:hooks:stop-->6<!--/devops:count:hooks:stop--></span>
   </div>
   <div class="card">
-    <h4><!--devops:count:skills-->22<!--/devops:count:skills--> Skills</h4>
+    <h4><!--devops:count:skills-->23<!--/devops:count:skills--> Skills</h4>
     <p style="color:var(--text2);font-size:.85rem">Slash commands: ship, release, commit, fix, setup-issue, setup-project, setup-readme, auto-usage, claude-extend-skill, setup-cleanup, auto-update, concept, run-agents, run-autonomous, run-burn, run-backlog, claude-learn, tune-harden, tune-polish, tune-rethink, auto-graph</p>
   </div>
   <div class="card">
@@ -217,10 +217,10 @@
 │   ├── hooks.json             <span style="color:var(--purple)"># Hook registry (event &rarr; command mapping)</span>
 │   ├── lib/                   <span style="color:var(--text2)"># plugin-guard, run-once, session-id</span>
 │   ├── session-start/         <span style="color:var(--purple)"># <!--devops:count:hooks:ss-->15<!--/devops:count:hooks:ss--> hooks (ss.*)</span>
-│   ├── user-prompt-submit/    <span style="color:var(--purple)"># <!--devops:count:hooks:prompt-->10<!--/devops:count:hooks:prompt--> hooks (prompt.*)</span>
-│   ├── pre-tool-use/          <span style="color:var(--purple)"># <!--devops:count:hooks:pre-->7<!--/devops:count:hooks:pre--> hooks (pre.*)</span>
+│   ├── user-prompt-submit/    <span style="color:var(--purple)"># <!--devops:count:hooks:prompt-->11<!--/devops:count:hooks:prompt--> hooks (prompt.*)</span>
+│   ├── pre-tool-use/          <span style="color:var(--purple)"># <!--devops:count:hooks:pre-->8<!--/devops:count:hooks:pre--> hooks (pre.*)</span>
 │   ├── post-tool-use/         <span style="color:var(--purple)"># <!--devops:count:hooks:post-->5<!--/devops:count:hooks:post--> hooks (post.*)</span>
-│   └── stop/                  <span style="color:var(--purple)"># <!--devops:count:hooks:stop-->5<!--/devops:count:hooks:stop--> hooks (stop.*)</span>
+│   └── stop/                  <span style="color:var(--purple)"># <!--devops:count:hooks:stop-->6<!--/devops:count:hooks:stop--> hooks (stop.*)</span>
 ├── mcp-server/
 │   ├── index.js               <span style="color:var(--orange)"># dotclaude-completion MCP</span>
 │   └── ship/
@@ -234,7 +234,7 @@
 │   ├── render-card.js         <span style="color:var(--warn)"># Completion card template engine</span>
 │   ├── build-id.js            <span style="color:var(--text2)"># Deterministic content hash</span>
 │   └── lib/usage-meter.js     <span style="color:var(--text2)"># Usage bar renderer</span>
-├── skills/                    <span style="color:var(--accent)"># <!--devops:count:skills-->22<!--/devops:count:skills--> skill definitions (SKILL.md + deep-knowledge/)</span>
+├── skills/                    <span style="color:var(--accent)"># <!--devops:count:skills-->23<!--/devops:count:skills--> skill definitions (SKILL.md + deep-knowledge/)</span>
 │   ├── ship/  release/  commit/  fix/  setup-issue/  setup-project/  setup-readme/
 │   ├── auto-usage/  claude-extend-skill/  setup-cleanup/  auto-update/
 │   ├── concept/  run-agents/  run-autonomous/  run-burn/  run-backlog/  claude-learn/

--- a/plugins/devops/hooks/hooks.json
+++ b/plugins/devops/hooks/hooks.json
@@ -50,6 +50,12 @@
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/pre-tool-use/pre.mcp.health.js" }
         ],
         "matcher": "mcp__plugin_devops_"
+      },
+      {
+        "hooks": [
+          { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/pre-tool-use/pre.strict.agent-gate.js" }
+        ],
+        "matcher": "Agent"
       }
     ],
     "PostToolUse": [
@@ -85,6 +91,7 @@
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/stop/stop.flow.browsertest.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/stop/stop.flow.guard.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/stop/stop.flow.selfcalibration.js" },
+          { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/stop/stop.strict.release.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/stop/stop.mcp.reap.js" }
         ]
       }
@@ -99,6 +106,7 @@
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/user-prompt-submit/prompt.issue.detect.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/user-prompt-submit/prompt.plugin.scope.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/user-prompt-submit/prompt.skill.enforce.js" },
+          { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/user-prompt-submit/prompt.strict.enforce.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/user-prompt-submit/prompt.ship.detect.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/user-prompt-submit/prompt.flow.appstart.js" },
           { "type": "command", "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/user-prompt-submit/prompt.worktree.branch-guard.js" }

--- a/plugins/devops/hooks/lib/strict-state.js
+++ b/plugins/devops/hooks/lib/strict-state.js
@@ -1,0 +1,353 @@
+#!/usr/bin/env node
+/**
+ * @module strict-state
+ * @version 0.1.0
+ * @description State, mention detection and the canonical contract text for
+ *   `/claude-strict` — literal scope, discretionary parameters.
+ *
+ * The mode file is a WORKTREE file (`.claude/strict-mode.json`): every git
+ * worktree has its own `.claude/`, so a mode armed in one worktree never leaks
+ * into another worktree of the same repo — exactly the "this branch only, not
+ * project-wide" scope the user asked for. It is gitignored via the
+ * `/setup-project` runtime block, like `batch-mode.json`.
+ *
+ * The stored `branch` is compared against the checked-out branch on every
+ * read: switching branches inside the worktree deactivates the mode instead of
+ * silently carrying it onto unrelated work.
+ *
+ * Three ways a mode comes to exist (`reason`):
+ *   on          `/claude-strict on` — lives until `off` or a branch switch.
+ *   inline      `/claude-strict <task>` — this turn; the Stop hook either binds
+ *               it to a workflow that the turn started or releases it.
+ *   concept /   bound to a workflow state file (`boundTo`); released the moment
+ *   autonomous  that file disappears. Safety expiry 24 h.
+ *
+ * Spec: docs/superpowers/specs/2026-09-04-claude-strict-design.md
+ */
+
+const fs   = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const MODE_FILE = 'strict-mode.json';
+
+/** Workflow state files an inline mode can be bound to, checked in order. */
+const BINDINGS = [
+  { reason: 'concept',    file: path.join('.claude', 'concept-active.json') },
+  { reason: 'autonomous', file: 'AUTONOMOUS-LOCKOUT.flag' },
+];
+
+const INLINE_EXPIRY_HOURS = 2;
+const BOUND_EXPIRY_HOURS  = 24;
+
+const CONTRACT_OPEN  = '[claude-strict contract]';
+const CONTRACT_CLOSE = '[/claude-strict contract]';
+
+/**
+ * The contract. SKILL.md carries the same block verbatim; a skill-text test
+ * asserts the two never drift. Keep it under 1 400 characters — it is
+ * injected on every strict turn.
+ */
+const CONTRACT_BLOCK = [
+  CONTRACT_OPEN,
+  'SCOPE IS LITERAL — measured in the vocabulary of the request.',
+  '- Only what the request names changes. No refactor, rename, doc update, new',
+  '  test, reformatting of untouched lines, "while I\'m here", new file /',
+  '  dependency / abstraction.',
+  '- Visual request ("the box border") → only that visible element changes; the',
+  '  technical route (import, selector) is yours if nothing else visible changes.',
+  '  Technical request ("rename fn X") → only that symbol.',
+  'DISCRETION covers ATTRIBUTES the request leaves open (colour, px, wording),',
+  'never the OBJECT. Ambiguous object: interactive → ask; autonomous → touch the',
+  'single most probable one; lead the report with the assumption.',
+  'TESTS: an assertion pinning the exact old value may be updated. Any other',
+  'failure → apply nothing, revert, report.',
+  'PRECEDENCE (scope only): overrides doc-maintenance, pre-mortem outputs, "make',
+  'reasonable decisions independently", concept zero-prompt invariant. Completion',
+  'card, /ship docs-sync and tune-polish approval stay.',
+  'PROPAGATION: put this block verbatim at the top of every Agent prompt and',
+  'every skill you invoke; it binds concept iterations and autonomous resumes.',
+  'REPORT (≤4 lines, before the card, omit empty lines):',
+  '  strict — requested: <literal ask>',
+  '  done: <what changed, file:line>',
+  '  chosen: <attribute = value (unspecified)>',
+  '  untouched: <noticed but out of scope>',
+  CONTRACT_CLOSE,
+].join('\n');
+
+// ── paths / io ─────────────────────────────────────────────────────────────
+
+function claudeDir(cwd) { return path.join(cwd || process.cwd(), '.claude'); }
+function modePath(cwd)  { return path.join(claudeDir(cwd), MODE_FILE); }
+
+function readMode(cwd) {
+  try {
+    const raw = JSON.parse(fs.readFileSync(modePath(cwd), 'utf8'));
+    return raw && typeof raw === 'object' ? raw : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeMode(cwd, mode) {
+  fs.mkdirSync(claudeDir(cwd), { recursive: true });
+  fs.writeFileSync(modePath(cwd), JSON.stringify(mode, null, 2) + '\n', 'utf8');
+  return mode;
+}
+
+function deactivate(cwd) {
+  try { fs.unlinkSync(modePath(cwd)); } catch { /* already gone */ }
+}
+
+// ── git ────────────────────────────────────────────────────────────────────
+
+function gitOut(cwd, args) {
+  try {
+    return execFileSync('git', args, {
+      cwd, timeout: 5000, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+/** Checked-out branch, or null outside a repo. Works on an unborn branch. */
+function currentBranch(cwd) {
+  const b = gitOut(cwd, ['symbolic-ref', '--short', '-q', 'HEAD']);
+  return b || null;
+}
+
+/** Directory of the repo's main worktree, or null. */
+function mainWorktree(cwd) {
+  const common = gitOut(cwd, ['rev-parse', '--path-format=absolute', '--git-common-dir']);
+  if (!common) return null;
+  return path.dirname(common);
+}
+
+// ── mode lifecycle ─────────────────────────────────────────────────────────
+
+function hoursFrom(t, h) { return new Date(t + h * 3600_000).toISOString(); }
+
+/**
+ * @param {string} cwd
+ * @param {{reason?:'on'|'inline'|'concept'|'autonomous', branch?:string|null,
+ *          sessionId?:string, boundTo?:string|null, now?:number}} [opts]
+ */
+function activate(cwd, opts = {}) {
+  const reason = opts.reason || 'inline';
+  const now = typeof opts.now === 'number' ? opts.now : Date.now();
+  const branch = opts.branch !== undefined ? opts.branch : currentBranch(cwd);
+  let expiresAt = null;
+  if (reason === 'inline') expiresAt = hoursFrom(now, INLINE_EXPIRY_HOURS);
+  else if (reason !== 'on') expiresAt = hoursFrom(now, BOUND_EXPIRY_HOURS);
+  return writeMode(cwd, {
+    active: true,
+    reason,
+    branch,
+    boundTo: opts.boundTo || null,
+    sessionId: opts.sessionId || null,
+    startedAt: new Date(now).toISOString(),
+    expiresAt,
+    noticedBranches: [],
+  });
+}
+
+/** Re-bind an existing mode to a workflow state file. */
+function bind(cwd, reason, boundTo, now) {
+  const mode = readMode(cwd) || activate(cwd, { reason: 'inline', now });
+  const t = typeof now === 'number' ? now : Date.now();
+  return writeMode(cwd, { ...mode, reason, boundTo, expiresAt: hoursFrom(t, BOUND_EXPIRY_HOURS) });
+}
+
+/** First workflow binding whose state file exists in `cwd`, or null. */
+function findBinding(cwd) {
+  for (const b of BINDINGS) {
+    if (fs.existsSync(path.join(cwd, b.file))) return b;
+  }
+  return null;
+}
+
+/**
+ * Is strict active here?
+ *
+ * @param {string} cwd
+ * @param {{branch?:string|null, now?:number, inherit?:boolean}} [opts]
+ *   inherit: when no mode exists in cwd, look at the main worktree (agents
+ *   spawned with `isolation: worktree` run on a `<parent>-<role>` branch).
+ * @returns {{active:boolean, mode:object|null, why:string|null, inherited?:boolean}}
+ */
+function evaluate(cwd, opts = {}) {
+  let mode = readMode(cwd);
+  let inherited = false;
+  if (!mode && opts.inherit) {
+    mode = resolveInherited(cwd);
+    inherited = !!mode;
+  }
+  if (!mode || mode.active !== true) return { active: false, mode: null, why: 'off' };
+  const now = typeof opts.now === 'number' ? opts.now : Date.now();
+  if (mode.expiresAt && now >= Date.parse(mode.expiresAt)) return { active: false, mode, why: 'expired' };
+  if (mode.boundTo && !fs.existsSync(path.join(inherited ? mainWorktree(cwd) || cwd : cwd, mode.boundTo))) {
+    return { active: false, mode, why: 'binding-gone' };
+  }
+  if (!inherited && mode.branch) {
+    const b = opts.branch !== undefined ? opts.branch : currentBranch(cwd);
+    if (b && b !== mode.branch) return { active: false, mode, why: 'branch-mismatch' };
+  }
+  return { active: true, mode, why: null, inherited };
+}
+
+function isActive(cwd, opts) { return evaluate(cwd, opts).active; }
+
+/**
+ * Mode of the main worktree, when this cwd is a sub-worktree on a branch
+ * derived from it (`<parent>-<role>` or `<parent>/<role>`).
+ */
+function resolveInherited(cwd) {
+  const main = mainWorktree(cwd);
+  if (!main || path.resolve(main) === path.resolve(cwd)) return null;
+  const mode = readMode(main);
+  if (!mode || mode.active !== true || !mode.branch) return null;
+  const b = currentBranch(cwd);
+  if (!b) return null;
+  if (b.startsWith(`${mode.branch}-`) || b.startsWith(`${mode.branch}/`)) return mode;
+  return null;
+}
+
+function branchNoticed(cwd, branch) {
+  const mode = readMode(cwd);
+  return !!(mode && Array.isArray(mode.noticedBranches) && mode.noticedBranches.includes(branch));
+}
+
+function markBranchNoticed(cwd, branch) {
+  const mode = readMode(cwd);
+  if (!mode) return;
+  const list = Array.isArray(mode.noticedBranches) ? mode.noticedBranches : [];
+  if (!list.includes(branch)) list.push(branch);
+  writeMode(cwd, { ...mode, noticedBranches: list });
+}
+
+// ── mention detection ──────────────────────────────────────────────────────
+
+/**
+ * `/claude-strict` (optionally `/devops:claude-strict`) as its own token:
+ * preceded by start-of-string, whitespace or opening punctuation — never a
+ * path segment (`docs/claude-strict.md`) and never inside backticks.
+ */
+const MENTION_RE = /(^|[\s([{"'>])\/(?:devops:)?claude-strict\b/i;
+const EXPANDED_NAME_RE = /<command-name>\s*\/?(?:devops:)?claude-strict\s*<\/command-name>/i;
+const EXPANDED_ARGS_RE = /<command-args>([\s\S]*?)<\/command-args>/i;
+
+const ROUTE_WORDS = {
+  on: /^(on|an|start|ein)$/i,
+  off: /^(off|aus|stop)$/i,
+  status: /^status$/i,
+};
+
+function routeFor(rest) {
+  const trimmed = (rest || '').trim();
+  if (!trimmed) return { route: 'status', rest: '' };
+  const first = trimmed.split(/\s+/)[0];
+  for (const [route, re] of Object.entries(ROUTE_WORDS)) {
+    if (re.test(first)) return { route, rest: trimmed.slice(first.length).trim() };
+  }
+  return { route: 'task', rest: trimmed };
+}
+
+/**
+ * @param {string} text raw user prompt
+ * @returns {{mentioned:boolean, route:'on'|'off'|'status'|'task'|null, rest:string}}
+ */
+function detectMention(text) {
+  const none = { mentioned: false, route: null, rest: '' };
+  if (typeof text !== 'string' || !text) return none;
+
+  if (text.includes('<command-name>')) {
+    // Expanded slash command: only OUR name counts; a mention inside another
+    // command's args is that command's business.
+    if (!EXPANDED_NAME_RE.test(text)) return none;
+    const argsMatch = text.match(EXPANDED_ARGS_RE);
+    const args = argsMatch ? argsMatch[1] : '';
+    return { mentioned: true, ...routeFor(args) };
+  }
+
+  const m = MENTION_RE.exec(text);
+  if (!m) return none;
+  const start = m.index + m[1].length;           // index of the '/'
+  const end = start + m[0].length - m[1].length;  // just past the token
+  if (text[start - 1] === '`' || text[end] === '`') return none;
+  return { mentioned: true, ...routeFor(text.slice(end)) };
+}
+
+// ── contract ───────────────────────────────────────────────────────────────
+
+function statusLine(mode, branch) {
+  const reason = mode && mode.reason ? mode.reason : 'inline';
+  const where = branch ? ` · branch ${branch}` : '';
+  const bound = mode && mode.boundTo ? ` · bound to ${mode.boundTo}` : '';
+  return `strict: ${reason}${where}${bound} · /claude-strict off`;
+}
+
+/** Status line + contract block, ready for additionalContext. */
+function contractText({ mode, branch } = {}) {
+  return `${statusLine(mode, branch)}\n${CONTRACT_BLOCK}`;
+}
+
+function hasContract(text) {
+  return typeof text === 'string' && text.includes(CONTRACT_OPEN);
+}
+
+// ── CLI ────────────────────────────────────────────────────────────────────
+
+function cli(argv) {
+  const cwd = process.cwd();
+  const cmd = argv[0];
+  const out = (o) => process.stdout.write(JSON.stringify(o) + '\n');
+  switch (cmd) {
+    case 'on': {
+      const mode = activate(cwd, { reason: 'on' });
+      out({ ok: true, active: true, reason: mode.reason, branch: mode.branch, path: modePath(cwd) });
+      return 0;
+    }
+    case 'off': {
+      const had = !!readMode(cwd);
+      deactivate(cwd);
+      out({ ok: true, active: false, removed: had });
+      return 0;
+    }
+    case 'status': {
+      const ev = evaluate(cwd);
+      out({
+        active: ev.active,
+        why: ev.why,
+        reason: ev.mode ? ev.mode.reason : null,
+        branch: ev.mode ? ev.mode.branch : null,
+        currentBranch: currentBranch(cwd),
+        boundTo: ev.mode ? ev.mode.boundTo : null,
+        expiresAt: ev.mode ? ev.mode.expiresAt : null,
+        path: modePath(cwd),
+      });
+      return 0;
+    }
+    case 'contract': {
+      process.stdout.write(CONTRACT_BLOCK + '\n');
+      return 0;
+    }
+    default:
+      process.stderr.write('usage: strict-state.js on|off|status|contract\n');
+      return 1;
+  }
+}
+
+if (require.main === module) {
+  process.exit(cli(process.argv.slice(2)));
+}
+
+module.exports = {
+  MODE_FILE, BINDINGS, INLINE_EXPIRY_HOURS, BOUND_EXPIRY_HOURS,
+  CONTRACT_OPEN, CONTRACT_CLOSE, CONTRACT_BLOCK,
+  modePath, readMode, deactivate, activate, bind, findBinding,
+  currentBranch, mainWorktree, evaluate, isActive, resolveInherited,
+  branchNoticed, markBranchNoticed,
+  detectMention, MENTION_RE,
+  statusLine, contractText, hasContract,
+};

--- a/plugins/devops/hooks/lib/strict-state.test.js
+++ b/plugins/devops/hooks/lib/strict-state.test.js
@@ -1,0 +1,264 @@
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import * as S from "./strict-state.js";
+
+const LIB = fileURLToPath(new URL("./strict-state.js", import.meta.url));
+
+const GIT_ENV = {
+  ...process.env,
+  GIT_AUTHOR_NAME: "t", GIT_AUTHOR_EMAIL: "t@t", GIT_COMMITTER_NAME: "t", GIT_COMMITTER_EMAIL: "t@t",
+};
+
+function git(cwd, ...args) {
+  const r = spawnSync("git", args, { cwd, encoding: "utf8", env: GIT_ENV });
+  if (r.status !== 0) throw new Error(`git ${args.join(" ")} failed: ${r.stderr}`);
+  return r.stdout.trim();
+}
+
+/** Throwaway repo on `branch` with one commit, so HEAD is born. */
+function repo(branch = "feat/x") {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "strict-state-"));
+  git(dir, "init", "-q", "-b", branch);
+  fs.writeFileSync(path.join(dir, "README.md"), "x\n");
+  git(dir, "add", ".");
+  git(dir, "commit", "-q", "-m", "init");
+  return dir;
+}
+
+let cwd;
+beforeEach(() => { cwd = repo(); });
+afterEach(() => { try { fs.rmSync(cwd, { recursive: true, force: true }); } catch { /* best effort */ } });
+
+// ── mode file ──────────────────────────────────────────────────────────────
+
+describe("activate / readMode", () => {
+  test("writes the mode file with the current branch and reason", () => {
+    const m = S.activate(cwd, { reason: "on" });
+    expect(fs.existsSync(S.modePath(cwd))).toBe(true);
+    expect(m.active).toBe(true);
+    expect(m.reason).toBe("on");
+    expect(m.branch).toBe("feat/x");
+    expect(m.expiresAt).toBeNull();
+    expect(S.readMode(cwd).branch).toBe("feat/x");
+  });
+
+  test("inline mode carries an expiry; explicit branch and sessionId are stored", () => {
+    const m = S.activate(cwd, { reason: "inline", sessionId: "s1", now: Date.parse("2026-09-04T10:00:00Z") });
+    expect(m.sessionId).toBe("s1");
+    expect(typeof m.expiresAt).toBe("string");
+    expect(Date.parse(m.expiresAt)).toBeGreaterThan(Date.parse("2026-09-04T10:00:00Z"));
+  });
+
+  test("readMode is null without a file and null on corrupt JSON", () => {
+    expect(S.readMode(cwd)).toBeNull();
+    fs.mkdirSync(path.join(cwd, ".claude"), { recursive: true });
+    fs.writeFileSync(S.modePath(cwd), "{not json", "utf8");
+    expect(S.readMode(cwd)).toBeNull();
+  });
+
+  test("deactivate removes the file and is idempotent", () => {
+    S.activate(cwd, { reason: "on" });
+    S.deactivate(cwd);
+    S.deactivate(cwd);
+    expect(fs.existsSync(S.modePath(cwd))).toBe(false);
+  });
+});
+
+describe("currentBranch", () => {
+  test("reads the checked-out branch", () => {
+    expect(S.currentBranch(cwd)).toBe("feat/x");
+  });
+  test("is null outside a repo", () => {
+    const plain = fs.mkdtempSync(path.join(os.tmpdir(), "strict-norepo-"));
+    try { expect(S.currentBranch(plain)).toBeNull(); }
+    finally { fs.rmSync(plain, { recursive: true, force: true }); }
+  });
+});
+
+describe("evaluate", () => {
+  test("off when there is no mode file", () => {
+    expect(S.evaluate(cwd)).toMatchObject({ active: false, why: "off" });
+  });
+
+  test("active on the same branch", () => {
+    S.activate(cwd, { reason: "on" });
+    expect(S.evaluate(cwd)).toMatchObject({ active: true, why: null });
+  });
+
+  test("branch-mismatch after switching branches", () => {
+    S.activate(cwd, { reason: "on" });
+    git(cwd, "checkout", "-q", "-b", "other");
+    expect(S.evaluate(cwd)).toMatchObject({ active: false, why: "branch-mismatch" });
+  });
+
+  test("expired when now is past expiresAt", () => {
+    const t0 = Date.parse("2026-09-04T10:00:00Z");
+    S.activate(cwd, { reason: "inline", now: t0 });
+    expect(S.evaluate(cwd, { now: t0 + 60_000 }).active).toBe(true);
+    expect(S.evaluate(cwd, { now: t0 + 48 * 3600_000 })).toMatchObject({ active: false, why: "expired" });
+  });
+
+  test("binding-gone when a bound workflow file has disappeared", () => {
+    S.activate(cwd, { reason: "inline" });
+    fs.mkdirSync(path.join(cwd, ".claude"), { recursive: true });
+    fs.writeFileSync(path.join(cwd, ".claude", "concept-active.json"), "{}");
+    S.bind(cwd, "concept", path.join(".claude", "concept-active.json"));
+    expect(S.evaluate(cwd)).toMatchObject({ active: true });
+    fs.unlinkSync(path.join(cwd, ".claude", "concept-active.json"));
+    expect(S.evaluate(cwd)).toMatchObject({ active: false, why: "binding-gone" });
+  });
+
+  test("no repo: branch check is skipped, mode counts", () => {
+    const plain = fs.mkdtempSync(path.join(os.tmpdir(), "strict-norepo-"));
+    try {
+      S.activate(plain, { reason: "on" });
+      expect(S.readMode(plain).branch).toBeNull();
+      expect(S.evaluate(plain)).toMatchObject({ active: true });
+    } finally { fs.rmSync(plain, { recursive: true, force: true }); }
+  });
+});
+
+describe("bindings", () => {
+  test("findBinding: none, concept, autonomous", () => {
+    expect(S.findBinding(cwd)).toBeNull();
+    fs.mkdirSync(path.join(cwd, ".claude"), { recursive: true });
+    fs.writeFileSync(path.join(cwd, ".claude", "concept-active.json"), "{}");
+    expect(S.findBinding(cwd)).toMatchObject({ reason: "concept" });
+    fs.unlinkSync(path.join(cwd, ".claude", "concept-active.json"));
+    fs.writeFileSync(path.join(cwd, "AUTONOMOUS-LOCKOUT.flag"), "{}");
+    expect(S.findBinding(cwd)).toMatchObject({ reason: "autonomous" });
+  });
+
+  test("bind rewrites reason and boundTo, keeps the branch", () => {
+    S.activate(cwd, { reason: "inline" });
+    const m = S.bind(cwd, "autonomous", "AUTONOMOUS-LOCKOUT.flag");
+    expect(m).toMatchObject({ reason: "autonomous", boundTo: "AUTONOMOUS-LOCKOUT.flag", branch: "feat/x" });
+    expect(typeof m.expiresAt).toBe("string");
+  });
+
+  test("branch notice bookkeeping", () => {
+    S.activate(cwd, { reason: "on" });
+    expect(S.branchNoticed(cwd, "other")).toBe(false);
+    S.markBranchNoticed(cwd, "other");
+    expect(S.branchNoticed(cwd, "other")).toBe(true);
+    expect(S.branchNoticed(cwd, "third")).toBe(false);
+  });
+});
+
+// ── inherited mode (worktree agents) ───────────────────────────────────────
+
+describe("resolveInherited", () => {
+  test("a worktree on <branch>-<role> inherits the main worktree's mode", () => {
+    S.activate(cwd, { reason: "on" });
+    const wt = path.join(os.tmpdir(), `strict-wt-${Date.now()}`);
+    git(cwd, "worktree", "add", "-q", wt, "-b", "feat/x-core");
+    try {
+      expect(S.readMode(wt)).toBeNull();
+      expect(S.resolveInherited(wt)).toMatchObject({ branch: "feat/x", reason: "on" });
+      expect(S.evaluate(wt, { inherit: true })).toMatchObject({ active: true, inherited: true });
+    } finally {
+      git(cwd, "worktree", "remove", "--force", wt);
+    }
+  });
+
+  test("an unrelated branch does not inherit", () => {
+    S.activate(cwd, { reason: "on" });
+    const wt = path.join(os.tmpdir(), `strict-wt-${Date.now()}`);
+    git(cwd, "worktree", "add", "-q", wt, "-b", "hotfix/y");
+    try {
+      expect(S.resolveInherited(wt)).toBeNull();
+      expect(S.evaluate(wt, { inherit: true }).active).toBe(false);
+    } finally {
+      git(cwd, "worktree", "remove", "--force", wt);
+    }
+  });
+});
+
+// ── mention detection ──────────────────────────────────────────────────────
+
+describe("detectMention", () => {
+  test("task with the remainder", () => {
+    expect(S.detectMention("/claude-strict mach den Rand dünner"))
+      .toEqual({ mentioned: true, route: "task", rest: "mach den Rand dünner" });
+  });
+  test("plugin-prefixed form and routes", () => {
+    expect(S.detectMention("/devops:claude-strict on").route).toBe("on");
+    expect(S.detectMention("/claude-strict an").route).toBe("on");
+    expect(S.detectMention("/claude-strict off").route).toBe("off");
+    expect(S.detectMention("/claude-strict aus").route).toBe("off");
+    expect(S.detectMention("/claude-strict status").route).toBe("status");
+    expect(S.detectMention("/claude-strict").route).toBe("status");
+  });
+  test("another slash command after it stays part of the task", () => {
+    expect(S.detectMention("/claude-strict /concept Rand-Varianten"))
+      .toEqual({ mentioned: true, route: "task", rest: "/concept Rand-Varianten" });
+  });
+  test("mid-sentence mention counts", () => {
+    expect(S.detectMention("bitte /claude-strict nur den Rand").mentioned).toBe(true);
+  });
+  test("not a mention: backticks, path segments, the word strict", () => {
+    expect(S.detectMention("siehe `/claude-strict` im README").mentioned).toBe(false);
+    expect(S.detectMention("lies docs/claude-strict.md").mentioned).toBe(false);
+    expect(S.detectMention("strict: true in tsconfig").mentioned).toBe(false);
+    expect(S.detectMention("be strict about types").mentioned).toBe(false);
+    expect(S.detectMention("").mentioned).toBe(false);
+    expect(S.detectMention(undefined).mentioned).toBe(false);
+  });
+  test("expanded slash command with args", () => {
+    const x = "<command-message>claude-strict is running…</command-message><command-name>/claude-strict</command-name><command-args>on</command-args>";
+    expect(S.detectMention(x)).toMatchObject({ mentioned: true, route: "on" });
+    const y = "<command-name>/devops:claude-strict</command-name><command-args>den Rand dünner</command-args>";
+    expect(S.detectMention(y)).toEqual({ mentioned: true, route: "task", rest: "den Rand dünner" });
+    const z = "<command-name>/concept</command-name><command-args>/claude-strict foo</command-args>";
+    expect(S.detectMention(z).mentioned).toBe(false);
+  });
+});
+
+// ── contract ───────────────────────────────────────────────────────────────
+
+describe("contract", () => {
+  test("block shape and size", () => {
+    expect(S.CONTRACT_BLOCK.startsWith(S.CONTRACT_OPEN)).toBe(true);
+    expect(S.CONTRACT_BLOCK.trimEnd().endsWith(S.CONTRACT_CLOSE)).toBe(true);
+    expect(S.CONTRACT_BLOCK.length).toBeLessThanOrEqual(1400);
+    for (const must of ["SCOPE IS LITERAL", "DISCRETION", "TESTS", "PRECEDENCE", "PROPAGATION", "REPORT", "tune-polish", "untouched"]) {
+      expect(S.CONTRACT_BLOCK).toContain(must);
+    }
+  });
+  test("contractText prefixes a status line", () => {
+    S.activate(cwd, { reason: "on" });
+    const t = S.contractText({ mode: S.readMode(cwd), branch: "feat/x" });
+    expect(t.split("\n")[0]).toMatch(/^strict: on · branch feat\/x · \/claude-strict off/);
+    expect(t).toContain(S.CONTRACT_OPEN);
+  });
+  test("hasContract", () => {
+    expect(S.hasContract(`x\n${S.CONTRACT_OPEN}\n…`)).toBe(true);
+    expect(S.hasContract("plain prompt")).toBe(false);
+    expect(S.hasContract(undefined)).toBe(false);
+  });
+});
+
+// ── CLI ────────────────────────────────────────────────────────────────────
+
+describe("CLI", () => {
+  function cli(...args) {
+    return spawnSync(process.execPath, [LIB, ...args], { cwd, encoding: "utf8", env: GIT_ENV });
+  }
+  test("on / status / off / contract", () => {
+    expect(cli("on").status).toBe(0);
+    expect(S.readMode(cwd)).toMatchObject({ reason: "on", branch: "feat/x" });
+    const st = JSON.parse(cli("status").stdout);
+    expect(st).toMatchObject({ active: true, reason: "on", branch: "feat/x" });
+    expect(cli("off").status).toBe(0);
+    expect(S.readMode(cwd)).toBeNull();
+    expect(JSON.parse(cli("status").stdout)).toMatchObject({ active: false });
+    expect(cli("contract").stdout).toContain(S.CONTRACT_OPEN);
+  });
+  test("unknown subcommand exits 1", () => {
+    expect(cli("bogus").status).toBe(1);
+  });
+});

--- a/plugins/devops/hooks/pre-tool-use/pre.strict.agent-gate.js
+++ b/plugins/devops/hooks/pre-tool-use/pre.strict.agent-gate.js
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+/**
+ * @hook pre.strict.agent-gate
+ * @version 0.1.0
+ * @event PreToolUse
+ * @plugin devops
+ * @description While `/claude-strict` is active, refuse an Agent spawn whose
+ *   prompt does not start with the contract block, and tell the caller how to
+ *   fix it. This is how strict reaches every subagent — recursively, because
+ *   plugin hooks also run inside subagents, so an agent spawning an agent hits
+ *   the same gate.
+ *
+ *   Why a gate and not a rewrite: Claude Code ignores `updatedInput` for the
+ *   Agent tool (anthropics/claude-code#44412), so the prompt cannot be patched
+ *   here. Refusing once with a precise reason makes the caller prepend the
+ *   block itself; the retry passes.
+ *
+ *   Worktree agents: an agent spawned with `isolation: worktree` runs in its
+ *   own checkout on `<parent>-<role>`. It has no mode file of its own, so the
+ *   gate falls back to the main worktree's mode when the branch derives from
+ *   the armed one (strict-state.resolveInherited).
+ *
+ *   Injects nothing — prompt.strict.enforce is the only contract injector.
+ */
+
+require('../lib/plugin-guard');
+
+const path = require('path');
+const S = require('../lib/strict-state');
+
+const LIB = path.resolve(__dirname, '..', 'lib', 'strict-state.js');
+
+let inputData = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', d => { inputData += d; });
+process.stdin.on('end', () => {
+  let hook;
+  try { hook = JSON.parse(inputData); } catch { process.exit(0); }
+
+  if (hook.tool_name && hook.tool_name !== 'Agent') process.exit(0);
+
+  const cwd = hook.cwd || process.cwd();
+  let ev;
+  try { ev = S.evaluate(cwd, { inherit: true }); } catch { process.exit(0); }
+  if (!ev.active) process.exit(0);
+
+  const input = hook.tool_input || {};
+  const prompt = typeof input.prompt === 'string' ? input.prompt : '';
+  if (S.hasContract(prompt)) process.exit(0);
+
+  const branch = ev.mode && ev.mode.branch ? ev.mode.branch : 'this worktree';
+  process.stderr.write(
+    `[claude-strict] BLOCKED: strict mode is active (${branch}) and this Agent prompt has no contract block.\n` +
+    `Every spawned agent inherits strict. Prepend the block VERBATIM as the first lines of the prompt and retry.\n` +
+    `Print it with:\n  node "${LIB}" contract\n` +
+    'Then the task text as before — do not paraphrase or shorten the block.\n',
+  );
+  process.exit(2);
+});

--- a/plugins/devops/hooks/pre-tool-use/pre.strict.agent-gate.test.js
+++ b/plugins/devops/hooks/pre-tool-use/pre.strict.agent-gate.test.js
@@ -1,0 +1,113 @@
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import * as S from "../lib/strict-state.js";
+
+const HOOK = fileURLToPath(new URL("./pre.strict.agent-gate.js", import.meta.url));
+
+const GIT_ENV = {
+  ...process.env,
+  GIT_AUTHOR_NAME: "t", GIT_AUTHOR_EMAIL: "t@t", GIT_COMMITTER_NAME: "t", GIT_COMMITTER_EMAIL: "t@t",
+};
+
+function git(cwd, ...args) {
+  const r = spawnSync("git", args, { cwd, encoding: "utf8", env: GIT_ENV });
+  if (r.status !== 0) throw new Error(`git ${args.join(" ")} failed: ${r.stderr}`);
+  return r.stdout.trim();
+}
+
+let cwd;
+
+function runHook(payload, at = cwd) {
+  const res = spawnSync(process.execPath, [HOOK], {
+    input: JSON.stringify({ cwd: at, session_id: "sess-1", tool_name: "Agent", ...payload }),
+    cwd: at,
+    encoding: "utf8",
+    env: GIT_ENV,
+  });
+  return { code: res.status, stdout: res.stdout || "", stderr: res.stderr || "" };
+}
+
+function enablePlugin(dir) {
+  fs.mkdirSync(path.join(dir, ".claude"), { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, ".claude", "settings.json"),
+    JSON.stringify({ enabledPlugins: { "devops@dotclaude": true } }),
+    "utf8",
+  );
+}
+
+beforeEach(() => {
+  cwd = fs.mkdtempSync(path.join(os.tmpdir(), "strict-gate-"));
+  git(cwd, "init", "-q", "-b", "feat/x");
+  enablePlugin(cwd);
+  fs.writeFileSync(path.join(cwd, "README.md"), "x\n");
+  git(cwd, "add", ".");
+  git(cwd, "commit", "-q", "-m", "init");
+});
+
+afterEach(() => {
+  try { fs.rmSync(cwd, { recursive: true, force: true }); } catch { /* best effort */ }
+});
+
+const PLAIN = { tool_input: { subagent_type: "devops:frontend", prompt: "Mach den Rand dünner." } };
+const WITH_BLOCK = { tool_input: { subagent_type: "devops:frontend", prompt: `${S.CONTRACT_BLOCK}\n\nMach den Rand dünner.` } };
+
+describe("inactive", () => {
+  test("no mode → silent allow", () => {
+    const r = runHook(PLAIN);
+    expect(r.code).toBe(0);
+    expect(r.stderr).toBe("");
+  });
+
+  test("branch mismatch → silent allow", () => {
+    S.activate(cwd, { reason: "on" });
+    git(cwd, "checkout", "-q", "-b", "other");
+    expect(runHook(PLAIN).code).toBe(0);
+  });
+});
+
+describe("active", () => {
+  beforeEach(() => S.activate(cwd, { reason: "on" }));
+
+  test("prompt without the block is refused with instructions", () => {
+    const r = runHook(PLAIN);
+    expect(r.code).toBe(2);
+    expect(r.stderr).toContain("[claude-strict]");
+    expect(r.stderr).toContain("contract");
+    expect(r.stderr).toContain("strict-state.js");
+    expect(r.stdout).toBe("");
+  });
+
+  test("prompt carrying the block passes silently", () => {
+    const r = runHook(WITH_BLOCK);
+    expect(r.code).toBe(0);
+    expect(r.stderr).toBe("");
+  });
+
+  test("another tool name is ignored even when the matcher misfires", () => {
+    expect(runHook({ ...PLAIN, tool_name: "Bash" }).code).toBe(0);
+  });
+
+  test("missing prompt field is treated as no block", () => {
+    expect(runHook({ tool_input: { subagent_type: "devops:qa" } }).code).toBe(2);
+  });
+});
+
+describe("worktree inheritance", () => {
+  test("an agent worktree on <branch>-<role> is gated by the parent's mode", () => {
+    S.activate(cwd, { reason: "on" });
+    const wt = path.join(os.tmpdir(), `strict-gate-wt-${Date.now()}`);
+    git(cwd, "worktree", "add", "-q", wt, "-b", "feat/x-frontend");
+    enablePlugin(wt);
+    try {
+      expect(runHook(PLAIN, wt).code).toBe(2);
+      expect(runHook(WITH_BLOCK, wt).code).toBe(0);
+    } finally {
+      git(cwd, "worktree", "remove", "--force", wt);
+    }
+  });
+});

--- a/plugins/devops/hooks/stop/stop.strict.release.js
+++ b/plugins/devops/hooks/stop/stop.strict.release.js
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+/**
+ * @hook stop.strict.release
+ * @version 0.1.0
+ * @event Stop
+ * @plugin devops
+ * @description Settles the lifetime of an inline `/claude-strict` mode at the
+ *   end of the turn that armed it. If the turn started a multi-turn workflow
+ *   (a concept session — `.claude/concept-active.json`; an autonomous run —
+ *   `AUTONOMOUS-LOCKOUT.flag`), the mode is bound to that workflow's state
+ *   file and lives exactly as long as the file does. Otherwise the inline mode
+ *   is released: the next prompt is normal unless it mentions the skill again.
+ *
+ *   Bound modes whose file has disappeared are released here too, so a
+ *   finished concept session never leaves a stale strict behind. A branch mode
+ *   (`/claude-strict on`) is never touched — only `off` or a branch switch
+ *   ends it.
+ *
+ *   Never blocks the stop. Advisory line on stderr only.
+ */
+
+require('../lib/plugin-guard');
+
+const fs = require('fs');
+const path = require('path');
+const S = require('../lib/strict-state');
+
+let inputData = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', d => { inputData += d; });
+process.stdin.on('end', () => {
+  let hook;
+  try { hook = JSON.parse(inputData); } catch { process.exit(0); }
+
+  const cwd = hook.cwd || process.cwd();
+  try {
+    const mode = S.readMode(cwd);
+    if (!mode || mode.active !== true) process.exit(0);
+
+    if (mode.reason === 'inline') {
+      const binding = S.findBinding(cwd);
+      if (binding) {
+        S.bind(cwd, binding.reason, binding.file);
+        process.stderr.write(`[claude-strict] inline strict bound to the running ${binding.reason} workflow (${binding.file}); it ends with it.\n`);
+      } else {
+        S.deactivate(cwd);
+      }
+      process.exit(0);
+    }
+
+    if (mode.boundTo && !fs.existsSync(path.join(cwd, mode.boundTo))) {
+      S.deactivate(cwd);
+      process.stderr.write(`[claude-strict] ${mode.reason} workflow ended — strict released.\n`);
+    }
+  } catch {
+    // advisory only
+  }
+  process.exit(0);
+});

--- a/plugins/devops/hooks/stop/stop.strict.release.test.js
+++ b/plugins/devops/hooks/stop/stop.strict.release.test.js
@@ -1,0 +1,91 @@
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import * as S from "../lib/strict-state.js";
+
+const HOOK = fileURLToPath(new URL("./stop.strict.release.js", import.meta.url));
+
+let cwd;
+
+function runHook(payload = {}) {
+  const res = spawnSync(process.execPath, [HOOK], {
+    input: JSON.stringify({ cwd, session_id: "sess-1", stop_hook_active: false, ...payload }),
+    cwd,
+    encoding: "utf8",
+  });
+  return { code: res.status, stdout: res.stdout || "", stderr: res.stderr || "" };
+}
+
+beforeEach(() => {
+  cwd = fs.mkdtempSync(path.join(os.tmpdir(), "strict-stop-"));
+  fs.mkdirSync(path.join(cwd, ".claude"), { recursive: true });
+  fs.writeFileSync(
+    path.join(cwd, ".claude", "settings.json"),
+    JSON.stringify({ enabledPlugins: { "devops@dotclaude": true } }),
+    "utf8",
+  );
+});
+
+afterEach(() => {
+  try { fs.rmSync(cwd, { recursive: true, force: true }); } catch { /* best effort */ }
+});
+
+test("no mode → silent", () => {
+  const r = runHook();
+  expect(r.code).toBe(0);
+  expect(r.stderr).toBe("");
+});
+
+test("inline with no workflow → released", () => {
+  S.activate(cwd, { reason: "inline", branch: null });
+  expect(runHook().code).toBe(0);
+  expect(S.readMode(cwd)).toBeNull();
+});
+
+test("inline while a concept session is open → bound to it", () => {
+  S.activate(cwd, { reason: "inline", branch: null });
+  fs.writeFileSync(path.join(cwd, ".claude", "concept-active.json"), "{}");
+  const r = runHook();
+  expect(r.stderr).toContain("concept");
+  expect(S.readMode(cwd)).toMatchObject({ reason: "concept", boundTo: path.join(".claude", "concept-active.json") });
+});
+
+test("inline during an autonomous lockout → bound to it", () => {
+  S.activate(cwd, { reason: "inline", branch: null });
+  fs.writeFileSync(path.join(cwd, "AUTONOMOUS-LOCKOUT.flag"), "{}");
+  runHook();
+  expect(S.readMode(cwd)).toMatchObject({ reason: "autonomous", boundTo: "AUTONOMOUS-LOCKOUT.flag" });
+});
+
+test("bound mode whose file is gone → released", () => {
+  S.activate(cwd, { reason: "inline", branch: null });
+  fs.writeFileSync(path.join(cwd, ".claude", "concept-active.json"), "{}");
+  runHook();
+  fs.unlinkSync(path.join(cwd, ".claude", "concept-active.json"));
+  const r = runHook();
+  expect(r.stderr).toContain("released");
+  expect(S.readMode(cwd)).toBeNull();
+});
+
+test("bound mode whose file still exists → kept", () => {
+  S.activate(cwd, { reason: "inline", branch: null });
+  fs.writeFileSync(path.join(cwd, ".claude", "concept-active.json"), "{}");
+  runHook();
+  runHook();
+  expect(S.readMode(cwd)).toMatchObject({ reason: "concept" });
+});
+
+test("branch mode is never touched", () => {
+  S.activate(cwd, { reason: "on", branch: null });
+  const r = runHook();
+  expect(r.stderr).toBe("");
+  expect(S.readMode(cwd)).toMatchObject({ reason: "on" });
+});
+
+test("never blocks the stop (no JSON decision on stdout)", () => {
+  S.activate(cwd, { reason: "inline", branch: null });
+  expect(runHook().stdout).toBe("");
+});

--- a/plugins/devops/hooks/user-prompt-submit/prompt.plugin.scope.js
+++ b/plugins/devops/hooks/user-prompt-submit/prompt.plugin.scope.js
@@ -40,7 +40,7 @@ const PLUGIN_SIGNALS = [
   /(^|\s)\/setup-(issue|project|readme|cleanup)\b/,
   /(^|\s)\/run-(agents|autonomous|backlog|burn)\b/,
   /(^|\s)\/tune-(harden|polish|rethink)\b/,
-  /(^|\s)\/claude-(learn|lint|extend-skill)\b/,
+  /(^|\s)\/claude-(learn|lint|extend-skill|batch|strict)\b/,
   /(^|\s)\/auto-(update|usage|graph)\b/,
   /\bcompletion[- ]card\b/i,
   // Hook filenames: {event}.{domain}.{action}.js — action segments may be

--- a/plugins/devops/hooks/user-prompt-submit/prompt.strict.enforce.js
+++ b/plugins/devops/hooks/user-prompt-submit/prompt.strict.enforce.js
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+/**
+ * @hook prompt.strict.enforce
+ * @version 0.1.0
+ * @event UserPromptSubmit
+ * @plugin devops
+ * @description Arms and enforces `/claude-strict` — literal scope, discretionary
+ *   parameters. A prompt that mentions `/claude-strict` arms the mode for this
+ *   worktree + branch (`on`), for this turn (`<task>`), or clears it (`off`).
+ *   Whenever the mode is active the contract block is injected as
+ *   additionalContext — once per turn, and on machine prompts too (autonomous
+ *   resumes, concept-bridge crons), because those are exactly the turns that
+ *   must stay strict without the user re-typing the skill.
+ *
+ *   This hook is the ONLY injector of the contract. The Agent gate
+ *   (pre.strict.agent-gate) refuses spawns that lack it but injects nothing,
+ *   so one turn never carries the block twice.
+ *
+ *   Never arms on a prompt that `/claude-batch` will collect: that prompt is
+ *   erased by the harness, so an armed mode would be invisible and answered by
+ *   nobody (see batch-state.willBeCollected).
+ *
+ *   Branch switch: a mode armed on branch A is inactive on branch B. The first
+ *   prompt on B gets a one-line notice, later ones nothing — the mode file
+ *   stays so `/claude-strict on` can re-arm and `off` can clear it.
+ *
+ *   Spec: docs/superpowers/specs/2026-09-04-claude-strict-design.md
+ */
+
+require('../lib/plugin-guard');
+
+const S = require('../lib/strict-state');
+const { willBeCollected } = require('../lib/batch-state');
+
+function emit(text) {
+  process.stdout.write(JSON.stringify({
+    hookSpecificOutput: { hookEventName: 'UserPromptSubmit', additionalContext: text },
+  }));
+}
+
+let inputData = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', d => { inputData += d; });
+process.stdin.on('end', () => {
+  let hook;
+  try { hook = JSON.parse(inputData); } catch { process.exit(0); }
+
+  const text = hook.prompt || hook.user_message || hook.message || '';
+  const cwd  = hook.cwd || process.cwd();
+
+  try {
+    if (willBeCollected(hook)) process.exit(0);
+
+    const mention = S.detectMention(text);
+    if (mention.mentioned) {
+      const existing = S.readMode(cwd);
+      if (mention.route === 'off') {
+        S.deactivate(cwd);
+        emit('[claude-strict] strict mode is off for this worktree. Confirm that in one line; nothing else changes.');
+        process.exit(0);
+      }
+      if (mention.route === 'on') {
+        S.activate(cwd, { reason: 'on', sessionId: hook.session_id });
+      } else if (mention.route === 'task') {
+        // A branch mode already covers this turn — never downgrade it to inline.
+        if (!(existing && existing.reason === 'on' && S.evaluate(cwd).active)) {
+          S.activate(cwd, { reason: 'inline', sessionId: hook.session_id });
+        }
+      }
+      // route 'status': the skill reports; the injection below shows the state.
+    }
+
+    const branch = S.currentBranch(cwd);
+    const ev = S.evaluate(cwd, { branch });
+    if (ev.active) {
+      emit(S.contractText({ mode: ev.mode, branch }));
+      process.exit(0);
+    }
+
+    if (ev.why === 'branch-mismatch' && ev.mode && branch && !S.branchNoticed(cwd, branch)) {
+      S.markBranchNoticed(cwd, branch);
+      emit(
+        `[claude-strict] strict was armed on branch \`${ev.mode.branch}\`; this worktree is now on ` +
+        `\`${branch}\`, so strict is inactive here. Tell the user in one line. ` +
+        '`/claude-strict on` re-arms for this branch, `/claude-strict off` clears the old mode.',
+      );
+    }
+  } catch {
+    // Advisory hook — a bug here must never cost the user a turn.
+  }
+  process.exit(0);
+});

--- a/plugins/devops/hooks/user-prompt-submit/prompt.strict.enforce.test.js
+++ b/plugins/devops/hooks/user-prompt-submit/prompt.strict.enforce.test.js
@@ -1,0 +1,160 @@
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import * as S from "../lib/strict-state.js";
+import * as B from "../lib/batch-state.js";
+
+const HOOK = fileURLToPath(new URL("./prompt.strict.enforce.js", import.meta.url));
+
+const GIT_ENV = {
+  ...process.env,
+  GIT_AUTHOR_NAME: "t", GIT_AUTHOR_EMAIL: "t@t", GIT_COMMITTER_NAME: "t", GIT_COMMITTER_EMAIL: "t@t",
+};
+
+function git(cwd, ...args) {
+  const r = spawnSync("git", args, { cwd, encoding: "utf8", env: GIT_ENV });
+  if (r.status !== 0) throw new Error(`git ${args.join(" ")} failed: ${r.stderr}`);
+  return r.stdout.trim();
+}
+
+let cwd;
+
+/** Run the hook exactly as the harness does: JSON on stdin, project as cwd. */
+function runHook(payload) {
+  const res = spawnSync(process.execPath, [HOOK], {
+    input: JSON.stringify({ cwd, session_id: "sess-1", ...payload }),
+    cwd,
+    encoding: "utf8",
+    env: GIT_ENV,
+  });
+  let json = null;
+  try { json = JSON.parse(res.stdout); } catch { /* not JSON */ }
+  const ctx = json && json.hookSpecificOutput ? json.hookSpecificOutput.additionalContext || "" : "";
+  return { code: res.status, stdout: res.stdout || "", stderr: res.stderr || "", ctx };
+}
+
+function count(haystack, needle) {
+  return haystack.split(needle).length - 1;
+}
+
+beforeEach(() => {
+  cwd = fs.mkdtempSync(path.join(os.tmpdir(), "strict-hook-"));
+  git(cwd, "init", "-q", "-b", "feat/x");
+  fs.mkdirSync(path.join(cwd, ".claude"), { recursive: true });
+  fs.writeFileSync(
+    path.join(cwd, ".claude", "settings.json"),
+    JSON.stringify({ enabledPlugins: { "devops@dotclaude": true } }),
+    "utf8",
+  );
+  fs.writeFileSync(path.join(cwd, "README.md"), "x\n");
+  git(cwd, "add", ".");
+  git(cwd, "commit", "-q", "-m", "init");
+});
+
+afterEach(() => {
+  try { fs.rmSync(cwd, { recursive: true, force: true }); } catch { /* best effort */ }
+});
+
+describe("inert", () => {
+  test("mode off, no mention → exit 0, nothing injected, no mode file", () => {
+    const r = runHook({ prompt: "mach den Button blau" });
+    expect(r.code).toBe(0);
+    expect(r.stdout).toBe("");
+    expect(S.readMode(cwd)).toBeNull();
+  });
+
+  test("the word strict alone is not a mention", () => {
+    const r = runHook({ prompt: "set strict: true in tsconfig" });
+    expect(r.stdout).toBe("");
+    expect(S.readMode(cwd)).toBeNull();
+  });
+});
+
+describe("arming by mention", () => {
+  test("inline task arms an inline mode and injects the contract", () => {
+    const r = runHook({ prompt: "/claude-strict mach den Rand der Box dünner" });
+    expect(r.code).toBe(0);
+    expect(S.readMode(cwd)).toMatchObject({ reason: "inline", branch: "feat/x", sessionId: "sess-1" });
+    expect(r.ctx).toContain(S.CONTRACT_OPEN);
+    expect(r.ctx.split("\n")[0]).toMatch(/^strict: inline · branch feat\/x/);
+  });
+
+  test("on arms a branch mode without expiry", () => {
+    const r = runHook({ prompt: "/claude-strict on" });
+    expect(S.readMode(cwd)).toMatchObject({ reason: "on", expiresAt: null });
+    expect(r.ctx).toContain("strict: on · branch feat/x");
+    expect(r.ctx).toContain(S.CONTRACT_OPEN);
+  });
+
+  test("expanded slash command arms too", () => {
+    runHook({ prompt: "<command-name>/claude-strict</command-name><command-args>on</command-args>" });
+    expect(S.readMode(cwd)).toMatchObject({ reason: "on" });
+  });
+
+  test("off removes the mode and says so in one line", () => {
+    S.activate(cwd, { reason: "on" });
+    const r = runHook({ prompt: "/claude-strict off" });
+    expect(S.readMode(cwd)).toBeNull();
+    expect(r.ctx).toMatch(/off/);
+    expect(r.ctx).not.toContain(S.CONTRACT_OPEN);
+  });
+
+  test("an inline mention while on does not downgrade the branch mode", () => {
+    S.activate(cwd, { reason: "on" });
+    runHook({ prompt: "/claude-strict noch den Schatten" });
+    expect(S.readMode(cwd)).toMatchObject({ reason: "on" });
+  });
+
+  test("the prompt field name does not matter", () => {
+    expect(runHook({ user_message: "/claude-strict on" }).ctx).toContain(S.CONTRACT_OPEN);
+    S.deactivate(cwd);
+    expect(runHook({ message: "/claude-strict on" }).ctx).toContain(S.CONTRACT_OPEN);
+  });
+});
+
+describe("active mode", () => {
+  beforeEach(() => S.activate(cwd, { reason: "on" }));
+
+  test("plain prompt gets exactly one contract", () => {
+    const r = runHook({ prompt: "und jetzt die Farbe" });
+    expect(count(r.ctx, S.CONTRACT_OPEN)).toBe(1);
+  });
+
+  test.each([
+    ["autonomous resume", "AUTONOMOUS_RESUME: weiter"],
+    ["concept cron", "Silently service the concept bridge on port 8742."],
+    ["backlog autostart", "RUN_BACKLOG_AUTOSTART: presence timeout. phase=gate"],
+  ])("machine prompt (%s) is still injected — those turns must stay strict", (_l, prompt) => {
+    expect(runHook({ prompt }).ctx).toContain(S.CONTRACT_OPEN);
+  });
+
+  test("branch mismatch: one notice, then silence, contract not injected", () => {
+    git(cwd, "checkout", "-q", "-b", "other");
+    const first = runHook({ prompt: "irgendwas" });
+    expect(first.ctx).toContain("feat/x");
+    expect(first.ctx).toContain("other");
+    expect(first.ctx).not.toContain(S.CONTRACT_OPEN);
+    const second = runHook({ prompt: "noch was" });
+    expect(second.stdout).toBe("");
+  });
+});
+
+describe("batch interaction", () => {
+  test("a prompt the batch hook will collect never arms strict", () => {
+    B.activate(cwd);
+    const r = runHook({ prompt: "/claude-strict den Rand dünner" });
+    expect(r.stdout).toBe("");
+    expect(S.readMode(cwd)).toBeNull();
+  });
+
+  test("the batch execute marker still gets the contract when strict is on", () => {
+    S.activate(cwd, { reason: "on" });
+    B.activate(cwd);
+    B.appendNote(cwd, "Rand dünner");
+    const r = runHook({ prompt: ">> los" });
+    expect(r.ctx).toContain(S.CONTRACT_OPEN);
+  });
+});

--- a/plugins/devops/skills/claude-strict/SKILL.md
+++ b/plugins/devops/skills/claude-strict/SKILL.md
@@ -154,7 +154,11 @@ untouched: focus ring now overlaps the border; docs/ui.md still says 2px
   are listed here, not hidden.
 - `chosen` — every attribute you decided. No line when nothing was open.
 - `untouched` — everything you noticed and deliberately did not change:
-  doc debt, adjacent glitches, failing tests, refactor bait.
+  doc debt, adjacent glitches, failing tests, refactor bait. Before writing
+  this line, grep the repo for the OLD value you replaced (`4px`, the old
+  colour, the old name): every hit outside `done` — a doc, a test, a sibling
+  selector — is an `untouched` entry. Reading is free under strict; only
+  the diff is closed.
 
 Then render the completion card as usual (the card is output, not diff).
 

--- a/plugins/devops/skills/claude-strict/SKILL.md
+++ b/plugins/devops/skills/claude-strict/SKILL.md
@@ -1,0 +1,192 @@
+---
+name: claude-strict
+version: 0.1.0
+description: >-
+  Strict mode — the deliverable is exactly what the prompt names, nothing wider;
+  only the attributes the prompt leaves open (colour, size, wording) are Claude's
+  call, and every such choice is reported. Applies recursively: to every skill
+  invoked in the same turn, every agent those skills spawn, every /concept
+  iteration and every autonomous resume the turn sets in motion. Two modes:
+  `/claude-strict <task>` for one prompt (and the workflow it starts), and
+  `/claude-strict on|off` for the whole worktree + branch — never project-wide.
+  Triggers on: "/claude-strict", "strict", "strikt", "genau so und nicht mehr",
+  "nur das ändern", "nichts anderes anfassen". Do NOT trigger for: ordinary
+  requests without a literal-scope signal, /tune-harden or /tune-polish scope
+  fences (they stay as they are), or TypeScript `strict` compiler options.
+argument-hint: "<task> | on | off | status"
+allowed-tools: Bash(node *), Bash(git *), Read, Write, Edit, Glob, Grep, Skill, Agent, AskUserQuestion, mcp__plugin_devops_dotclaude-completion__render_completion_card
+---
+
+# claude-strict — Literal Scope, Discretionary Parameters
+
+Spec: `docs/superpowers/specs/2026-09-04-claude-strict-design.md`
+
+The user says what may change. That set is closed. What the user does NOT
+say about it (the colour of the border, the exact pixel value, the wording of
+a label) is yours to decide — and to report, so a wrong guess is a one-word
+correction instead of a wrong diff.
+
+State lives in `.claude/strict-mode.json` of the **current worktree**. The
+hooks `prompt.strict.enforce` (inject), `pre.strict.agent-gate` (refuse agent
+spawns without the block) and `stop.strict.release` (bind or release an
+inline mode) do the mechanical part; this skill does the judgment part.
+
+## Step 0 — Load Extensions
+
+Silently check (do not surface "not found"):
+1. `~/.claude/skills/claude-strict/SKILL.md` + `reference.md`
+2. `{project}/.claude/skills/claude-strict/SKILL.md` + `reference.md`
+3. Merge: project > global > plugin defaults
+
+## Step 1 — Route the invocation
+
+Route on the **first token** of `$ARGUMENTS` only. No argument → **status**.
+
+| Argument | Branch |
+|---|---|
+| `on`, `an`, `start` | Step 5 — arm the branch mode (`on`) |
+| `off`, `aus`, `stop` | Step 5 — clear the mode |
+| `status`, none | Step 5 — report |
+| *anything else* (free text, including another slash command such as `/concept …`) | **task** — Step 3, under the contract in Step 2 |
+
+A task argument is never filed or deferred: `/claude-strict /concept Rand-Varianten`
+means "run /concept, strictly". The hook has already armed an inline mode for
+this turn (`reason: inline`); you do not arm it again.
+
+## Step 2 — The contract
+
+This block is the single source of truth, mirrored from
+`hooks/lib/strict-state.js` (`CONTRACT_BLOCK`) — a test keeps the two
+identical. It is already in your context this turn (injected by the hook);
+read it as binding, not as advice.
+
+```
+[claude-strict contract]
+SCOPE IS LITERAL — measured in the vocabulary of the request.
+- Only what the request names changes. No refactor, rename, doc update, new
+  test, reformatting of untouched lines, "while I'm here", new file /
+  dependency / abstraction.
+- Visual request ("the box border") → only that visible element changes; the
+  technical route (import, selector) is yours if nothing else visible changes.
+  Technical request ("rename fn X") → only that symbol.
+DISCRETION covers ATTRIBUTES the request leaves open (colour, px, wording),
+never the OBJECT. Ambiguous object: interactive → ask; autonomous → touch the
+single most probable one; lead the report with the assumption.
+TESTS: an assertion pinning the exact old value may be updated. Any other
+failure → apply nothing, revert, report.
+PRECEDENCE (scope only): overrides doc-maintenance, pre-mortem outputs, "make
+reasonable decisions independently", concept zero-prompt invariant. Completion
+card, /ship docs-sync and tune-polish approval stay.
+PROPAGATION: put this block verbatim at the top of every Agent prompt and
+every skill you invoke; it binds concept iterations and autonomous resumes.
+REPORT (≤4 lines, before the card, omit empty lines):
+  strict — requested: <literal ask>
+  done: <what changed, file:line>
+  chosen: <attribute = value (unspecified)>
+  untouched: <noticed but out of scope>
+[/claude-strict contract]
+```
+
+**How to read "vocabulary of the request".** The scope is measured at the
+level the user spoke. "Make the box border thinner" is a visual request: the
+border is the scope, and whether you edit a CSS variable, a class, or add the
+one import that the change needs is your business — as long as no other
+visible thing changes. "Rename `fetchUser` to `loadUser`" is a technical
+request: the symbol is the scope, its call sites are the same symbol, its
+docstring is not. Never translate a visual request into a technical scope
+that is wider than the visual one ("the border is in a shared mixin, so I
+updated the mixin" changes every box — that is not the request).
+
+**Grey zone, one rule each:**
+
+| Case | Rule |
+|---|---|
+| The change needs a syntactic companion (import, export entry, existing registry line) | In scope. Report it under `done`. A new file, dependency or abstraction is NOT a companion — that is out. |
+| A test asserts the exact old value | Update that assertion; it IS the requested change. Report it. |
+| Any other test fails | Apply nothing, revert what you tried, report under `untouched` with the failing test's name. The consequence is the user's call. |
+| The named element would become invisible or non-functional | Stop before applying and report. Malicious compliance is not compliance. |
+| An adjacent element now looks off | Do the change; the neighbour goes to `untouched`. |
+| The object is ambiguous ("the border" — there are three) | Interactive: ask with `AskUserQuestion`, the candidates as options. Autonomous (agent directive says no questions, `AUTONOMOUS_*` prompt, lockout flag present): change the single most probable one and make the assumption the first `done` line. |
+| The request is impossible or contradicts the code | Change nothing, report. |
+
+## Step 3 — Execute the task under the contract
+
+1. Read the task text (the remainder after the first token, or the whole
+   prompt when invoked inline). Identify the **objects** (closed set) and the
+   **open attributes** (your call).
+2. Do the work. Apply the pre-mortem as thinking only — its outputs (extra
+   guards, extra tests, narrowed scope) are diff and go to `untouched`.
+3. **Propagation — mandatory, mechanical:**
+   - **Agent** tool: the prompt starts with the contract block, verbatim.
+     The gate refuses a spawn without it; on refusal, prepend and retry — do
+     not paraphrase the block. Nested agents inherit the same duty; say so
+     in the agent prompt ("forward this block to every agent you spawn").
+   - **Skill** tool: invoke the other skill normally; the contract is in
+     context. Where the callee has a flag channel (`/tune-harden`,
+     `/tune-polish`: `--invoked-by=…`), also pass `--strict`. For `/concept`:
+     the `implement` action executes the literally selected items only;
+     `iterate` is unchanged (it never touches code anyway).
+   - **Autonomous** runners (`/run-autonomous`, `/run-backlog`, `/run-agents`):
+     include `strict=on` in the task line of any `AUTONOMOUS_AUTOSTART:` /
+     `RUN_BACKLOG_AUTOSTART:` cron prompt you create, so a re-launched session
+     re-reads the contract from the prompt even before the hook fires.
+4. **Multi-turn workflows.** If this turn starts a concept session or an
+   autonomous run, the Stop hook binds the inline mode to it automatically
+   (`.claude/concept-active.json`, `AUTONOMOUS-LOCKOUT.flag`) and releases it
+   when that file disappears. Announce the binding in one line when you see
+   it happen (the hook writes `[claude-strict] … bound to …` on stderr);
+   nothing to arm by hand.
+
+## Step 4 — Strict report, then the card
+
+Right before the completion card, ≤ 4 lines, omit empty ones, no prose
+around it:
+
+```
+strict — requested: box border thinner
+done: src/box.css:12 border-width 2px → 1px
+chosen: border-color #3a3a3a (unspecified — was inherited grey)
+untouched: focus ring now overlaps the border; docs/ui.md still says 2px
+```
+
+- `requested` — the literal ask in the user's words.
+- `done` — every change, `file:line`. Companion edits (import, assertion)
+  are listed here, not hidden.
+- `chosen` — every attribute you decided. No line when nothing was open.
+- `untouched` — everything you noticed and deliberately did not change:
+  doc debt, adjacent glitches, failing tests, refactor bait.
+
+Then render the completion card as usual (the card is output, not diff).
+
+## Step 5 — `on` / `off` / `status`
+
+All three go through the state CLI; never edit the mode file by hand:
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/hooks/lib/strict-state.js" on
+node "${CLAUDE_PLUGIN_ROOT}/hooks/lib/strict-state.js" off
+node "${CLAUDE_PLUGIN_ROOT}/hooks/lib/strict-state.js" status
+```
+
+- **on** — arms strict for this worktree on the current branch, no expiry.
+  Every later prompt in this worktree is strict until `off` or a branch
+  switch. Confirm in one line: branch name, and that other worktrees are not
+  affected. If the CLI reports `branch: null` (no git repo), say the mode is
+  bound to the directory instead.
+- **off** — clears the mode. One line.
+- **status** — relay the JSON as one human line: active or not, reason,
+  branch, bound workflow, expiry. When `why` is `branch-mismatch`, say which
+  branch armed it and offer `on` / `off`.
+
+The hook already performed `on`/`off` when the command was typed as a slash
+command, so the CLI call is idempotent — run it anyway and report what it
+returns; never assume.
+
+## What strict is NOT
+
+- Not a caution mode. Do not ask more questions than the ambiguity rule
+  requires; do not add confirmation gates.
+- Not a refusal mode. A request that needs one import gets the import.
+- Not a replacement for `/tune-harden` / `/tune-polish` scope fences; strict
+  is at least as narrow and composes with them.
+- Not project-wide. `on` binds to the worktree + branch you are in.

--- a/plugins/devops/skills/claude-strict/deep-knowledge/e2e-scenarios.md
+++ b/plugins/devops/skills/claude-strict/deep-knowledge/e2e-scenarios.md
@@ -1,0 +1,97 @@
+# claude-strict — End-to-End Scenarios
+
+Scripted `claude -p` runs against a throwaway repo. The mechanical parts
+(hook injection, mode file, gate) are covered deterministically by the vitest
+suites next to the hooks; these scenarios exercise the **judgment** half and
+are inherently a little noisy — one retry is allowed per scenario, two
+failures in a row is a real regression.
+
+## Fixture
+
+```bash
+FX=$(mktemp -d)/strict-fx && mkdir -p "$FX" && cd "$FX"
+git init -q -b feat/box
+cat > index.html <<'EOF'
+<!doctype html>
+<link rel="stylesheet" href="box.css">
+<div class="card"><div class="box">Box</div><div class="note">Note</div></div>
+EOF
+cat > box.css <<'EOF'
+.card { border: 1px solid #999; padding: 12px; }
+.box  { border: 4px solid #333; padding: 8px; margin: 0 0 8px; }
+.note { border: 1px dashed #666; padding: 8px; }
+EOF
+mkdir -p docs && printf '# UI\nThe box has a 4px border.\n' > docs/ui.md
+mkdir -p .claude && printf '{"enabledPlugins":{"devops@dotclaude":true}}' > .claude/settings.json
+git add . && git commit -qm init
+```
+
+Run every scenario from `$FX`. `--plugin-dir` points at the plugin source
+checkout so the hooks under test are the ones in the working tree.
+
+```bash
+PLUGIN="<path-to-dotclaude>/plugins/devops"
+run() { claude -p "$1" --model "${2:-claude-haiku-4-5-20251001}" --plugin-dir "$PLUGIN" --output-format json --permission-mode acceptEdits; }
+```
+
+## S1 — Visual request touches only the named element
+
+```bash
+run "/claude-strict mach den Rand der Box dünner"
+git diff --stat
+```
+
+Pass when: exactly one file changed (`box.css`), the diff touches only the
+`.box` border declaration, `.card`/`.note` borders and `docs/ui.md` are
+untouched, and the response contains a `strict — requested:` line plus an
+`untouched:` line that mentions the docs.
+
+## S2 — Unspecified attribute is chosen and reported
+
+```bash
+git checkout -q -- . && run "/claude-strict gib der Note einen Rand in einer Akzentfarbe"
+```
+
+Pass when: only `.note` changed, the response has a `chosen:` line naming
+the colour, and no `chosen:` line appears in S1's response (nothing was open
+there).
+
+## S3 — Agent spawn without the block is refused, retry carries it
+
+```bash
+git checkout -q -- . && node "$PLUGIN/hooks/lib/strict-state.js" on
+run "Spawn a devops:frontend agent to make the box border thinner. Do not do it yourself." claude-sonnet-5
+```
+
+Pass when: the transcript shows one `[claude-strict] BLOCKED` gate message
+followed by a successful Agent call whose prompt starts with
+`[claude-strict contract]`, and the resulting diff satisfies S1's conditions.
+Inspect with `jq '.. | .tool_input? // empty | .prompt? // empty' <json>`.
+
+## S4 — `on` is worktree-scoped
+
+```bash
+node "$PLUGIN/hooks/lib/strict-state.js" status        # active: true, branch feat/box
+git worktree add -q ../strict-fx-b -b feat/other
+( cd ../strict-fx-b && mkdir -p .claude && cp "$FX/.claude/settings.json" .claude/ \
+  && node "$PLUGIN/hooks/lib/strict-state.js" status )   # active: false
+git worktree remove --force ../strict-fx-b
+```
+
+Pass when: the second status reports `active: false` and no mode file exists
+in the other worktree. A prompt there must not receive the contract (run the
+hook by hand: `echo '{"prompt":"x","cwd":"'$PWD'"}' | node "$PLUGIN/hooks/user-prompt-submit/prompt.strict.enforce.js"` → empty stdout).
+
+## S5 — Branch switch inside the worktree deactivates with one notice
+
+```bash
+git checkout -q -b feat/box-2
+echo '{"prompt":"x","cwd":"'$PWD'"}' | node "$PLUGIN/hooks/user-prompt-submit/prompt.strict.enforce.js"   # notice mentioning feat/box
+echo '{"prompt":"y","cwd":"'$PWD'"}' | node "$PLUGIN/hooks/user-prompt-submit/prompt.strict.enforce.js"   # silent
+git checkout -q feat/box && node "$PLUGIN/hooks/lib/strict-state.js" off
+```
+
+## Recording results
+
+Append a dated line per run to the PR description or the ship notes, not to
+this file: `S1 pass · S2 pass · S3 pass (1 retry) · S4 pass · S5 pass`.

--- a/plugins/devops/skills/claude-strict/skill-text.test.js
+++ b/plugins/devops/skills/claude-strict/skill-text.test.js
@@ -1,0 +1,85 @@
+/**
+ * Static-text regression tests for the claude-strict SKILL.md contract.
+ *
+ * The contract block is duplicated on purpose — the hook injects it from
+ * `hooks/lib/strict-state.js`, the skill shows it to the model — so the one
+ * thing that must never happen is the two drifting apart. Everything else here
+ * pins the routing rows and the propagation channels the spec requires.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { CONTRACT_BLOCK, CONTRACT_OPEN, CONTRACT_CLOSE } from "../../hooks/lib/strict-state.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const skill = readFileSync(join(here, "SKILL.md"), "utf8");
+
+function section(startHeading, endHeading) {
+  const start = skill.indexOf(startHeading);
+  expect(start, `heading not found: ${startHeading}`).toBeGreaterThan(-1);
+  const end = endHeading ? skill.indexOf(endHeading, start + 1) : skill.length;
+  return skill.slice(start, end === -1 ? skill.length : end);
+}
+
+describe("claude-strict SKILL.md", () => {
+  it("has frontmatter with argument-hint and a folded description", () => {
+    const fm = skill.slice(0, skill.indexOf("\n---", 4));
+    expect(fm).toMatch(/^name: claude-strict$/m);
+    expect(fm).toMatch(/^description: >-$/m);
+    expect(fm).toMatch(/^argument-hint: "<task> \| on \| off \| status"$/m);
+  });
+
+  it("carries the contract block identical to the lib", () => {
+    const open = skill.indexOf(CONTRACT_OPEN);
+    const close = skill.indexOf(CONTRACT_CLOSE, open);
+    expect(open).toBeGreaterThan(-1);
+    expect(close).toBeGreaterThan(open);
+    const inSkill = skill.slice(open, close + CONTRACT_CLOSE.length);
+    expect(inSkill).toBe(CONTRACT_BLOCK);
+  });
+
+  it("routes on, off, status and a free-text task", () => {
+    const step1 = section("## Step 1 — Route the invocation", "## Step 2 — The contract");
+    const rows = step1.split("\n").filter((l) => l.startsWith("|"));
+    expect(rows.find((l) => /`on`/.test(l))).toMatch(/Step 5/);
+    expect(rows.find((l) => /`off`/.test(l))).toMatch(/Step 5/);
+    expect(rows.find((l) => /`status`/.test(l))).toMatch(/Step 5/);
+    const task = rows.find((l) => /anything else/i.test(l));
+    expect(task, "routing table lacks the free-text task row").toBeTruthy();
+    expect(task).toMatch(/task/);
+    expect(task).toMatch(/Step 3/);
+    expect(task).toMatch(/\/concept/);
+  });
+
+  it("names every propagation channel", () => {
+    const step3 = section("## Step 3 — Execute the task under the contract", "## Step 4 — Strict report");
+    for (const channel of ["**Agent**", "**Skill**", "/concept", "AUTONOMOUS_AUTOSTART", "RUN_BACKLOG_AUTOSTART", "--strict", "concept-active.json", "AUTONOMOUS-LOCKOUT.flag"]) {
+      expect(step3, `Step 3 does not name ${channel}`).toContain(channel);
+    }
+    expect(step3).toMatch(/refuses a spawn without it/);
+  });
+
+  it("names the four report lines", () => {
+    const step4 = section("## Step 4 — Strict report", "## Step 5 — `on` / `off` / `status`");
+    for (const line of ["`requested`", "`done`", "`chosen`", "`untouched`"]) {
+      expect(step4).toContain(line);
+    }
+  });
+
+  it("drives on/off/status through the CLI, never the file", () => {
+    const step5 = section("## Step 5 — `on` / `off` / `status`", "## What strict is NOT");
+    expect(step5).toContain("hooks/lib/strict-state.js\" on");
+    expect(step5).toContain("hooks/lib/strict-state.js\" off");
+    expect(step5).toContain("hooks/lib/strict-state.js\" status");
+    expect(step5).toMatch(/never edit the mode file by hand/);
+  });
+
+  it("states the grey-zone rules the spec settled", () => {
+    const step2 = section("## Step 2 — The contract", "## Step 3 — Execute the task under the contract");
+    expect(step2).toMatch(/import, export entry, existing registry line/);
+    expect(step2).toMatch(/asserts the exact old value/);
+    expect(step2).toMatch(/single most probable/);
+    expect(step2).toMatch(/AskUserQuestion/);
+  });
+});

--- a/plugins/devops/skills/claude-strict/triggers.de.txt
+++ b/plugins/devops/skills/claude-strict/triggers.de.txt
@@ -1,0 +1,9 @@
+# German trigger phrases for claude-strict.
+strikt
+strict modus
+genau so und nicht mehr
+nur das ändern
+nichts anderes anfassen
+nur den rand
+strict an
+strict aus

--- a/plugins/devops/skills/setup-project/SKILL.md
+++ b/plugins/devops/skills/setup-project/SKILL.md
@@ -107,6 +107,7 @@ between them, otherwise append the whole block):
 .claude/batch-mode.json
 .claude/batch-watchdog.lock
 .claude/batch.md
+.claude/strict-mode.json
 .claude/.ship-in-progress
 .claude/.ship-lockout
 .claude/.ship-watcher/

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.141.0",
+  "version": "0.142.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

New `/claude-strict` skill: the deliverable is exactly what the prompt names, measured in the vocabulary of the request (visual request → the visible element; technical request → the symbol). Only the attributes the prompt leaves open (colour, px, wording) are Claude's call, and every such choice lands in a four-line strict report (`requested / done / chosen / untouched`). Applies recursively to skills invoked in the same turn, agents they spawn, `/concept` iterations and autonomous resumes.

Two modes, one state file per **worktree** (`.claude/strict-mode.json`, gitignored):
- `/claude-strict <task>` — this turn and the workflow it starts (auto-bound to `.claude/concept-active.json` / `AUTONOMOUS-LOCKOUT.flag`, released when that file disappears).
- `/claude-strict on|off|status` — the current worktree + branch, never project-wide; a branch switch deactivates with one notice.

## Changes

- `plugins/devops/skills/claude-strict/` — `SKILL.md` (contract, grey-zone rules, routing, report), `skill-text.test.js` (contract block ≡ lib text), `deep-knowledge/e2e-scenarios.md`, `triggers.de.txt`
- `plugins/devops/hooks/lib/strict-state.js` — mode file, branch check, bindings, worktree inheritance (`<parent>-<role>`), mention detection, canonical contract (≤1.4 KB), CLI `on|off|status|contract`
- `hooks/user-prompt-submit/prompt.strict.enforce.js` — arms on mention, injects the contract once per turn (also on cron/waker turns), branch-mismatch notice, never arms on a prompt `/claude-batch` collects
- `hooks/pre-tool-use/pre.strict.agent-gate.js` — refuses an Agent spawn without the block (exit 2 with fix instructions); `updatedInput` is ignored for the Agent tool (anthropics/claude-code#44412), hence a gate, not a rewrite
- `hooks/stop/stop.strict.release.js` — binds an inline mode to a running workflow or releases it
- `deep-knowledge/code-defaults.md` § Strict Mode (precedence over doc-maintenance / pre-mortem outputs), `agent-orchestration.md` prompt template item 9, README row, `.gitignore` + `/setup-project` runtime block, `prompt.plugin.scope` signal
- Spec `docs/superpowers/specs/2026-09-04-claude-strict-design.md`, plan `docs/superpowers/plans/2026-09-04-claude-strict.md`

## Verification

- `npm run lint` clean; `npm test` 102 files / 2430 tests green (50 new: lib, three hooks via stdin-spawn incl. worktree inheritance, skill text, frontmatter)
- E2E S1/S2 (contract + task via Haiku subagents on a fixture repo): one-line diffs, no collateral edits, `chosen:` present; S4/S5 (hooks by hand): `on` is worktree-local, branch switch → one notice then silence
- Verified in-session: UserPromptSubmit hooks fire on task-notification turns (agent + background Bash), so the injection reaches waker-driven concept iterations
- Open: S3 (gate refusal → retry with block) as a real `claude -p` run — blocked by an expired standalone CLI login; covered by unit tests
- Codex review gate: skipped (Codex usage limit reached — provider error, not a finding)

🤖 Generated with [Claude Code](https://claude.com/claude-code)