### PR TITLE
fix(cleanup): protect the session, not just its branch

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.145.0"
+    "version": "0.145.1"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.145.0",
+      "version": "0.145.1",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.145.0",
+      "version": "0.145.1",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.145.1] — 2026-09-06
+
+### Fixed
+
+- **`/setup-cleanup`'s "active sessions are UNTOUCHABLE" rule protected branches but not the sessions themselves.** The rule was written as a list of forbidden commands — `git branch -D`, `git push origin --delete`, checkout — and a list of verbs silently permits every verb it forgot to name. A cross-repo sweep obeyed it exactly: it refused to delete a live session's branch, then removed that session's worktree anyway, because `git worktree remove` was not on the list. The session kept running and lost nothing, but only because the branch it had already committed to survived elsewhere.
+
+  The protected set is now a set of **subjects** — the branch, its worktree directory, the repo it lives in, and any process running inside it — with the commands demoted to examples, and it must be rebuilt immediately before each destructive action rather than once at classification time, because a sweep across many repos outlives the session state it was classified against. `deep-knowledge/git-hygiene.md` gains the general rule and the four operation classes a guard has to cover (ref, worktree, file, and process mutation), plus the reason a partial guard is worse than none: it reads as coverage. Detection was widened in the same pass — a `git worktree list --porcelain` scan that only collects `branch refs/heads/` lines misses **detached** worktrees entirely, and scanning the `.claude/worktrees/` directory misses worktrees registered outside it; both were live blind spots, not hypotheticals.
+
 ## [0.145.0] — 2026-09-06
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.145.0**
+**Version: 0.145.1**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.145.0",
+  "version": "0.145.1",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/deep-knowledge/git-hygiene.md
+++ b/plugins/devops/deep-knowledge/git-hygiene.md
@@ -101,3 +101,32 @@ Enforced by the parallel-agent guard introduced in #193. See also
   changes after merge.
 - **Pre-tool-use guard** — warns when a git-mutating command is issued from the
   main repo root while a worktree for the current session is active.
+
+### Protection scope covers every operation class
+
+A "protected" or "live session" set protects the **subject**, not one verb. Once
+a repo, worktree, branch, or path is in that set, it is off-limits to *every*
+destructive operation class in the sweep:
+
+| Class | Examples |
+|-------|----------|
+| Ref mutation | `branch -D`, `push --delete`, `checkout`, `reset --hard` |
+| Worktree mutation | `worktree remove`, `worktree prune`, directory deletion |
+| File mutation | writing `.gitignore`, committing, staging |
+| Process mutation | killing a process whose cwd or argv points into the path |
+
+- **Never enumerate the covered verbs.** A rule written as a list of forbidden
+  commands silently permits every command absent from the list — which is how a
+  guard that correctly refused to delete a branch still removed the worktree
+  holding it. State the scope by subject and treat the list as examples.
+- **Re-check immediately before each destructive action, not once at
+  classification time.** A sweep across many repos runs for minutes; sessions
+  start, stop, and switch branches inside that window, so a set built at the
+  start is already stale by the time the last repo is reached.
+- **Derive liveness from the running system**, not from a hand-maintained
+  constant: registered worktrees (`git worktree list --porcelain`), session
+  metadata, and live process cwd/argv. A hard-coded path list drifts the moment
+  a session moves.
+- **A partial guard is worse than none** — it reads as coverage. If a sweep
+  cannot protect a subject across all four classes, it must skip that subject
+  entirely and report it, not protect it in some classes only.

--- a/plugins/devops/skills/setup-cleanup/SKILL.md
+++ b/plugins/devops/skills/setup-cleanup/SKILL.md
@@ -88,8 +88,15 @@ set immediately before each delete/remove/kill — never once at classification
 time and then trust it for the rest of the run.
 
 **Detection:** `git worktree list --porcelain` -> every line starting with
-`branch refs/heads/` is a protected branch. Build this set FIRST and check
-it before EVERY delete operation.
+`branch refs/heads/` is a protected branch, and every `worktree ` line is a
+protected **path** — including the detached ones, which have no `branch` line
+at all and would otherwise look unprotected. Rebuild this set immediately
+before each destructive action, not once at the start.
+
+A worktree registration is not the only evidence of a live session. Also treat
+as protected: any path a running process names in its cwd or argv, and any
+worktree outside `.claude/worktrees/` (`git worktree list` reports those too —
+a path-prefix scan of that directory alone misses them).
 
 **Membership test — exact ref equality only.** A candidate is protected when
 its **full branch name** is an element of the set, nothing else:

--- a/plugins/devops/skills/setup-cleanup/SKILL.md
+++ b/plugins/devops/skills/setup-cleanup/SKILL.md
@@ -58,15 +58,34 @@ Do NOT proceed. End the skill.
 ## SAFETY: Worktree Branch Protection
 
 **HARD RULE — no exceptions:**
-Branches attached to active worktrees (Aktive Sessions) are UNTOUCHABLE. You MUST NOT:
+Branches attached to active worktrees (Aktive Sessions) are UNTOUCHABLE, and so
+is **everything else belonging to that session** — its worktree directory, the
+repo it lives in, and any process running inside it. The examples below are
+examples, not the boundary:
 - Delete them locally (`git branch -D`)
 - Delete them remotely (`git push origin --delete`)
 - Checkout/switch away from them in their worktree
+- Remove or prune their worktree (`git worktree remove`, directory deletion)
+- Kill a process whose cwd or argv points into their worktree
+- Write files into them (including `.gitignore` hygiene fixes)
 - Recommend them for deletion
 - Include them in any cleanup batch
 
 These branches represent active Claude Code sessions. Deleting them breaks
 the worktree and causes data loss.
+
+**The protected set is a set of subjects, not a list of verbs.** A guard that
+enumerates forbidden commands permits every command it forgot to name — the
+failure mode that let a sweep correctly refuse `branch -D` on a live session
+and then remove that session's worktree anyway. Scope rules and the four
+operation classes a guard must cover:
+`{PLUGIN_ROOT}/deep-knowledge/git-hygiene.md` § Protection scope covers every
+operation class.
+
+**Re-check before every destructive action.** A sweep over many repos runs long
+enough for sessions to start, stop, or switch branches. Rebuild the protected
+set immediately before each delete/remove/kill — never once at classification
+time and then trust it for the rest of the run.
 
 **Detection:** `git worktree list --porcelain` -> every line starting with
 `branch refs/heads/` is a protected branch. Build this set FIRST and check

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.145.0",
+  "version": "0.145.1",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

`/setup-cleanup`'s "active sessions are UNTOUCHABLE" rule listed the forbidden
commands (`git branch -D`, `git push origin --delete`, checkout). A list of verbs
silently permits every verb it forgot to name.

Found the hard way during a 20-repo cleanup sweep: the sweep obeyed the rule
exactly — refused to delete a live session's branch — and then removed that
session's worktree, because `git worktree remove` was not on the list. The
session kept running and lost nothing, but only because it had already committed
to a branch that survived elsewhere.

## Changes

- **The protected set is a set of subjects, not verbs.** Branch, worktree
  directory, containing repo, and any process running inside it. The commands
  are demoted to examples.
- **Re-check before every destructive action**, not once at classification time
  — a sweep across many repos outlives the session state it was classified
  against. Two sessions started mid-sweep during the run that surfaced this.
- **Detection widened.** Collecting only `branch refs/heads/` lines from
  `git worktree list --porcelain` misses **detached** worktrees, which have no
  branch line; scanning `.claude/worktrees/` misses worktrees registered outside
  it. Both were live blind spots in the same sweep, not hypotheticals.
- **`deep-knowledge/git-hygiene.md`** gains the general rule, the four operation
  classes a guard must cover (ref / worktree / file / process mutation), and why
  a partial guard is worse than none: it reads as coverage.

## Testing

- 2531 tests pass, lint clean
- Reverse-propagation check: `setup-cleanup` was the only skill stating
  protection as a verb enumeration; `ship` already scopes by subject
  ("Only own branch/worktree") and needed no change

🤖 Generated with [Claude Code](https://claude.com/claude-code)