### PR TITLE
feat(burn): depth-before-breadth spend model, per-task landing

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.143.0"
+    "version": "0.144.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.143.0",
+      "version": "0.144.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.143.0",
+      "version": "0.144.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.144.0] — 2026-09-06
+
+### Changed
+
+- **`/run-burn` now spends the budget on depth per task before breadth, and lands every task on its own.** The skill maximised spend *rate*: `composite-prompt.md` instructed "IMMER die maximale Agent-Anzahl nutzen (full devops roster)" and "Nie idle sein", overriding the very rules `agent-orchestration.md` states beside it — "include an agent only if it adds concrete value, not for coverage" and "reserve large fan-out for genuinely breadth-parallel work; most coding tasks do not need it (15× token overhead)". Tests were deferred to one closing QA wave and everything merged at the end, so until that tail ran no task was finished. When the weekly limit landed, N agents were in flight, nothing had landed, and the whole spend was gone.
+
+  Burn now separates the two ways a budget can be consumed and prefers the one that does not multiply loss. **Depth** — stronger models, `effort: high`, higher tool-call ceilings, redteam/QA/po passes per task — raises the cost of a task without raising how many tasks can be lost; burn overrides the model defaults **upward only** and never downgrades for cost, which is the lever the skill lacked entirely (Step 6 previously spoke only of downgrading for cost). **Breadth** — parallel lanes — became a throughput filler, derived from `(remaining% − reserve) / hours-until-reset` and capped at four rather than "the full roster, always". An **uplift floor** of 1.5× against a normal `/run-agents` run gates the whole thing: a burn indistinguishable from a normal run refuses to start and says so, because that is a burn nobody needed.
+
+  Every queue item must now be independently landable, and lands on its own — commit, targeted tests for the changed modules, merge into `burn/<slug>`, push. The full QA run became an ordinary queue task instead of the gate everything waited on, so a mid-run limit costs one task instead of the run. A 5 % reserve stops new spawns and drains what is in flight; `BURN-STATE.json` and a new Step 0.5 resume recover a run that was cut off anyway, re-deriving profile and lanes from *current* usage instead of the dead window's numbers. Mechanical tasks (lint, rename, dependency bump) stay on `standard` whatever the profile — opus on a lint fix is spend without quality. Spec: `docs/superpowers/specs/2026-09-06-run-burn-depth-vs-breadth-design.md`.
+
+### Fixed
+
+- **Two documents `/run-autonomous` loads gave opposite orders about pushing.** `autonomous-execution.md` banned `git push (any branch)` and stated that all changes stay local; `agent-orchestration.md` required `git push -u origin <integration-branch>` after every wave, on the grounds that a local-only commit does not survive a worktree re-sync, a CI reset, or a session killed by the token limit. Both are read in the same run, and the durability half is what a burn depends on. The ban is now scoped to what it was actually protecting — shared branches and force-push — and the exception (the run's **own** integration or sub-branch, non-force, no PR, no ship, `main` never touched) is stated in both files as well as in the Step 5 summary that repeated the blanket version.
+
 ## [0.143.0] — 2026-09-05
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.143.0**
+**Version: 0.144.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/docs/superpowers/specs/2026-09-06-run-burn-depth-vs-breadth-design.md
+++ b/docs/superpowers/specs/2026-09-06-run-burn-depth-vs-breadth-design.md
@@ -1,0 +1,142 @@
+# run-burn — Depth vs. Breadth, Reserve, Durability
+
+**Date:** 2026-09-06
+**Status:** Approved
+**Skill version:** `run-burn` 0.3.0 → 0.4.0
+
+## Problem
+
+`/run-burn` exhausted the weekly token budget without finishing anything. When
+the usage limit landed, the run held N in-flight agents and zero landed work, so
+the entire spend was lost.
+
+Three causes, all in the shipped skill:
+
+1. **Burn overrode the orchestration safeguards it was built on.**
+   `composite-prompt.md` instructed *"IMMER die maximale Agent-Anzahl nutzen
+   (full devops roster)"* and *"Nie idle sein"*, directly contradicting
+   `agent-orchestration.md`: *"Include an agent only if it adds concrete value —
+   not for coverage"* and *"Reserve large fan-out for genuinely breadth-parallel
+   work; most coding tasks do not need it (15× token overhead)"*.
+
+2. **Budget was measured once and never again.** Step 2 read usage at the start.
+   No re-check, no reserve, no admission control per task.
+
+3. **Value landed only at the end.** One integration branch, one final QA run,
+   one report — plus the explicit rule *"Tests erst am Ende als QA-Wave"*. Until
+   that tail ran, no task was done. Sub-branches were committed locally but not
+   pushed, so a session death or a worktree prune erased them.
+
+Underlying all three: burn optimized for **spend rate** rather than **landed work
+per token**. Parallelism does not increase the total budget — it compresses the
+same spend into less wall-clock time while linearly increasing how much unlanded
+work is in flight when the limit hits.
+
+## Goal
+
+Burn exists to consume the remaining weekly budget before it resets, and the user
+must *feel* the difference against a normal `/run-agents` run — otherwise the
+skill has no reason to exist. The uplift may come from either dimension, but it
+must be real.
+
+## Design
+
+### Two spend dimensions
+
+| Dimension | Spends by | In-flight unlanded work | Loss on hard stop |
+|-----------|-----------|-------------------------|-------------------|
+| **Depth** | Better model, higher effort, higher tool-call ceiling, extra review passes per task | unchanged | at most 1 task |
+| **Breadth** | More lanes working different tasks at once | grows linearly with lane count | up to N tasks |
+
+Depth is the cheaper failure mode. **Depth first; breadth only fills the
+throughput gap depth cannot close.**
+
+### Uplift floor
+
+```
+uplift = max(depthFactor, lanes / baselineLanes)
+```
+
+`uplift >= 1.5` is a hard gate. Below it, burn refuses to run and points at
+`/run-agents`. A burn indistinguishable from a normal run is a burn the user did
+not need.
+
+### Depth profiles
+
+`standard` (1.0) · `deep` (1.8) · `max` (2.6). Factors are planning estimates for
+the floor check and lane maths, not measured token ratios.
+
+Burn overrides `agent-orchestration.md` § Model & Effort Defaults **upward only**
+— it never downgrades a model for cost. Mechanical tasks (lint, rename, import
+sort, dependency bump) stay at `standard` regardless of profile: opus on a lint
+fix is spend without quality.
+
+### Plan derivation
+
+```
+spendable       = remainingPct - RESERVE            # RESERVE = 5
+requiredPerHour = spendable / hoursUntilReset
+laneHourly(p)   = BASE_PCT_PER_LANE_HOUR * depthFactor(p)
+lanes           = clamp(ceil(requiredPerHour / laneHourly(max)), 1, LANE_CAP)
+```
+
+`spendable < 10` caps the profile at `deep` and lanes at 1. If lanes hit the cap
+and still cannot consume `requiredPerHour`, the shortfall is reported honestly
+rather than papered over with more agents.
+
+### In-run recalibration
+
+Per-agent token use is not observable from the orchestrator; the aggregate weekly
+number is the only feedback signal. Before each spawn, compare `observedPerHour`
+against `requiredPerHour` and add or drop a lane outside a 0.6×–1.6× band.
+
+### Conveyor landing protocol
+
+Every queue item must be independently landable — one coherent commit, own
+targeted tests green, meaningful without any later item. Per task: implement →
+commit (unfinished as `wip:`) → targeted tests → merge into `burn/<slug>` →
+`git push -u origin burn/<slug>` → update `BURN-STATE.json` → next task.
+
+The full QA run becomes an ordinary queue task at the end, **not a gate**. This
+is what turns a mid-run limit into the loss of one task instead of the run.
+
+### Reserve and drain
+
+Usage is re-read before each spawn (60 s freshness window). At
+`remainingPct <= RESERVE`, burn stops spawning, drains in-flight lanes, merges,
+pushes, and renders the report and completion card.
+
+### Durability
+
+`BURN-STATE.json` is written after every state transition and carries the queue,
+landed SHAs, in-flight branches, and the derived plan. Step 0.5 offers resume;
+on resume the profile and lanes are re-derived from *current* usage, and
+in-flight branches are verified rather than trusted. Worktrees with commits not
+reachable from the integration branch are never pruned.
+
+### Push guardrail — contradiction resolved
+
+`autonomous-execution.md` banned `git push (any branch)` while
+`agent-orchestration.md` required `git push -u origin <integration-branch>` after
+each wave. `/run-autonomous` loads both. Resolved in favour of durability, scoped
+narrowly:
+
+- **Allowed:** non-force push of the run's own integration/sub-branch to origin.
+- **Forbidden:** push to `main`/`master` or any shared branch, force-push to
+  anything, PRs, ship, external comms.
+
+## Out of scope (YAGNI)
+
+- Per-agent token accounting — not observable from the orchestrator.
+- Mid-run model downgrade — contradicts burn's purpose.
+- New MCP tooling — this is a skill and documentation change only.
+
+## Files
+
+| File | Change |
+|------|--------|
+| `plugins/devops/skills/run-burn/SKILL.md` | 0.3.0 → 0.4.0; new Step 0.5 (resume), Step 2 rewritten as plan derivation, Step 6 gains landability/size/per-task depth, Step 7 passes the derived plan, rules rewritten |
+| `plugins/devops/skills/run-burn/deep-knowledge/burn-scheduler.md` | **new** — dimensions, uplift floor, profiles, derivation, recalibration, reserve, conveyor, lane mechanics, `BURN-STATE.json`, resume |
+| `plugins/devops/skills/run-burn/deep-knowledge/composite-prompt.md` | rewritten — max-fan-out and end-QA guidance removed, plan/conveyor/reserve guidance added |
+| `plugins/devops/deep-knowledge/autonomous-execution.md` | push ban narrowed to shared branches + force-push; durability exception documented |
+| `plugins/devops/deep-knowledge/agent-orchestration.md` | burn's upward-only model override noted; push rule cross-linked to the exception |

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.143.0",
+  "version": "0.144.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/deep-knowledge/agent-orchestration.md
+++ b/plugins/devops/deep-knowledge/agent-orchestration.md
@@ -53,6 +53,11 @@ frontmatter. When you override a model at invocation, show it as `default → ov
 
 **Model override rules:**
 - Override `model` at invocation for cost control: `Agent({ subagent_type: "research", model: "sonnet", ... })`
+- **`/run-burn` inverts this**: it overrides **upward only** (sonnet → opus,
+  effort → high) per its depth profile, and never downgrades for cost. Its goal
+  is to consume the remaining weekly budget as depth-per-task rather than as
+  breadth-of-unfinished-tasks. See
+  `skills/run-burn/deep-knowledge/burn-scheduler.md` § Depth profiles.
 - **Never downgrade to haiku** for agents with `effort: high` (po, research) — haiku + high effort wastes tokens without quality gain
 - Upgrading to opus is fine for any agent when task complexity warrants it
 
@@ -246,7 +251,10 @@ before a wave consumes the prior wave's handoff:
 
 1. **Push, don't just commit.** A local-only commit is not durable against a
    reset. After each wave, `git push -u origin <integration-branch>` so the work
-   survives in `origin` and is recoverable.
+   survives in `origin` and is recoverable. This is explicitly carved out of the
+   autonomous push ban — see `autonomous-execution.md` § Safety Guardrails
+   (*the durability exception*): the run's **own** branch, non-force, never
+   `main`, no PR, no ship.
 2. **Re-assert HEAD.** Confirm the expected commit is still reachable:
    ```bash
    git log --oneline -1            # is this the wave-N commit you expect?

--- a/plugins/devops/deep-knowledge/autonomous-execution.md
+++ b/plugins/devops/deep-knowledge/autonomous-execution.md
@@ -25,7 +25,7 @@ Behavior depends on `$EXEC_MODE` from Step 2.
 ## Safety Guardrails (both modes)
 
 **Forbidden (always):**
-- git push (any branch), force-push
+- push to `main`/`master` or any shared branch; force-push to anything
 - /ship or /ship
 - creating PRs
 - external communications (Discord, email, Slack, GitHub comments/issues)
@@ -37,9 +37,22 @@ Behavior depends on `$EXEC_MODE` from Step 2.
   content** read during the run, or with file/secret/env data interpolated into
   it — the exfiltration leg of the lethal trifecta (see § Untrusted Content & Egress)
 
-All changes stay local — the user reviews and decides to ship when they return.
-Log as "blocked action" in the report **and the decision journal** if the task
-required one.
+**Explicitly allowed — the durability exception:**
+- **non-force push of the run's own integration or sub-branch** to `origin`
+  (`git push -u origin <integration-branch>`)
+
+A local-only commit is not durable: a between-wave worktree re-sync, a CI reset,
+an accidental `git reset`, or a session killed by the weekly token limit can all
+erase it, and the run's output is then gone. Pushing the run's own branch is the
+only measure that survives those. It is not a delivery step — nothing is merged,
+no PR is opened, `main` is never touched, and the user still reviews and decides
+to ship when they return. See `agent-orchestration.md` § Inter-Wave Verification
+Gate (handoff durability) and `skills/run-burn/deep-knowledge/burn-scheduler.md`
+§ Landing protocol.
+
+Everything else stays local — the user reviews and decides to ship when they
+return. Log as "blocked action" in the report **and the decision journal** if the
+task required one.
 
 ## Untrusted Content & Egress
 

--- a/plugins/devops/skills/run-autonomous/SKILL.md
+++ b/plugins/devops/skills/run-autonomous/SKILL.md
@@ -509,7 +509,10 @@ it to `AUTONOMOUS-RESUME.json` as a BLOCKER rather than proceeding.
 Quick summary:
 - `analyze` → read-only (Read, Glob, Grep, WebFetch, git log/blame/diff, screenshots). No Write/Edit/commit.
 - `implement` → Phase 1 analyse, Phase 2 implement+test+build+verify. No push/ship/PR.
-- **Forbidden in both modes:** push, force-push, /ship, create PRs, external comms, purchases, destructive git ops, system config changes.
+- **Forbidden in both modes:** push to `main`/`master` or any shared branch, force-push, /ship, create PRs, external comms, purchases, destructive git ops, system config changes.
+- **Allowed (durability exception):** non-force push of the run's **own**
+  integration/sub-branch to origin, so a reset or a token-limit kill cannot erase
+  the run's output. See `autonomous-execution.md` § Safety Guardrails.
 
 ### Strategy
 

--- a/plugins/devops/skills/run-burn/SKILL.md
+++ b/plugins/devops/skills/run-burn/SKILL.md
@@ -1,8 +1,11 @@
 ---
 name: run-burn
-version: 0.3.0
+version: 0.4.0
 description: >-
-  High-throughput autonomous task runner with aggressive parallelization.
+  Autonomous task runner that consumes the remaining weekly budget before it
+  resets — as depth per task (better models, higher effort, extra review passes)
+  first, added parallel lanes second — and lands every task individually so a
+  mid-run limit costs one task, not the whole run.
   EXPLICIT INVOCATION ONLY — the user must type /run-burn to activate.
   Do NOT trigger on any phrasing, keyword, or intent — not on "burn",
   "budget", "limit", "aufbrauchen", "maximize", "alles verbrauchen",
@@ -22,9 +25,18 @@ allowed-tools: >-
 
 # Run Burn
 
-Maximize the remaining weekly token budget. Collect tasks from all sources, then
-launch autonomous mode with aggressive parallelization to get maximum value out
-of the remaining time window.
+Consume the remaining weekly token budget before it resets, and turn it into
+**landed, verified work** rather than spend rate. Collect tasks from all sources,
+derive a plan that is measurably more than a normal `/run-agents` run, then launch
+autonomous mode with that plan.
+
+Burn spends along two dimensions — **depth** (better models, higher effort, extra
+review passes per task) and **breadth** (more parallel lanes). Depth is preferred
+because it raises the cost of a task without raising how many tasks can be lost
+when the limit hits; breadth fills the remaining throughput gap. The derivation,
+the uplift floor that makes a burn worth running, the reserve, and the durability
+protocol all live in `deep-knowledge/burn-scheduler.md` — **read that file at the
+start of Step 2.**
 
 **This skill MUST only run when explicitly invoked via `/run-burn`.**
 Never trigger from hooks, prompt phrasing, or heuristic matching.
@@ -36,6 +48,31 @@ Silently check (do not surface "not found"):
 2. `{project}/.claude/skills/run-burn/SKILL.md` + `reference.md`
 3. Merge: project > global > plugin defaults
 
+Extension-overridable knobs: `RESERVE`, `LANE_CAP`, `BASE_PCT_PER_LANE_HOUR`
+(see `deep-knowledge/burn-scheduler.md`).
+
+## Step 0.5 — Resume Detection
+
+Before the confirmation gate, check for `BURN-STATE.json` in the project root.
+
+If it exists with a non-empty `queue` or `inFlight`, a previous burn was cut off
+— by the weekly limit, a crash, or a session end. Ask via `AskUserQuestion`:
+
+> Ein abgebrochener Burn liegt vor: {done} Tasks gelandet, {queue} offen,
+> {inFlight} unklar. Fortsetzen oder neu starten?
+
+Options: `["Fortsetzen", "Neu starten"]`
+
+- **Fortsetzen** → adopt `integrationBranch`, skip everything in `done`, verify
+  each `inFlight` branch for commits and either merge it or requeue the task.
+  Then run **Step 2** (the stored plan is from the previous window and is stale —
+  `profile` and `lanes` must be re-derived from current usage), skip Steps 3–5
+  (the queue already exists), and continue at Step 6.
+- **Neu starten** → archive to `BURN-STATE.prev.json` (never delete — it is the
+  only record of the previous run's branches) and continue to Step 1.
+
+Full protocol: `deep-knowledge/burn-scheduler.md` § Resume.
+
 ## Step 1 — Burn Confirmation Gate
 
 **MANDATORY — never skip this step.**
@@ -44,9 +81,10 @@ Before doing ANYTHING else, ask via `AskUserQuestion`:
 
 > **BURN MODE**
 >
-> Dieser Modus verbraucht aggressiv dein verbleibendes Weekly-Budget
-> durch maximale Parallelisierung. Bei aktivierter Zusatznutzung kann
-> das über dein Standardlimit hinausgehen.
+> Dieser Modus verbraucht dein verbleibendes Weekly-Budget gezielt vor dem
+> Reset — primär über mehr Tiefe pro Task (stärkere Modelle, höherer Effort,
+> zusätzliche Review-Durchläufe), sekundär über parallele Lanes. Bei
+> aktivierter Zusatznutzung kann das über dein Standardlimit hinausgehen.
 >
 > Bist du sicher, dass du den Burn-Modus starten willst?
 
@@ -55,24 +93,45 @@ Options: `["Ja, burn starten", "Nein, abbrechen"]`
 - **"Ja, burn starten"** → proceed to Step 2
 - **"Nein, abbrechen"** → stop immediately, output: "Burn abgebrochen." — do nothing else
 
-## Step 2 — Budget Assessment
+## Step 2 — Budget Assessment & Plan Derivation
 
-Fetch current usage data to understand how much budget remains:
+**Read `deep-knowledge/burn-scheduler.md` first.** It owns the formulas below;
+this step only applies them.
+
+Fetch current usage data:
 
 ```bash
 node "${CLAUDE_PLUGIN_ROOT}/scripts/refresh-usage-headless.js" --quiet --summary
 ```
 
 Read `~/.claude/usage-live.json` and compute:
-- **Weekly remaining %** — how much of the weekly budget is left
-- **Time remaining** — hours until weekly reset
-- **Burn capacity** — rough estimate: "remaining %" split across available time
+- **`remainingPct`** — weekly budget left
+- **`hoursUntilReset`** — hours until the weekly reset
+- **`spendable`** = `remainingPct - RESERVE`
+- **`requiredPerHour`** = `spendable / hoursUntilReset`
 
-Present a one-line summary:
-> **Budget: {remaining}% | Reset in {hours}h | Modus: BURN**
+Then derive the plan **depth first, breadth only to fill** (§ Deriving the plan):
 
-If weekly remaining is < 10%, warn:
-> "Nur noch {X}% übrig — Burn-Modus bringt hier wenig. Trotzdem starten?"
+1. `spendable < 10` → cap profile at `deep`, `lanes` at 1.
+2. Otherwise start at profile `max`, compute
+   `lanes = ceil(requiredPerHour / laneHourly(max))`, clamp to `LANE_CAP`.
+3. Compute `uplift = max(depthFactor, lanes / baselineLanes)`.
+
+**Uplift floor — hard gate.** If `uplift < 1.5`, do NOT run a burn. Output and
+stop:
+
+> Restbudget und Zeitfenster tragen keinen spürbaren Burn-Effekt (uplift {x}×).
+> Nimm `/run-agents` — gleiches Ergebnis, weniger Aufwand.
+
+Otherwise present a one-line summary:
+
+> **Budget: {remaining}% | Reset in {hours}h | Profil: {profile} | Lanes: {n} | Uplift: {x}× | Reserve: {r}%**
+
+If `lanes` hit `LANE_CAP` and still cannot consume `requiredPerHour`, say so
+plainly — do not invent extra lanes to close a gap fan-out cannot close:
+
+> Bei {cap} Lanes und Profil {profile} bleiben ca. {gap}% ungenutzt — das
+> Zeitfenster gibt nicht mehr her.
 
 ## Step 3 — Primary Task Intake
 
@@ -168,6 +227,24 @@ Merge all discovered tasks into a single prioritized backlog:
 - Merge tasks that touch the same files/modules into a single work unit
 - Identify conflicts (two tasks modifying the same function) — sequence them
 
+### Landability & Size
+
+Two attributes per task, both required before it may enter the queue:
+
+- **Landable** — one coherent commit, its own targeted tests green, meaningful
+  without any later task. Split anything larger into landable units; drop what
+  cannot be split. This is what makes a mid-run limit cost one task instead of
+  the whole run.
+- **Size class** — `S` / `M` / `L`. A coarse guard so the reserve gate can refuse
+  a task that cannot plausibly fit in `spendable`. Not a token estimate.
+
+### Per-Task Depth
+
+Assign each task the run's profile, **except** mechanical tasks (lint fix, import
+sort, rename, dependency bump, generated-file refresh) which stay at `standard`
+— opus on a lint fix is spend without quality. See
+`deep-knowledge/burn-scheduler.md` § Depth profiles.
+
 ### Plan Presentation
 
 Present the consolidated plan:
@@ -175,35 +252,40 @@ Present the consolidated plan:
 ```
 ## Burn Plan
 
-**Budget**: {remaining}% | **Tasks**: {count} | **Geschaetzte Agents**: {N}
+**Budget**: {remaining}% | **Reset in**: {hours}h | **Reserve**: {r}%
+**Profil**: {profile} | **Lanes**: {n} | **Uplift**: {x}× ggü. /run-agents
+**Tasks**: {count} ({S}×S · {M}×M · {L}×L)
 
 ### P0 — Hauptauftrag
-- {user's primary task}
+- {user's primary task}  [{size}, {profile}]
 
 ### P1 — Blocking
-- {lint errors, failing tests, ...}
+- {lint errors, failing tests, ...}  [{size}, standard]
 
 ### P2 — Zugewiesene Issues
-- #{number}: {title}
+- #{number}: {title}  [{size}, {profile}]
 
 ### P3–P5 — Zusaetzliche Tasks
 - {list, grouped}
 
-### Execution Strategy
-- Waves: {N waves planned}
-- Agents per wave (+ model): {Wave 1: core (sonnet) · Wave 2: frontend, windows (sonnet) · Wave 3: qa (sonnet)}
-- Estimated token usage: {aggressive / moderate}
+### Execution
+- Conveyor: jeder Task landet einzeln (commit → targeted tests → merge → push)
+- Integration-Branch: burn/{slug}
+- Modelle: {role: default → override, ...}
+- Abschluss-QA: eigener Task am Ende, kein Gate
+- Drain bei <= {r}% Restbudget
 ```
 
-Model per agent comes from `{PLUGIN_ROOT}/deep-knowledge/agent-orchestration.md` § Model & Effort
-Defaults (`opus` for po/research/redteam, `sonnet` for the rest). Show a `default →
-override` when you downgrade a model for cost (§ Model override rules) so the budget
-impact is visible.
+Models come from `{PLUGIN_ROOT}/deep-knowledge/agent-orchestration.md` § Model &
+Effort Defaults, **upgraded** per the chosen depth profile. Always show
+`default → override` so the budget impact is visible. Burn never downgrades a
+model for cost — that is what `/run-agents` is for.
 
 Wait for user confirmation:
 - "go" / "ja" / "burn" → proceed as planned
 - Modifications → adjust
-- "weniger" → reduce scope to P0–P2 only
+- "weniger" → reduce scope to P0–P2 only (queue shrinks; profile and lanes stay —
+  they are budget-derived, not scope-derived)
 
 ## Step 7 — Launch Autonomous with Burn Guidance
 
@@ -214,9 +296,15 @@ execution, reporting, shutdown).
 ### Composite Prompt Construction
 
 Build the autonomous task prompt from the template in
-`deep-knowledge/composite-prompt.md` — it specifies the Hauptauftrag +
-prioritized task list + burn-guidance (browser Edge Credo, parallelization
-rules, throughput optimization, task ordering, result consolidation).
+`deep-knowledge/composite-prompt.md` — it carries the Hauptauftrag, the
+prioritized task list with size class and per-task profile, and the burn
+guidance (browser Edge Credo, the derived depth/lane plan, the conveyor landing
+protocol, the reserve gate, and BURN-STATE bookkeeping).
+
+The derived plan (`profile`, `lanes`, `RESERVE`, `requiredPerHour`,
+`integrationBranch`) is part of the prompt — the autonomous run must not
+re-derive it, only recalibrate it per
+`deep-knowledge/burn-scheduler.md` § In-run recalibration.
 
 **Important:** Pass the filled-in prompt as `$ARGUMENTS` to the autonomous
 skill. The autonomous skill then handles Steps 2–8 of its own flow
@@ -227,9 +315,25 @@ shutdown).
 
 - **NEVER auto-trigger** — this skill runs ONLY on explicit `/run-burn` invocation
 - **NEVER skip the plan step** — always present the consolidated plan and wait for confirmation
-- **NEVER skip budget assessment** — the user needs to know remaining capacity
-- **Respect autonomous guardrails** — burn mode amplifies throughput, not permissions.
-  All safety rules from run-autonomous still apply (no push, no ship, no external comms)
+- **NEVER skip budget assessment** — the plan is derived from it, not guessed
+- **Depth before breadth** — raise the profile first, add lanes only to close a
+  throughput gap depth cannot close. Breadth is the lossy dimension.
+- **Never downgrade a model for cost** — burn overrides `agent-orchestration.md`
+  § Model & Effort Defaults **upward only**. A burn that saves tokens is not a burn.
+- **Uplift floor is a hard gate** — `uplift < 1.5` means burn is the wrong tool.
+  Say so and stop; do not run a burn that is indistinguishable from `/run-agents`.
+- **Every task lands on its own** — commit → targeted tests → merge → push, per
+  task. Never batch landing to the end of the run.
+- **Push the integration branch, never main** — non-force, no PR, no ship. This
+  is the one push exception in `autonomous-execution.md` § Safety Guardrails;
+  every other outbound action stays forbidden.
+- **Respect autonomous guardrails** — burn mode amplifies throughput and depth,
+  not permissions. All other safety rules from run-autonomous still apply.
+- **Reserve is not optional** — stop spawning at `RESERVE`, drain, report.
+- **BURN-STATE.json after every transition** — it is the only thing that survives
+  a hard stop.
+- **Never prune a worktree with unmerged commits** — check with
+  `git merge-base --is-ancestor` before any cleanup.
 - **Deduplication is mandatory** — never let two agents modify the same file simultaneously
 - **Primary task always wins** — if budget is tight, drop P3+ tasks, never the user's prompt
 - **NEVER skip the confirmation gate** — Step 1 is mandatory, even if the user says "just do it"

--- a/plugins/devops/skills/run-burn/deep-knowledge/burn-scheduler.md
+++ b/plugins/devops/skills/run-burn/deep-knowledge/burn-scheduler.md
@@ -1,0 +1,212 @@
+# Burn Scheduler — Depth, Breadth, Reserve, Durability
+
+Read this at the start of `/run-burn` Step 2. It defines how a burn plan is
+derived, what makes a burn worth running at all, and how work is kept durable
+when the weekly limit lands mid-run.
+
+## Why this file exists
+
+Burn's earlier guidance was "always use the maximum agent count, never be idle".
+That maximizes *spend rate* while leaving every task unfinished at the moment the
+limit hits — the run ends with N in-flight agents and nothing landed. Burn's goal
+is **landed, verified work per token**, with spend as the means, not the end.
+
+## The two spend dimensions
+
+There are exactly two ways to consume the remaining budget, and they fail
+differently:
+
+| Dimension | Spends by | In-flight unlanded work | Loss on hard stop |
+|-----------|-----------|-------------------------|-------------------|
+| **Depth** | Better model, higher effort, higher tool-call ceiling, extra review passes per task | unchanged | at most 1 task |
+| **Breadth** | More lanes working different tasks at once | grows linearly with lane count | up to N tasks |
+
+Depth is the cheaper failure mode: it raises the cost of a task without raising
+the number of tasks that can be lost. **Prefer depth. Use breadth only as a
+throughput filler** when depth alone cannot consume the budget in the remaining
+wall-clock window.
+
+## The uplift floor — what makes a burn a burn
+
+Burn must be *noticeably* more than a normal `/run-agents` run on at least one
+dimension. A burn that lands at baseline is a burn the user did not need.
+
+```
+baselineLanes  = lanes /run-agents would pick for this task set (complexity tier)
+breadthFactor  = lanes / baselineLanes
+depthFactor    = from the profile table below
+uplift         = max(depthFactor, breadthFactor)
+```
+
+**Floor: `uplift >= 1.5`.** If the derived plan does not clear it, do not run a
+burn — report:
+
+> Restbudget und Zeitfenster tragen keinen spuerbaren Burn-Effekt (uplift {x}x).
+> Nimm `/run-agents` — gleiches Ergebnis, weniger Aufwand.
+
+## Depth profiles
+
+| Profile | Model | Effort | Tool-call ceiling | Extra passes per task | depthFactor |
+|---------|-------|--------|-------------------|-----------------------|-------------|
+| `standard` | per `agent-orchestration.md` § Model & Effort Defaults | default | 15–30 | — | 1.0 |
+| `deep` | opus for core, frontend, ai, windows, qa (po/research/redteam are opus already) | high | 40–60 | redteam review + second QA | 1.8 |
+| `max` | opus for every agent | high | 60+ | redteam + second QA + po review | 2.6 |
+
+`depthFactor` values are **planning estimates** used for the floor check and the
+lane maths. They are not measured token ratios and must not be reported as spend
+predictions.
+
+This is the one place burn is allowed to override
+`agent-orchestration.md` § Model & Effort Defaults — and it overrides **upward
+only**. Burn never downgrades a model for cost; that is what `/run-agents` is for.
+
+**Depth is capped by task substance, not only by budget.** A mechanical task
+(lint fix, import sort, rename, dependency bump, generated-file refresh) stays at
+`standard` regardless of the run's profile — opus on a lint fix is spend without
+quality. Substantive tasks (feature, refactor, bugfix with an unclear root cause,
+API or contract design) take the run's profile. Record the profile actually used
+per task in `BURN-STATE.json` so the report shows where the budget went.
+
+## Deriving the plan
+
+```
+RESERVE                = 5      # % of weekly budget
+LANE_CAP               = 4      # override via skill extension
+BASE_PCT_PER_LANE_HOUR = 1.5    # calibrate per project
+
+spendable       = remainingPct - RESERVE
+requiredPerHour = spendable / hoursUntilReset
+laneHourly(p)   = BASE_PCT_PER_LANE_HOUR * depthFactor(p)
+```
+
+Selection order — **depth first, breadth only to fill**:
+
+1. If `spendable < 10`, cap the profile at `deep` and `lanes` at 1. A near-empty
+   budget cannot support max-depth fan-out; the floor check then decides whether
+   the run is worth starting at all.
+2. Otherwise start at profile `max`. Compute
+   `lanes = ceil(requiredPerHour / laneHourly(max))`.
+3. `lanes <= 1` → one lane at `max`. Depth alone consumes the budget; adding
+   lanes would only add loss surface.
+4. Otherwise clamp `lanes` to `LANE_CAP`.
+5. If `lanes` hit the cap and `lanes * laneHourly(max) < requiredPerHour`, the
+   budget cannot be consumed in the window. Say so plainly, run at the cap, and
+   do not invent extra lanes to close a gap that fan-out cannot close.
+6. Run the floor check.
+
+## In-run recalibration
+
+Per-agent token consumption is not observable from the orchestrator — only the
+aggregate weekly number is. That aggregate is the only feedback loop burn has.
+Before each new task spawn:
+
+```
+observedPerHour = (remainingAtStart - remainingNow) / hoursElapsed
+```
+
+- `observedPerHour < 0.6 * requiredPerHour` → under-burning. Add a lane (up to
+  `LANE_CAP`) or raise the profile for the next task.
+- `observedPerHour > 1.6 * requiredPerHour` → over-burning; the reserve will be
+  reached early. Drop a lane.
+
+Log every adjustment as one line in `AUTONOMOUS-LOG.md`.
+
+## Reserve and drain
+
+- Re-read usage before each new task spawn. A snapshot 60 s old or newer counts
+  as fresh; otherwise refresh:
+  ```bash
+  node "${CLAUDE_PLUGIN_ROOT}/scripts/refresh-usage-headless.js" --quiet --summary
+  ```
+  Re-check **per task**, never per tool call — the headless scrape costs seconds.
+- `remainingPct <= RESERVE` → **drain phase**: spawn nothing new, let in-flight
+  lanes finish, merge, push, render the report and the completion card.
+- Never start a task whose size class cannot plausibly fit in `spendable`. Size
+  classes are S / M / L, assigned in Step 6 — a coarse guard, not a token
+  estimate.
+
+## Landing protocol — the conveyor
+
+Every queue item must be an **independently landable unit**: one coherent commit,
+its own targeted tests green, no dependency on a later item to be meaningful. An
+item that is not independently landable is split in Step 6 or dropped.
+
+Per task, in order:
+
+1. Agent implements on `burn/<slug>-<role>-<n>`.
+2. Agent commits **before returning**. Unfinished work is committed as `wip:`
+   with a message naming what is missing — nothing is left uncommitted.
+3. Targeted tests for the changed modules only, not the full suite.
+4. Orchestrator merges the sub-branch into the integration branch `burn/<slug>`.
+5. `git push -u origin burn/<slug>` — non-force, never `main`/`master`, no PR,
+   no ship. See `autonomous-execution.md` § Safety Guardrails.
+6. Update `BURN-STATE.json`.
+7. Pull the next task.
+
+The full QA run is an ordinary queue task at the end, **not a gate**. No task
+waits on it to count as done. This is what makes a mid-run limit cost one task
+instead of all of them.
+
+## Lane mechanics
+
+- `lanes == 1` → spawn **foreground**. This avoids the spawn-triggered worktree
+  re-sync window documented in `agent-orchestration.md` § Inter-Wave Verification
+  Gate.
+- `lanes > 1` → spawn with `run_in_background: true`. Merge and push on each
+  completion, one at a time — never two merges concurrently.
+- **Never remove or prune a worktree** whose branch holds commits not reachable
+  from the integration branch. Check before any cleanup:
+  ```bash
+  git merge-base --is-ancestor <sub-branch> burn/<slug> || echo "unmerged — keep"
+  ```
+
+## BURN-STATE.json
+
+Written to the project root after **every** state transition (task started, task
+landed, lane count changed, profile changed, drain entered).
+
+```json
+{
+  "version": 1,
+  "slug": "burn-2026-09-06-1420",
+  "integrationBranch": "burn/burn-2026-09-06-1420",
+  "profile": "max",
+  "lanes": 3,
+  "laneCap": 4,
+  "reservePct": 5,
+  "plan": {
+    "requiredPerHour": 6.2,
+    "baselineLanes": 2,
+    "uplift": 2.6
+  },
+  "budgetAt": { "remainingPct": 41, "checkedAt": "2026-09-06T14:20:00Z" },
+  "queue": [
+    { "id": "t7", "task": "...", "size": "M", "priority": "P2", "profile": "max" }
+  ],
+  "done": [
+    { "id": "t1", "task": "...", "sha": "abc1234", "pushed": true, "profile": "max" }
+  ],
+  "inFlight": [
+    { "id": "t4", "task": "...", "agent": "core", "branch": "burn/...-core-4", "worktree": "..." }
+  ],
+  "drained": false
+}
+```
+
+## Resume
+
+`/run-burn` Step 0.5 checks for `BURN-STATE.json` before anything else.
+
+If it exists with a non-empty `queue` or `inFlight`:
+
+1. Offer resume via `AskUserQuestion` — resume, or discard and start fresh.
+2. On resume: adopt `integrationBranch`, skip everything in `done`, re-derive
+   `profile` and `lanes` from **current** usage (the previous window's numbers
+   are stale), and treat `inFlight` entries as unverified — check each branch for
+   commits and either merge them or requeue the task.
+3. On discard: archive the file to `BURN-STATE.prev.json` and start fresh. Never
+   delete it outright — it is the only record of the previous run's branches.
+
+This composes with the existing `AUTONOMOUS-RESUME.json` mechanism from
+`run-autonomous` Step 0.5; it does not replace it. `BURN-STATE.json` tracks the
+task conveyor, `AUTONOMOUS-RESUME.json` tracks the autonomous session envelope.

--- a/plugins/devops/skills/run-burn/deep-knowledge/composite-prompt.md
+++ b/plugins/devops/skills/run-burn/deep-knowledge/composite-prompt.md
@@ -5,16 +5,29 @@ to `/run-autonomous`. The autonomous skill handles Steps 2–8 of its
 own flow (desktop questions, permission priming, execution, reporting,
 optional shutdown).
 
+The plan values below (`profile`, `lanes`, `RESERVE`, `requiredPerHour`,
+`integrationBranch`) come from `/run-burn` Step 2. The autonomous run **applies**
+them — it does not re-derive them. It may only recalibrate per
+`skills/run-burn/deep-knowledge/burn-scheduler.md` § In-run recalibration.
+
 ```
-BURN MODE ACTIVE — Maximale Parallelisierung.
+BURN MODE ACTIVE — Tiefe vor Breite, jeder Task landet einzeln.
 
 ## Hauptauftrag
 {user's primary task from Step 3}
 
-## Zusaetzliche Tasks (nach Prioritaet)
-{P1 tasks}
-{P2 tasks}
-{P3–P5 tasks}
+## Task-Queue (nach Prioritaet, mit Size + Profil)
+{P1 tasks}   [size, profile]
+{P2 tasks}   [size, profile]
+{P3–P5 tasks} [size, profile]
+
+## Burn-Plan (abgeleitet — nicht neu herleiten)
+- Profil: {profile}          # standard | deep | max
+- Lanes: {lanes}
+- Reserve: {RESERVE}% weekly
+- requiredPerHour: {x}%/h
+- Integration-Branch: burn/{slug}
+- Uplift ggue. /run-agents: {x}x
 
 ## Burn-Guidance
 
@@ -22,31 +35,39 @@ BURN MODE ACTIVE — Maximale Parallelisierung.
 - Alle Browser-Interaktion folgt dem Edge Credo (deep-knowledge/browser-tool-strategy.md § Edge Credo)
 - Edge only, Claude Extension only, User-Context, Tab-Reuse — auch im Burn-Modus
 
-### Parallelisierung
-- IMMER die maximale Agent-Anzahl nutzen (full devops roster: core, frontend,
-  ai, windows, designer, qa, po, research — je nach Relevanz)
-- Waves wo moeglich zusammenlegen: wenn keine harte Abhaengigkeit besteht,
-  können Agents aus verschiedenen Waves parallel starten
-- Für unabhängige Tasks: separate Feature-Branches + separate Agent-Gruppen
-  die gleichzeitig laufen
-- Research-Agent im Hintergrund für alle Tasks die Kontext brauchen
+### Tiefe (der primaere Hebel)
+- Modelle gemaess Profil AUFWERTEN, nie fuer Kosten downgraden
+- Effort und Tool-Call-Ceiling gemaess Profil-Tabelle setzen
+- Extra-Passes pro Task gemaess Profil (redteam-Review, zweiter QA, po-Review)
+- Mechanische Tasks (Lint, Rename, Import-Sort, Dependency-Bump) bleiben auf
+  `standard` — opus auf einem Lint-Fix ist Verbrauch ohne Qualitaet
 
-### Durchsatz-Optimierung
-- Keine übertriebene Planung — direkt starten
-- Bei Zweifeln: implementieren statt recherchieren
-- Tests erst am Ende als QA-Wave, nicht nach jedem Einzeltask
-- Lint/Type-Fixes können ohne eigenen Agent inline passieren
-- Kleine Tasks (< 5 Minuten geschätzt) direkt inline, nicht delegieren
+### Breite (nur zum Auffuellen)
+- Genau {lanes} Lanes, nicht mehr. Lanes sind budget-abgeleitet, kein Maximum.
+- lanes == 1 → Agent im Vordergrund spawnen (vermeidet das Worktree-Resync-Fenster)
+- lanes > 1  → run_in_background, aber immer nur EIN Merge gleichzeitig
+- Agent-Auswahl folgt deep-knowledge/agent-orchestration.md § Agent Selection:
+  nur Rollen mit konkretem Beitrag, nicht der volle Roster zur Abdeckung
 
-### Task-Reihenfolge
-- P0 und P1 Tasks starten sofort in Wave 1
-- P2+ Tasks starten parallel sobald Agents frei werden
-- Wenn ein Agent früher fertig wird: nächsten Task aus der Queue ziehen
-- Nie idle sein — immer den nächsten Task starten
+### Landing-Protokoll (pro Task, in dieser Reihenfolge)
+1. Agent implementiert auf burn/{slug}-<role>-<n>
+2. Agent committet VOR der Rueckmeldung — Unfertiges als `wip:` mit Angabe was fehlt
+3. Gezielte Tests nur fuer die geaenderten Module, nicht die volle Suite
+4. Merge in burn/{slug}
+5. git push -u origin burn/{slug}   (non-force, nie main, kein PR, kein Ship)
+6. BURN-STATE.json aktualisieren
+7. Naechsten Task ziehen
 
-### Ergebnis-Konsolidierung
-- Alle Änderungen auf dem gleichen Integration-Branch sammeln
-- Sub-Branches pro Agent, sequentiell mergen
-- Ein finaler QA-Durchlauf über alle Änderungen
-- AUTONOMOUS-REPORT.html muss alle Tasks und deren Status enthalten
+### Reserve-Gate
+- Vor JEDEM neuen Spawn Usage pruefen (Snapshot <= 60s gilt als frisch)
+- remaining <= {RESERVE}% → Drain: nichts Neues spawnen, laufende Lanes zu Ende,
+  mergen, pushen, Report + Completion-Card
+- Task nie starten, dessen Size-Klasse nicht mehr in `spendable` passt
+
+### Abschluss
+- Der volle QA-Durchlauf ist ein normaler Task am Ende der Queue, KEIN Gate.
+  Kein Task wartet auf ihn, um als erledigt zu zaehlen.
+- AUTONOMOUS-REPORT.html enthaelt alle Tasks mit Status, verwendetem Profil und
+  Landing-SHA
+- Nie einen Worktree entfernen, dessen Branch unmerged Commits hat
 ```

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.143.0",
+  "version": "0.144.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

`/run-burn` maximized spend *rate* rather than landed work. `composite-prompt.md` instructed *"IMMER die maximale Agent-Anzahl nutzen (full devops roster)"* and *"Nie idle sein"*, overriding the rules `agent-orchestration.md` states beside it. Tests were deferred to one closing QA wave and everything merged at the end — so when the weekly limit landed, N agents were in flight, nothing had landed, and the whole spend was gone.

## What changed

**Two spend dimensions, depth preferred.** Depth (stronger models, `effort: high`, higher tool-call ceilings, redteam/QA/po passes per task) raises the cost of a task without raising how many tasks can be lost. Breadth (parallel lanes) multiplies loss linearly. Burn now maximizes depth first and adds lanes only to close a throughput gap depth cannot close.

- Burn overrides the model defaults **upward only** and never downgrades for cost — the lever the skill lacked entirely (Step 6 previously spoke only of downgrading).
- Lanes derived from `(remaining% − reserve) / hours-until-reset`, capped at 4.
- **Uplift floor** of 1.5× vs `/run-agents` gates the run: a burn indistinguishable from a normal run refuses to start.
- Mechanical tasks (lint, rename, dependency bump) stay on `standard` whatever the profile.

**Conveyor landing.** Every queue item must be independently landable and lands on its own — commit, targeted tests, merge into `burn/<slug>`, push. The full QA run becomes an ordinary queue task instead of the gate everything waited on, so a mid-run limit costs one task instead of the run.

**Reserve + resume.** A 5 % reserve stops new spawns and drains what is in flight. `BURN-STATE.json` plus a new Step 0.5 resume recover a run that was cut off anyway, re-deriving profile and lanes from *current* usage.

## Fixed — a live doc contradiction

`autonomous-execution.md` banned `git push (any branch)`; `agent-orchestration.md` required `git push -u origin <integration-branch>` after every wave for durability. Both are read in the same `/run-autonomous` run. The ban is now scoped to shared branches and force-push; the durability exception (the run's **own** branch, non-force, no PR, no ship, `main` never touched) is stated in both files and in the Step 5 summary that repeated the blanket version.

## Verification

- `npm test` — 104 files, 2466 passed, 3 skipped, exit 0 (run standalone; `ship_build`'s test step failed twice on the `onTaskUpdate` vitest-worker RPC contention flake documented in the 0.144.0 predecessor entry, with no failing test in its output).
- `npm run lint` — clean.
- Codex review gate unavailable: the Codex CLI returned its own usage-limit error.

Spec: `docs/superpowers/specs/2026-09-06-run-burn-depth-vs-breadth-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)