### PR TITLE
feat(concept): reality check against main before implementing

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.145.1"
+    "version": "0.146.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.145.1",
+      "version": "0.146.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.145.1",
+      "version": "0.146.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.146.0] — 2026-09-06
+
+### Added
+
+- **`/concept` now re-checks an approved plan against the default branch before implementing it.** A concept session lives for hours or days while `main` keeps moving — other sessions, other PRs, other ships. Clicking "Mit Feedback implementieren" implemented the plan as approved, so a renamed file, a changed contract or work somebody had already done reached the diff unremarked and was found in review, if at all. The implement path now runs a reality check before writing a single line: on material drift it does not implement, it appends **one** extra round — mechanically an ordinary iteration, marked `data-reality-check`, with its own "Realitäts-Check" tab and an explainer naming the commits that landed — carrying every decision the drift raises. Submitting that round with implement writes the code.
+
+  The hard requirement was that this must never become a trap, so it has **two independent guards**. The marker on the section short-circuits the check, which is exact: implementing from a reality-check round always implements. And the baseline advances on *every* submission of such a round — iterate as well as implement — so the same drift cannot force a second one even if the marker were lost to a bad rewrite, a legacy page or a resumed session working from a page it did not write. Both would have to fail on the same round to produce two forced rounds in a row. An ordinary iterate round re-arms the check, which is the user opting back in rather than a deadlock: the next implement is measured against the advanced baseline, so only drift that landed since can raise it again.
+
+  The split between code and judgment is deliberate. `scripts/concept-drift.js` produces facts only — the commits, the changed paths (a rename contributes *both* sides, which is the drift class that matters most), and their intersection with the paths the concept names — while the force classes stay with the model: a file deleted or renamed, a contract changed, the functionality already built, a user decision that lost its basis. Version bumps, CHANGELOG, docs, tests-only changes and formatting never force a round, and no drift card may be shown without the SHA and path it comes from. **Every unresolvable condition fails safe** — no repo, no remote, a default branch that is not called `main`, a detached HEAD, an offline or slow fetch, a shallow clone, a baseline erased by a force-push — and lets the implement through; a network hiccup must never block an implement order. The check announces itself as its own progress step before the fetch, so the added wait cannot read as a stalled submission, and it never reports `phase: "implemented"` on that path — a panel showing "Implementierung abgeschlossen" over an empty diff would be worse than the problem being solved.
+
 ## [0.145.1] — 2026-09-06
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.145.1**
+**Version: 0.146.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.145.1",
+  "version": "0.146.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/scripts/concept-drift.js
+++ b/plugins/devops/scripts/concept-drift.js
@@ -1,0 +1,375 @@
+#!/usr/bin/env node
+/**
+ * @script concept-drift
+ * @version 0.1.0
+ * @plugin devops
+ * @description The reality check behind `/concept`'s implement gate: has the
+ *   default branch moved under this concept while the user was iterating on it?
+ *
+ *   A concept session lives for hours or days. `main` keeps moving — other
+ *   sessions, other PRs, other ships. When the user finally clicks "Mit Feedback
+ *   implementieren", the plan they approved may reference a file that was
+ *   renamed, a contract that changed, or work somebody already did. Implementing
+ *   it verbatim then produces wrong, dead or duplicate code.
+ *
+ *   This script does NOT decide whether that matters. It produces the FACTS —
+ *   which commits landed, which paths they touched, which of them intersect the
+ *   paths the concept references — and Claude applies the force classes from
+ *   `skills/concept/deep-knowledge/reality-check.md` to them. Splitting it that
+ *   way is deliberate: the half that must be deterministic (git plumbing, and
+ *   above all the fail-safe behaviour) is code, and the half that needs judgment
+ *   stays with the model.
+ *
+ *   **Fail SAFE, never fail closed.** Every unresolvable condition — no repo, no
+ *   remote, no default branch, detached HEAD, offline, slow fetch, shallow clone,
+ *   a baseline SHA that a force-push erased, git missing from PATH — resolves to
+ *   `verdict: "skip"` with `safe: true`, which means "implement, do not hold the
+ *   user up". A network hiccup must never block an implement order. The one thing
+ *   this script may never do is report drift it did not verify.
+ *
+ *   Modes:
+ *     (default)   --state <abs> [--paths a,b] [--paths-file f] [--timeout 30]
+ *                 Compare the recorded baseline against the current remote tip.
+ *                 Prints one JSON object on stdout. Never writes the state file.
+ *     --capture   --state <abs> [--sha <sha>]
+ *                 Record the baseline. With no --sha, records the remote tip as
+ *                 it is right now (concept open). With --sha, records exactly the
+ *                 commit a check just examined — advancing the baseline past
+ *                 drift the user has now decided on, so the same drift can never
+ *                 force a second round.
+ *
+ *   Exit code is 0 for every outcome including a dead remote; only invalid
+ *   arguments exit 2. A non-zero exit would surface as a failed Bash call and
+ *   invite Claude to "fix" a perfectly normal offline repo.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const DEFAULTS = {
+  timeout: 30, // seconds, whole-script budget for network-touching git calls
+  maxCommits: 50,
+  maxPaths: 200,
+};
+
+function parseArgs(argv) {
+  const out = { state: '', paths: [], pathsFile: '', sha: '', capture: false, ...DEFAULTS };
+  for (let i = 0; i < argv.length; i++) {
+    if (!argv[i].startsWith('--')) continue;
+    const key = argv[i].slice(2);
+    if (key === 'capture') { out.capture = true; continue; }
+    const raw = argv[i + 1];
+    if (raw === undefined || raw.startsWith('--')) continue;
+    i++;
+    if (key === 'state') out.state = raw;
+    else if (key === 'sha') out.sha = raw;
+    else if (key === 'paths-file') out.pathsFile = raw;
+    else if (key === 'paths') out.paths = splitPaths(raw);
+    // hasOwn, not `in` — `in` walks the prototype chain, so `--toString 5`
+    // would set junk on the options object.
+    else if (Object.prototype.hasOwnProperty.call(DEFAULTS, key)) out[key] = Number(raw);
+  }
+  return out;
+}
+
+function splitPaths(raw) {
+  return String(raw)
+    .split(/[,\n\r]+/)
+    .map((p) => p.trim().replace(/\\/g, '/').replace(/^\.\//, ''))
+    .filter(Boolean);
+}
+
+function validate(opts) {
+  // Enforced, not merely described: a relative path resolved against the caller's
+  // cwd is the exact defect `concept-watch.js` already had to fix, and this
+  // script is invoked from whatever directory Claude happens to be in.
+  if (!opts.state || !path.isAbsolute(opts.state)) {
+    return 'state must be the ABSOLUTE path to concept-active.json';
+  }
+  if (!(opts.timeout > 0)) return 'timeout must be a positive number';
+  if (opts.sha && !/^[0-9a-f]{7,40}$/i.test(opts.sha)) return 'sha must be a hex commit id';
+  return null;
+}
+
+/** The project root is the state file's grandparent: `<root>/.claude/concept-active.json`. */
+function repoRoot(statePath) {
+  return path.dirname(path.dirname(statePath));
+}
+
+function readState(statePath) {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(statePath, 'utf8'));
+    return parsed && typeof parsed === 'object' ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read-modify-write of the shared state file. Only ever ADDS the baseline keys —
+ * `port`, `html_path`, `cron_id` and friends belong to the bridge and stay
+ * untouched, because the watchers key their liveness decisions off them.
+ */
+function writeBaseline(statePath, fields) {
+  const state = readState(statePath);
+  if (!state) return false;
+  const next = { ...state, ...fields };
+  const tmp = `${statePath}.drift.tmp`;
+  try {
+    fs.writeFileSync(tmp, `${JSON.stringify(next, null, 2)}\n`);
+    fs.renameSync(tmp, statePath);
+    return true;
+  } catch {
+    try { fs.unlinkSync(tmp); } catch { /* best effort */ }
+    return false;
+  }
+}
+
+/**
+ * Every git call in this script goes through here, and every one of them may
+ * fail. `null` means "could not answer" and always routes to a safe skip —
+ * callers must never treat it as "no drift found".
+ */
+function git(args, cwd, timeoutSec) {
+  try {
+    return execFileSync('git', args, {
+      cwd,
+      timeout: Math.max(1, Math.round(timeoutSec * 1000)),
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      windowsHide: true,
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function isRepo(cwd, timeoutSec) {
+  return git(['rev-parse', '--git-dir'], cwd, timeoutSec) !== null;
+}
+
+function hasOrigin(cwd, timeoutSec) {
+  const remotes = git(['remote'], cwd, timeoutSec);
+  return typeof remotes === 'string' && remotes.split(/\s+/).includes('origin');
+}
+
+/**
+ * The remote's default branch, without assuming it is called `main`. Falls back
+ * through the two conventional names before giving up — `origin/HEAD` is unset
+ * in plenty of clones, and giving up there would disable the check for them.
+ */
+function detectDefaultBranch(cwd, timeoutSec) {
+  const symbolic = git(['symbolic-ref', '--short', 'refs/remotes/origin/HEAD'], cwd, timeoutSec);
+  if (symbolic && symbolic.startsWith('origin/')) return symbolic.slice('origin/'.length);
+  for (const candidate of ['main', 'master']) {
+    if (git(['rev-parse', '--verify', '--quiet', `refs/remotes/origin/${candidate}`], cwd, timeoutSec)) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+/** A commit id that is not in the object store any more (force-push, shallow clone). */
+function commitExists(sha, cwd, timeoutSec) {
+  return git(['cat-file', '-e', `${sha}^{commit}`], cwd, timeoutSec) !== null;
+}
+
+function parseCommits(raw, limit) {
+  if (!raw) return [];
+  return raw
+    .split('\n')
+    .filter(Boolean)
+    .slice(0, limit)
+    .map((line) => {
+      const sep = line.indexOf(' ');
+      const sha = sep === -1 ? line : line.slice(0, sep);
+      const subject = sep === -1 ? '' : line.slice(sep + 1);
+      return { sha: (sha || '').slice(0, 12), subject: subject || '' };
+    });
+}
+
+/**
+ * `--name-status` rather than `--name-only`, because a rename is the single most
+ * common way a concept goes stale and `R` lines carry BOTH paths. Dropping the
+ * old one would hide exactly the drift class this feature exists to catch.
+ */
+function parseChangedPaths(raw, limit) {
+  if (!raw) return [];
+  const out = [];
+  for (const line of raw.split('\n')) {
+    if (!line) continue;
+    const parts = line.split('\t');
+    const status = (parts[0] || '').charAt(0);
+    for (const p of parts.slice(1)) {
+      if (!p) continue;
+      const norm = p.replace(/\\/g, '/');
+      if (!out.some((e) => e.path === norm)) out.push({ path: norm, status: status || 'M' });
+    }
+    if (out.length >= limit) break;
+  }
+  return out.slice(0, limit);
+}
+
+/**
+ * A referenced path matches a changed path when either contains the other as a
+ * path prefix — so naming a directory in the concept catches changes to files
+ * inside it, and naming a file catches a change to the directory entry itself.
+ * Substring matching is deliberately NOT used: `hooks/a.js` must not match
+ * `other/hooks/a.js.bak`.
+ */
+function intersect(changed, referenced) {
+  const refs = referenced.map((r) => r.replace(/\/+$/, ''));
+  const hits = [];
+  for (const c of changed) {
+    for (const r of refs) {
+      if (!r) continue;
+      if (c.path === r || c.path.startsWith(`${r}/`) || r.startsWith(`${c.path}/`)) {
+        hits.push({ ...c, matched: r });
+        break;
+      }
+    }
+  }
+  return hits;
+}
+
+function skip(reason, extra = {}) {
+  return { verdict: 'skip', safe: true, reason, ...extra };
+}
+
+/**
+ * @returns {{verdict:'skip'|'clear'|'candidates', safe:boolean, reason:string, ...}}
+ *   `candidates` never means "force a round" — it means "here are the facts,
+ *   apply the force classes". Only Claude decides that.
+ */
+function check(opts, deps = {}) {
+  const run = deps.git || git;
+  const cwd = deps.cwd || repoRoot(opts.state);
+  const budget = opts.timeout;
+
+  const state = readState(opts.state);
+  if (!state) return skip('no-state');
+
+  if (!(deps.isRepo || isRepo)(cwd, budget)) return skip('no-repo');
+  if (!(deps.hasOrigin || hasOrigin)(cwd, budget)) return skip('no-remote');
+
+  const branch = state.baseline_ref || (deps.detectDefaultBranch || detectDefaultBranch)(cwd, budget);
+  if (!branch) return skip('no-default-branch');
+
+  const baselineSha = typeof state.baseline_sha === 'string' ? state.baseline_sha : '';
+  if (!baselineSha) return skip('no-baseline', { branch });
+
+  // Network step. A failure here is NOT drift — the local tracking ref may be
+  // days old, so a diff computed against it would be a lie in either direction.
+  const fetched = run(['fetch', '--quiet', 'origin', branch], cwd, budget);
+  if (fetched === null) return skip('fetch-failed', { branch });
+
+  const headSha = run(['rev-parse', `refs/remotes/origin/${branch}`], cwd, budget);
+  if (!headSha) return skip('no-remote-ref', { branch });
+
+  const baseline = { ref: branch, sha: baselineSha };
+  const head = { ref: `origin/${branch}`, sha: headSha.slice(0, 12) };
+
+  if (headSha.startsWith(baselineSha) || baselineSha.startsWith(headSha)) {
+    return { verdict: 'clear', safe: true, reason: 'unchanged', baseline, head, commits: [], changed: [], overlap: [], advanceTo: headSha };
+  }
+
+  // A baseline the object store no longer holds (force-push, shallow clone,
+  // pruned) cannot be diffed against. Re-anchor and let this implement through.
+  if (!(deps.commitExists || commitExists)(baselineSha, cwd, budget)) {
+    return skip('baseline-gone', { baseline, head, advanceTo: headSha });
+  }
+
+  const range = `${baselineSha}..${headSha}`;
+  const commits = parseCommits(run(['log', '--no-merges', '--format=%H %s', range], cwd, budget), opts.maxCommits);
+  const changed = parseChangedPaths(run(['diff', '--name-status', range], cwd, budget), opts.maxPaths);
+
+  if (!changed.length) {
+    return { verdict: 'clear', safe: true, reason: 'no-file-changes', baseline, head, commits, changed: [], overlap: [], advanceTo: headSha };
+  }
+
+  const referenced = opts.paths;
+  if (!referenced.length) {
+    // No path list means no cheap pre-filter is possible. Hand over everything
+    // and let Claude judge — under-reporting drift is the one failure mode this
+    // script must not have.
+    return { verdict: 'candidates', safe: true, reason: 'no-path-filter', baseline, head, commits, changed, overlap: [], referenced: [], advanceTo: headSha };
+  }
+
+  const overlap = intersect(changed, referenced);
+  if (!overlap.length) {
+    return { verdict: 'clear', safe: true, reason: 'no-overlap', baseline, head, commits, changed, overlap: [], referenced, advanceTo: headSha };
+  }
+
+  return { verdict: 'candidates', safe: true, reason: 'overlap', baseline, head, commits, changed, overlap, referenced, advanceTo: headSha };
+}
+
+/** `--capture`: record (or advance) the baseline. Never blocks, never throws. */
+function capture(opts, deps = {}) {
+  const run = deps.git || git;
+  const cwd = deps.cwd || repoRoot(opts.state);
+  const budget = opts.timeout;
+
+  if (!readState(opts.state)) return { captured: false, reason: 'no-state' };
+  if (!(deps.isRepo || isRepo)(cwd, budget)) return { captured: false, reason: 'no-repo' };
+  if (!(deps.hasOrigin || hasOrigin)(cwd, budget)) return { captured: false, reason: 'no-remote' };
+
+  const branch = (deps.detectDefaultBranch || detectDefaultBranch)(cwd, budget);
+  if (!branch) return { captured: false, reason: 'no-default-branch' };
+
+  let sha = opts.sha;
+  if (!sha) {
+    run(['fetch', '--quiet', 'origin', branch], cwd, budget);
+    sha = run(['rev-parse', `refs/remotes/origin/${branch}`], cwd, budget);
+  }
+  if (!sha) return { captured: false, reason: 'no-remote-ref', branch };
+
+  const ok = (deps.writeBaseline || writeBaseline)(opts.state, {
+    baseline_ref: branch,
+    baseline_sha: sha,
+    baseline_captured_at: new Date().toISOString(),
+  });
+  return ok
+    ? { captured: true, reason: 'ok', branch, sha: sha.slice(0, 12) }
+    : { captured: false, reason: 'state-write-failed', branch };
+}
+
+module.exports = {
+  parseArgs,
+  validate,
+  splitPaths,
+  repoRoot,
+  readState,
+  writeBaseline,
+  detectDefaultBranch,
+  parseCommits,
+  parseChangedPaths,
+  intersect,
+  check,
+  capture,
+  DEFAULTS,
+};
+
+if (require.main === module) {
+  const opts = parseArgs(process.argv.slice(2));
+  const err = validate(opts);
+  if (err) {
+    process.stderr.write(`concept-drift: ${err}\n`);
+    process.stderr.write('usage: concept-drift.js --state <abs path> [--paths a,b] [--paths-file f] [--timeout 30]\n');
+    process.stderr.write('       concept-drift.js --capture --state <abs path> [--sha <sha>]\n');
+    process.exit(2);
+  }
+  if (opts.pathsFile) {
+    try { opts.paths = opts.paths.concat(splitPaths(fs.readFileSync(opts.pathsFile, 'utf8'))); } catch { /* optional */ }
+  }
+  let result;
+  try {
+    result = opts.capture ? capture(opts) : check(opts);
+  } catch (e) {
+    // An internal error must degrade to "implement", never to a blocked user.
+    result = opts.capture
+      ? { captured: false, reason: 'internal-error', error: e && e.message }
+      : skip('internal-error', { error: e && e.message });
+  }
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+}

--- a/plugins/devops/scripts/concept-drift.test.js
+++ b/plugins/devops/scripts/concept-drift.test.js
@@ -1,0 +1,263 @@
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  parseArgs,
+  validate,
+  splitPaths,
+  readState,
+  writeBaseline,
+  parseCommits,
+  parseChangedPaths,
+  intersect,
+  check,
+  capture,
+} from "./concept-drift.js";
+
+// The contract this file pins, in one sentence: a reality check may refuse to
+// answer, but it may never block an implement order. Every unresolvable
+// condition has to come back `verdict: "skip", safe: true` — because the caller
+// (SKILL.md § 5b step 0) treats exactly that as "proceed to implement".
+//
+// The second contract is the deadlock guard's other half: a completed check
+// always reports `advanceTo`, so the baseline moves past drift the user has
+// already decided on and the same drift can never force a second round.
+
+let root;
+let statePath;
+
+const LIVE = {
+  port: 8883,
+  html_path: "docs/concepts/2026-09-06-x.html",
+  slug: "x",
+  server_pid: 4242,
+  cron_id: "ab12cd34",
+  started_at: "2026-09-06T10:00:00.000Z",
+};
+
+function writeState(obj) {
+  fs.mkdirSync(path.dirname(statePath), { recursive: true });
+  fs.writeFileSync(statePath, typeof obj === "string" ? obj : JSON.stringify(obj));
+}
+
+/** A fake git: `matchers` maps a substring of the joined argv to a return value. */
+function fakeGit(matchers) {
+  return (args) => {
+    const key = args.join(" ");
+    for (const [needle, value] of Object.entries(matchers)) {
+      if (key.includes(needle)) return typeof value === "function" ? value(args) : value;
+    }
+    return null;
+  };
+}
+
+const OK_DEPS = {
+  cwd: "/repo",
+  isRepo: () => true,
+  hasOrigin: () => true,
+  detectDefaultBranch: () => "main",
+  commitExists: () => true,
+};
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), "concept-drift-"));
+  statePath = path.join(root, ".claude", "concept-active.json");
+});
+
+afterEach(() => {
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe("args", () => {
+  test("state must be absolute — a relative path resolves against the caller's cwd", () => {
+    expect(validate(parseArgs(["--state", ".claude/concept-active.json"]))).toMatch(/ABSOLUTE/);
+    expect(validate(parseArgs(["--state", path.join(root, "s.json")]))).toBeNull();
+  });
+
+  test("--capture is a flag, not a value", () => {
+    const opts = parseArgs(["--capture", "--state", path.join(root, "s.json")]);
+    expect(opts.capture).toBe(true);
+    expect(opts.state).toBe(path.join(root, "s.json"));
+  });
+
+  test("a bogus sha is rejected rather than written into the state file", () => {
+    expect(validate(parseArgs(["--state", path.join(root, "s.json"), "--sha", "not-a-sha"]))).toMatch(/hex/);
+  });
+
+  test("prototype keys cannot be smuggled in as options", () => {
+    const opts = parseArgs(["--state", path.join(root, "s.json"), "--toString", "5"]);
+    expect(typeof opts.toString).toBe("function");
+  });
+
+  test("paths are normalised to forward slashes", () => {
+    expect(splitPaths("plugins\\devops\\x.js, ./a/b")).toEqual(["plugins/devops/x.js", "a/b"]);
+  });
+});
+
+describe("path intersection", () => {
+  test("exact hit, and a directory reference catches files inside it", () => {
+    const changed = [{ path: "plugins/devops/hooks/a.js", status: "M" }];
+    expect(intersect(changed, ["plugins/devops/hooks/a.js"])).toHaveLength(1);
+    expect(intersect(changed, ["plugins/devops/hooks"])).toHaveLength(1);
+    expect(intersect(changed, ["plugins/devops/hooks/"])).toHaveLength(1);
+  });
+
+  test("a changed directory matches a file referenced inside it", () => {
+    expect(intersect([{ path: "plugins/devops", status: "M" }], ["plugins/devops/hooks/a.js"])).toHaveLength(1);
+  });
+
+  test("substring lookalikes do not match", () => {
+    const changed = [{ path: "other/hooks/a.js.bak", status: "M" }];
+    expect(intersect(changed, ["hooks/a.js"])).toEqual([]);
+  });
+});
+
+describe("diff parsing", () => {
+  test("a rename contributes BOTH paths — the old one is the drift that matters", () => {
+    const parsed = parseChangedPaths("R096\told/name.js\tnew/name.js", 50);
+    expect(parsed.map((p) => p.path)).toEqual(["old/name.js", "new/name.js"]);
+    expect(parsed[0].status).toBe("R");
+  });
+
+  test("commit lines split on the first space only", () => {
+    const parsed = parseCommits("abc123def456 fix(x): subject with spaces", 10);
+    expect(parsed).toEqual([{ sha: "abc123def456", subject: "fix(x): subject with spaces" }]);
+  });
+});
+
+describe("check — every unresolvable condition fails SAFE", () => {
+  const cases = [
+    ["no-state", () => {}, {}],
+    ["no-repo", () => writeState(LIVE), { isRepo: () => false }],
+    ["no-remote", () => writeState(LIVE), { hasOrigin: () => false }],
+    ["no-default-branch", () => writeState(LIVE), { detectDefaultBranch: () => null }],
+    ["no-baseline", () => writeState(LIVE), {}],
+  ];
+
+  for (const [reason, setup, extraDeps] of cases) {
+    test(`${reason} → skip, safe`, () => {
+      setup();
+      const res = check({ state: statePath, paths: [], timeout: 5 }, { ...OK_DEPS, ...extraDeps, git: fakeGit({}) });
+      expect(res).toMatchObject({ verdict: "skip", safe: true, reason });
+    });
+  }
+
+  test("an offline fetch is not 'no drift' — it is a skip", () => {
+    writeState({ ...LIVE, baseline_ref: "main", baseline_sha: "aaaaaaa" });
+    const res = check({ state: statePath, paths: [], timeout: 5 }, { ...OK_DEPS, git: fakeGit({}) });
+    expect(res).toMatchObject({ verdict: "skip", safe: true, reason: "fetch-failed" });
+  });
+
+  test("a force-pushed-away baseline re-anchors instead of blocking", () => {
+    writeState({ ...LIVE, baseline_ref: "main", baseline_sha: "aaaaaaa" });
+    const res = check(
+      { state: statePath, paths: [], timeout: 5 },
+      { ...OK_DEPS, commitExists: () => false, git: fakeGit({ fetch: "", "rev-parse": "bbbbbbbbbbbb" }) },
+    );
+    expect(res).toMatchObject({ verdict: "skip", safe: true, reason: "baseline-gone" });
+    expect(res.advanceTo).toBe("bbbbbbbbbbbb");
+  });
+});
+
+describe("check — verdicts", () => {
+  test("remote tip unchanged → clear, no visible round", () => {
+    writeState({ ...LIVE, baseline_ref: "main", baseline_sha: "aaaaaaaaaaaa" });
+    const res = check(
+      { state: statePath, paths: ["plugins/x.js"], timeout: 5 },
+      { ...OK_DEPS, git: fakeGit({ fetch: "", "rev-parse": "aaaaaaaaaaaa" }) },
+    );
+    expect(res).toMatchObject({ verdict: "clear", reason: "unchanged" });
+  });
+
+  test("main moved but nowhere near the concept → clear", () => {
+    writeState({ ...LIVE, baseline_ref: "main", baseline_sha: "aaaaaaaaaaaa" });
+    const res = check(
+      { state: statePath, paths: ["plugins/devops/skills/concept"], timeout: 5, maxCommits: 50, maxPaths: 200 },
+      {
+        ...OK_DEPS,
+        git: fakeGit({
+          fetch: "",
+          "rev-parse": "bbbbbbbbbbbb",
+          log: "bbbbbbbbbbbb chore: bump deps",
+          diff: "M\tpackage-lock.json",
+        }),
+      },
+    );
+    expect(res).toMatchObject({ verdict: "clear", reason: "no-overlap" });
+    expect(res.advanceTo).toBe("bbbbbbbbbbbb");
+  });
+
+  test("main touched a referenced path → candidates, with the evidence attached", () => {
+    writeState({ ...LIVE, baseline_ref: "main", baseline_sha: "aaaaaaaaaaaa" });
+    const res = check(
+      { state: statePath, paths: ["plugins/devops/hooks/pre.x.js"], timeout: 5, maxCommits: 50, maxPaths: 200 },
+      {
+        ...OK_DEPS,
+        git: fakeGit({
+          fetch: "",
+          "rev-parse": "bbbbbbbbbbbb",
+          log: "bbbbbbbbbbbb feat(hooks): rename pre.x",
+          diff: "R100\tplugins/devops/hooks/pre.x.js\tplugins/devops/hooks/pre.y.js",
+        }),
+      },
+    );
+    expect(res.verdict).toBe("candidates");
+    expect(res.overlap.map((o) => o.path)).toContain("plugins/devops/hooks/pre.x.js");
+    // Evidence is mandatory: a drift card without a SHA + path may not be shown.
+    expect(res.commits[0]).toMatchObject({ sha: "bbbbbbbbbbbb" });
+    expect(res.advanceTo).toBe("bbbbbbbbbbbb");
+  });
+
+  test("without a path filter it hands over everything rather than claiming 'clear'", () => {
+    writeState({ ...LIVE, baseline_ref: "main", baseline_sha: "aaaaaaaaaaaa" });
+    const res = check(
+      { state: statePath, paths: [], timeout: 5, maxCommits: 50, maxPaths: 200 },
+      {
+        ...OK_DEPS,
+        git: fakeGit({ fetch: "", "rev-parse": "bbbbbbbbbbbb", log: "bbbbbbbbbbbb x", diff: "M\tanything.js" }),
+      },
+    );
+    expect(res).toMatchObject({ verdict: "candidates", reason: "no-path-filter" });
+  });
+});
+
+describe("capture — baseline bookkeeping", () => {
+  test("adds the baseline keys and leaves the bridge's own fields untouched", () => {
+    writeState(LIVE);
+    const res = capture(
+      { state: statePath, sha: "", timeout: 5 },
+      { ...OK_DEPS, git: fakeGit({ fetch: "", "rev-parse": "cccccccccccc" }) },
+    );
+    expect(res).toMatchObject({ captured: true, branch: "main" });
+    const after = readState(statePath);
+    expect(after.baseline_ref).toBe("main");
+    expect(after.baseline_sha).toBe("cccccccccccc");
+    expect(after.baseline_captured_at).toMatch(/^\d{4}-/);
+    expect(after.port).toBe(LIVE.port);
+    expect(after.html_path).toBe(LIVE.html_path);
+    expect(after.cron_id).toBe(LIVE.cron_id);
+  });
+
+  test("--sha pins the exact commit a check examined, without re-fetching", () => {
+    writeState(LIVE);
+    const res = capture(
+      { state: statePath, sha: "dddddddddddd", timeout: 5 },
+      { ...OK_DEPS, git: fakeGit({ "rev-parse": "eeeeeeeeeeee" }) },
+    );
+    expect(res.captured).toBe(true);
+    expect(readState(statePath).baseline_sha).toBe("dddddddddddd");
+  });
+
+  test("a repo with no remote reports it instead of throwing", () => {
+    writeState(LIVE);
+    expect(capture({ state: statePath, sha: "", timeout: 5 }, { ...OK_DEPS, hasOrigin: () => false })).toMatchObject({
+      captured: false,
+      reason: "no-remote",
+    });
+  });
+
+  test("writeBaseline refuses to invent a state file that is not there", () => {
+    expect(writeBaseline(path.join(root, "missing.json"), { baseline_sha: "x" })).toBe(false);
+  });
+});

--- a/plugins/devops/skills/concept/SKILL.md
+++ b/plugins/devops/skills/concept/SKILL.md
@@ -719,8 +719,23 @@ not always the project root the state file lives in — both then exited
 prevent. They also tolerate the state file not existing yet (60 s grace), so
 launching them here, before step 4 writes it, is safe.
 
+**Capture the reality-check baseline right after writing the state file:**
+
+```bash
+node "{plugin-root}/scripts/concept-drift.js" --capture \
+     --state "{project-root}/.claude/concept-active.json"
+```
+
+It records the default branch's current remote tip into the state file, which is
+what the implement gate later diffs against (Step 5b step 0). Capture it at
+concept open, not at first implement — a baseline taken minutes before the
+implement click would show no drift at all, which is precisely the failure this
+gate exists to prevent. In a repo with no remote the call is a silent no-op and
+the gate stays disabled for the session; that is intended.
+
 The state file (`port`, `html_path`, `slug`, `server_pid`, `cron_id`,
-`started_at`) is what makes the concept survivable across Claude restarts:
+`started_at`, plus `baseline_ref` / `baseline_sha` / `baseline_captured_at`)
+is what makes the concept survivable across Claude restarts:
 the `ss.concept.resume` SessionStart hook reads it, verifies the bridge
 is still running via `GET /heartbeat`, and tells the new session whether
 to re-arm the polling cron or pick up an unprocessed submission. Without
@@ -869,10 +884,44 @@ never re-run a completed step. The checkpoint records what the previous run
 1. **Summarize** what was selected/rejected/commented
 2. **Do NOT modify code, files, or external systems** — iterate ONLY updates
    the concept page
-3. Proceed to Step 5c (append next iteration with refined options that
+3. **If the submitted section carries `data-reality-check`, advance the
+   baseline** before appending — the user has just answered that drift, and a
+   decision they made is never asked again:
+   ```bash
+   node "{plugin-root}/scripts/concept-drift.js" --capture \
+        --state "{project-root}/.claude/concept-active.json" --sha <section's data-reality-head>
+   ```
+   The commit to pin is the one that round was generated from, and the round
+   carries it itself in `data-reality-head` — so this works from a resumed
+   session that never saw the check run.
+   Skipping this is the one way the gate can feel like a loop: iterate once more
+   after a reality check, click implement, and the same already-answered cards
+   come back. The state file is not code and not an external system — this stays
+   inside the iterate guarantee.
+4. Proceed to Step 5c (append next iteration with refined options that
    reflect the Miteinbeziehen/Verwerfen choices)
 
 **`action: "implement"` ("Mit Feedback implementieren" button):**
+
+0. **Reality check — run this BEFORE writing anything.** The default branch may
+   have moved since this concept was written, which would make the approved plan
+   produce wrong, dead or duplicate code. Full procedure, force classes and
+   resume semantics: `deep-knowledge/reality-check.md`. In short:
+   - **Skip the check entirely** when the just-submitted section carries
+     `data-reality-check` — that round WAS the check, and implementing from it
+     goes straight through. This is what makes a second forced round impossible.
+   - Otherwise `POST /status {"phase":"reality-check","version":$NOTED_VERSION}`
+     (before the fetch, so the longer wait stays legible), then run
+     `node "{plugin-root}/scripts/concept-drift.js" --state "{project-root}/.claude/concept-active.json" --paths "<paths the concept names>"`.
+   - `verdict: "skip"` or `"clear"` → advance the baseline (`--capture --sha
+     <advanceTo>`) and continue with step 1 below. Every unresolvable condition
+     — no remote, offline, force-pushed baseline — lands here: the check never
+     blocks an implement order.
+   - `verdict: "candidates"` → apply the force classes. Nothing that must force
+     → continue with step 1, mentioning the drift in the final report. Something
+     must force → checkpoint `reality-check-forced`, then append ONE
+     reality-check round instead of implementing (Step 5c) and stop. Do NOT post
+     `phase: "implemented"` — no code was written.
 1. **Summarize** what was selected/rejected/commented
 2. **Execute** the decisions as real changes — "Execute" means Claude acts:
    - For plans: implement the approved steps
@@ -1068,6 +1117,15 @@ separate "in-place edit" vs. "new file" distinction anymore.
 For `action: "iterate"` → append a regular iteration section.
 For `action: "implement"` → append a **final-report section** (one-time,
 see § "Final-report append (implement only)" below).
+For `action: "implement"` that Step 5b step 0 diverted → append a **regular
+iteration section carrying `data-reality-check` and
+`data-reality-head="<examined sha>"`** instead, with the
+`{{iteration.reality_tab}}` label on its tab and the `.reality-banner`
+explainer as its first child. Everything else about the append is identical to
+a normal iteration, including the append checklist and the `/reset` ordering.
+**Read the file back and confirm both attributes landed before `/reload`** — a
+marker that silently failed to write re-arms a check the user already answered.
+See `deep-knowledge/reality-check.md` § The forced round.
 For `action: "finalize"` → no new section; rewrite the existing final-report
 HTML in place (linked `[Issue #NNN]` labels for routed items, a shipped note
 when part B ran) and POST `/reload`.
@@ -1224,6 +1282,13 @@ re-launch the waker and carry on. If it is `true`, compare `_version` against
 the one you last processed: **equal means the previous round's `/reset` never
 landed**, not that the user resubmitted. Retry the reset instead of running the
 same payload again.
+
+**One exception, and check it before applying that shortcut: `GET /recovery`.**
+If a `reality-check-*` checkpoint sits on that same `_version`, the previous run
+did not finish and simply fail to reset — it died mid-round, and the reset was
+never due. Resetting there discards the user's implement click with no code, no
+round and no error. Resume from the recorded verdict instead
+(`deep-knowledge/reality-check.md` § Checkpoints and resume).
 
 Skipping it is how a concept silently stops responding after iteration 1: the
 page still shows a green indicator (the pulser keeps `claude_ts` warm), the user

--- a/plugins/devops/skills/concept/deep-knowledge/bridge-server.md
+++ b/plugins/devops/skills/concept/deep-knowledge/bridge-server.md
@@ -419,7 +419,10 @@ AND provides HTTP endpoints for heartbeat and decision exchange.
      "slug": "auth-middleware-redesign",
      "server_pid": 12345,
      "cron_id": "ab12cd34",
-     "started_at": "2026-04-12T14:30:00.000Z"
+     "started_at": "2026-04-12T14:30:00.000Z",
+     "baseline_ref": "main",
+     "baseline_sha": "4f2a1c9e77b3",
+     "baseline_captured_at": "2026-04-12T14:30:02.000Z"
    }
    ```
 
@@ -433,6 +436,14 @@ AND provides HTTP endpoints for heartbeat and decision exchange.
      session-only cron died with the prior session and cannot be reaped).
    - `started_at` — ISO-8601 UTC. Lets the hook age-out stale state after
      ~24 h even if cleanup did not run.
+   - `baseline_ref` / `baseline_sha` / `baseline_captured_at` — the reality
+     check's anchor: the default branch and the **remote** tip this concept was
+     written against, written by `scripts/concept-drift.js --capture` right
+     after this file is created and advanced after every check. Remote rather
+     than local, so it stays meaningful when the session runs inside a worktree
+     while this file lives at the project root. Absent in a repo with no remote
+     (and on pages generated before the gate existed) — the implement gate then
+     skips silently rather than blocking. See `reality-check.md` § Baseline.
 
    Path: ALWAYS `<project-cwd>/.claude/concept-active.json` (NOT a worktree
    subpath, NOT under `docs/`). The hook reads this exact path and silently

--- a/plugins/devops/skills/concept/deep-knowledge/iteration-rules.md
+++ b/plugins/devops/skills/concept/deep-knowledge/iteration-rules.md
@@ -13,6 +13,7 @@ selections, read-only comments).
 | First generation | Write the file with `<section data-iteration="1" data-active>` and one tab "Iteration 1" | Tab 1 active |
 | Feedback loop iteration (Step 5c) | Append `<section data-iteration="N+1" data-active>` to the same file, remove `data-active` from the previous section, freeze it, add a new tab and make it active | New tab "Iteration N+1" auto-active, old tab selectable and read-only |
 | Fundamental rework ("nochmal neu") | Same as a feedback iteration — just another tab. The full history stays visible. | Another tab appended |
+| Implement submission diverted by the reality check (Step 5b step 0) | Append `<section data-iteration="N+1" data-reality-check data-reality-head="{sha}" data-active>` — an ordinary iteration in every mechanical respect, with the `.reality-banner` explainer first and one flat decision card per drift item. Tab label `{{iteration.reality_tab}}` ("Realitäts-Check" / "Reality check") with `data-reality-check` on the chip, NEVER "Iteration N+1". Freeze the previous section as usual. NO `phase: "implemented"` — no code was written. | New tab "Realitäts-Check" auto-active, both submit buttons live. Implementing from it skips the check and writes code, so two forced rounds can never follow each other. See `reality-check.md` |
 | Implementation finished (Step 5b implement branch) | Append `<section data-iteration="N+1" data-final-report data-active>` with the Abschlussbericht structure. Add a new tab carrying `data-final-report` and label `{{iteration.final_tab}}` ("Abschlussbericht" / "Final report") — NEVER "Iteration N+1". Freeze the previous section the same way. | New tab "Abschlussbericht" auto-active. Right panel switches to `panel-final-report` (no iterate/implement buttons). At most one final-report section per concept session. |
 | Close-out from final report (`action: "finalize"`) | Do NOT append a new section. Rewrite the existing final-report HTML in place: for routed issues add `disabled` to the `[data-open-questions]` checkboxes and append an `.oq-issue-link` `<a>` with the GitHub issue URL; for a successful ship add the version note to the Zusammenfassung. Keep `data-active` on the final-report section. | Same final-report tab stays active; routed items become read-only audit entries. `refreshFinalizeWizard()` drops the wizard's issues step once every checkbox in the section is disabled. |
 
@@ -21,6 +22,12 @@ selections, read-only comments).
   append a section to the existing file and POST `/reload` (see Step 5c).
 - The active iteration is the only one that accepts input. Submit sends
   decisions for the active iteration only.
+- **A freeze removes `data-active` from the section and nothing else.** Every
+  other `data-*` — `data-iteration`, `data-iteration-template`,
+  `data-final-report`, `data-reality-check` — survives verbatim into the frozen
+  round. `data-reality-check` in particular is read back by the implement gate
+  to decide that this round already WAS the check; dropping it during a rewrite
+  re-arms a question the user has already answered.
 - Freeze previous iterations visually: disabled tri-state buttons showing
   which state the user submitted, read-only comment fields with the text
   the user entered. Users can click back to earlier tabs to review their

--- a/plugins/devops/skills/concept/deep-knowledge/reality-check.md
+++ b/plugins/devops/skills/concept/deep-knowledge/reality-check.md
@@ -1,0 +1,268 @@
+# Reality Check — the implement gate
+
+A concept session lives for hours or days. The default branch keeps moving
+while it does: other sessions, other PRs, other ships. When the user finally
+clicks **"Mit Feedback implementieren"**, the plan they approved may reference
+a file that has since been renamed, a contract that has since changed, or work
+somebody has already done. Implementing it verbatim then produces wrong, dead
+or duplicate code — and the user only finds out in review.
+
+So `action: "implement"` re-checks the concept against the current default
+branch **before writing a single line**. If the drift materially conflicts with
+the plan, Claude does not implement: it appends **one** extra round —
+mechanically an ordinary iteration, marked `data-reality-check` — that asks the
+user about the drift, and implements straight through on the next submit.
+
+## The contract, in four sentences
+
+1. An implement submission can be diverted into a reality-check round **at most
+   once**. Submitting implement *from* a reality-check round always implements.
+2. The diverted round contains **every** decision the drift raises. Nothing may
+   be deferred to a hypothetical second forced round.
+3. An ordinary `iterate` round re-arms the check — so a user who chooses to keep
+   iterating still gets a fresh check when they next click implement. That is
+   not a deadlock; it is the user opting back in.
+4. Any condition that cannot be resolved — no remote, no default branch,
+   offline, a force-pushed baseline — **fails safe**: implement proceeds.
+
+## Why it cannot deadlock — two independent lines of defence
+
+**Line 1, the marker.** The forced section carries `data-reality-check`. Step 0
+below reads it off the just-submitted section and skips the whole check. This is
+the primary guard and it is exact.
+
+**Line 2, the baseline.** Every completed check advances the recorded baseline
+to the commit it examined. So even if the marker were lost — a bad rewrite, a
+legacy page, a resumed session working from a page it did not write — the drift
+that caused the first round is now *behind* the baseline and cannot produce a
+second one. The user would have to receive genuinely new drift, from commits
+that landed after the first check, to see another forced round. That is a
+correct outcome, not a loop.
+
+Both lines have to fail simultaneously, on the same round, for the user to see
+two forced rounds in a row. Neither is allowed to be treated as optional.
+
+## Step 0 — the skip ladder
+
+Run this **before** any code is written and before any `POST /status
+{phase:"implemented"}`. First hit wins:
+
+| # | Condition | How to check | Result |
+|---|---|---|---|
+| S1 | The submitted section carries `data-reality-check` | read the section you are about to freeze | **skip → implement** |
+| S2 | This `_version` already has a reality-check checkpoint | `GET /recovery`, look for `step: "reality-check-*"` | **replay the recorded verdict** — never re-decide |
+| S3 | Baseline unresolvable | `concept-drift.js` returns `verdict: "skip"` | **skip → implement**, note it in the final report |
+| S4 | Remote tip == baseline | `verdict: "clear"`, `reason: "unchanged"` | **skip → implement** |
+| S5 | Nothing the concept references was touched | `verdict: "clear"`, `reason: "no-overlap"` \| `"no-file-changes"` | **skip → implement**, advance the baseline |
+
+Only `verdict: "candidates"` reaches the judgment step below. Everything else
+implements, and S3–S5 additionally advance the baseline (§ Baseline).
+
+**S1 is a read of the HTML, not of memory.** After a crash-and-resume you may be
+looking at a page you did not write. The attribute on disk is the truth.
+
+## The check
+
+```bash
+# 1. Tell the panel a check is starting — BEFORE the fetch, so the widened
+#    pickup→write window cannot look like a stall (see § Timing below).
+curl -s -X POST -H "Content-Type: application/json" \
+     -d "{\"phase\":\"reality-check\",\"version\":$NOTED_VERSION}" \
+     http://localhost:$PORT/status
+
+# 2. Facts, not judgment. --paths carries the files/directories the concept
+#    actually names; the script returns everything either way.
+node "{plugin-root}/scripts/concept-drift.js" \
+     --state "{project-root}/.claude/concept-active.json" \
+     --paths "plugins/devops/hooks,plugins/devops/skills/concept/SKILL.md"
+```
+
+A 409 on step 1 means a newer submission landed while we were picking this one
+up — abandon the check and loop back to Step 5a with the new payload. Do not
+carry a verdict across submissions.
+
+**What goes into `--paths`:** every file and directory the concept commits to
+touching — the ones named in the variants the user kept, in their comments, and
+in the plan you are about to implement. Directories are fine and preferred when
+the concept talks about an area rather than a file. Err wide: a path too many
+costs a cheap comparison, a path too few hides the drift this gate exists for.
+Omitting `--paths` entirely is legitimate for a concept that names no paths at
+all — the script then returns `candidates` with the full change list and the
+force classes are applied to that by hand, rather than pretending the absence
+of a filter means the absence of drift.
+
+`concept-drift.js` is deliberately incapable of forcing a round. It resolves the
+default branch without assuming it is called `main`, fetches with a timeout,
+diffs baseline..tip, and returns commits, changed paths (renames contribute
+*both* sides) and the intersection with `--paths`. Every failure it can hit —
+no repo, no remote, no `origin/HEAD`, git missing, offline, shallow clone, a
+baseline erased by a force-push — comes back `verdict: "skip", safe: true`.
+**A network hiccup must never block an implement order.**
+
+## Force classes
+
+The whole judgment reduces to one question:
+
+> Would implementing exactly as designed now produce code that is **wrong, dead
+> or duplicate**?
+
+Only then. Applied to `candidates`:
+
+**Must force** — each of these on its own is enough:
+1. A file, module or symbol the concept names was **deleted, renamed or moved**.
+2. A contract the concept builds on **changed**: a function signature, a hook
+   event name, a JSON/schema shape, a CLI flag, a template placeholder, a
+   validation-gate entry, an endpoint's payload.
+3. The functionality **already exists** — someone landed the same intent in the
+   same artifact.
+4. A decision the user already made has **lost its basis** (the variant they
+   picked is gone, the file they chose to extend no longer exists).
+
+**Never force** — regardless of commit count:
+- no intersection with anything the concept references;
+- version bumps, CHANGELOG, docs, tests-only changes, formatting, dependency
+  patches, reverts that net out to zero.
+
+**Mention, do not force:** neighbouring changes that break no contract, new
+reusable helpers the implementation could now use, convention updates. These
+belong in the final report's *Zusammenfassung* / *Nächste Schritte*, not on the
+page. Interrupting an implement order for a nicety is how a safety feature turns
+into a nuisance.
+
+**Evidence is mandatory.** Every drift card names the short SHA and the path it
+comes from, rendered in the section's `.reality-evidence` block. No SHA, no
+card, no force. A claim the user cannot verify is a claim they have to take on
+trust, and this round exists precisely because trust in the plan has become
+questionable.
+
+## The forced round
+
+Mechanically an ordinary iteration — Step 5c in full: freeze the previous
+section, run the append checklist (`iteration-rules.md` § Iteration append
+checklist, including the `GET /draft` confirmation that the round's comments are
+safe on the bridge), `/reload`, then `/reset`, then re-launch the pickup waker.
+It is not a special case of the append; it is an append that happens to carry a
+marker.
+
+What differs:
+
+- `<section data-iteration="N+1" data-reality-check data-reality-head="<sha>"
+  data-active>` and a matching tab carrying `data-reality-check` with the label
+  `{{iteration.reality_tab}}` — never "Iteration N+1". The markers go on the
+  section and the tab, and nowhere else; in particular never inside a block that
+  § 2.6's engine-drift re-sync copies verbatim from `templates.md`, which would
+  overwrite them.
+- `data-reality-head` is the commit the check examined. It is what the baseline
+  advances to when this round is answered, and keeping it on the round rather
+  than only in a checkpoint means a resumed session that never watched the check
+  run can still advance correctly.
+- **Read the file back after writing it** and confirm both attributes are
+  present on the new section before posting `/reload`. The append is a
+  hand-written HTML rewrite; a marker that silently failed to land re-arms a
+  check the user has already answered, and nothing else in the pipeline would
+  notice.
+- The section opens with the `.reality-banner` explainer (`templates.md`
+  § Reality-check section explainer): headline, what landed, the commit
+  evidence, and the reassurance that the implement order still stands.
+- Both submit buttons behave exactly as everywhere else. **No third button.**
+  "Implement anyway, ignore the drift" is every card on Verwerfen plus the
+  implement button; "this concept is obsolete" is Claude's own recommendation
+  on a class-3 card, which the user accepts by submitting.
+
+**Never POST `phase: "implemented"` on this path.** No code was written. The
+panel would show "Implementierung abgeschlossen" over an empty diff, and the
+user would believe the work shipped.
+
+### Completeness — what "all important decisions" forbids
+
+The round is generated from **one** completed diff pass. Before rendering it,
+the analysis is finished; nothing is left to look up later. Concretely, the
+following are forbidden in a reality-check round:
+
+- any card that says "we'll clarify this in the next round";
+- conditional cards ("if you pick A, we'll ask about B") — flatten them, every
+  card independently answerable, each with Claude's recommendation;
+- a card whose answer depends on another card of the same round;
+- a catch-all "other open points" card.
+
+If Claude discovers a new question *during* the subsequent implementation, it
+does not go back to the page. It is decided, documented in the final report, and
+routed to a follow-up issue via the close-out wizard.
+
+## Baseline
+
+Stored in `.claude/concept-active.json` — deliberately **not** in the HTML,
+which the engine-drift re-sync rewrites:
+
+```json
+"baseline_ref": "main",
+"baseline_sha": "4f2a1c9e77b3",
+"baseline_captured_at": "2026-09-06T10:00:00.000Z"
+```
+
+It records the **remote** tip, so it stays valid no matter which checkout or
+worktree the session runs in — the state file lives at the project root while
+the session may well be working inside a worktree.
+
+Captured at concept open (Step 3), and advanced by:
+
+```bash
+node "{plugin-root}/scripts/concept-drift.js" --capture \
+     --state "{project-root}/.claude/concept-active.json" --sha <advanceTo>
+```
+
+**Advance it on every submission of a reality-check round — iterate as well as
+implement — and after every check that came back clear.** `--sha` pins exactly
+the commit the check examined (`advanceTo` from the script, and afterwards the
+round's own `data-reality-head`), so commits that landed *during* the round are
+still unexamined and can legitimately raise a later check.
+
+Getting this wrong is the one way the feature can feel like a loop: leave the
+baseline behind and a user who answers the drift cards, runs one ordinary
+iterate round, and then clicks implement is handed the same, already-answered
+cards a second time. Decisions the user has made are final and are never asked
+again.
+
+## Checkpoints and resume
+
+A forced round produces no externally-visible artifact, but it **consumes** an
+implement submission — so it is exactly the kind of state a resumed run cannot
+reconstruct. Checkpoint it **before** the HTML write:
+
+```bash
+curl -s -X POST -H "Content-Type: application/json" \
+  -d '{"action":"implement","step":"reality-check-forced","status":"done",
+       "version":<noted _version>,
+       "artifacts":{"baseline":"4f2a1c9","head":"9be03d1","items":3}}' \
+  http://localhost:$PORT/progress
+```
+
+Use `reality-check-clear` for a check that let the implement through, and
+`reality-check-skipped` with the script's `reason` for a fail-safe skip.
+
+On resume, `GET /recovery` disambiguates the three states that otherwise look
+identical from the outside:
+
+| progress shows | What actually happened | Do this |
+|---|---|---|
+| nothing | the check never ran | run Step 0 normally |
+| `reality-check-forced` | the round was decided; the HTML write may or may not have landed | read the page — marker present ⇒ done, absent ⇒ re-append from the recorded verdict. **Never re-decide** |
+| `reality-check-clear` \| `-skipped` | the check passed; implement may be half-written | verify the artifacts (`git rev-parse`, `gh pr view`, read the files) and continue implementing from what you observe |
+
+This also amends the equal-`_version` rule in SKILL.md § 5d. "Equal version on a
+live `/pending` means the previous `/reset` never landed, so retry the reset" is
+correct *unless* a reality-check checkpoint sits on that version — in which case
+the previous run died mid-round and the reset was never due. Consult
+`/recovery` before applying the shortcut; resetting there would silently
+discard the user's implement click.
+
+## Timing
+
+The check adds work between pickup and the first code write, which is the window
+the panel's stale-restore watches. That is why `POST /status
+{phase:"reality-check"}` happens *first*, before the fetch: the user sees the
+step, the page stays coherent, and a re-submission during the check surfaces as
+a clean 409 rather than a second forced round.
+
+The `git fetch` and everything after it are capped (`--timeout`, default 30 s).
+A check that cannot finish inside its budget is a check that returns `skip`.

--- a/plugins/devops/skills/concept/deep-knowledge/templates.md
+++ b/plugins/devops/skills/concept/deep-knowledge/templates.md
@@ -64,6 +64,8 @@ must see their own language. The locale hint is authoritative.
 | `panel.step_implemented_active`| Implementation in progress     | Implementierung läuft |
 | `panel.step_waiting`           | Waiting…                       | Warten… |
 | `panel.step_ready`             | Ready to ship                  | Bereit zum Shippen |
+| `panel.step_reality_check`     | Reality check                  | Realitäts-Check |
+| `panel.step_reality_check_active` | Checking against the default branch… | Prüfe gegen den Default-Branch… |
 | `panel.frozen`                 | Frozen iteration               | Eingefrorene Iteration |
 | `panel.frozen_hint`            | You are reading an earlier round. It is read-only — its decisions were already submitted. | Du liest eine frühere Runde. Sie ist schreibgeschützt — ihre Entscheidungen wurden bereits übermittelt. |
 | `panel.frozen_back`            | Back to the current round      | Zurück zur aktuellen Runde |
@@ -87,7 +89,13 @@ must see their own language. The locale hint is authoritative.
 | `iteration.label`              | Iterations                     | Iterationen |
 | `iteration.active_suffix`      | · active                       | · aktiv |
 | `iteration.final_tab`          | Final report                   | Abschlussbericht |
+| `iteration.reality_tab`        | Reality check                  | Realitäts-Check |
 | `nav.sections`                 | Sections                       | Abschnitte |
+| `reality.headline`             | The default branch moved while this concept was open | Der Default-Branch hat sich bewegt, während dieses Konzept offen war |
+| `reality.intro`                | These changes landed after this concept was written. Implementing it unchanged would produce wrong, dead or duplicate code — so this round asks you about them first. | Diese Änderungen sind gelandet, nachdem dieses Konzept geschrieben wurde. Unverändert umgesetzt würde das falschen, toten oder doppelten Code erzeugen — deshalb fragt diese Runde sie zuerst ab. |
+| `reality.reassure`             | Your implement order is not lost: submitting this round with "Implement with feedback" implements directly, with no further check. | Dein Implement-Auftrag ist nicht verloren: Wenn du diese Runde mit „Mit Feedback implementieren" abschickst, wird direkt implementiert — ohne erneute Prüfung. |
+| `reality.evidence`             | Landed on the default branch   | Auf dem Default-Branch gelandet |
+| `reality.recommendation`       | Recommendation                 | Empfehlung |
 | `final.status_heading`         | Close out concept              | Concept abschliessen |
 | `final.open_questions`         | Open questions & TODOs         | Offene Fragen & TODOs |
 | `final.create_issues_hint`     | Unchecked items are dropped — they end with the concept. | Nicht angehakte Punkte fallen weg — sie enden mit dem Concept. |
@@ -302,12 +310,14 @@ the `[ui-locale: ...]` hint produced.
       </div>
 
       <!-- Post-submit state: waiting for Claude. The progress list shows
-           three steps so the user can see whether the submission has only
+           four steps so the user can see whether the submission has only
            been sent (step 1), whether Claude's cron has picked it up
-           (step 2), and — for implement-action submissions — whether the
-           actual code change finished (step 3). The third <li> stays
-           hidden for iterate-action submissions; submitWithAction sets
-           the `hidden` attribute based on the action. -->
+           (step 2), whether the concept is being re-checked against the
+           default branch (step 3) and — for implement-action submissions —
+           whether the actual code change finished (step 4). Step 4 is
+           hidden for iterate-action submissions; submitWithAction sets its
+           `hidden` attribute from the action. Step 3 stays hidden until the
+           check actually runs and reveals it — see § Submit Progress Steps. -->
       <div id="panel-submitted" style="display: none;">
         <div class="submitted-indicator">
           <span class="check-icon">✓</span>
@@ -321,6 +331,12 @@ the `[ui-locale: ...]` hint produced.
           <li data-step="received" data-state="active">
             <span class="step-icon" aria-hidden="true">⏳</span>
             <span class="step-label">{{panel.step_received}}</span>
+          </li>
+          <li data-step="reality-check" data-state="pending" hidden>
+            <span class="step-icon" aria-hidden="true">○</span>
+            <span class="step-label" data-state-label="pending">{{panel.step_reality_check}}</span>
+            <span class="step-label" data-state-label="active">{{panel.step_reality_check_active}}</span>
+            <span class="step-label" data-state-label="done">{{panel.step_reality_check}}</span>
           </li>
           <li data-step="implemented" data-state="pending" hidden>
             <span class="step-icon" aria-hidden="true">○</span>
@@ -1842,6 +1858,12 @@ it today.
           <li data-step="received" data-state="active">
             <span class="step-icon" aria-hidden="true">⏳</span>
             <span class="step-label">{{panel.step_received}}</span>
+          </li>
+          <li data-step="reality-check" data-state="pending" hidden>
+            <span class="step-icon" aria-hidden="true">○</span>
+            <span class="step-label" data-state-label="pending">{{panel.step_reality_check}}</span>
+            <span class="step-label" data-state-label="active">{{panel.step_reality_check_active}}</span>
+            <span class="step-label" data-state-label="done">{{panel.step_reality_check}}</span>
           </li>
           <li data-step="implemented" data-state="pending" hidden>
             <span class="step-icon" aria-hidden="true">○</span>
@@ -5757,8 +5779,10 @@ html[data-template="design"] .frozen-bar {
      data-state="active"  → currently happening (full text color, ⏳ icon
                             with a slow pulse so the user sees motion)
      data-state="done"    → completed (success color, ✓ icon)
-   The third <li> (data-step="implemented") is only revealed for
-   action="implement" submissions; submitWithAction sets its `hidden`. */
+   The <li data-step="implemented"> is only revealed for action="implement"
+   submissions; submitWithAction sets its `hidden`. The <li
+   data-step="reality-check"> before it stays hidden even then, and is
+   unhidden by updateStatusSteps only if the check actually runs. */
 .status-steps {
   list-style: none;
   padding: 0;
@@ -6096,6 +6120,55 @@ html[data-template="design"] .frozen-bar {
 }
 .iteration-tab[data-final-report]:not([aria-selected="true"])::before {
   content: "";
+}
+
+/* Iteration tab styling for a reality-check round. Warning-toned, not error-
+   toned: nothing went wrong, the branch simply moved, and the round is a
+   normal iteration the user answers and moves on from. Loud enough that the
+   user understands why an implement click produced another round, quiet
+   enough that it does not read as a blocker. */
+.iteration-tab[data-reality-check] {
+  border-color: var(--warning-color, #d29922);
+  color: var(--warning-color, #d29922);
+}
+.iteration-tab[data-reality-check][aria-selected="true"] {
+  background: color-mix(in srgb, var(--warning-color, #d29922) 15%, transparent);
+  border-color: var(--warning-color, #d29922);
+  color: var(--text-color, #c9d1d9);
+}
+.iteration-tab[data-reality-check]::before {
+  content: "⟲ ";
+  color: var(--warning-color, #d29922);
+}
+
+/* The explainer that opens a reality-check section. It is the first thing the
+   user reads after clicking implement and NOT getting code, so it carries the
+   whole "why am I looking at this" load — including the reassurance that the
+   implement order still stands. */
+.reality-banner {
+  border: 1px solid var(--warning-color, #d29922);
+  border-left-width: 4px;
+  border-radius: 8px;
+  padding: 1rem 1.25rem;
+  margin-bottom: 1.5rem;
+  background: color-mix(in srgb, var(--warning-color, #d29922) 8%, transparent);
+}
+.reality-banner h2 {
+  margin: 0 0 0.5rem;
+  font-size: 1.05rem;
+  color: var(--text-color, #c9d1d9);
+}
+.reality-banner p { margin: 0.4rem 0 0; color: var(--text-secondary, #8b949e); }
+.reality-banner .reality-reassure { color: var(--text-color, #c9d1d9); font-weight: 600; }
+.reality-evidence {
+  margin: 0.6rem 0 0;
+  padding: 0.5rem 0.75rem;
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--text-secondary, #8b949e) 10%, transparent);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.78rem;
+  color: var(--text-secondary, #8b949e);
+  overflow-x: auto;
 }
 
 /* Open-questions section — checkbox list with optional "[Issue #NNN]"
@@ -8337,7 +8410,7 @@ function restorePanelToReady() {
 
 ## Submit Progress Steps
 
-The submitted panel renders a three-step progress list so the user can
+The submitted panel renders a four-step progress list so the user can
 see exactly where the submission is in Claude's pipeline. The states the
 list tracks:
 
@@ -8345,7 +8418,15 @@ list tracks:
 |---|---|---|
 | 1 · Übermittelt | The user just clicked submit (POST /decisions succeeded) | Always |
 | 2 · Claude verarbeitet | First `/pending=true` response on the server (the pickup waker, or the backup cron, picked up the submission) — surfaces via `_picked_up_at` in `/decisions` | Always |
-| 3 · Implementierung abgeschlossen | Claude POSTs `/status {phase: "implemented"}` after the implement branch finishes — surfaces via `_phase === "implemented"` in `/decisions` | Only for `action: "implement"` submissions |
+| 3 · Realitäts-Check | Claude POSTs `/status {phase: "reality-check"}` before re-checking the concept against the default branch (`reality-check.md` § The check) — surfaces via `_phase === "reality-check"` | Only once that POST arrives — a check that resolves instantly, or is skipped outright, never shows a step |
+| 4 · Implementierung abgeschlossen | Claude POSTs `/status {phase: "implemented"}` after the implement branch finishes — surfaces via `_phase === "implemented"` in `/decisions` | Only for `action: "implement"` submissions |
+
+**Step 3 reveals itself, it is not pre-armed.** `resetStatusSteps` leaves it
+hidden even for an implement submission, because the overwhelmingly common case
+is a remote that has not moved — and a step that appears, sits at "pending" and
+then flips straight to done would advertise work that never happened. It becomes
+visible the moment the `reality-check` phase actually lands, which is also the
+only moment its duration is worth showing.
 
 The browser only writes step state in `submitWithAction` (reset to baseline)
 and in `updateStatusSteps` (advance based on server fields). After
@@ -8367,11 +8448,20 @@ function _setStep(name, state, icon) {
 }
 
 // Baseline shown immediately after a submit click. Step 1 done, step 2
-// active (waiting for /pending pickup), step 3 either hidden (iterate)
-// or pending-and-visible (implement).
+// active (waiting for /pending pickup), the implement step either hidden
+// (iterate) or pending-and-visible (implement), and the reality-check step
+// ALWAYS hidden — it reveals itself only if the check actually runs, see
+// § Submit Progress Steps.
 function resetStatusSteps(action) {
   _setStep('submitted', 'done', '✓');
   _setStep('received', 'active', '⏳');
+  const rc = _stepEl('reality-check');
+  if (rc) {
+    rc.hidden = true;
+    rc.dataset.state = 'pending';
+    const rcIcon = rc.querySelector('.step-icon');
+    if (rcIcon) rcIcon.textContent = '○';
+  }
   const impl = _stepEl('implemented');
   if (impl) {
     impl.hidden = (action !== 'implement');
@@ -8400,6 +8490,20 @@ function updateStatusSteps(data) {
       }
     }
   }
+  if (data && data._phase === 'reality-check' && _submittedAction === 'implement') {
+    // The check is running. Reveal the step now — this is the only place that
+    // unhides it, so a skipped or instant check never advertises itself.
+    // reality-check implies received, same monotonic argument as below.
+    const recv = _stepEl('received');
+    if (recv && recv.dataset.state !== 'done') {
+      _setStep('received', 'done', '✓');
+    }
+    const rc = _stepEl('reality-check');
+    if (rc && rc.dataset.state !== 'done') {
+      rc.hidden = false;
+      _setStep('reality-check', 'active', '⏳');
+    }
+  }
   if (data && data._phase === 'implemented' && _submittedAction === 'implement') {
     // implemented implies received — if /status arrives before the cron's
     // /pending=true has stamped _picked_up_at (rare but possible: Claude
@@ -8408,6 +8512,12 @@ function updateStatusSteps(data) {
     const recv = _stepEl('received');
     if (recv && recv.dataset.state !== 'done') {
       _setStep('received', 'done', '✓');
+    }
+    // Same for the reality check, but only when it made itself visible — an
+    // invisible step must not pop into existence already ticked.
+    const rc = _stepEl('reality-check');
+    if (rc && !rc.hidden && rc.dataset.state !== 'done') {
+      _setStep('reality-check', 'done', '✓');
     }
     const impl = _stepEl('implemented');
     if (impl && !impl.hidden && impl.dataset.state !== 'done') {
@@ -8636,9 +8746,16 @@ design and free include them identically.
           data-iteration="1" aria-selected="false" aria-controls="iter-1">
     Iteration 1
   </button>
-  <button class="iteration-tab" role="tab"
+  <!-- Reality-check tab: a NORMAL iteration in every mechanical respect —
+       it keeps the running data-iteration counter, both submit buttons, and
+       the ordinary freeze behaviour. Only the label and the
+       data-reality-check flag differ, so the user can see at a glance why an
+       implement click produced another round. Appended only by the implement
+       path when the default branch drifted; never two in a row. See
+       reality-check.md. -->
+  <button class="iteration-tab" role="tab" data-reality-check
           data-iteration="2" aria-selected="false" aria-controls="iter-2">
-    Iteration 2
+    {{iteration.reality_tab}}
   </button>
   <!-- Final-report tab: same DOM contract (data-iteration carries the
        running counter), distinct labelling + the data-final-report
@@ -8654,7 +8771,7 @@ design and free include them identically.
 
 <main>
   <section id="iter-1" data-iteration="1" hidden>…frozen round 1…</section>
-  <section id="iter-2" data-iteration="2" hidden>…frozen round 2…</section>
+  <section id="iter-2" data-iteration="2" data-reality-check hidden>…frozen reality check…</section>
   <section id="iter-3" data-iteration="3" data-final-report data-active>
     …final report (Abschlussbericht)…
   </section>
@@ -8672,6 +8789,42 @@ Rules:
   Once it exists, no further iterate/implement submissions are
   accepted (the panel-final-report has no such buttons). The only
   submission the final-report tab can produce is `action: "finalize"`.
+- `data-reality-check` marks a round the implement path inserted because the
+  default branch drifted. It goes on **both** the section and its tab, and it
+  is load-bearing, not decorative: submitting implement from a section that
+  carries it skips the check and implements immediately, which is what stops
+  two forced rounds in a row. The section additionally carries
+  `data-reality-head="<sha>"` — the commit that check examined, which the
+  baseline advances to once the round is answered. A concept may contain several over its life —
+  but never two adjacent ones, because the round after a reality check is
+  always either the implementation or an ordinary iterate round. See
+  `reality-check.md`.
+
+### Reality-check section explainer
+
+The first child of a `data-reality-check` section, before any decision card.
+It answers the only question the user has at that moment — "I clicked
+implement, why am I reading this?" — and it is copied with the wording from
+the locale table, never improvised:
+
+```html
+<section id="iter-2" data-iteration="2" data-reality-check
+         data-reality-head="9be03d1f4c22" data-active>
+  <div class="reality-banner" role="note">
+    <h2>{{reality.headline}}</h2>
+    <p>{{reality.intro}}</p>
+    <p class="reality-evidence">4f2a1c9 · feat(hooks): rename pre.x → pre.y<br>
+       9be03d1 · refactor(bridge): /status payload now requires version</p>
+    <p class="reality-reassure">{{reality.reassure}}</p>
+  </div>
+  <!-- …one flat, independently answerable decision card per drift item… -->
+</section>
+```
+
+`.reality-evidence` carries the actual commits — short SHA + subject, one per
+line. It is not optional: a drift claim the user cannot verify is a claim they
+have to take on trust, and `reality-check.md` § Force classes forbids showing
+a card without that evidence.
 
 ### Tab Bar CSS
 
@@ -8727,6 +8880,13 @@ section[data-iteration]:not([data-active]) select {
 When appending iteration N+1, Claude must freeze the previous section:
 
 1. Remove `data-active`, add `hidden` to the previous `<section>`.
+   **`data-active` is the ONLY attribute a freeze removes from the section
+   element.** Every other `data-*` on it — `data-iteration`,
+   `data-iteration-template`, `data-final-report`, `data-reality-check` —
+   survives verbatim. This is not cosmetic bookkeeping: `data-reality-check`
+   is what tells the implement path that this round was already the forced
+   one, and dropping it while rewriting the file re-arms a check that has
+   already been answered.
 2. On every `input`, `textarea`, `select`, `button` inside it: set `disabled`.
 3. On every `textarea`, `input[type="text"]`: set `readonly`.
 4. For bi-state buttons: keep the `aria-pressed`/selected class exactly as

--- a/plugins/devops/skills/concept/deep-knowledge/validation-gate.md
+++ b/plugins/devops/skills/concept/deep-knowledge/validation-gate.md
@@ -37,7 +37,7 @@ no legitimate matches — do not "keep it as a convenience". The decision panel
 
 ## Phase 1 — Shared patterns (ALL templates)
 
-Every concept page must contain these 58 patterns, regardless of template
+Every concept page must contain these 60 patterns, regardless of template
 (the numbering carries `b` suffixes where a pattern was added next to a
 related one — count the rows, not the highest number):
 
@@ -67,7 +67,7 @@ related one — count the rows, not the highest number):
 | 20 | `submit-implement-btn` | Secondary submit: implement action (real changes) |
 | 21 | `querySelectorAll('input, select, textarea')` inside `collectDecisions` | Generic form catch-all (no hand-listed selectors per field) |
 | 22 | `data-active]` selector inside `collectDecisions` | Catch-all is scoped to the active iteration only |
-| 23 | `status-steps` | Submit-panel progress list (Übermittelt → Verarbeitet → Implementiert) — see templates.md § Submit Progress Steps |
+| 23 | `status-steps` | Submit-panel progress list (Übermittelt → Verarbeitet → Realitäts-Check → Implementiert) — see templates.md § Submit Progress Steps |
 | 24 | `updateStatusSteps` | Wires `_picked_up_at` / `_phase` from `/decisions` polling into the progress list |
 | 25 | `data.claude_ts` inside `pollHeartbeat` | The poller MUST read JSON and assign `claude_ts` (not `server_ts`, not the raw response object). HTTP-200 alone is not enough — the daemon self-pulse keeps `server_ts` fresh forever, so an HTTP-only check leaves the indicator green while Claude's cron is dead. |
 | 26 | `_setCacheHints(` inside `checkClaudeConnection` | The checker MUST wire the per-button cache hint to the disconnected state, so a click made while Claude is offline reads as visibly queued (then auto-delivered by the Offline Submit Queue) rather than lost. Submit buttons stay enabled in every state — the queue, not a disabled button, is what prevents a black hole. |
@@ -100,6 +100,8 @@ related one — count the rows, not the highest number):
 | 51 | `markDockSubmitted` AND `unmarkDockSubmitted` (the latter CALLED from `restorePanelToReady`) — AND NOT `clearDock()` anywhere on the submit path | The dock keeps every character when a round is submitted; only editing is taken away. The round stays LIVE until Claude appends the next section, so its comments are the only on-screen record of what was sent — emptying the dock at submit time meant a detour into an older tab and back came home blank on a round that had not even been answered. The un-mark is not optional: every path that hands control back on a round that did not go through (507, or the safety timeout when Claude stopped answering) re-arms the submit buttons, and a ready panel over a read-only comment surface lets the user re-submit without being able to change anything first. |
 | 52 | `_carryOverTypedWork` — AND NO `removeItem(STORAGE_KEY)` anywhere | Nothing may delete the state blob. TTL expiry and a page-version change prune it key by key (every `text:` entry is kept, the rest is dropped, the original is archived under `-archive`); the panel reset clears panel flags only. Each of those was once a one-line "clean up local state" that deleted every comment on the page — and two of them fire exactly when things are already going wrong (a bridge that answered 507; Claude stuck on a usage limit past `PROCESSED_SAFETY_MS`). |
 | 53 | `section[data-iteration]:not([data-active])` inside `saveState`'s `persistable` — AND a `viewing-frozen` guard on `#feedback-dock` | A frozen round is never persisted. Browsing an old tab is allowed and ends every `showScreen()` in a `saveState()`, and `applyDockFreezeState()` has painted that round's submitted comments into the shared dock — so without both exclusions the old round's answers are written over the live round's unsent ones, silently. ENGINE entry. |
+| 54 | `data-step="reality-check"` in the `#status-steps` list — AND a `_phase === 'reality-check'` branch in `updateStatusSteps` | The implement gate's progress step. The reality check sits between the pickup and the first code write, so without it a minutes-long check reads as a stalled submission and the user re-clicks implement — which is one of the few ways to reach a second forced round. The `<li>` must ship `hidden` and be unhidden ONLY by that branch: pre-arming it would advertise a check on every implement, and the overwhelmingly common case is a branch that has not moved. See templates.md § Submit Progress Steps. ENGINE entry — see § Engine drift on iteration append. |
+| 55 | `iteration-tab[data-reality-check]` (the CSS) — required on any page that already contains a `section[data-iteration][data-reality-check]` | The reality-check round's tab marker. `data-reality-check` on the section is what tells the implement path "this round WAS the check, implement straight through"; the chip styling is how the user understands why an implement click produced another round instead of code. A page carrying the section without the styling still behaves correctly but looks like an unexplained extra iteration. Both the section and its chip carry the attribute — see reality-check.md § The forced round. |
 | 45 | `section[data-design]:not([data-design-active="true"])` | The CSS backstop for "exactly one design and one screen paint". Designs and screens are `position:absolute; inset:0`, so a single inactive section that ships without `hidden` does not sit somewhere wrong — it paints on top of the active one. Measured on a real page: three designs, five screens, all stacked on the same square, headings and mockups interleaved. `hidden` cannot be the only guard because the markup is merely ASKED to emit it. Must be `:has()`-guarded, together with the matching `section[data-screen]:not([data-screen-active="true"])` rule and `body:not([data-view-active="true"]) section[data-view]`. See templates.md § Layout CSS. |
 
 **Failure for 21 / 22:** if either pattern is missing, the page is rejected
@@ -177,13 +179,20 @@ to twice since.
 
 Before appending, run the gate over the existing HTML. When any ENGINE entry
 fails — 30b (frozen bar + veil relock), 44 (attachments), 46 / 47
-(design-mode chrome), 48 (scroll boxes), 49–53 (comment durability), or the
-tab-switch patterns — re-sync that whole shared block **verbatim from
-templates.md** BEFORE the new section goes in. Re-sync the block, not the one
-line the grep flagged: these blocks fail in halves, and a page missing one
-literal is a page carrying a stale copy of everything around it. Appending
-first and patching after leaves the freshly appended iteration wired to the
-old engine.
+(design-mode chrome), 48 (scroll boxes), 49–53 (comment durability), 54
+(reality-check progress step), or the tab-switch patterns — re-sync that whole
+shared block **verbatim from templates.md** BEFORE the new section goes in.
+Re-sync the block, not the one line the grep flagged: these blocks fail in
+halves, and a page missing one literal is a page carrying a stale copy of
+everything around it. Appending first and patching after leaves the freshly
+appended iteration wired to the old engine.
+
+**Re-syncing must never touch `section[data-iteration]` attributes.** Entry 54
+lives in the panel skeleton and the status-step JS, both of which the re-sync
+replaces wholesale; `data-reality-check` lives on the iteration sections and
+their chips, which it does not. Keep it that way — a re-sync that rewrote a
+section's attributes would erase the marker that stops an already-answered
+reality check from being asked again.
 
 **49–53 come first, before any other repair, and before the append.** They
 are the only entries whose failure mode is destroying the user's work rather

--- a/plugins/devops/skills/concept/reality-check.test.js
+++ b/plugins/devops/skills/concept/reality-check.test.js
@@ -1,0 +1,337 @@
+import { describe, test, expect } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import vm from "node:vm";
+import { fileURLToPath } from "node:url";
+
+// The reality check diverts an `implement` submission into ONE extra round when
+// the default branch moved under the concept. Everything here pins the two
+// properties that keep that from becoming a trap:
+//
+//   1. It can happen at most once per implement attempt — the marker on the
+//      section short-circuits the check, and the advancing baseline makes the
+//      same drift unable to force a second round even if the marker is lost.
+//   2. It never lies about what happened — no "Implementierung abgeschlossen"
+//      over an empty diff, and no progress step for a check that did not run.
+//
+// The behavioural half runs the reference status-step JS out of templates.md on
+// a DOM stub, the same way frozen-veil-bar.test.js runs showIteration().
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DK = path.join(__dirname, "deep-knowledge");
+const md = fs.readFileSync(path.join(DK, "templates.md"), "utf8");
+const gate = fs.readFileSync(path.join(DK, "validation-gate.md"), "utf8");
+const iterRules = fs.readFileSync(path.join(DK, "iteration-rules.md"), "utf8");
+const bridge = fs.readFileSync(path.join(DK, "bridge-server.md"), "utf8");
+const realityDoc = fs.readFileSync(path.join(DK, "reality-check.md"), "utf8");
+const skill = fs.readFileSync(path.join(__dirname, "SKILL.md"), "utf8");
+
+// Line-based scanner (same reason as panel-chrome.test.js): a lazy regex
+// desynchronises on the first block whose body contains a fence.
+function scanBlocks(src) {
+  const lines = src.split("\n");
+  const out = [];
+  let open = null, body = [];
+  for (let i = 0; i < lines.length; i++) {
+    const m = /^```(.*)$/.exec(lines[i]);
+    if (m) {
+      if (open === null) { open = { info: m[1].trim(), start: i + 2 }; body = []; }
+      else { out.push({ info: open.info, line: open.start, code: body.join("\n") }); open = null; }
+      continue;
+    }
+    if (open) body.push(lines[i]);
+  }
+  return out;
+}
+const BLOCKS = scanBlocks(md);
+const HTML_BLOCKS = BLOCKS.filter((b) => b.info === "html");
+const cssSource = BLOCKS.filter((b) => b.info === "css").map((b) => b.code).join("\n");
+
+function fnSource(name) {
+  const m = md.match(new RegExp("function " + name + "\\([^)]*\\) \\{[\\s\\S]*?\\n\\}"));
+  if (!m) throw new Error("function " + name + " not found in templates.md");
+  return m[0];
+}
+
+describe("reality check — markup", () => {
+  test("every skeleton with a progress list ships the reality-check step, hidden, before the implement step", () => {
+    const skeletons = HTML_BLOCKS.filter((b) => b.code.includes('id="status-steps"'));
+    expect(skeletons.length).toBe(2); // Common Structure + design overlay
+    for (const b of skeletons) {
+      const where = `html block at line ${b.line}`;
+      expect(b.code, where).toContain('data-step="reality-check"');
+      // Hidden in the markup: only updateStatusSteps may reveal it, so a check
+      // that never ran never advertises itself.
+      expect(b.code, where).toMatch(/<li data-step="reality-check" data-state="pending" hidden>/);
+      expect(b.code, where).toContain("{{panel.step_reality_check}}");
+      expect(b.code, where).toContain("{{panel.step_reality_check_active}}");
+      // Order matters — the check happens before the code is written.
+      expect(b.code.indexOf('data-step="reality-check"'), where)
+        .toBeLessThan(b.code.indexOf('data-step="implemented"'));
+    }
+  });
+
+  test("the tab bar reference carries a reality-check chip with the locale label", () => {
+    const bar = HTML_BLOCKS.find((b) => b.code.includes('class="iteration-tabs"') && b.code.includes("{{iteration.final_tab}}"));
+    expect(bar).toBeDefined();
+    expect(bar.code).toContain("data-reality-check");
+    expect(bar.code).toContain("{{iteration.reality_tab}}");
+  });
+
+  test("the explainer block is a reference skeleton, not a suggestion", () => {
+    const banner = HTML_BLOCKS.find((b) => b.code.includes('class="reality-banner"'));
+    expect(banner).toBeDefined();
+    expect(banner.code).toContain("{{reality.headline}}");
+    expect(banner.code).toContain("{{reality.intro}}");
+    expect(banner.code).toContain("{{reality.reassure}}");
+    // The evidence line is what makes a drift claim checkable.
+    expect(banner.code).toContain("reality-evidence");
+    // It lives on a marked section, and that section is a normal iteration.
+    expect(banner.code).toMatch(/<section [^>]*data-iteration="\d+"[^>]*data-reality-check/);
+    // The examined commit rides on the round itself, so a resumed session can
+    // advance the baseline without having watched the check run.
+    expect(banner.code).toMatch(/data-reality-head="[0-9a-f]{7,40}"/);
+  });
+
+  test("locale table carries every new string in en and de", () => {
+    const keys = [
+      "panel.step_reality_check",
+      "panel.step_reality_check_active",
+      "iteration.reality_tab",
+      "reality.headline",
+      "reality.intro",
+      "reality.reassure",
+      "reality.evidence",
+      "reality.recommendation",
+    ];
+    for (const key of keys) {
+      const row = md.split("\n").find((l) => l.startsWith("| `" + key + "`"));
+      expect(row, key).toBeDefined();
+      const cells = row.split("|").map((s) => s.trim()).filter(Boolean);
+      expect(cells.length, key).toBe(3);
+    }
+  });
+});
+
+describe("reality check — CSS", () => {
+  test("the tab chip is warning-toned, distinct from the final-report chip", () => {
+    expect(cssSource).toMatch(/\.iteration-tab\[data-reality-check\] \{/);
+    expect(cssSource).toMatch(/\.iteration-tab\[data-reality-check\]\[aria-selected="true"\] \{/);
+    const rule = /\.iteration-tab\[data-reality-check\] \{([\s\S]*?)\}/.exec(cssSource)[1];
+    expect(rule).toContain("--warning-color");
+  });
+
+  test("the explainer banner is styled, so it cannot render as an unstyled paragraph", () => {
+    expect(cssSource).toMatch(/\.reality-banner \{/);
+    expect(cssSource).toMatch(/\.reality-evidence \{/);
+  });
+});
+
+// ── Behavioural run of the reference status-step JS against a DOM stub ──
+
+function makeStub() {
+  const mkEl = (step) => {
+    const icon = { textContent: "○" };
+    return {
+      hidden: false,
+      dataset: { state: "pending", step },
+      querySelector: (sel) => (sel === ".step-icon" ? icon : null),
+      _icon: icon,
+    };
+  };
+  const steps = {
+    submitted: mkEl("submitted"),
+    received: mkEl("received"),
+    "reality-check": mkEl("reality-check"),
+    implemented: mkEl("implemented"),
+  };
+  const document = {
+    querySelector: (sel) => {
+      const m = /^#status-steps li\[data-step="([a-z-]+)"\]$/.exec(sel);
+      return m ? steps[m[1]] || null : null;
+    },
+  };
+  return { document, steps };
+}
+
+function loadRuntime(action) {
+  const stub = makeStub();
+  const ctx = {
+    document: stub.document,
+    _submittedAt: Date.now(),
+    _submittedAction: action,
+    console,
+  };
+  vm.createContext(ctx);
+  const src = [
+    fnSource("_stepEl"),
+    fnSource("_setStep"),
+    fnSource("resetStatusSteps"),
+    fnSource("updateStatusSteps"),
+    "globalThis.resetStatusSteps = resetStatusSteps;",
+    "globalThis.updateStatusSteps = updateStatusSteps;",
+  ].join("\n");
+  new vm.Script(src, { filename: "templates.md#status-steps" }).runInContext(ctx);
+  return { ...stub, reset: ctx.resetStatusSteps, update: ctx.updateStatusSteps };
+}
+
+describe("reality check — progress step behaviour (reference JS on a DOM stub)", () => {
+  test("a fresh implement submission does NOT pre-arm the step", () => {
+    const r = loadRuntime("implement");
+    r.reset("implement");
+    expect(r.steps["reality-check"].hidden).toBe(true);
+    expect(r.steps.implemented.hidden).toBe(false);
+  });
+
+  test("an iterate submission arms neither the check nor the implement step", () => {
+    const r = loadRuntime("iterate");
+    r.reset("iterate");
+    expect(r.steps["reality-check"].hidden).toBe(true);
+    expect(r.steps.implemented.hidden).toBe(true);
+  });
+
+  test("pickup alone leaves the check step hidden — the common case is no drift", () => {
+    const r = loadRuntime("implement");
+    r.reset("implement");
+    r.update({ _picked_up_at: 1 });
+    expect(r.steps.received.dataset.state).toBe("done");
+    expect(r.steps["reality-check"].hidden).toBe(true);
+  });
+
+  test("the reality-check phase reveals the step and marks it active", () => {
+    const r = loadRuntime("implement");
+    r.reset("implement");
+    r.update({ _phase: "reality-check" });
+    expect(r.steps["reality-check"].hidden).toBe(false);
+    expect(r.steps["reality-check"].dataset.state).toBe("active");
+    // Monotonic: a check implies the submission was picked up.
+    expect(r.steps.received.dataset.state).toBe("done");
+  });
+
+  test("a check that ran is ticked when the implementation completes", () => {
+    const r = loadRuntime("implement");
+    r.reset("implement");
+    r.update({ _phase: "reality-check" });
+    r.update({ _phase: "implemented" });
+    expect(r.steps["reality-check"].dataset.state).toBe("done");
+    expect(r.steps.implemented.dataset.state).toBe("done");
+  });
+
+  test("a check that never ran does not pop into existence already ticked", () => {
+    const r = loadRuntime("implement");
+    r.reset("implement");
+    r.update({ _phase: "implemented" });
+    expect(r.steps["reality-check"].hidden).toBe(true);
+    expect(r.steps["reality-check"].dataset.state).toBe("pending");
+    expect(r.steps.implemented.dataset.state).toBe("done");
+  });
+
+  test("an iterate submission never shows a check step, whatever the server says", () => {
+    const r = loadRuntime("iterate");
+    r.reset("iterate");
+    r.update({ _phase: "reality-check" });
+    expect(r.steps["reality-check"].hidden).toBe(true);
+  });
+});
+
+describe("reality check — the deadlock guard is written down, not implied", () => {
+  test("SKILL.md runs the check as step 0 of implement, before any code", () => {
+    expect(skill).toContain("Reality check — run this BEFORE writing anything");
+    expect(skill).toContain("concept-drift.js");
+    // The guard itself.
+    expect(skill).toMatch(/Skip the check entirely.*data-reality-check/s);
+  });
+
+  test("SKILL.md forbids reporting an implementation that did not happen", () => {
+    expect(skill).toMatch(/Do NOT post\s*\n?\s*`phase: "implemented"` — no code was written/);
+  });
+
+  test("SKILL.md routes the forced round through the normal append, not a special case", () => {
+    expect(skill).toMatch(/append a \*\*regular\s*\n?iteration section carrying `data-reality-check`/);
+    expect(skill).toContain("{{iteration.reality_tab}}");
+  });
+
+  test("answering a forced round advances the baseline — including via iterate", () => {
+    // Without this, one ordinary round after a reality check brings the same
+    // already-answered cards back on the next implement. That is the single
+    // most likely way this feature could feel like a loop.
+    expect(skill).toMatch(/If the submitted section carries `data-reality-check`, advance the\s*\n?\s*baseline/);
+    expect(skill).toContain("data-reality-head");
+    expect(realityDoc).toContain("data-reality-head");
+  });
+
+  test("the forced round's marker is verified on disk, not assumed", () => {
+    expect(skill).toMatch(/Read the file back and confirm both attributes landed before `\/reload`/);
+    expect(realityDoc).toMatch(/\*\*Read the file back after writing it\*\*/);
+  });
+
+  test("the equal-version shortcut in 5d consults /recovery first", () => {
+    expect(skill).toContain("GET /recovery");
+    expect(skill).toMatch(/reality-check-\*` checkpoint sits on that same `_version`/);
+  });
+
+  test("the baseline is captured at concept open, not at first implement", () => {
+    expect(skill).toContain("--capture");
+    expect(skill).toMatch(/Capture it at\s*\n?concept open, not at first implement/);
+    expect(bridge).toContain("baseline_ref");
+    expect(bridge).toContain("baseline_sha");
+  });
+
+  test("iteration-rules.md has the row and protects the marker through a freeze", () => {
+    expect(iterRules).toContain("Implement submission diverted by the reality check");
+    expect(iterRules).toMatch(/freeze removes `data-active` from the section and nothing else/);
+    expect(iterRules).toContain("data-reality-check");
+  });
+
+  test("templates.md pins the same freeze rule where the freeze is specified", () => {
+    expect(md).toMatch(/`data-active` is the ONLY attribute a freeze removes/);
+  });
+
+  test("the validation gate covers both halves and counts them", () => {
+    expect(gate).toMatch(/\| 54 \| `data-step="reality-check"`/);
+    expect(gate).toMatch(/\| 55 \| `iteration-tab\[data-reality-check\]`/);
+    expect(gate).toContain("these 60 patterns");
+    // 54 is an engine entry, so a page generated before the gate existed gets
+    // it re-synced on its next append instead of silently missing it forever.
+    expect(gate).toMatch(/49–53 \(comment durability\), 54\s*\n?\(reality-check progress step\)/);
+  });
+});
+
+describe("reality check — the doctrine document", () => {
+  test("both lines of defence are stated as independent", () => {
+    expect(realityDoc).toContain("Line 1, the marker");
+    expect(realityDoc).toContain("Line 2, the baseline");
+    expect(realityDoc).toMatch(/Both lines have to fail simultaneously/);
+  });
+
+  test("every unresolvable condition fails safe, in writing", () => {
+    expect(realityDoc).toMatch(/A network hiccup must never block an implement order/);
+    expect(realityDoc).toMatch(/\*\*fails safe\*\*: implement proceeds/);
+  });
+
+  test("the baseline advances on BOTH submissions of a forced round", () => {
+    expect(realityDoc).toMatch(/Advance it on every submission of a reality-check round — iterate as well as\s*\n?implement/);
+  });
+
+  test("completeness is a prohibition list, not an aspiration", () => {
+    expect(realityDoc).toContain("we'll clarify this in the next round");
+    expect(realityDoc).toContain("conditional cards");
+    expect(realityDoc).toContain("catch-all");
+  });
+
+  test("no third button, and evidence is mandatory", () => {
+    expect(realityDoc).toContain("**No third button.**");
+    expect(realityDoc).toMatch(/No SHA, no\s*\n?card, no force/);
+  });
+
+  test("force classes name what must NOT force, so a routine commit cannot", () => {
+    expect(realityDoc).toContain("**Never force**");
+    expect(realityDoc).toMatch(/version bumps, CHANGELOG, docs, tests-only changes/);
+  });
+
+  test("resume replays a recorded verdict instead of re-deciding", () => {
+    expect(realityDoc).toContain("reality-check-forced");
+    expect(realityDoc).toContain("reality-check-clear");
+    expect(realityDoc).toMatch(/\*\*Never re-decide\*\*/);
+  });
+});

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.145.1",
+  "version": "0.146.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

A concept session lives for hours or days while the default branch keeps moving. Clicking "Mit Feedback implementieren" implemented the plan exactly as approved — so a renamed file, a changed contract, or work somebody had already done reached the diff unremarked.

The implement path now re-checks the concept against the current default branch **before writing any code**. On material drift it appends ONE extra round — mechanically an ordinary iteration, marked `data-reality-check`, with its own "Realitäts-Check" tab and an explainer naming the commits that landed — carrying every decision the drift raises. Submitting that round with implement writes the code.

## Why it cannot deadlock

Two independent guards:

1. **The marker.** Implementing from a `data-reality-check` round short-circuits the check. Exact, and the primary guard.
2. **The baseline.** It advances on *every* submission of such a round — iterate as well as implement — so the same drift cannot force a second one even if the marker were lost to a bad rewrite, a legacy page, or a resumed session working from a page it did not write.

Both would have to fail on the same round to produce two forced rounds in a row. An ordinary iterate round re-arms the check against the *advanced* baseline — the user opting back in, not a deadlock.

## Code vs. judgment

`scripts/concept-drift.js` produces facts only: commits, changed paths (a rename contributes both sides), and their intersection with the paths the concept names. The force classes stay with the model — file deleted/renamed, contract changed, functionality already built, a user decision that lost its basis. Version bumps, CHANGELOG, docs, tests-only and formatting never force a round; no drift card may be shown without its SHA and path.

**Every unresolvable condition fails safe** — no repo, no remote, a non-`main` default branch, detached HEAD, offline, shallow clone, force-pushed baseline — and lets the implement through. A network hiccup must never block an implement order. The check also never posts `phase: "implemented"` on that path: a panel reading "Implementierung abgeschlossen" over an empty diff would be worse than the problem being solved.

## Testing

- 2589 tests / 108 files green, lint clean. 53 tests are new (25 for the script's verdict + fail-safe matrix, 28 pinning the contract across SKILL.md, iteration-rules, templates, the validation gate and the doctrine doc).
- The script was additionally smoke-tested against this repo's real git: capture → `main @ 9ca95c3`; check → `clear/unchanged`; baseline rewound 15 commits → `candidates` with 15 real commits and 101 paths; filtered to an untouched area → `clear/no-overlap`; filtered to a touched one → `candidates/overlap`; erased baseline and non-repo cwd → `skip`, safe.

## Notes

- The local test run hit `spawnSync ETIMEDOUT` in the `git-sync.*` suites — process spawns on the shipping machine were measured ~30× slower than normal (`git --version` at 1020 ms). With the timeout raised, all 2589 pass; those suites are untouched by this change. CI is the clean-environment check.
- The Codex review gate could not run: the account hit its usage limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)