### PR TITLE
feat(card): pending layer — no SHIP prompt while agents still run

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.144.0"
+    "version": "0.145.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.144.0",
+      "version": "0.145.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.144.0",
+      "version": "0.145.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.145.0] — 2026-09-06
+
+### Fixed
+
+- **A completion card rendered while background agents were still working ended on "SHIP oder ÄNDERN?".** A turn hands back the moment the assistant stops writing, but a subagent started with `run_in_background` — or a backgrounded Bash task — keeps going, and its result arrives later as a task-notification. The card was rendered at that moment and had no way to say so: every variant's CTA is written for a finished turn, so the last line of the card asked the user to act on a result that did not exist yet. `ship-successful` was the worst of them — "Alles ERLEDIGT" while an agent was mid-edit — but `ready`, `test`, `analysis` and `fallback` all made the same claim in their own words.
+
+  The fix is a **layer, not a variant**. `pending: [{ name, kind, doing }]` sits on top of whichever variant the turn earned: the body still reports what is true — changes, tests, delivery, repo state — and only the CTA is replaced, with `⏳ NOCH NICHT FERTIG. Agent \`devops:frontend\` arbeitet — ich MELDE mich`, plus a block naming each open item and stating that the card predates its results. A dedicated variant was the obvious move and the wrong one: "still running" is orthogonal to what a card reports, so a `pending` variant would have cost a shipped-but-not-finished turn its delivery track and version footer. The precedent was already in the codebase — `state.deployPending` flips the ship CTA the same way for merged-but-undeployed infra. The CTA **names** what is running rather than counting it (`2 Agenten (\`a\`, \`b\`) arbeiten`, capped at two names plus a `+N` tail), because "1 agent is working" does not tell you whether to wait ten seconds or ten minutes.
+
+  It is enforced, not self-reported. `stop.flow.guard` gained a third gate that reads the open work out of the transcript itself: the launch markers (`Async agent launched successfully` with its `agentId`, `Command running in background with ID:`) open a task, a `<task-notification>` closes it, and a `SendMessage` resume re-opens one — a chronological state machine, so the set at the end is the true state. It reads a 1 MB tail rather than the 200 KB the card gate needs, since an agent launched early in a long turn is exactly the one that would be missed, and short-circuits when no launch marker is present at all. A card that omits `pending` while work is in flight is blocked once and re-requested. `post.flow.completion` injects the instruction the moment a background job starts, so that block stays rare. Internal agent ids never reach the card or the hook reason — only the agent type or the task label.
+
+### Changed
+
+- **The `analysis` CTA no longer opens with a hollow "DONE".** `## 📋 DONE — LIES dir durch` was the card for a question answered, where nothing was completed and nothing is on disk; the status word carried no information and the actual call to action was already the second half. It is now `## 📋 LIES dir durch — FRAGEN?` (`## 📋 READ through — QUESTIONS?`), which also states what the variant is for: a question-and-answer round the user can continue.
+
 ## [0.144.0] — 2026-09-06
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -427,7 +427,7 @@ Wk  ━━━─╏─────────   18% +2%   · 5d 3h left
 ````
 
 <details>
-<summary><strong>See all other variants</strong> — ready, ship-blocked, test, test-minimal, analysis, aborted, fallback, ship-successful (direct push)</summary>
+<summary><strong>See all other variants</strong> — ready, ship-blocked, test, test-minimal, analysis, aborted, fallback, ship-successful (direct push), pending</summary>
 
 ### test — code edits + app running, user must verify
 
@@ -604,7 +604,7 @@ Wk  ━━━─╏─────────   19% +2%   · 5d 6h left
 
 📌 `a3f9b21`
 
-## 📋 DONE — READ through
+## 📋 READ through — QUESTIONS?
 
 ---
 ````
@@ -689,9 +689,43 @@ Wk  ━━──╏─────────   15% +1%   · 4d 22h left
 ---
 ````
 
+### pending — a background agent is still working
+
+Not a variant but a layer: when the turn ends while a background subagent or task
+is still running, `pending` names it and replaces the CTA of **whichever** variant
+the card carries — so it never asks you to SHIP or act on a result that does not
+exist yet. The rest of the card still reports what is true.
+
+````
+---
+
+## ✨✨✨ First version verified and pushed ✨✨✨
+
+**Changes**
+* Concept → color-style correction handed to a background agent
+
+⏳ **STILL RUNNING — not finished:**
+* `devops:frontend` — switch color style to design tokens
+
+_This card reports the state BEFORE those results._
+
+```
+5h  ━━╏───────────   14% +1%   · 4h 20m left
+Wk  ━━──╏─────────   16% +1%   · 5d 2h left
+```
+
+---
+
+📌 `c41a21a`
+
+### ⏳ NOT DONE YET. agent `devops:frontend` is working — I'll REPORT back
+
+---
+````
+
 </details>
 
-8 variants total. The card always fires — see [completion-card.md](plugins/devops/templates/completion-card.md) for the full template spec.
+8 variants total, plus the `pending` layer. The card always fires — see [completion-card.md](plugins/devops/templates/completion-card.md) for the full template spec.
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.144.0**
+**Version: 0.145.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.144.0",
+  "version": "0.145.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/deep-knowledge/plugin-behavior.md
+++ b/plugins/devops/deep-knowledge/plugin-behavior.md
@@ -100,6 +100,12 @@ Subagents inherit all output contracts:
 - Completion card for code-change tasks
 - Visual verification for UI changes
 - If a subagent can't render a card, the main context must render it
+- **A turn that ends while a background subagent is still running must render its
+  card with `pending`** — naming each open agent/task. That replaces the CTA of
+  every variant with "⏳ NOCH NICHT FERTIG … ich MELDE mich", so the card never
+  asks the user to SHIP or act on a result that has not arrived. `stop.flow.guard`
+  reads the open work out of the transcript and blocks a card that omits it.
+  Never put an internal agentId in a card — use the agent type or task label.
 
 ## Extension Model
 

--- a/plugins/devops/hooks/lib/card-guard.js
+++ b/plugins/devops/hooks/lib/card-guard.js
@@ -5,15 +5,20 @@
  *   plus the validation half of the V&V gate. Split out of stop.flow.guard.js so
  *   the rules can be unit-tested without mocking stdin or temp files.
  *
- *   Two stacked gates, both one-block (stop_hook_active yields):
+ *   Three stacked gates, all one-block (stop_hook_active yields):
  *     1. Completion card — block when work happened but no card was rendered.
  *     2. Validation — once a card exists, block when a code change owes a
  *        validation attestation (validationPending && !validationAttested). The
  *        `validation` field rides on the card; the MCP sets the attested flag
  *        when it is populated. This is the "did we build the RIGHT thing" half;
  *        the test gate (stop.flow.browsertest) is the "did we build it right".
+ *     3. Pending — once a card exists, block when background subagents / tasks
+ *        are still running and the card did not declare them (`pending`). Open
+ *        work is proven from the transcript (lib/pending-tasks.js), so the card
+ *        cannot end a turn with a CTA that asks the user to act on results that
+ *        do not exist yet.
  *
- *   Inputs: flag state (work/card/validation) + transcript + stop_hook_active.
+ *   Inputs: flag state (work/card/validation/pending) + transcript + stop_hook_active.
  *   Output: { action: 'block' | 'pass', reason?, resetFlags }.
  */
 
@@ -83,13 +88,16 @@ function lastAssistantContainsCard(transcriptContent) {
  *                                     not the user. Never enforce the card.
  * @param {boolean} [s.validationPending]  — a code change owes a validation attestation
  * @param {boolean} [s.validationAttested] — the card was rendered with a `validation` field
+ * @param {string[]} [s.openTaskNames] — background subagents / tasks still running at
+ *                                     turn end (names only — ids stay internal)
+ * @param {boolean} [s.pendingAttested] — the card was rendered with a `pending` field
  * @param {string}  [s.pluginRoot]   — active install root, so the block reason can name
  *                                     the offline renderer path for this install
  * @returns {{ action: 'block' | 'pass', resetFlags: boolean, reason?: string }}
  */
 function decideAction({
   workHappened, cardRendered, stopHookActive, substantial, silent,
-  validationPending, validationAttested, pluginRoot,
+  validationPending, validationAttested, openTaskNames, pendingAttested, pluginRoot,
 }) {
   if (silent) {
     // Background tick (cron git-sync, concept bridge poll, autonomous loop).
@@ -123,6 +131,20 @@ function decideAction({
       action: 'block',
       resetFlags: false,
       reason: buildValidationReason(),
+    };
+  }
+
+  // Gate 3 — a card rendered while background subagents / tasks are STILL
+  // running must declare them. Without `pending`, the card's CTA asks the user
+  // to act ("SHIP or CHANGE?", "All DONE") on results that do not exist yet.
+  // Detected from the transcript, not self-reported, so the gate cannot be
+  // talked out of. Independent of `active`: launching an agent is itself work.
+  const open = openTaskNames || [];
+  if (cardRendered && open.length > 0 && !pendingAttested) {
+    return {
+      action: 'block',
+      resetFlags: false,
+      reason: buildPendingReason(open),
     };
   }
 
@@ -165,6 +187,12 @@ function buildBlockReason(pluginRoot) {
     '  zero file changes (analysis/explain/audit) → analysis',
     '  unsure → fallback',
     '',
+    'PENDING (orthogonal to the variant): if background subagents or tasks you',
+    'started are STILL running, also pass `pending` — [{ name, kind, doing }] —',
+    'naming each. It replaces the CTA with "⏳ NOCH NICHT FERTIG … ich MELDE mich",',
+    'so the card never asks the user to act on a result that does not exist yet.',
+    'Never put an internal agentId in the card; use the agent type / task label.',
+    '',
     'IMPORTANT: The MCP result is hidden in a collapsed UI block.',
     'Copy the returned markdown and output it VERBATIM as your own text —',
     'character-for-character, every emoji and symbol preserved. The card is',
@@ -191,8 +219,46 @@ function buildValidationReason() {
   ].join('\n');
 }
 
+function buildPendingReason(names) {
+  const list = names.map(n => `  - ${n}`).join('\n');
+  return [
+    '[stop.flow.guard] Background work is STILL RUNNING — the completion card has no `pending` field.',
+    '',
+    'Started this session and not finished yet:',
+    list,
+    '',
+    'The card was rendered as if the turn were over. Its CTA therefore asks the',
+    'user to act ("SHIP or CHANGE?", "All DONE") on a result that does not exist',
+    'yet — exactly the wrong call to action while agents are still working.',
+    '',
+    'Re-render `mcp__plugin_devops_dotclaude-completion__render_completion_card` NOW',
+    'with `pending` populated, then relay the card VERBATIM as the LAST output:',
+    '  pending: [{ name: "<agent type or task label>", kind: "agent" | "task",',
+    '              doing: "<what it is working on>" }]',
+    '',
+    'Keep the variant and every other field as they were — the body still reports',
+    'what IS true. `pending` only corrects the last line, to',
+    '"⏳ NOCH NICHT FERTIG. … — ich MELDE mich".',
+    '',
+    'Use the names listed above. NEVER put an internal agentId in the card.',
+    '',
+    'If the work has in fact already finished, collect the results first and then',
+    'render the real completion card — do not declare it pending to get past this.',
+  ].join('\n');
+}
+
 /** Cap transcript bytes read into memory — we only need the last assistant message. */
 const TRANSCRIPT_TAIL_BYTES = 200 * 1024; // 200 KB
+
+/**
+ * Wider slice used when the pending gate also has to scan the transcript. A
+ * background agent can be launched many tool calls before the turn ends, so the
+ * 200 KB tail that suffices for "last assistant message" can miss its launch
+ * marker — and a missed launch is a false "all done", the exact bug the gate
+ * exists to prevent. scanOpenTasks short-circuits when no marker is present, so
+ * the wider read costs a file read and nothing else on ordinary turns.
+ */
+const PENDING_TAIL_BYTES = 1024 * 1024; // 1 MB
 
 /**
  * Safely read a transcript file — returns '' on any error so decideAction
@@ -203,12 +269,12 @@ const TRANSCRIPT_TAIL_BYTES = 200 * 1024; // 200 KB
  * a truncated first line at the buffer boundary is harmless — malformed
  * JSON lines are already skipped by lastAssistantText.
  */
-function safeReadTranscript(transcriptPath) {
+function safeReadTranscript(transcriptPath, tailBytes = TRANSCRIPT_TAIL_BYTES) {
   if (!transcriptPath) return '';
   let fd;
   try {
     const size = fs.statSync(transcriptPath).size;
-    const start = Math.max(0, size - TRANSCRIPT_TAIL_BYTES);
+    const start = Math.max(0, size - tailBytes);
     const length = size - start;
     fd = fs.openSync(transcriptPath, 'r');
     const buf = Buffer.alloc(length);
@@ -225,6 +291,7 @@ module.exports = {
   SUBSTANTIAL_CHARS,
   CARD_MARKER,
   TRANSCRIPT_TAIL_BYTES,
+  PENDING_TAIL_BYTES,
   lastAssistantText,
   lastAssistantTextLength,
   isSubstantialAnswer,
@@ -232,5 +299,6 @@ module.exports = {
   decideAction,
   buildBlockReason,
   buildValidationReason,
+  buildPendingReason,
   safeReadTranscript,
 };

--- a/plugins/devops/hooks/lib/card-guard.test.js
+++ b/plugins/devops/hooks/lib/card-guard.test.js
@@ -7,6 +7,7 @@ import {
   decideAction,
   buildBlockReason,
   buildValidationReason,
+  buildPendingReason,
   SUBSTANTIAL_CHARS,
   CARD_MARKER,
 } from "./card-guard.js";
@@ -327,6 +328,138 @@ describe("decideAction — validation gate", () => {
       substantial: false,
     });
     expect(d.action).toBe("pass");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// decideAction — pending gate (background work still running at turn end)
+// ---------------------------------------------------------------------------
+
+describe("decideAction — pending gate", () => {
+  test("card rendered + open background work + not attested → BLOCK (pending)", () => {
+    const d = decideAction({
+      workHappened: true,
+      cardRendered: true,
+      stopHookActive: false,
+      substantial: false,
+      openTaskNames: ["devops:frontend"],
+      pendingAttested: false,
+    });
+    expect(d.action).toBe("block");
+    expect(d.resetFlags).toBe(false);
+    expect(d.reason).toMatch(/STILL RUNNING/);
+    expect(d.reason).toMatch(/devops:frontend/);
+  });
+
+  test("card rendered + open background work + attested → pass", () => {
+    const d = decideAction({
+      workHappened: true,
+      cardRendered: true,
+      stopHookActive: false,
+      substantial: false,
+      openTaskNames: ["devops:frontend"],
+      pendingAttested: true,
+    });
+    expect(d.action).toBe("pass");
+    expect(d.resetFlags).toBe(true);
+  });
+
+  test("nothing open → a card-rendered turn passes (back-compat)", () => {
+    const d = decideAction({
+      workHappened: true,
+      cardRendered: true,
+      stopHookActive: false,
+      substantial: false,
+      openTaskNames: [],
+      pendingAttested: false,
+    });
+    expect(d.action).toBe("pass");
+  });
+
+  test("no card yet → card gate wins over pending gate", () => {
+    const d = decideAction({
+      workHappened: true,
+      cardRendered: false,
+      stopHookActive: false,
+      substantial: false,
+      openTaskNames: ["devops:qa"],
+      pendingAttested: false,
+    });
+    expect(d.action).toBe("block");
+    expect(d.reason).toMatch(/render_completion_card/);
+    expect(d.reason).not.toMatch(/STILL RUNNING/);
+  });
+
+  test("validation gate is checked before the pending gate", () => {
+    const d = decideAction({
+      workHappened: true,
+      cardRendered: true,
+      stopHookActive: false,
+      substantial: false,
+      validationPending: true,
+      validationAttested: false,
+      openTaskNames: ["devops:qa"],
+      pendingAttested: false,
+    });
+    expect(d.reason).toMatch(/Validation required/);
+  });
+
+  test("fires without other work — launching an agent is itself the work", () => {
+    const d = decideAction({
+      workHappened: false,
+      cardRendered: true,
+      stopHookActive: false,
+      substantial: false,
+      openTaskNames: ["devops:qa"],
+      pendingAttested: false,
+    });
+    expect(d.action).toBe("block");
+    expect(d.reason).toMatch(/STILL RUNNING/);
+  });
+
+  test("stop_hook_active yields the pending gate too (one-block, never wedge)", () => {
+    const d = decideAction({
+      workHappened: true,
+      cardRendered: true,
+      stopHookActive: true,
+      substantial: false,
+      openTaskNames: ["devops:qa"],
+      pendingAttested: false,
+    });
+    expect(d.action).toBe("pass");
+    expect(d.resetFlags).toBe(true);
+  });
+
+  test("a silent turn never fires the pending gate", () => {
+    const d = decideAction({
+      workHappened: true,
+      cardRendered: true,
+      stopHookActive: false,
+      substantial: false,
+      silent: true,
+      openTaskNames: ["devops:qa"],
+      pendingAttested: false,
+    });
+    expect(d.action).toBe("pass");
+  });
+});
+
+describe("buildPendingReason", () => {
+  test("names each open item and the pending field", () => {
+    const r = buildPendingReason(["devops:frontend", "npm test"]);
+    expect(r).toMatch(/devops:frontend/);
+    expect(r).toMatch(/npm test/);
+    expect(r).toMatch(/pending/);
+    expect(r).toMatch(/render_completion_card/);
+    expect(r).toMatch(/VERBATIM|LAST/);
+  });
+
+  test("forbids putting an internal agentId in the card", () => {
+    expect(buildPendingReason(["devops:qa"])).toMatch(/NEVER put an internal agentId/);
+  });
+
+  test("tells the model not to fake pending to get past the gate", () => {
+    expect(buildPendingReason(["devops:qa"])).toMatch(/do not declare it pending/);
   });
 });
 

--- a/plugins/devops/hooks/lib/pending-tasks.js
+++ b/plugins/devops/hooks/lib/pending-tasks.js
@@ -1,0 +1,176 @@
+/**
+ * @module pending-tasks
+ * @version 0.1.0
+ * @description Detects background work that is STILL RUNNING when a turn ends —
+ *   subagents launched with run_in_background and backgrounded Bash tasks.
+ *
+ *   The card is rendered at the moment the turn hands back, so without this the
+ *   CTA of every variant ("SHIP or CHANGE?", "All DONE") asks the user to act on
+ *   a result that does not exist yet. The `pending` card field corrects that
+ *   line; this module is the enforcement half — it proves from the transcript
+ *   whether such work is open, rather than trusting self-report.
+ *
+ *   Signals (verified against real transcripts):
+ *     start  · agent — tool_result text "Async agent launched successfully"
+ *                      carrying "agentId: <id>"
+ *     start  · task  — tool_result text "Command running in background with ID: <id>"
+ *     resume · agent — a SendMessage tool_use addressed `to: <id>`
+ *     end    · both  — a <task-notification> block naming <task-id><id></task-id>
+ *
+ *   Scanned chronologically as a state machine, so a resume after a completion
+ *   re-opens the task and the final set reflects the true end-of-turn state.
+ *
+ *   SECURITY: agent ids are harness-internal and must never reach the user.
+ *   openTaskNames() is the only export intended for user-visible text; the ids
+ *   returned by scanOpenTasks stay inside the hook for counting and matching.
+ */
+
+/** Text a background Agent launch returns. */
+const AGENT_LAUNCH_MARKER = 'Async agent launched successfully';
+/** Captures the agent id from that same tool_result. */
+const AGENT_ID_RE = /agentId:\s*([A-Za-z0-9_-]+)/;
+/** Text a backgrounded Bash call returns, with its task id. */
+const BASH_BG_RE = /Command running in background with ID:\s*([A-Za-z0-9_-]+)/;
+/** A task-notification means that task STOPPED (it fires when the agent stops). */
+const TASK_NOTIFICATION_RE = /<task-id>\s*([A-Za-z0-9_-]+)\s*<\/task-id>/g;
+
+/** Max characters of a Bash command used as a fallback label. */
+const COMMAND_LABEL_MAX = 40;
+
+/** Flatten a tool_result's content into searchable text. */
+function resultText(block) {
+  const c = block && block.content;
+  if (typeof c === 'string') return c;
+  if (!Array.isArray(c)) return '';
+  return c.map(p => (p && typeof p.text === 'string' ? p.text : '')).join('\n');
+}
+
+/**
+ * User-facing label for a launched item. Never the agent id — that is internal
+ * harness metadata the user must not be shown.
+ * @param {object} input — the tool_use input that launched it
+ * @param {'agent'|'task'} kind
+ */
+function labelFor(input, kind) {
+  const i = input || {};
+  if (kind === 'agent') {
+    return String(i.subagent_type || i.description || 'agent').trim();
+  }
+  const desc = String(i.description || '').trim();
+  if (desc) return desc;
+  const cmd = String(i.command || '').trim().replace(/\s+/g, ' ');
+  if (!cmd) return 'task';
+  return cmd.length > COMMAND_LABEL_MAX ? cmd.slice(0, COMMAND_LABEL_MAX) + '…' : cmd;
+}
+
+/**
+ * Walk a JSONL transcript and return the background work still open at its end.
+ *
+ * @param {string} transcriptContent — raw JSONL (a tail slice is fine)
+ * @returns {Array<{ id: string, kind: 'agent'|'task', name: string }>}
+ */
+function scanOpenTasks(transcriptContent) {
+  if (!transcriptContent) return [];
+
+  // Fast path for the overwhelming majority of turns: no launch marker anywhere
+  // in the slice means nothing can be open, so skip the per-line JSON parsing.
+  if (!transcriptContent.includes(AGENT_LAUNCH_MARKER) &&
+      !transcriptContent.includes('Command running in background with ID:')) {
+    return [];
+  }
+
+  /** toolu_* → the tool_use that produced it, so a launch result can be named. */
+  const launchers = new Map();
+  /** id → { kind, name } for everything currently open, insertion-ordered. */
+  const open = new Map();
+  /** id → name, kept across completions so a resume can recover the label
+   *  instead of falling back to the id (which must never reach the user). */
+  const known = new Map();
+
+  for (const raw of transcriptContent.split('\n')) {
+    const line = raw.trim();
+    if (!line) continue;
+
+    // A task-notification can arrive wrapped in several entry shapes
+    // (queue-operation, attachment, user message). Match the raw line — the
+    // marker is distinctive enough and survives every wrapper.
+    if (line.includes('<task-notification>')) {
+      TASK_NOTIFICATION_RE.lastIndex = 0;
+      let m;
+      while ((m = TASK_NOTIFICATION_RE.exec(line)) !== null) open.delete(m[1]);
+      // Fall through: the same line carries nothing else we care about.
+      continue;
+    }
+
+    let entry;
+    try { entry = JSON.parse(line); } catch { continue; }
+    const content = entry && entry.message && entry.message.content;
+    if (!Array.isArray(content)) continue;
+
+    for (const block of content) {
+      if (!block || typeof block !== 'object') continue;
+
+      if (block.type === 'tool_use') {
+        if (block.id) launchers.set(block.id, block);
+        // A SendMessage to a known agent re-opens it: the harness notifies again
+        // when it stops, so a prior completion must not stick.
+        const to = block.input && block.input.to;
+        if (block.name === 'SendMessage' && to && !open.has(String(to))) {
+          const id = String(to);
+          // Never label with the id — recover the launch name, else stay generic.
+          open.set(id, { kind: 'agent', name: known.get(id) || 'agent' });
+        }
+        continue;
+      }
+
+      if (block.type !== 'tool_result') continue;
+      const text = resultText(block);
+      if (!text) continue;
+      const launcher = launchers.get(block.tool_use_id);
+      const input = launcher && launcher.input;
+
+      if (text.includes(AGENT_LAUNCH_MARKER)) {
+        const m = text.match(AGENT_ID_RE);
+        if (m) {
+          const name = labelFor(input, 'agent');
+          known.set(m[1], name);
+          open.set(m[1], { kind: 'agent', name });
+        }
+        continue;
+      }
+      const bg = text.match(BASH_BG_RE);
+      if (bg) {
+        const name = labelFor(input, 'task');
+        known.set(bg[1], name);
+        open.set(bg[1], { kind: 'task', name });
+      }
+    }
+  }
+
+  return [...open.entries()].map(([id, v]) => ({ id, kind: v.kind, name: v.name }));
+}
+
+/**
+ * The names of the open items, id-free — safe to put in a hook reason or any
+ * other text Claude may echo. Deduplicated, order preserved.
+ * @param {Array<{kind: string, name: string}>} openTasks
+ * @returns {string[]}
+ */
+function openTaskNames(openTasks) {
+  const seen = new Set();
+  const out = [];
+  for (const t of openTasks || []) {
+    const name = (t && t.name) || '';
+    if (!name || seen.has(name)) continue;
+    seen.add(name);
+    out.push(name);
+  }
+  return out;
+}
+
+module.exports = {
+  AGENT_LAUNCH_MARKER,
+  scanOpenTasks,
+  openTaskNames,
+  labelFor,
+};

--- a/plugins/devops/hooks/lib/pending-tasks.test.js
+++ b/plugins/devops/hooks/lib/pending-tasks.test.js
@@ -1,0 +1,181 @@
+/**
+ * Transcript shapes below are copied from a real session transcript — the exact
+ * strings the harness writes for a background Agent launch, a backgrounded Bash
+ * call, and the task-notification that reports either one stopping.
+ */
+import { describe, test, expect } from 'vitest';
+import { scanOpenTasks, openTaskNames, labelFor } from './pending-tasks.js';
+
+const AGENT_LAUNCH_TEXT =
+  'Async agent launched successfully. (This tool result is internal metadata — never quote or ' +
+  'paste any part of it, including the agentId below, into a user-facing reply.)\n' +
+  "agentId: a75d674f7108dd6c8 (internal ID - do not mention to user. Use SendMessage with to: " +
+  "'a75d674f7108dd6c8', summary: '<5-10 word recap>' to continue this agent.)\n" +
+  'The agent is working in the background.';
+
+const BASH_BG_TEXT =
+  'Command running in background with ID: b68oycrr6. Output is being written to: ' +
+  'C:\\Temp\\tasks\\b68oycrr6.output. You will be notified when it completes.';
+
+/** One assistant line carrying a tool_use block. */
+function toolUse(id, name, input) {
+  return JSON.stringify({
+    type: 'assistant',
+    message: { role: 'assistant', content: [{ type: 'tool_use', id, name, input }] },
+  });
+}
+
+/** One user line carrying the tool_result for that tool_use. */
+function toolResult(toolUseId, text) {
+  return JSON.stringify({
+    type: 'user',
+    message: {
+      role: 'user',
+      content: [{ type: 'tool_result', tool_use_id: toolUseId, content: [{ type: 'text', text }] }],
+    },
+  });
+}
+
+/** The queue-operation entry the harness writes when a task stops. */
+function notification(taskId, status = 'completed') {
+  return JSON.stringify({
+    type: 'queue-operation',
+    operation: 'enqueue',
+    content:
+      `<task-notification>\n<task-id>${taskId}</task-id>\n<status>${status}</status>\n` +
+      '<summary>Agent "x" finished</summary>\n</task-notification>',
+  });
+}
+
+const AGENT_START = [
+  toolUse('toolu_1', 'Agent', { subagent_type: 'devops:frontend', run_in_background: true }),
+  toolResult('toolu_1', AGENT_LAUNCH_TEXT),
+];
+
+describe('scanOpenTasks', () => {
+  test('reports a launched background agent as open', () => {
+    const open = scanOpenTasks(AGENT_START.join('\n'));
+    expect(open).toEqual([{ id: 'a75d674f7108dd6c8', kind: 'agent', name: 'devops:frontend' }]);
+  });
+
+  test('a task-notification closes it again', () => {
+    const open = scanOpenTasks([...AGENT_START, notification('a75d674f7108dd6c8')].join('\n'));
+    expect(open).toEqual([]);
+  });
+
+  test('reports a backgrounded Bash task, labelled by its description', () => {
+    const lines = [
+      toolUse('toolu_2', 'Bash', { command: 'npm test', description: 'Run the suite', run_in_background: true }),
+      toolResult('toolu_2', BASH_BG_TEXT),
+    ];
+    expect(scanOpenTasks(lines.join('\n')))
+      .toEqual([{ id: 'b68oycrr6', kind: 'task', name: 'Run the suite' }]);
+  });
+
+  test('tracks agents and tasks side by side', () => {
+    const lines = [
+      ...AGENT_START,
+      toolUse('toolu_2', 'Bash', { command: 'npm test', run_in_background: true }),
+      toolResult('toolu_2', BASH_BG_TEXT),
+    ];
+    expect(scanOpenTasks(lines.join('\n')).map(t => t.kind)).toEqual(['agent', 'task']);
+  });
+
+  test('closes only the task the notification names', () => {
+    const lines = [
+      ...AGENT_START,
+      toolUse('toolu_2', 'Bash', { command: 'npm test', run_in_background: true }),
+      toolResult('toolu_2', BASH_BG_TEXT),
+      notification('b68oycrr6'),
+    ];
+    expect(scanOpenTasks(lines.join('\n')).map(t => t.name)).toEqual(['devops:frontend']);
+  });
+
+  test('a SendMessage resume re-opens a completed agent', () => {
+    const lines = [
+      ...AGENT_START,
+      notification('a75d674f7108dd6c8'),
+      toolUse('toolu_3', 'SendMessage', { to: 'a75d674f7108dd6c8', message: 'keep going' }),
+    ];
+    // Re-opened, and still labelled by its type — never by the internal id.
+    expect(scanOpenTasks(lines.join('\n')))
+      .toEqual([{ id: 'a75d674f7108dd6c8', kind: 'agent', name: 'devops:frontend' }]);
+  });
+
+  test('a resumed agent closes again on its next notification', () => {
+    const lines = [
+      ...AGENT_START,
+      notification('a75d674f7108dd6c8'),
+      toolUse('toolu_3', 'SendMessage', { to: 'a75d674f7108dd6c8' }),
+      notification('a75d674f7108dd6c8'),
+    ];
+    expect(scanOpenTasks(lines.join('\n'))).toEqual([]);
+  });
+
+  test('a foreground agent is never reported (no launch marker)', () => {
+    const lines = [
+      toolUse('toolu_1', 'Agent', { subagent_type: 'devops:qa', run_in_background: false }),
+      toolResult('toolu_1', 'Here is what I found: the suite passes.'),
+    ];
+    expect(scanOpenTasks(lines.join('\n'))).toEqual([]);
+  });
+
+  test('survives malformed lines, blank lines and empty input', () => {
+    expect(scanOpenTasks('')).toEqual([]);
+    expect(scanOpenTasks(undefined)).toEqual([]);
+    const lines = ['{ not json', '', ...AGENT_START, 'also not json'];
+    expect(scanOpenTasks(lines.join('\n')).length).toBe(1);
+  });
+
+  test('a truncated leading line does not lose a later launch', () => {
+    const lines = ['ent","message":{"content":[]}}', ...AGENT_START];
+    expect(scanOpenTasks(lines.join('\n')).length).toBe(1);
+  });
+
+  test('a notification without a matching launch is harmless', () => {
+    expect(scanOpenTasks(notification('unknown-id'))).toEqual([]);
+  });
+
+  test('falls back to a generic label when the launching tool_use is out of slice', () => {
+    // Tail slice starts after the tool_use — the result is still counted.
+    const open = scanOpenTasks(toolResult('toolu_gone', AGENT_LAUNCH_TEXT));
+    expect(open).toEqual([{ id: 'a75d674f7108dd6c8', kind: 'agent', name: 'agent' }]);
+  });
+});
+
+describe('openTaskNames', () => {
+  test('returns names only — never the internal id', () => {
+    const names = openTaskNames(scanOpenTasks(AGENT_START.join('\n')));
+    expect(names).toEqual(['devops:frontend']);
+    expect(names.join(' ')).not.toContain('a75d674f7108dd6c8');
+  });
+
+  test('deduplicates repeated names and preserves order', () => {
+    expect(openTaskNames([
+      { name: 'devops:qa' }, { name: 'devops:frontend' }, { name: 'devops:qa' },
+    ])).toEqual(['devops:qa', 'devops:frontend']);
+  });
+
+  test('skips unnamed entries and tolerates no input', () => {
+    expect(openTaskNames([{ name: '' }, null])).toEqual([]);
+    expect(openTaskNames(undefined)).toEqual([]);
+  });
+});
+
+describe('labelFor', () => {
+  test('prefers subagent_type, then description', () => {
+    expect(labelFor({ subagent_type: 'devops:qa', description: 'x' }, 'agent')).toBe('devops:qa');
+    expect(labelFor({ description: 'Review the diff' }, 'agent')).toBe('Review the diff');
+    expect(labelFor({}, 'agent')).toBe('agent');
+  });
+
+  test('truncates a long command used as a task label', () => {
+    const label = labelFor({ command: 'x'.repeat(80) }, 'task');
+    expect(label.endsWith('…')).toBe(true);
+    expect(label.length).toBe(41);
+  });
+
+  test('collapses whitespace in a multi-line command', () => {
+    expect(labelFor({ command: 'npm  run\n  build' }, 'task')).toBe('npm run build');
+  });
+});

--- a/plugins/devops/hooks/post-tool-use/post.flow.completion.js
+++ b/plugins/devops/hooks/post-tool-use/post.flow.completion.js
@@ -22,6 +22,11 @@
  *     - validation-pending — any source change owes a validation attestation in
  *       the completion card; a new edit clears a prior validation-attested flag.
  *   Subagent delegation does not satisfy any of these gates.
+ *
+ *   Also detects background work started by the current call (a run_in_background
+ *   Agent, a backgrounded Bash task) and injects the `pending` instruction right
+ *   away, so a card rendered before those results arrive declares them instead of
+ *   being bounced by stop.flow.guard's pending gate.
  */
 
 require('../lib/plugin-guard');
@@ -31,6 +36,7 @@ const os = require('os');
 const path = require('path');
 const { sessionFile, readSessionFile, writeSessionFile } = require('../lib/session-id');
 const { getLocale, t } = require('../lib/locale');
+const { AGENT_LAUNCH_MARKER, labelFor } = require('../lib/pending-tasks');
 const {
   classifyProfile,
   carveOutsFromProfile,
@@ -102,6 +108,27 @@ const DESKTOP_TEST_DICT = {
     optNo: 'Nein, manuell testen',
   },
 };
+
+/**
+ * Did THIS tool call start background work that outlives the turn?
+ * Reads the same launch markers the Stop gate scans for (lib/pending-tasks.js),
+ * but from the live tool_response, so the reminder can fire immediately.
+ *
+ * @param {object} hook — PostToolUse payload
+ * @returns {{ kind: 'agent'|'task', name: string }|null}
+ */
+function detectBackgroundLaunch(hook) {
+  const r = hook && hook.tool_response;
+  const text = typeof r === 'string' ? r : (r ? JSON.stringify(r) : '');
+  if (!text) return null;
+  if (text.includes(AGENT_LAUNCH_MARKER)) {
+    return { kind: 'agent', name: labelFor(hook.tool_input, 'agent') };
+  }
+  if (text.includes('Command running in background with ID:')) {
+    return { kind: 'task', name: labelFor(hook.tool_input, 'task') };
+  }
+  return null;
+}
 
 let inputData = '';
 process.stdin.setEncoding('utf8');
@@ -273,6 +300,24 @@ process.stdin.on('end', () => {
     'once and re-requested (see deep-knowledge/test-autonomy.md).',
     'Card LAST, nothing after the closing ---.',
   );
+
+  // Background work started by THIS tool call. Injected loudly and immediately,
+  // so the card carries `pending` on the first try instead of being bounced by
+  // the Stop gate — a block costs a whole extra turn.
+  const launched = detectBackgroundLaunch(hook);
+  if (launched) {
+    lines.push(
+      '',
+      `[pending] ${launched.kind === 'agent' ? 'Background agent' : 'Background task'} started: ${launched.name}`,
+      'It keeps running after you hand the turn back. If you finish this turn before',
+      'its result arrives, the completion card MUST carry the `pending` field:',
+      `  pending: [{ name: "${launched.name}", kind: "${launched.kind}", doing: "<what it is working on>" }]`,
+      'That replaces the CTA of every variant with "⏳ NOCH NICHT FERTIG. … — ich MELDE',
+      'mich" — without it the card would tell the user to SHIP or act on a result that',
+      'does not exist yet. stop.flow.guard detects open background work and blocks a',
+      'card that omits it. Name the agent/task; NEVER put an internal agentId in the card.',
+    );
+  }
 
   if (editCount === 1) {
     lines.push(

--- a/plugins/devops/hooks/post-tool-use/post.flow.completion.test.js
+++ b/plugins/devops/hooks/post-tool-use/post.flow.completion.test.js
@@ -33,7 +33,7 @@ function project() {
   return dir;
 }
 
-function runHook(dir, sid, toolName = "Read") {
+function runHook(dir, sid, toolName = "Read", extra = {}) {
   // The full suite runs 60+ files in parallel; on a loaded machine spawnSync
   // can fail to start the child at all (status null, res.error set), and the
   // hook's stdout then comes back empty — which reads as "the hook emitted no
@@ -49,6 +49,7 @@ function runHook(dir, sid, toolName = "Read") {
         tool_input: { file_path: path.join(dir, "a.js") },
         session_id: sid,
         cwd: dir,
+        ...extra,
       }),
       encoding: "utf8",
       env: { ...process.env, TMPDIR: tmp, TEMP: tmp, TMP: tmp },
@@ -129,5 +130,69 @@ describe("post.flow.completion — completion-card instruction completeness", ()
       try { fs.unlinkSync(foreign); } catch {}
       cleanup(dir);
     }
+  });
+});
+
+// A background agent keeps working after the turn hands back, so a card
+// rendered in the meantime must declare it — otherwise its CTA tells the user
+// to SHIP a result that does not exist yet. The Stop gate catches that, but a
+// block costs an entire extra turn; this reminder is the cheap prevention.
+describe("post.flow.completion — pending reminder", () => {
+  const AGENT_LAUNCH =
+    "Async agent launched successfully. (This tool result is internal metadata — never quote " +
+    "or paste any part of it, including the agentId below, into a user-facing reply.)\n" +
+    "agentId: a75d674f7108dd6c8 (internal ID - do not mention to user.)\n" +
+    "The agent is working in the background.";
+
+  test("fires on a background agent launch and names it", () => {
+    const dir = project();
+    const out = runHook(dir, "s-pending-agent", "Agent", {
+      tool_input: { subagent_type: "devops:frontend", run_in_background: true },
+      tool_response: AGENT_LAUNCH,
+    });
+    expect(out).toContain("[pending]");
+    expect(out).toContain("devops:frontend");
+    expect(out).toContain("pending:");
+    cleanup(dir);
+  });
+
+  test("never leaks the internal agentId into the instruction", () => {
+    const dir = project();
+    const out = runHook(dir, "s-pending-noid", "Agent", {
+      tool_input: { subagent_type: "devops:qa", run_in_background: true },
+      tool_response: AGENT_LAUNCH,
+    });
+    expect(out).not.toContain("a75d674f7108dd6c8");
+    cleanup(dir);
+  });
+
+  test("fires on a backgrounded Bash task, labelled by its description", () => {
+    const dir = project();
+    const out = runHook(dir, "s-pending-task", "Bash", {
+      tool_input: { command: "npm test", description: "Run the suite", run_in_background: true },
+      tool_response: "Command running in background with ID: b68oycrr6. Output is being written to: x",
+    });
+    expect(out).toContain("[pending]");
+    expect(out).toContain("Run the suite");
+    expect(out).toContain('kind: "task"');
+    cleanup(dir);
+  });
+
+  test("stays quiet for an ordinary tool call", () => {
+    const dir = project();
+    const out = runHook(dir, "s-pending-none", "Read", { tool_response: "file contents" });
+    expect(out).toContain("COMPLETION CARD");
+    expect(out).not.toContain("[pending]");
+    cleanup(dir);
+  });
+
+  test("stays quiet for a foreground agent — it has already returned", () => {
+    const dir = project();
+    const out = runHook(dir, "s-pending-fg", "Agent", {
+      tool_input: { subagent_type: "devops:qa", run_in_background: false },
+      tool_response: "Here is the review: everything looks fine.",
+    });
+    expect(out).not.toContain("[pending]");
+    cleanup(dir);
   });
 });

--- a/plugins/devops/hooks/stop/stop.flow.guard.js
+++ b/plugins/devops/hooks/stop/stop.flow.guard.js
@@ -12,7 +12,11 @@
  *   blocked stop cycle (stop_hook_active=false):
  *     1. no card rendered AND (tool calls happened OR substantial prose), OR
  *     2. a card exists but a code change owes validation
- *        (validation-pending set, validation-attested not).
+ *        (validation-pending set, validation-attested not), OR
+ *     3. a card exists but background subagents / tasks are still running and
+ *        the card did not declare them (`pending` field, pending-attested not).
+ *        Open work is read from the transcript, not from a flag — completions
+ *        arrive as task-notifications, which no tool hook ever sees.
  *
  *   Pass (silent exit 0) otherwise — flags are reset so the next turn is
  *   evaluated independently.
@@ -28,7 +32,9 @@ const {
   isSubstantialAnswer,
   lastAssistantContainsCard,
   safeReadTranscript,
+  PENDING_TAIL_BYTES,
 } = require('../lib/card-guard');
+const { scanOpenTasks, openTaskNames } = require('../lib/pending-tasks');
 
 let inputData = '';
 process.stdin.setEncoding('utf8');
@@ -49,22 +55,26 @@ process.stdin.on('end', () => {
   const silentResult = readSessionFile('dotclaude-devops-silent-turn', sessionId, EXACT);
   const valPendingResult = readSessionFile('dotclaude-devops-validation-pending', sessionId, EXACT);
   const valAttestedResult = readSessionFile('dotclaude-devops-validation-attested', sessionId, EXACT);
+  const pendAttestedResult = readSessionFile('dotclaude-devops-pending-attested', sessionId, EXACT);
 
   const workHappened = workResult !== null;
   const flagCardRendered = cardResult !== null;
   const silent = silentResult !== null;
   const validationPending = valPendingResult !== null;
   const validationAttested = valAttestedResult !== null;
+  const pendingAttested = pendAttestedResult !== null;
   const stopHookActive = hook.stop_hook_active === true;
 
-  // Scan transcript when the flag state alone cannot settle the decision:
-  //  - no card flag → might still have rendered the card (marker scan = backup)
-  //  - no work and no card → need substantial-answer heuristic
-  // Silent turns skip the transcript scan entirely — enforcement is off.
-  const transcript = (!flagCardRendered && !silent)
-    ? safeReadTranscript(hook.transcript_path)
-    : '';
+  // Scan the transcript unless this is a silent tick. It answers two questions:
+  //  - did the last assistant message already carry a card / substantial prose
+  //    (backup for a failed flag write, plus the chat-only heuristic), and
+  //  - is background work still running (Gate 3), which no flag can tell us —
+  //    completions arrive as task-notifications, not as tool calls.
+  // The wider PENDING slice is used so an agent launched early in a long turn
+  // is still seen; scanOpenTasks short-circuits when no launch marker is there.
+  const transcript = silent ? '' : safeReadTranscript(hook.transcript_path, PENDING_TAIL_BYTES);
   const substantial = isSubstantialAnswer(transcript);
+  const openTasks = silent ? [] : openTaskNames(scanOpenTasks(transcript));
   // Backup detection: if the last assistant text already contains the card
   // marker, treat as rendered even when the flag write failed.
   const cardRendered = flagCardRendered || lastAssistantContainsCard(transcript);
@@ -77,6 +87,8 @@ process.stdin.on('end', () => {
     silent,
     validationPending,
     validationAttested,
+    openTaskNames: openTasks,
+    pendingAttested,
     // Active install root — the block reason names the offline renderer under it
     // for the case where the MCP server never connected this session.
     pluginRoot: process.env.CLAUDE_PLUGIN_ROOT || path.resolve(__dirname, '..', '..'),
@@ -89,6 +101,9 @@ process.stdin.on('end', () => {
     // Validation flags are owned by this gate — clear them at a clean turn end.
     if (valPendingResult) try { fs.unlinkSync(valPendingResult.filePath); } catch {}
     if (valAttestedResult) try { fs.unlinkSync(valAttestedResult.filePath); } catch {}
+    // Same for the pending attestation: it attests THIS turn's card, so the next
+    // turn must re-declare any work that is still running.
+    if (pendAttestedResult) try { fs.unlinkSync(pendAttestedResult.filePath); } catch {}
   }
 
   if (decision.action === 'block') {

--- a/plugins/devops/mcp-server/index.card.test.js
+++ b/plugins/devops/mcp-server/index.card.test.js
@@ -272,3 +272,102 @@ describe("render_completion_card — projects without a usable origin", () => {
     expect(text).not.toMatch(/READY — SHIP oder ÄNDERN/);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Pending layer — background work still running at turn end
+// ---------------------------------------------------------------------------
+
+describe("pending layer", () => {
+  test("replaces the ready CTA so the card never asks for a SHIP mid-flight", async () => {
+    const text = await cardText({
+      variant: "ready",
+      summary: "Erste Version gepusht",
+      lang: "de",
+      session_id: "test-pending-1",
+      changes: [{ area: "concept", description: "Farbstil-Korrektur angestoßen" }],
+      pending: [{ name: "devops:frontend", doing: "Farbstil auf Tokens umstellen" }],
+    });
+    expect(text).toMatch(/### ⏳ NOCH NICHT FERTIG\. Agent `devops:frontend` arbeitet — ich MELDE mich/);
+    expect(text).not.toMatch(/READY — SHIP oder ÄNDERN/);
+  });
+
+  test("overrides the ship-successful CTA too — a merge is not 'all done' mid-flight", async () => {
+    const text = await cardText({
+      variant: "ship-successful",
+      summary: "Gemerged, Doku-Agent läuft",
+      lang: "de",
+      session_id: "test-pending-2",
+      state: { pushed: true, merged: "main", branch: "feat/x" },
+      pending: [{ name: "devops:research", doing: "Doku nachziehen" }],
+    });
+    expect(text).toMatch(/NOCH NICHT FERTIG/);
+    expect(text).not.toMatch(/Alles ERLEDIGT/);
+    // The body keeps reporting what IS true — only the CTA is corrected.
+    expect(text).toMatch(/origin\/main/);
+  });
+
+  test("renders the pending block naming what is still running", async () => {
+    const text = await cardText({
+      variant: "analysis",
+      summary: "Agenten losgeschickt",
+      lang: "de",
+      session_id: "test-pending-3",
+      pending: [
+        { name: "devops:qa", doing: "Suite läuft" },
+        { name: "npm run build", kind: "task" },
+      ],
+    });
+    expect(text).toMatch(/⏳ \*\*LÄUFT NOCH — nicht abgeschlossen:\*\*/);
+    expect(text).toMatch(/\* `devops:qa` — Suite läuft/);
+    expect(text).toMatch(/\* `npm run build`/);
+    expect(text).toMatch(/Diese Card berichtet den Stand VOR diesen Ergebnissen/);
+  });
+
+  test("English card uses the English pending wording", async () => {
+    const text = await cardText({
+      variant: "ready",
+      summary: "Pushed first version",
+      lang: "en",
+      session_id: "test-pending-5",
+      pending: [{ name: "devops:frontend" }],
+    });
+    expect(text).toMatch(/### ⏳ NOT DONE YET\. agent `devops:frontend` is working/);
+    expect(text).not.toMatch(/READY — SHIP or CHANGE/);
+  });
+
+  test("an empty pending array leaves the normal CTA alone", async () => {
+    const text = await cardText({
+      variant: "ready",
+      summary: "Nichts offen",
+      lang: "de",
+      session_id: "test-pending-6",
+      pending: [],
+    });
+    expect(text).toMatch(/READY — SHIP oder ÄNDERN/);
+    expect(text).not.toMatch(/NOCH NICHT FERTIG/);
+  });
+});
+
+describe("analysis CTA", () => {
+  test("is the call to action alone — no hollow DONE for a question answered", async () => {
+    const text = await cardText({
+      variant: "analysis",
+      summary: "Frage beantwortet",
+      lang: "de",
+      session_id: "test-analysis-cta-de",
+    });
+    expect(text).toMatch(/### 📋 LIES dir durch — FRAGEN\?/);
+    expect(text).not.toMatch(/DONE — LIES dir durch/);
+  });
+
+  test("English analysis CTA drops DONE as well", async () => {
+    const text = await cardText({
+      variant: "analysis",
+      summary: "Question answered",
+      lang: "en",
+      session_id: "test-analysis-cta-en",
+    });
+    expect(text).toMatch(/### 📋 READ through — QUESTIONS\?/);
+    expect(text).not.toMatch(/DONE — READ through/);
+  });
+});

--- a/plugins/devops/mcp-server/index.cli.test.js
+++ b/plugins/devops/mcp-server/index.cli.test.js
@@ -128,6 +128,36 @@ describe("--render-card CLI fallback", () => {
     expect(out).not.toContain("dropped by the clamp");
   });
 
+  test("coerces a JSON-string `pending` and overrides the CTA with it", async () => {
+    const out = await renderCard({
+      variant: "ready",
+      summary: "Agent läuft noch",
+      lang: "de",
+      session_id: "cli-test-pending",
+      pending: JSON.stringify([{ name: "devops:frontend", doing: "Farbstil" }]),
+    });
+    expect(out).toContain("NOCH NICHT FERTIG");
+    expect(out).toContain("devops:frontend");
+    expect(out).not.toContain("READY — SHIP oder ÄNDERN");
+  });
+
+  test("writes the pending-attested flag so the Stop gate is satisfied", async () => {
+    const session = "cli-test-pending-flag";
+    const attested = join(tmpdir(), `dotclaude-devops-pending-attested-${session}`);
+    try { unlinkSync(attested); } catch { /* best effort */ }
+
+    await renderCard({
+      variant: "ready", summary: "Agent läuft", session_id: session,
+      pending: [{ name: "devops:qa" }],
+    });
+    expect(existsSync(attested)).toBe(true);
+    try { unlinkSync(attested); } catch { /* best effort */ }
+
+    // An empty array attests nothing — the flag must stay absent.
+    await renderCard({ variant: "ready", summary: "Nichts offen", session_id: session, pending: [] });
+    expect(existsSync(attested)).toBe(false);
+  });
+
   test("an unknown variant still yields a card instead of an error", async () => {
     const out = await renderCard({ variant: "not-a-variant", summary: "Unbekannte Variante", session_id: "cli-test-variant" });
     expect(out).toMatch(/✨✨✨ Unbekannte Variante ✨✨✨/);

--- a/plugins/devops/mcp-server/index.js
+++ b/plugins/devops/mcp-server/index.js
@@ -45,6 +45,7 @@ import { join, resolve, dirname } from "node:path";
 import { homedir, tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { correctShipVariant, renderDowngradeNote } from "./lib/variant-guard.js";
+import { hasPending, pendingWhat, renderPendingBlock } from "./lib/pending.js";
 import { clampText, clampList } from "./lib/soft-limits.js";
 import {
   assessFreshness,
@@ -309,9 +310,11 @@ const CTA = {
     'ship-blocked':           '## \u26d4 BLOCKED. {reason} \u2014 FIX or SKIP?',
     test:                     '## \ud83e\uddea DONE \u2014 SHIP after your TEST?',
     'test-minimal':           '## \u25b6\ufe0f STARTED. {description} \u2014 HAVE FUN',
-    analysis:                 '## \ud83d\udccb DONE \u2014 READ through',
+    analysis:                 '## \ud83d\udccb READ through \u2014 QUESTIONS?',
     aborted:                  '## \ud83d\udeab ABORTED. {reason} \u2014 What should I TRY?',
     fallback:                 '## \ud83d\udd27 DONE \u2014 Anything ELSE?',
+    // Pending layer \u2014 overrides EVERY variant's CTA while background work runs.
+    pending:                  '## \u23f3 NOT DONE YET. {what} \u2014 I\u2019ll REPORT back',
   },
   de: {
     'ship-successful-merged':      '## \ud83d\ude80 SHIPPED{chan}. merged \u2192 origin/{merged} \u2014 Alles ERLEDIGT',
@@ -327,9 +330,11 @@ const CTA = {
     'ship-blocked':           '## \u26d4 BLOCKED. {reason} \u2014 FIX oder SKIP?',
     test:                     '## \ud83e\uddea DONE \u2014 SHIP nach deinem TEST?',
     'test-minimal':           '## \u25b6\ufe0f STARTED. {description} \u2014 VIEL SPASS',
-    analysis:                 '## \ud83d\udccb DONE \u2014 LIES dir durch',
+    analysis:                 '## \ud83d\udccb LIES dir durch \u2014 FRAGEN?',
     aborted:                  '## \ud83d\udeab ABORTED. {reason} \u2014 Was soll ich VERSUCHEN?',
     fallback:                 '## \ud83d\udd27 DONE \u2014 Noch was ANDERES?',
+    // Pending layer \u2014 overrides EVERY variant's CTA while background work runs.
+    pending:                  '## \u23f3 NOCH NICHT FERTIG. {what} \u2014 ich MELDE mich',
   },
 };
 
@@ -674,9 +679,22 @@ function renderDeployGate(items, lang) {
   return labels.header + '\n' + bullets.join('\n') + '\n\n_' + labels.hint + '_';
 }
 
-function renderCTA(variant, cta, lang, state, delivery) {
+function renderCTA(variant, cta, lang, state, delivery, pending) {
   const templates = CTA[lang] || CTA.de;
   cta = cta || {};
+
+  // Pending layer — background subagents / tasks the turn started are STILL
+  // running. Every other CTA on this card would ask the user to act on a result
+  // that does not exist yet ("SHIP or CHANGE?", "All DONE"), so the pending CTA
+  // replaces it on EVERY variant. Deliberately the first check: it outranks the
+  // ship / release wording, since "not finished" is the truer statement about
+  // the turn than any milestone the body reports. The body keeps its facts —
+  // only the one line that tells the user what to do is corrected.
+  if (hasPending(pending)) {
+    const tpl = templates.pending || CTA.de.pending;
+    // Always H3 — "still running" is a routine status, never a payoff moment.
+    return tpl.replace('{what}', pendingWhat(pending, lang)).replace(/^## /, '### ');
+  }
 
   let key;
   if (variant === 'ship-successful') {
@@ -916,6 +934,19 @@ function renderCard(input, meterText, buildId) {
     }
   }
 
+  // Pending layer — background subagents / tasks still running at turn end.
+  // Variant-agnostic (like validation and deployGate): whatever the card's
+  // variant claims, this block says the turn is a snapshot taken BEFORE those
+  // results. Placed above the test/deploy blocks because it qualifies them too —
+  // any test instruction below is provisional while work is still in flight.
+  {
+    const pendingBlock = renderPendingBlock(input.pending, lang);
+    if (pendingBlock) {
+      parts.push(pendingBlock);
+      parts.push('');
+    }
+  }
+
   // User test steps (test variant)
   if (config.userTest) {
     const testBlock = renderUserTest(input.userTest, lang);
@@ -987,7 +1018,7 @@ function renderCard(input, meterText, buildId) {
     }
   }
 
-  parts.push(renderCTA(variant, input.cta, lang, input.state, input.delivery));
+  parts.push(renderCTA(variant, input.cta, lang, input.state, input.delivery, input.pending));
   parts.push('');
 
   parts.push('---');
@@ -1135,7 +1166,7 @@ const CARD_VARIANTS = [
 /** Structured fields the MCP schema accepts as either an object or a JSON string. */
 const JSON_FIELDS = [
   'changes', 'tests', 'state', 'cta', 'userTest', 'userFinalTest',
-  'deployGate', 'validation', 'delivery', 'promotion',
+  'deployGate', 'validation', 'delivery', 'promotion', 'pending',
 ];
 
 /** Prefix that carries the relay contract with the card itself. */
@@ -1228,6 +1259,11 @@ function buildCompletionCard(params) {
     writeFileSync(join(tmpdir(), 'dotclaude-devops-card-rendered-' + key), new Date().toISOString());
     if (Array.isArray(params.validation) && params.validation.length > 0) {
       writeFileSync(join(tmpdir(), 'dotclaude-devops-validation-attested-' + key), new Date().toISOString());
+    }
+    // pending-attested satisfies the pending gate — set only when the field
+    // actually carries items (an empty array declares nothing).
+    if (hasPending(params.pending)) {
+      writeFileSync(join(tmpdir(), 'dotclaude-devops-pending-attested-' + key), new Date().toISOString());
     }
   } catch (e) {
     console.error('[dotclaude-completion-mcp] Failed to write completion flag:', e.message);
@@ -1481,6 +1517,17 @@ server.registerTool(
           }),
         ])).optional(),
       ).describe("User-final-test items — for changes where automation cannot cover the last step (packaged Electron/Tauri without desktop takeover, 3rd-party integrations). Pass strings for local final tests; pass { action, afterDeployment: true } for 3rd-party items that require deployment first. Available in all variants except test-minimal and test — in the test variant all manual steps go into userTest (single test section, no duplicate)."),
+      pending: z.preprocess(
+        v => typeof v === 'string' ? tryParse(v) : v,
+        z.array(z.union([
+          z.string(),
+          z.object({
+            name: z.string().describe("What is running, named: the agent type ('devops:frontend') or the task label ('npm test'). Shown in the CTA, so the user reads WHICH agent — never pass an internal agentId."),
+            kind: z.enum(["agent", "task"]).optional().describe("'agent' (default) = background subagent; 'task' = backgrounded Bash command."),
+            doing: z.string().optional().describe("Short description of the work it is doing, e.g. 'Farbstil auf Tokens umstellen'."),
+          }),
+        ])).optional(),
+      ).describe("Background work STILL RUNNING at turn end — subagents started with run_in_background, or backgrounded Bash tasks. MANDATORY whenever such work is in flight: it overrides the CTA of EVERY variant with '⏳ NOCH NICHT FERTIG. {what} — ich MELDE mich' and renders a block naming each item, so the card never asks the user to SHIP or act on a result that does not exist yet. The card body still reports what IS true; only the call to action is corrected. stop.flow.guard blocks the turn when open background work is detected and this field is missing."),
       deployGate: z.preprocess(
         v => typeof v === 'string' ? tryParse(v) : v,
         z.array(z.union([

--- a/plugins/devops/mcp-server/lib/pending.js
+++ b/plugins/devops/mcp-server/lib/pending.js
@@ -1,0 +1,163 @@
+/**
+ * Pure helpers for the completion card's `pending` layer.
+ *
+ * A turn can END while work it started is still RUNNING — background subagents
+ * (`Agent` with run_in_background) and backgrounded Bash tasks keep going after
+ * the assistant hands the turn back. The card is rendered at that moment, so
+ * every variant's CTA ("SHIP or CHANGE?", "All DONE") would ask the user to act
+ * on a result that does not exist yet.
+ *
+ * `pending` is therefore NOT a variant but a LAYER over every variant: the body
+ * of the card stays true (the changes, tests and repo state really are what they
+ * say), while the CTA — the one line that tells the user what to do — is
+ * replaced by "not done yet, I'll report back", and a block names WHAT is still
+ * running. Same shape as the existing `state.deployPending` override, which
+ * flips the ship CTA for merged-but-undeployed artifacts.
+ *
+ * Extracted from index.js so the wording is unit-testable without booting the
+ * MCP server (index.js connects a stdio transport at import time).
+ */
+
+/** Names shown inline in the CTA before it collapses into a "+N" tail. */
+const CTA_NAME_LIMIT = 2;
+
+/** Bullets rendered in the pending block. */
+const BLOCK_ITEM_LIMIT = 4;
+
+const PENDING_LABEL = {
+  de: {
+    header: '⏳ **LÄUFT NOCH — nicht abgeschlossen:**',
+    hint: 'Diese Card berichtet den Stand VOR diesen Ergebnissen.',
+    agentOne: 'Agent', agentMany: 'Agenten',
+    taskOne: 'Task', taskMany: 'Tasks',
+    verbOne: 'arbeitet', verbMany: 'arbeiten',
+    taskVerbOne: 'läuft', taskVerbMany: 'laufen',
+    mixedVerb: 'laufen',
+  },
+  en: {
+    header: '⏳ **STILL RUNNING — not finished:**',
+    hint: 'This card reports the state BEFORE those results.',
+    agentOne: 'agent', agentMany: 'agents',
+    taskOne: 'task', taskMany: 'tasks',
+    verbOne: 'is working', verbMany: 'are working',
+    taskVerbOne: 'is running', taskVerbMany: 'are running',
+    mixedVerb: 'running',
+  },
+};
+
+/**
+ * Coerce the accepted input shapes into a uniform item list.
+ * Accepts plain strings ("devops:frontend") and objects
+ * ({ kind, name, doing }). Anything unusable is dropped rather than thrown —
+ * a card with a slightly thinner pending block still beats no card.
+ *
+ * @param {Array<string|object>|undefined} pending
+ * @returns {Array<{ kind: 'agent'|'task', name: string, doing: string }>}
+ */
+export function normalizePending(pending) {
+  if (!Array.isArray(pending)) return [];
+  const out = [];
+  for (const raw of pending) {
+    if (typeof raw === 'string') {
+      const name = raw.trim();
+      if (name) out.push({ kind: 'agent', name, doing: '' });
+      continue;
+    }
+    if (!raw || typeof raw !== 'object') continue;
+    const name = String(raw.name || '').trim();
+    const doing = String(raw.doing || '').trim();
+    if (!name && !doing) continue;
+    out.push({
+      kind: raw.kind === 'task' ? 'task' : 'agent',
+      name,
+      doing,
+    });
+  }
+  return out;
+}
+
+/** True when the card must switch to the pending CTA. */
+export function hasPending(pending) {
+  return normalizePending(pending).length > 0;
+}
+
+/** `a`, `b` — code-fenced names, capped, with a "+N" tail for the rest. */
+function nameList(items) {
+  const named = items.filter(i => i.name);
+  if (named.length === 0) return '';
+  const shown = named.slice(0, CTA_NAME_LIMIT).map(i => '`' + i.name + '`');
+  const rest = named.length - shown.length;
+  if (rest > 0) shown.push('+' + rest);
+  return shown.join(', ');
+}
+
+/** "Agent `x` arbeitet" for one group (all agents, or all tasks). */
+function groupPhrase(items, L, kind) {
+  const n = items.length;
+  const names = nameList(items);
+  const noun = kind === 'task'
+    ? (n === 1 ? L.taskOne : L.taskMany)
+    : (n === 1 ? L.agentOne : L.agentMany);
+  const verb = kind === 'task'
+    ? (n === 1 ? L.taskVerbOne : L.taskVerbMany)
+    : (n === 1 ? L.verbOne : L.verbMany);
+
+  // One named item reads better without the count: "Agent `qa` arbeitet".
+  if (n === 1 && names) return `${noun} ${names} ${verb}`;
+  if (names) return `${n} ${noun} (${names}) ${verb}`;
+  return `${n} ${noun} ${verb}`;
+}
+
+/**
+ * The `{what}` slot of the pending CTA — names what is still running so the
+ * line says WHICH agent, not just that something is busy.
+ *
+ * @param {Array} pending — raw or normalized items
+ * @param {'de'|'en'} lang
+ * @returns {string} e.g. "Agent `devops:frontend` arbeitet"
+ */
+export function pendingWhat(pending, lang) {
+  const L = PENDING_LABEL[lang] || PENDING_LABEL.de;
+  const items = normalizePending(pending);
+  if (items.length === 0) return '';
+
+  const agents = items.filter(i => i.kind === 'agent');
+  const tasks = items.filter(i => i.kind === 'task');
+
+  if (tasks.length === 0) return groupPhrase(agents, L, 'agent');
+  if (agents.length === 0) return groupPhrase(tasks, L, 'task');
+
+  // Mixed: lead with the named agents, append the task count.
+  const names = nameList(agents);
+  const agentNoun = agents.length === 1 ? L.agentOne : L.agentMany;
+  const taskNoun = tasks.length === 1 ? L.taskOne : L.taskMany;
+  const head = !names
+    ? `${agents.length} ${agentNoun}`
+    : (agents.length === 1 ? `${agentNoun} ${names}` : `${agents.length} ${agentNoun} (${names})`);
+  return `${head} + ${tasks.length} ${taskNoun} ${L.mixedVerb}`;
+}
+
+/**
+ * The pending block — one bullet per still-running item, plus the hint that the
+ * card predates their results. Rendered above the footer on every variant.
+ *
+ * @param {Array} pending — raw or normalized items
+ * @param {'de'|'en'} lang
+ * @returns {string} markdown block, '' when nothing is pending
+ */
+export function renderPendingBlock(pending, lang) {
+  const L = PENDING_LABEL[lang] || PENDING_LABEL.de;
+  const items = normalizePending(pending);
+  if (items.length === 0) return '';
+
+  const bullets = items.slice(0, BLOCK_ITEM_LIMIT).map(it => {
+    const label = it.name ? '`' + it.name + '`' : (it.kind === 'task' ? L.taskOne : L.agentOne);
+    return '* ' + label + (it.doing ? ' — ' + it.doing : '');
+  });
+  const rest = items.length - bullets.length;
+  if (rest > 0) bullets.push('* +' + rest);
+
+  return L.header + '\n' + bullets.join('\n') + '\n\n_' + L.hint + '_';
+}
+
+export { PENDING_LABEL, CTA_NAME_LIMIT, BLOCK_ITEM_LIMIT };

--- a/plugins/devops/mcp-server/lib/pending.test.js
+++ b/plugins/devops/mcp-server/lib/pending.test.js
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "vitest";
+import {
+  normalizePending, hasPending, pendingWhat, renderPendingBlock,
+} from "./pending.js";
+
+describe("normalizePending", () => {
+  it("accepts bare strings as agents", () => {
+    expect(normalizePending(["devops:frontend"]))
+      .toEqual([{ kind: "agent", name: "devops:frontend", doing: "" }]);
+  });
+
+  it("defaults kind to agent and keeps doing", () => {
+    expect(normalizePending([{ name: "qa", doing: "runs the suite" }]))
+      .toEqual([{ kind: "agent", name: "qa", doing: "runs the suite" }]);
+  });
+
+  it("keeps an explicit task kind", () => {
+    expect(normalizePending([{ name: "npm test", kind: "task" }])[0].kind).toBe("task");
+  });
+
+  it("drops unusable entries rather than throwing", () => {
+    expect(normalizePending([null, "", { }, 42, { name: "  " }])).toEqual([]);
+  });
+
+  it("returns [] for a non-array", () => {
+    expect(normalizePending(undefined)).toEqual([]);
+    expect(normalizePending("devops:qa")).toEqual([]);
+  });
+});
+
+describe("hasPending", () => {
+  it("is false for absent / empty / unusable input", () => {
+    expect(hasPending(undefined)).toBe(false);
+    expect(hasPending([])).toBe(false);
+    expect(hasPending([null, ""])).toBe(false);
+  });
+
+  it("is true as soon as one usable item exists", () => {
+    expect(hasPending(["devops:frontend"])).toBe(true);
+  });
+});
+
+describe("pendingWhat — the CTA slot", () => {
+  it("names the single agent instead of just counting it", () => {
+    expect(pendingWhat(["devops:frontend"], "de")).toBe("Agent `devops:frontend` arbeitet");
+    expect(pendingWhat(["devops:frontend"], "en")).toBe("agent `devops:frontend` is working");
+  });
+
+  it("names both agents with the count when there are two", () => {
+    expect(pendingWhat(["devops:frontend", "devops:qa"], "de"))
+      .toBe("2 Agenten (`devops:frontend`, `devops:qa`) arbeiten");
+  });
+
+  it("caps the names and reports the rest as +N", () => {
+    expect(pendingWhat(["a", "b", "c", "d"], "de")).toBe("4 Agenten (`a`, `b`, +2) arbeiten");
+  });
+
+  it("uses task wording for backgrounded tasks", () => {
+    expect(pendingWhat([{ name: "npm test", kind: "task" }], "de")).toBe("Task `npm test` läuft");
+    expect(pendingWhat([{ name: "npm test", kind: "task" }], "en")).toBe("task `npm test` is running");
+  });
+
+  it("leads with the named agents when agents and tasks are mixed", () => {
+    expect(pendingWhat([{ name: "devops:qa" }, { name: "npm test", kind: "task" }], "de"))
+      .toBe("Agent `devops:qa` + 1 Task laufen");
+    expect(pendingWhat([{ name: "a" }, { name: "b" }, { name: "t", kind: "task" }], "de"))
+      .toBe("2 Agenten (`a`, `b`) + 1 Task laufen");
+  });
+
+  it("falls back to a plain count when nothing carries a name", () => {
+    expect(pendingWhat([{ doing: "something" }], "de")).toBe("1 Agent arbeitet");
+  });
+
+  it("is empty when nothing is pending", () => {
+    expect(pendingWhat([], "de")).toBe("");
+  });
+
+  it("falls back to German for an unknown language", () => {
+    expect(pendingWhat(["x"], "fr")).toBe("Agent `x` arbeitet");
+  });
+});
+
+describe("renderPendingBlock", () => {
+  it("renders one bullet per item with its work description", () => {
+    const block = renderPendingBlock(
+      [{ name: "devops:frontend", doing: "Farbstil auf Tokens umstellen" }], "de",
+    );
+    expect(block).toContain("⏳ **LÄUFT NOCH — nicht abgeschlossen:**");
+    expect(block).toContain("* `devops:frontend` — Farbstil auf Tokens umstellen");
+  });
+
+  it("states that the card predates those results", () => {
+    expect(renderPendingBlock(["a"], "de")).toContain("_Diese Card berichtet den Stand VOR diesen Ergebnissen._");
+    expect(renderPendingBlock(["a"], "en")).toContain("_This card reports the state BEFORE those results._");
+  });
+
+  it("caps the bullets and reports the remainder", () => {
+    const block = renderPendingBlock(["a", "b", "c", "d", "e", "f"], "de");
+    expect(block).toContain("* +2");
+    expect(block.split("\n").filter(l => l.startsWith("* ")).length).toBe(5);
+  });
+
+  it("is empty when nothing is pending", () => {
+    expect(renderPendingBlock([], "de")).toBe("");
+    expect(renderPendingBlock(undefined, "de")).toBe("");
+  });
+});

--- a/plugins/devops/templates/completion-card.md
+++ b/plugins/devops/templates/completion-card.md
@@ -386,7 +386,7 @@ Format: `## {icon} {STATUS}. {context} — {sentence with VERB}`
 | 3 | ship-blocked | `## ⛔ BLOCKED. {{reason}} — FIX or SKIP?` |
 | 4 | test | `## 🧪 DONE — SHIP after your TEST?` |
 | 5 | test-minimal | `## ▶️ STARTED. {{user-facing-description}} — HAVE FUN` |
-| 6 | analysis | `## 📋 DONE — READ through` |
+| 6 | analysis | `## 📋 READ through — QUESTIONS?` |
 | 7 | aborted | `## 🚫 ABORTED. {{reason}} — What should I TRY?` |
 | 8 | fallback | `## 🔧 DONE — Anything ELSE?` |
 
@@ -400,9 +400,49 @@ Format: `## {icon} {STATUS}. {context} — {sentence with VERB}`
 | 3 | ship-blocked | `## ⛔ BLOCKED. {{reason}} — FIX oder SKIP?` |
 | 4 | test | `## 🧪 DONE — SHIP nach deinem TEST?` |
 | 5 | test-minimal | `## ▶️ STARTED. {{user-facing-description}} — VIEL SPASS` |
-| 6 | analysis | `## 📋 DONE — LIES dir durch` |
+| 6 | analysis | `## 📋 LIES dir durch — FRAGEN?` |
 | 7 | aborted | `## 🚫 ABORTED. {{reason}} — Was soll ich VERSUCHEN?` |
 | 8 | fallback | `## 🔧 DONE — Noch was ANDERES?` |
+
+### Pending override — background work still running
+
+`pending` is **not a variant**. It is a layer that applies on top of whichever
+variant the turn earned, for the case where the turn ends while work it started
+is still running: a subagent launched with `run_in_background`, or a backgrounded
+Bash task. Their results arrive later, as a task-notification.
+
+Without it every CTA above lies about the same thing — it asks the user to act
+("SHIP or CHANGE?", "All DONE") on a result that does not exist yet. So when
+`pending` carries items, it **replaces the CTA of every variant**, always as `###`
+(still-running is a status, never a payoff moment):
+
+| Lang | CTA |
+|------|-----|
+| EN | `### ⏳ NOT DONE YET. {{what}} — I'll REPORT back` |
+| DE | `### ⏳ NOCH NICHT FERTIG. {{what}} — ich MELDE mich` |
+
+`{{what}}` **names** what is running, so the line says which agent — not merely
+that something is busy: `Agent \`devops:frontend\` arbeitet` · `2 Agenten
+(\`a\`, \`b\`) arbeiten` · `Task \`npm test\` läuft`. Names are capped at two,
+with a `+N` tail. Never put an internal agentId in a card — use the agent type or
+task label.
+
+A block above the footer lists the open items, and states that the card predates
+their results:
+
+```markdown
+⏳ **LÄUFT NOCH — nicht abgeschlossen:**
+* `devops:frontend` — Farbstil auf Tokens umstellen
+
+_Diese Card berichtet den Stand VOR diesen Ergebnissen._
+```
+
+The rest of the card is untouched: changes, tests, delivery and state still
+report what IS true. Only the call to action is corrected.
+
+Enforced, not self-reported: `stop.flow.guard` reads the open work out of the
+transcript (`hooks/lib/pending-tasks.js` — launch markers in, task-notifications
+out) and blocks a card that omits `pending` while work is still in flight.
 
 ### Footer line
 

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.144.0",
+  "version": "0.145.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

A turn hands back the moment the assistant stops writing, but a subagent started with `run_in_background` — or a backgrounded Bash task — keeps going. The completion card was rendered at that moment with no way to say so, so its last line asked the user to act on a result that did not exist yet: "SHIP oder ÄNDERN?", or worse, "Alles ERLEDIGT" while an agent was mid-edit.

## What changed

**`pending` is a layer, not a variant.** `pending: [{ name, kind, doing }]` sits on top of whichever variant the turn earned. The body keeps its facts — changes, tests, delivery, repo state — and only the CTA is replaced:

```
### ⏳ NOCH NICHT FERTIG. Agent `devops:frontend` arbeitet — ich MELDE mich
```

plus a block naming each open item and stating that the card predates its results. A dedicated variant would have cost a shipped-but-not-finished turn its delivery track and version footer; "still running" is orthogonal to what a card reports. The precedent was already here — `state.deployPending` flips the ship CTA the same way. The CTA **names** what runs rather than counting it (capped at two names plus a `+N` tail).

**Enforced, not self-reported.** `stop.flow.guard` gained a third gate that reads the open work out of the transcript: launch markers (`Async agent launched successfully` + `agentId`, `Command running in background with ID:`) open a task, a `<task-notification>` closes it, a `SendMessage` resume re-opens one. A chronological state machine, so the final set is the true state. It reads a 1 MB tail (an agent launched early in a long turn is exactly the one that would be missed) and short-circuits when no launch marker is present. `post.flow.completion` injects the instruction the moment a background job starts, so the block stays rare. Internal agent ids never reach the card or the hook reason.

**`analysis` CTA drops its hollow "DONE".** Answering a question completes nothing and puts nothing on disk. Now `## 📋 LIES dir durch — FRAGEN?` / `## 📋 READ through — QUESTIONS?`.

## Tests

62 new tests across 5 files; full suite 2528 passed / 3 skipped, eslint clean. The transcript fixtures are copied from a real session transcript — the exact strings the harness writes.

## Notes

- The Codex review gate was skipped: the Codex CLI reported its usage limit exhausted (non-blocking per the ship skill's failure-tolerance rule).
- `ship_build` reported the test step as failed on the vitest worker `onTaskUpdate` RPC timeout under parallel load — the same contention flake capped in 0.143.0, not a test failure. Verified separately: `npm run test` exits 0 with 2528 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)