### PR TITLE
feat(card): concept phase CTA — bridge tasks are not pending work

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.147.0"
+    "version": "0.148.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.147.0",
+      "version": "0.148.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.147.0",
+      "version": "0.148.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.148.0] — 2026-09-06
+
+### Added
+
+- **A concept card no longer counts its own plumbing as unfinished work.** While a `/concept` page is open, three detached Bash tasks run for the whole session — the bridge server, the keepalive pulser and the pickup waker. They never yield a result; they *are* the waiting. The pending gate counted them anyway, so every card rendered mid-concept read "⏳ NOCH NICHT FERTIG. 3 Tasks (Start the concept bridge server on port 8840, Launch the keepalive pulser …) laufen — ich MELDE mich", naming infrastructure where the only true statement was "waiting for your decisions". The transcript scanner now recognizes those tasks — by the script they run or the role their launch description names — and never opens them, so `stop.flow.guard` ignores them; a real agent or `npm test` launched alongside is still reported. The PostToolUse reminder that fires on a background launch says `[concept]` for these instead of `[pending]`, so the model is not steered into listing them.
+
+  **The card gained a `concept` field for the state a concept can actually be in.** `concept: { phase }` — `waiting` (default), `iterating` or `implementing` — replaces the CTA of every variant, and outranks `pending`, with "🧭 CONCEPT läuft. Warte auf deine Entscheidungen auf der Seite / Arbeite an der nächsten Iteration / Arbeite an der Implementierung — ich MELDE mich". Real content work still goes into `pending` and is folded into that line rather than replacing it — `Arbeite an der Implementierung mit Agent \`devops:frontend\``, `… mit 1 Workflow + 2 Agenten` — while the pending block and the dim name row keep naming each item. A JSON string, a bare phase string and an object are all accepted; an open concept with an unknown phase reads as waiting, because the only wrong card here is one that asks for a SHIP. The concept skill documents the mid-concept cards and that the final card, rendered after cleanup, carries no `concept` at all.
+
 ## [0.147.0] — 2026-09-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.147.0**
+**Version: 0.148.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.147.0",
+  "version": "0.148.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/deep-knowledge/plugin-behavior.md
+++ b/plugins/devops/deep-knowledge/plugin-behavior.md
@@ -106,6 +106,13 @@ Subagents inherit all output contracts:
   asks the user to SHIP or act on a result that has not arrived. `stop.flow.guard`
   reads the open work out of the transcript and blocks a card that omits it.
   Never put an internal agentId in a card — use the agent type or task label.
+- **A turn that ends with a `/concept` page open renders its card with
+  `concept: { phase }`** (`waiting` · `iterating` · `implementing`) — the CTA
+  becomes "🧭 CONCEPT läuft. Warte auf deine Entscheidungen / Arbeite an der
+  nächsten Iteration / Arbeite an der Implementierung — ich MELDE mich" and
+  outranks `pending`. The concept bridge's own tasks (server, keepalive pulser,
+  pickup waker) are infrastructure, never `pending`; the guard ignores them.
+  Real content agents still go into `pending` and are folded into that line.
 
 ## Extension Model
 

--- a/plugins/devops/hooks/lib/card-guard.js
+++ b/plugins/devops/hooks/lib/card-guard.js
@@ -16,7 +16,9 @@
  *        are still running and the card did not declare them (`pending`). Open
  *        work is proven from the transcript (lib/pending-tasks.js), so the card
  *        cannot end a turn with a CTA that asks the user to act on results that
- *        do not exist yet.
+ *        do not exist yet. The concept bridge's own tasks (server, keepalive
+ *        pulser, pickup waker) are infrastructure and never count — a concept
+ *        that is merely open renders `concept: { phase }`, not `pending`.
  *
  *   Inputs: flag state (work/card/validation/pending) + transcript + stop_hook_active.
  *   Output: { action: 'block' | 'pass', reason?, resetFlags }.
@@ -193,6 +195,12 @@ function buildBlockReason(pluginRoot) {
     'the CTA with "⏳ NOCH NICHT FERTIG … ich MELDE mich", so the card never asks',
     'the user to act on a result that does not exist yet. Never put an internal',
     'agentId in the card; use the agent type / workflow name / task label.',
+    'CONCEPT (outranks pending): if a /concept page is OPEN, pass `concept` —',
+    '{ phase: "waiting" | "iterating" | "implementing" } — and the CTA becomes',
+    '"🧭 CONCEPT läuft. Warte auf deine Entscheidungen / Arbeite an der nächsten',
+    'Iteration / Arbeite an der Implementierung — ich MELDE mich". The bridge',
+    'server, keepalive pulser and pickup waker are infrastructure, NOT pending —',
+    'never list them; this gate ignores them.',
     '',
     'IMPORTANT: The MCP result is hidden in a collapsed UI block.',
     'Copy the returned markdown and output it VERBATIM as your own text —',
@@ -243,6 +251,9 @@ function buildPendingReason(names) {
     '"⏳ NOCH NICHT FERTIG. … — ich MELDE mich".',
     '',
     'Use the names listed above. NEVER put an internal agentId in the card.',
+    'If a /concept page is open, ALSO pass `concept: { phase }` — the concept CTA',
+    'then folds this work into its own line ("… mit 2 Agenten") instead of the',
+    'generic "NOCH NICHT FERTIG".',
     '',
     'If the work has in fact already finished, collect the results first and then',
     'render the real completion card — do not declare it pending to get past this.',

--- a/plugins/devops/hooks/lib/pending-tasks.js
+++ b/plugins/devops/hooks/lib/pending-tasks.js
@@ -1,9 +1,18 @@
 /**
  * @module pending-tasks
- * @version 0.2.0
+ * @version 0.3.0
  * @description Detects background work that is STILL RUNNING when a turn ends —
  *   subagents launched with run_in_background, backgrounded Bash tasks, and
  *   whole Workflow runs (which fan out to agents of their own).
+ *
+ *   INFRASTRUCTURE IS NOT WORK. The concept skill keeps three detached Bash
+ *   tasks alive for as long as a concept page is open — the bridge server, the
+ *   keepalive pulser and the pickup waker. They produce no result the user is
+ *   waiting for; they ARE the waiting. Counting them turned every concept card
+ *   into "3 Tasks laufen — ich MELDE mich", which names plumbing instead of the
+ *   one true statement (waiting for decisions / working on the next iteration /
+ *   implementing). isConceptInfra() recognizes them by the script they run or
+ *   the role their description names, and scanOpenTasks never opens them.
  *
  *   The card is rendered at the moment the turn hands back, so without this the
  *   CTA of every variant ("SHIP or CHANGE?", "All DONE") asks the user to act on
@@ -93,6 +102,25 @@ function canLaunch(launcher, kind) {
  */
 function announces(text, marker) {
   return text.trimStart().startsWith(marker);
+}
+
+/**
+ * The concept bridge's own background tasks — matched on the script the command
+ * runs (the durable signal) or on the role the launch description names (the
+ * shape the skill prescribes when the script path is resolved inside the
+ * command through a shell variable and never appears literally).
+ */
+const CONCEPT_INFRA_RE =
+  /concept-server\.py|concept-watch\.js|concept[- ]bridge|keepalive pulser|pickup waker|concept[- ]watch/i;
+
+/**
+ * True when a Bash launch is concept-bridge infrastructure rather than work.
+ * @param {object} input — the Bash tool_use input ({ command, description })
+ */
+function isConceptInfra(input) {
+  const i = input || {};
+  return CONCEPT_INFRA_RE.test(String(i.command || ''))
+    || CONCEPT_INFRA_RE.test(String(i.description || ''));
 }
 
 /** Max characters of a Bash command used as a fallback label. */
@@ -302,6 +330,9 @@ function scanOpenTasks(transcriptContent) {
       const bg = canLaunch(launcher, 'task')
         && announces(text, BASH_LAUNCH_MARKER) && text.match(BASH_BG_RE);
       if (bg) {
+        // Concept bridge plumbing (server / pulser / waker) runs for the whole
+        // concept session and yields no result — it is never "still running work".
+        if (isConceptInfra(input)) continue;
         const name = labelFor(input, 'task');
         known.set(bg[1], name);
         open.set(bg[1], { kind: 'task', name });
@@ -337,6 +368,7 @@ module.exports = {
   LAUNCH_TOOLS,
   canLaunch,
   announces,
+  isConceptInfra,
   scanOpenTasks,
   openTaskNames,
   labelFor,

--- a/plugins/devops/hooks/lib/pending-tasks.test.js
+++ b/plugins/devops/hooks/lib/pending-tasks.test.js
@@ -4,7 +4,7 @@
  * call, and the task-notification that reports either one stopping.
  */
 import { describe, test, expect } from 'vitest';
-import { scanOpenTasks, openTaskNames, labelFor } from './pending-tasks.js';
+import { scanOpenTasks, openTaskNames, labelFor, isConceptInfra } from './pending-tasks.js';
 
 const AGENT_LAUNCH_TEXT =
   'Async agent launched successfully. (This tool result is internal metadata — never quote or ' +
@@ -406,5 +406,88 @@ describe('scanOpenTasks — Bash output is not a launch announcement', () => {
       toolResult('toolu_e', AGENT_LAUNCH_TEXT),
     ].join('\n'));
     expect(open).toEqual([]);
+  });
+});
+
+describe('scanOpenTasks — concept bridge infrastructure is not work', () => {
+  const SERVER_CMD =
+    'PLUGIN_ROOT=$(ls -d ~/.claude/plugins/cache/dotclaude/devops/*/scripts/concept-server.py | head -1); ' +
+    'python "$PLUGIN_ROOT" 8840 "C:/repo" --html "docs/concepts/2026-09-06-eve.html"';
+  const PULSER_CMD =
+    'node "$(ls -d ~/.claude/plugins/cache/dotclaude/devops/*/scripts/concept-watch.js | head -1)" ' +
+    '--mode pulse --port 8840 --state "C:/repo/.claude/concept-active.json"';
+  const WAKER_CMD = PULSER_CMD.replace('--mode pulse', '--mode watch');
+
+  function bgLaunch(id, taskId, input) {
+    return [
+      toolUse(id, 'Bash', input),
+      toolResult(id, BASH_BG_TEXT.replace('b68oycrr6', taskId)),
+    ];
+  }
+
+  test('the bridge server, pulser and waker open nothing', () => {
+    const open = scanOpenTasks([
+      ...bgLaunch('toolu_s', 'srv1', { command: SERVER_CMD, description: 'Start the concept bridge server on port 8840' }),
+      ...bgLaunch('toolu_p', 'pls1', { command: PULSER_CMD, description: 'Launch the keepalive pulser for the concept bridge' }),
+      ...bgLaunch('toolu_w', 'wkr1', { command: WAKER_CMD, description: 'Launch the pickup waker' }),
+    ].join('\n'));
+    expect(open).toEqual([]);
+  });
+
+  test('recognized by the script alone when the description says nothing', () => {
+    const open = scanOpenTasks(
+      bgLaunch('toolu_p', 'pls1', { command: PULSER_CMD, description: 'Background poller' }).join('\n'),
+    );
+    expect(open).toEqual([]);
+  });
+
+  test('recognized by the role alone when the script path is resolved in a variable', () => {
+    const open = scanOpenTasks(
+      bgLaunch('toolu_s', 'srv1', {
+        command: 'python "$SERVER" 8840 "C:/repo" --html "docs/concepts/x.html"',
+        description: 'Start the concept bridge server on port 8840',
+      }).join('\n'),
+    );
+    expect(open).toEqual([]);
+  });
+
+  test('real work launched alongside the plumbing is still reported', () => {
+    const open = scanOpenTasks([
+      ...bgLaunch('toolu_s', 'srv1', { command: SERVER_CMD, description: 'Start the concept bridge server' }),
+      ...bgLaunch('toolu_w', 'wkr1', { command: WAKER_CMD, description: 'Launch the pickup waker' }),
+      ...AGENT_START,
+      ...bgLaunch('toolu_t', 'tst1', { command: 'npm test', description: 'Baseline test run' }),
+    ].join('\n'));
+    expect(open).toEqual([
+      { id: 'a75d674f7108dd6c8', kind: 'agent', name: 'devops:frontend' },
+      { id: 'tst1', kind: 'task', name: 'Baseline test run' },
+    ]);
+  });
+
+  test('an ordinary task whose command merely mentions a concept page is still work', () => {
+    const open = scanOpenTasks(
+      bgLaunch('toolu_t', 'tst1', {
+        command: 'node scripts/concept-gate.js docs/concepts/x.html',
+        description: 'Validate the concept page',
+      }).join('\n'),
+    );
+    expect(open).toEqual([{ id: 'tst1', kind: 'task', name: 'Validate the concept page' }]);
+  });
+});
+
+describe('isConceptInfra', () => {
+  test('matches the three bridge scripts and their role names', () => {
+    expect(isConceptInfra({ command: 'python x/concept-server.py 8840 .' })).toBe(true);
+    expect(isConceptInfra({ command: 'node x/concept-watch.js --mode pulse' })).toBe(true);
+    expect(isConceptInfra({ description: 'Launch the keepalive pulser' })).toBe(true);
+    expect(isConceptInfra({ description: 'Re-launch the pickup waker' })).toBe(true);
+    expect(isConceptInfra({ description: 'Restart the concept bridge on the same port' })).toBe(true);
+  });
+
+  test('does not match unrelated work or empty input', () => {
+    expect(isConceptInfra({ command: 'npm test', description: 'Run the suite' })).toBe(false);
+    expect(isConceptInfra({ command: 'node scripts/concept-drift.js --capture' })).toBe(false);
+    expect(isConceptInfra({})).toBe(false);
+    expect(isConceptInfra(undefined)).toBe(false);
   });
 });

--- a/plugins/devops/hooks/post-tool-use/post.flow.completion.js
+++ b/plugins/devops/hooks/post-tool-use/post.flow.completion.js
@@ -37,7 +37,7 @@ const path = require('path');
 const { sessionFile, readSessionFile, writeSessionFile } = require('../lib/session-id');
 const { getLocale, t } = require('../lib/locale');
 const {
-  AGENT_LAUNCH_MARKER, BASH_LAUNCH_MARKER, WORKFLOW_LAUNCH_MARKER, labelFor,
+  AGENT_LAUNCH_MARKER, BASH_LAUNCH_MARKER, WORKFLOW_LAUNCH_MARKER, labelFor, isConceptInfra,
 } = require('../lib/pending-tasks');
 const {
   classifyProfile,
@@ -116,8 +116,13 @@ const DESKTOP_TEST_DICT = {
  * Reads the same launch markers the Stop gate scans for (lib/pending-tasks.js),
  * but from the live tool_response, so the reminder can fire immediately.
  *
+ * A backgrounded Bash task that is concept-bridge plumbing (server, keepalive
+ * pulser, pickup waker) is reported as kind 'concept-infra': it runs for the
+ * whole concept and never yields a result, so it must NOT end up in `pending` —
+ * the Stop gate ignores it, and the card carries `concept` instead.
+ *
  * @param {object} hook — PostToolUse payload
- * @returns {{ kind: 'agent'|'task'|'workflow', name: string }|null}
+ * @returns {{ kind: 'agent'|'task'|'workflow'|'concept-infra', name: string }|null}
  */
 /** How the reminder names each kind of launched work. */
 const LAUNCH_NOUN = {
@@ -137,7 +142,8 @@ function detectBackgroundLaunch(hook) {
     return { kind: 'workflow', name: labelFor(hook.tool_input, 'workflow', text) };
   }
   if (text.includes(BASH_LAUNCH_MARKER)) {
-    return { kind: 'task', name: labelFor(hook.tool_input, 'task') };
+    const kind = isConceptInfra(hook.tool_input) ? 'concept-infra' : 'task';
+    return { kind, name: labelFor(hook.tool_input, 'task') };
   }
   return null;
 }
@@ -317,7 +323,21 @@ process.stdin.on('end', () => {
   // so the card carries `pending` on the first try instead of being bounced by
   // the Stop gate — a block costs a whole extra turn.
   const launched = detectBackgroundLaunch(hook);
-  if (launched) {
+  if (launched && launched.kind === 'concept-infra') {
+    lines.push(
+      '',
+      `[concept] Bridge infrastructure started: ${launched.name}`,
+      'This is plumbing for the open concept page, NOT pending work — it never yields',
+      'a result. Do NOT list it (nor the bridge server / keepalive pulser / pickup',
+      'waker) under `pending`; stop.flow.guard ignores these tasks. While the concept',
+      'stays open, render every completion card with the `concept` field instead:',
+      '  concept: { phase: "waiting" | "iterating" | "implementing" }',
+      'That sets the CTA to "🧭 CONCEPT läuft. Warte auf deine Entscheidungen /',
+      'Arbeite an der nächsten Iteration / Arbeite an der Implementierung — ich MELDE',
+      'mich". Real content agents or workflows still go into `pending` and are folded',
+      'into that line ("… mit 2 Agenten").',
+    );
+  } else if (launched) {
     lines.push(
       '',
       `[pending] ${LAUNCH_NOUN[launched.kind] || 'Background task'} started: ${launched.name}`,

--- a/plugins/devops/hooks/post-tool-use/post.flow.completion.test.js
+++ b/plugins/devops/hooks/post-tool-use/post.flow.completion.test.js
@@ -196,3 +196,54 @@ describe("post.flow.completion — pending reminder", () => {
     cleanup(dir);
   });
 });
+
+// The concept bridge's own background tasks (server, keepalive pulser, pickup
+// waker) run for the whole concept and never yield a result. Flagging them as
+// `pending` produced cards that said "3 Tasks laufen — ich MELDE mich" while the
+// only true statement was "waiting for your decisions". The hook now routes
+// them to the `concept` field instead.
+describe("post.flow.completion — concept bridge infrastructure is not pending", () => {
+  const BG = "Command running in background with ID: b68oycrr6. Output is being written to: x";
+
+  test("the bridge server launch asks for `concept`, not `pending`", () => {
+    const dir = project();
+    const out = runHook(dir, "s-concept-server", "Bash", {
+      tool_input: {
+        command: 'python "$PLUGIN_ROOT" 8840 "C:/repo" --html "docs/concepts/x.html"',
+        description: "Start the concept bridge server on port 8840",
+        run_in_background: true,
+      },
+      tool_response: BG,
+    });
+    expect(out).toContain("[concept]");
+    expect(out).toContain("concept: { phase:");
+    expect(out).not.toContain("[pending]");
+    cleanup(dir);
+  });
+
+  test("the keepalive pulser is recognized by its script even with a bland description", () => {
+    const dir = project();
+    const out = runHook(dir, "s-concept-pulser", "Bash", {
+      tool_input: {
+        command: 'node "$(ls -d ~/.claude/plugins/cache/dotclaude/devops/*/scripts/concept-watch.js | head -1)" --mode pulse --port 8840 --state "C:/repo/.claude/concept-active.json"',
+        description: "Background poller",
+        run_in_background: true,
+      },
+      tool_response: BG,
+    });
+    expect(out).toContain("[concept]");
+    expect(out).not.toContain("[pending]");
+    cleanup(dir);
+  });
+
+  test("an ordinary background task still gets the pending reminder", () => {
+    const dir = project();
+    const out = runHook(dir, "s-concept-other", "Bash", {
+      tool_input: { command: "npm test", description: "Run the suite", run_in_background: true },
+      tool_response: BG,
+    });
+    expect(out).toContain("[pending]");
+    expect(out).not.toContain("[concept]");
+    cleanup(dir);
+  });
+});

--- a/plugins/devops/mcp-server/index.card.test.js
+++ b/plugins/devops/mcp-server/index.card.test.js
@@ -448,3 +448,84 @@ describe("pending layer — workflows and the name line", () => {
     expect(text).toMatch(/^> ⏳ `abcd`, `devops:qa`$/m);
   });
 });
+
+// A /concept page open at turn end is a checkpoint in a loop that ends on the
+// page, not in chat. The bridge's own background tasks are plumbing, so the
+// card must not say "3 Tasks laufen"; it says which of the three true states
+// the concept is in, and folds any REAL content work into that line.
+describe("concept layer", () => {
+  test("waiting: replaces the ready CTA with the concept wait line", async () => {
+    const text = await cardText({
+      variant: "ready",
+      summary: "Concept eve-panel iteration 3 geöffnet",
+      lang: "de",
+      session_id: "test-concept-1",
+      changes: [{ area: "concept", description: "Iteration 3 angehängt" }],
+      concept: { phase: "waiting" },
+    });
+    expect(text).toContain("### 🧭 CONCEPT läuft. Warte auf deine Entscheidungen auf der Seite — ich MELDE mich");
+    expect(text).not.toContain("READY — SHIP oder ÄNDERN");
+    expect(text).not.toContain("NOCH NICHT FERTIG");
+  });
+
+  test("a bare phase string is accepted", async () => {
+    const text = await cardText({
+      variant: "analysis", summary: "Concept offen", lang: "de",
+      session_id: "test-concept-2", concept: "iterating",
+    });
+    expect(text).toContain("### 🧭 CONCEPT läuft. Arbeite an der nächsten Iteration — ich MELDE mich");
+  });
+
+  test("implementing with content agents folds them into the line and keeps the block", async () => {
+    const text = await cardText({
+      variant: "ready",
+      summary: "Implement-Runde gestartet",
+      lang: "de",
+      session_id: "test-concept-3",
+      concept: { phase: "implementing" },
+      pending: [
+        { name: "devops:frontend", doing: "Panel-Layout umbauen" },
+        { name: "devops:core", doing: "Bridge-Endpunkt ergänzen" },
+      ],
+    });
+    expect(text).toContain("### 🧭 CONCEPT läuft. Arbeite an der Implementierung mit 2 Agenten — ich MELDE mich");
+    // The pending block and the dim name line still name the agents.
+    expect(text).toContain("LÄUFT NOCH — nicht abgeschlossen");
+    expect(text).toContain("> ⏳ `devops:frontend`, `devops:core`");
+    expect(text).not.toContain("NOCH NICHT FERTIG");
+  });
+
+  test("English wording", async () => {
+    const text = await cardText({
+      variant: "ready", summary: "Concept open", lang: "en",
+      session_id: "test-concept-4",
+      concept: { phase: "implementing" }, pending: [{ name: "devops:frontend" }],
+    });
+    expect(text).toContain("### 🧭 CONCEPT open. Working on the implementation with agent `devops:frontend` — I’ll REPORT back");
+  });
+
+  test("outranks the pending CTA — the concept phase is the truer statement", async () => {
+    const text = await cardText({
+      variant: "ready", summary: "x", lang: "de", session_id: "test-concept-5",
+      concept: "waiting", pending: [{ name: "devops:research", doing: "Doku" }],
+    });
+    expect(text).toContain("### 🧭 CONCEPT läuft. Warte auf deine Entscheidungen auf der Seite · Agent `devops:research` arbeitet — ich MELDE mich");
+    expect(text).not.toContain("NOCH NICHT FERTIG");
+  });
+
+  test("a JSON-string concept field is coerced like the other structured fields", async () => {
+    const text = await cardText({
+      variant: "ready", summary: "x", lang: "de", session_id: "test-concept-6",
+      concept: '{"phase":"iterating"}',
+    });
+    expect(text).toContain("Arbeite an der nächsten Iteration");
+  });
+
+  test("no concept field leaves the normal CTA alone", async () => {
+    const text = await cardText({
+      variant: "ready", summary: "x", lang: "de", session_id: "test-concept-7",
+    });
+    expect(text).toContain("READY — SHIP oder ÄNDERN");
+    expect(text).not.toContain("CONCEPT läuft");
+  });
+});

--- a/plugins/devops/mcp-server/index.js
+++ b/plugins/devops/mcp-server/index.js
@@ -45,7 +45,7 @@ import { join, resolve, dirname } from "node:path";
 import { homedir, tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { correctShipVariant, renderDowngradeNote } from "./lib/variant-guard.js";
-import { hasPending, pendingWhat, renderPendingBlock, renderPendingLine } from "./lib/pending.js";
+import { hasPending, pendingWhat, renderPendingBlock, renderPendingLine, hasConcept, conceptWhat } from "./lib/pending.js";
 import { clampText, clampList } from "./lib/soft-limits.js";
 import {
   assessFreshness,
@@ -315,6 +315,9 @@ const CTA = {
     fallback:                 '## \ud83d\udd27 DONE \u2014 Anything ELSE?',
     // Pending layer \u2014 overrides EVERY variant's CTA while background work runs.
     pending:                  '## \u23f3 NOT DONE YET. {what} \u2014 I\u2019ll REPORT back',
+    // Concept layer — a concept page is open; outranks pending (the bridge's own
+    // tasks are plumbing, and any real work is folded into {what}).
+    concept:                  '## 🧭 CONCEPT open. {what} — I’ll REPORT back',
   },
   de: {
     'ship-successful-merged':      '## \ud83d\ude80 SHIPPED{chan}. merged \u2192 origin/{merged} \u2014 Alles ERLEDIGT',
@@ -335,6 +338,9 @@ const CTA = {
     fallback:                 '## \ud83d\udd27 DONE \u2014 Noch was ANDERES?',
     // Pending layer \u2014 overrides EVERY variant's CTA while background work runs.
     pending:                  '## \u23f3 NOCH NICHT FERTIG. {what} \u2014 ich MELDE mich',
+    // Concept layer — a concept page is open; outranks pending (the bridge's own
+    // tasks are plumbing, and any real work is folded into {what}).
+    concept:                  '## 🧭 CONCEPT läuft. {what} — ich MELDE mich',
   },
 };
 
@@ -679,9 +685,22 @@ function renderDeployGate(items, lang) {
   return labels.header + '\n' + bullets.join('\n') + '\n\n_' + labels.hint + '_';
 }
 
-function renderCTA(variant, cta, lang, state, delivery, pending) {
+function renderCTA(variant, cta, lang, state, delivery, pending, concept) {
   const templates = CTA[lang] || CTA.de;
   cta = cta || {};
+
+  // Concept layer — a concept page is open, so this turn is a checkpoint in a
+  // loop that ends on the page, not in chat. The bridge server, keepalive
+  // pulser and pickup waker run for the whole concept and are NOT pending work
+  // (stop.flow.guard ignores them), so the CTA must not say "3 Tasks laufen";
+  // it says which of the three true states the concept is in — waiting for
+  // decisions, working on the next iteration, implementing — and folds any REAL
+  // background work (content agents, a workflow) into that sentence. Outranks
+  // the pending layer for exactly that reason.
+  if (hasConcept(concept)) {
+    const tpl = templates.concept || CTA.de.concept;
+    return tpl.replace('{what}', conceptWhat(concept, pending, lang)).replace(/^## /, '### ');
+  }
 
   // Pending layer — background subagents / tasks the turn started are STILL
   // running. Every other CTA on this card would ask the user to act on a result
@@ -1031,7 +1050,7 @@ function renderCard(input, meterText, buildId) {
     }
   }
 
-  parts.push(renderCTA(variant, input.cta, lang, input.state, input.delivery, input.pending));
+  parts.push(renderCTA(variant, input.cta, lang, input.state, input.delivery, input.pending, input.concept));
   parts.push('');
 
   parts.push('---');
@@ -1179,7 +1198,7 @@ const CARD_VARIANTS = [
 /** Structured fields the MCP schema accepts as either an object or a JSON string. */
 const JSON_FIELDS = [
   'changes', 'tests', 'state', 'cta', 'userTest', 'userFinalTest',
-  'deployGate', 'validation', 'delivery', 'promotion', 'pending',
+  'deployGate', 'validation', 'delivery', 'promotion', 'pending', 'concept',
 ];
 
 /** Prefix that carries the relay contract with the card itself. */
@@ -1541,6 +1560,15 @@ server.registerTool(
           }),
         ])).optional(),
       ).describe("Background work STILL RUNNING at turn end — subagents started with run_in_background, backgrounded Bash tasks, or Workflow runs. MANDATORY whenever such work is in flight: it overrides the CTA of EVERY variant with '⏳ NOCH NICHT FERTIG. {what} — ich MELDE mich', names the first three items on a dim line directly above that CTA, and renders a block naming each item with what it is doing, so the card never asks the user to SHIP or act on a result that does not exist yet. The card body still reports what IS true; only the call to action is corrected. stop.flow.guard blocks the turn when open background work is detected and this field is missing."),
+      concept: z.preprocess(
+        v => typeof v === 'string' ? tryParse(v) : v,
+        z.union([
+          z.enum(["waiting", "iterating", "implementing"]),
+          z.object({
+            phase: z.enum(["waiting", "iterating", "implementing"]).optional().describe("'waiting' (default) = the page is open and the next step is the user's submission; 'iterating' = a submission was processed and the next iteration is being produced; 'implementing' = an implement submission is being executed."),
+          }),
+        ]).optional(),
+      ).describe("A /concept page is OPEN at turn end. Replaces the CTA of every variant — and outranks `pending` — with '🧭 CONCEPT läuft. {phase} — ich MELDE mich', where {phase} is one of: Warte auf deine Entscheidungen · Arbeite an der nächsten Iteration · Arbeite an der Implementierung. Real background work (content agents, a workflow) still goes into `pending` and is folded into that sentence ('… mit 2 Agenten'). The concept bridge's own tasks — bridge server, keepalive pulser, pickup waker — are infrastructure: NEVER list them in `pending`; stop.flow.guard ignores them."),
       deployGate: z.preprocess(
         v => typeof v === 'string' ? tryParse(v) : v,
         z.array(z.union([

--- a/plugins/devops/mcp-server/lib/pending.js
+++ b/plugins/devops/mcp-server/lib/pending.js
@@ -244,4 +244,102 @@ export function renderPendingBlock(pending, lang) {
   return L.header + '\n' + bullets.join('\n') + '\n\n_' + L.hint + '_';
 }
 
-export { PENDING_LABEL, CTA_NAME_LIMIT, LINE_NAME_LIMIT, BLOCK_ITEM_LIMIT, NAME_MAX };
+/**
+ * The `{what}` slot shape WITHOUT a verb — "Agent `x`" or "2 Agenten + 1 Task".
+ * Used where the sentence already has its verb (the concept CTA: "Arbeite an
+ * der Implementierung mit …"), so pendingWhat's "arbeiten" would double it.
+ */
+function pendingShape(pending, lang) {
+  const L = PENDING_LABEL[lang] || PENDING_LABEL.de;
+  const items = normalizePending(pending);
+  if (items.length === 0) return '';
+  if (items.length === 1) {
+    const names = nameList(items, CTA_NAME_LIMIT);
+    return names ? noun(L, items[0].kind, 1) + ' ' + names : '1 ' + noun(L, items[0].kind, 1);
+  }
+  return groupsOf(items)
+    .map(g => g.items.length + ' ' + noun(L, g.kind, g.items.length))
+    .join(' + ');
+}
+
+// ---------------------------------------------------------------------------
+// Concept layer — a concept page is open, so the turn is a checkpoint
+// ---------------------------------------------------------------------------
+//
+// While a concept page is open, the turn always ends in one of three states,
+// and none of them is "background work is running": the bridge server, the
+// keepalive pulser and the pickup waker are plumbing that stays up for the
+// whole concept — they never produce a result, they ARE the waiting. So the
+// concept CTA replaces the pending CTA and states the one thing that is true:
+// waiting for decisions, working on the next iteration, or implementing. Real
+// content agents (a frontend agent, a research workflow) still count and are
+// folded into the sentence — "Arbeite an der Implementierung mit 2 Agenten".
+
+/** Phases a concept session can be in when a turn hands back. */
+export const CONCEPT_PHASES = ['waiting', 'iterating', 'implementing'];
+
+const CONCEPT_LABEL = {
+  de: {
+    waiting: 'Warte auf deine Entscheidungen auf der Seite',
+    iterating: 'Arbeite an der nächsten Iteration',
+    implementing: 'Arbeite an der Implementierung',
+    with: 'mit',
+  },
+  en: {
+    waiting: 'Waiting for your decisions on the page',
+    iterating: 'Working on the next iteration',
+    implementing: 'Working on the implementation',
+    with: 'with',
+  },
+};
+
+/**
+ * Coerce the accepted `concept` shapes — a phase string or `{ phase }` — into
+ * `{ phase }`, or null when no concept is open. A truthy value with an unknown
+ * or missing phase still means "a concept is open" and defaults to waiting:
+ * the safe reading, since the only wrong card here is one that asks for a SHIP.
+ *
+ * @param {string|object|undefined} concept
+ * @returns {{ phase: 'waiting'|'iterating'|'implementing' }|null}
+ */
+export function normalizeConcept(concept) {
+  if (!concept) return null;
+  // A JSON-encoded object arrives as a string through the CLI fallback and any
+  // caller that skipped the schema's preprocess — parse it rather than reading
+  // the whole blob as an unknown phase.
+  if (typeof concept === 'string' && concept.trim().startsWith('{')) {
+    try { concept = JSON.parse(concept); } catch { /* keep the string */ }
+  }
+  const raw = typeof concept === 'string' ? concept : (typeof concept === 'object' ? concept.phase : '');
+  const phase = String(raw == null ? '' : raw).trim().toLowerCase();
+  return { phase: CONCEPT_PHASES.includes(phase) ? phase : 'waiting' };
+}
+
+/** True when the card must switch to the concept CTA. */
+export function hasConcept(concept) {
+  return normalizeConcept(concept) !== null;
+}
+
+/**
+ * The `{what}` slot of the concept CTA — the phase sentence, with any real
+ * background work folded in: "Arbeite an der Implementierung mit Agent
+ * `devops:frontend`". While waiting, open work is unusual, so it is appended
+ * as its own clause instead of pretending the wait is done "with" it.
+ *
+ * @param {string|object} concept
+ * @param {Array} [pending] — raw or normalized items (content work only; the
+ *   bridge's own tasks never belong here)
+ * @param {'de'|'en'} lang
+ * @returns {string} '' when no concept is open
+ */
+export function conceptWhat(concept, pending, lang) {
+  const c = normalizeConcept(concept);
+  if (!c) return '';
+  const L = CONCEPT_LABEL[lang] || CONCEPT_LABEL.de;
+  const shape = pendingShape(pending, lang);
+  if (!shape) return L[c.phase];
+  if (c.phase === 'waiting') return L[c.phase] + ' · ' + pendingWhat(pending, lang);
+  return L[c.phase] + ' ' + L.with + ' ' + shape;
+}
+
+export { PENDING_LABEL, CONCEPT_LABEL, CTA_NAME_LIMIT, LINE_NAME_LIMIT, BLOCK_ITEM_LIMIT, NAME_MAX };

--- a/plugins/devops/mcp-server/lib/pending.test.js
+++ b/plugins/devops/mcp-server/lib/pending.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   normalizePending, hasPending, pendingWhat, renderPendingLine, renderPendingBlock,
-  NAME_MAX,
+  NAME_MAX, normalizeConcept, hasConcept, conceptWhat,
 } from "./pending.js";
 
 describe("normalizePending", () => {
@@ -179,5 +179,61 @@ describe("renderPendingBlock", () => {
   it("is empty when nothing is pending", () => {
     expect(renderPendingBlock([], "de")).toBe("");
     expect(renderPendingBlock(undefined, "de")).toBe("");
+  });
+});
+
+describe("concept layer", () => {
+  it("normalizes a phase string and a { phase } object alike", () => {
+    expect(normalizeConcept("implementing")).toEqual({ phase: "implementing" });
+    expect(normalizeConcept({ phase: "iterating" })).toEqual({ phase: "iterating" });
+    expect(normalizeConcept({ phase: " Waiting " })).toEqual({ phase: "waiting" });
+  });
+
+  it("an open concept with an unknown or missing phase defaults to waiting", () => {
+    expect(normalizeConcept({})).toEqual({ phase: "waiting" });
+    expect(normalizeConcept({ phase: "done" })).toEqual({ phase: "waiting" });
+    expect(normalizeConcept(true)).toEqual({ phase: "waiting" });
+  });
+
+  it("nothing open → null, and hasConcept follows", () => {
+    expect(normalizeConcept(undefined)).toBeNull();
+    expect(normalizeConcept(null)).toBeNull();
+    expect(normalizeConcept("")).toBeNull();
+    expect(hasConcept(undefined)).toBe(false);
+    expect(hasConcept("waiting")).toBe(true);
+  });
+
+  it("states the phase alone when no content work is running", () => {
+    expect(conceptWhat("waiting", [], "de")).toBe("Warte auf deine Entscheidungen auf der Seite");
+    expect(conceptWhat("iterating", undefined, "de")).toBe("Arbeite an der nächsten Iteration");
+    expect(conceptWhat("implementing", [], "de")).toBe("Arbeite an der Implementierung");
+    expect(conceptWhat("implementing", [], "en")).toBe("Working on the implementation");
+  });
+
+  it("folds a single content agent into the implementing sentence by name", () => {
+    expect(conceptWhat("implementing", [{ name: "devops:frontend" }], "de"))
+      .toBe("Arbeite an der Implementierung mit Agent `devops:frontend`");
+    expect(conceptWhat("implementing", [{ name: "devops:frontend" }], "en"))
+      .toBe("Working on the implementation with agent `devops:frontend`");
+  });
+
+  it("folds several items in as counts per class, biggest unit first", () => {
+    const mix = [
+      { name: "devops:frontend" }, { name: "devops:core" },
+      { name: "harden-pass", kind: "workflow" }, { name: "npm test", kind: "task" },
+    ];
+    expect(conceptWhat("iterating", mix, "de"))
+      .toBe("Arbeite an der nächsten Iteration mit 1 Workflow + 2 Agenten + 1 Task");
+    expect(conceptWhat("iterating", mix, "en"))
+      .toBe("Working on the next iteration with 1 workflow + 2 agents + 1 task");
+  });
+
+  it("while waiting, open work is its own clause rather than 'with'", () => {
+    expect(conceptWhat("waiting", [{ name: "devops:research" }], "de"))
+      .toBe("Warte auf deine Entscheidungen auf der Seite · Agent `devops:research` arbeitet");
+  });
+
+  it("returns nothing when no concept is open", () => {
+    expect(conceptWhat(undefined, [{ name: "x" }], "de")).toBe("");
   });
 });

--- a/plugins/devops/skills/concept/SKILL.md
+++ b/plugins/devops/skills/concept/SKILL.md
@@ -712,6 +712,11 @@ is idle and has multi-minute gaps in practice (observed: 638 s with the cron
 registered and the session idle). It stays armed as the backup pickup path,
 never as the primary one.
 
+**Neither task — nor the bridge server — is pending work.** They run for the
+whole concept and never yield a result; they are the waiting itself.
+`stop.flow.guard` ignores them, and they must NEVER appear in a completion
+card's `pending` field. See § Completion cards while the concept is open.
+
 Pass the state file's **absolute** path via `--state`. The watchers used to
 test a relative `.claude/concept-active.json` against their own cwd, which is
 not always the project root the state file lives in — both then exited
@@ -758,6 +763,28 @@ Pick the wording that matches the `[ui-locale: ...]` hint injected by
 **de:**
 > Concept geöffnet. Triff deine Entscheidungen auf der Seite und klick
 > "Entscheidungen abschicken" wenn du fertig bist — ich übernehme dann.
+
+### Completion cards while the concept is open
+
+Every turn that ends with the concept still open — right after opening the
+page, after each processing round, after a stale wake — renders its completion
+card with the `concept` field. That replaces the CTA of whatever variant the
+turn earned (and outranks `pending`) with the one statement that is true:
+
+| `concept.phase` | When | CTA (DE) |
+|---|---|---|
+| `waiting` (default) | Page is open, next step is the user's submission | `🧭 CONCEPT läuft. Warte auf deine Entscheidungen auf der Seite — ich MELDE mich` |
+| `iterating` | A submission was processed and the next iteration is still being produced (e.g. by background agents) | `🧭 CONCEPT läuft. Arbeite an der nächsten Iteration — ich MELDE mich` |
+| `implementing` | An `implement` submission is being executed and the turn hands back before it lands | `🧭 CONCEPT läuft. Arbeite an der Implementierung — ich MELDE mich` |
+
+Real content work still goes into `pending` — a feature agent implementing the
+submission, a research workflow preparing the next round — and the card folds
+it into that line (`… mit 2 Agenten`) and names each item in the pending block.
+The bridge server, keepalive pulser and pickup waker are **not** content work:
+never list them there. A card that names them is the bug this field fixes.
+
+The final card (Step 6b) carries no `concept` field: by then the bridge is
+down and the concept is closed.
 
 ## Step 4 — Monitor via HTTP Bridge
 
@@ -1487,7 +1514,9 @@ Call `mcp__plugin_devops_dotclaude-completion__render_completion_card`:
 
 Pass: `variant`, `summary` (e.g. "Concept auth-middleware-redesign finalized"),
 `lang`, `session_id`, `changes` (what the concept covered and which decisions
-were acted on), and `state` when files changed.
+were acted on), and `state` when files changed. Do **not** pass `concept` here —
+the concept is closed; that field belongs to the mid-concept cards only (Step 3
+§ Completion cards while the concept is open).
 
 Output the returned markdown VERBATIM as the LAST thing in the response —
 nothing after the closing `---`.

--- a/plugins/devops/skills/concept/deep-knowledge/bridge-server.md
+++ b/plugins/devops/skills/concept/deep-knowledge/bridge-server.md
@@ -406,6 +406,15 @@ AND provides HTTP endpoints for heartbeat and decision exchange.
    processing round the REPL is busy. That window is closed by re-launching
    early, not by the cron.
 
+   **None of the three is pending work.** The server, the pulser and the waker
+   run for the whole concept and never yield a result — they are the waiting
+   itself. `stop.flow.guard` recognizes them (by `concept-server.py` /
+   `concept-watch.js` in the command, or by the role the launch description
+   names) and ignores them; a completion card must never list them under
+   `pending`. A card rendered while the concept is open carries
+   `concept: { phase }` instead (SKILL.md § Completion cards while the concept
+   is open).
+
 4. **Persist active-concept state.** Write `.claude/concept-active.json` in
    the project root with the metadata the SessionStart resume hook
    (`ss.concept.resume`) needs to recover this concept after a Claude

--- a/plugins/devops/templates/completion-card.md
+++ b/plugins/devops/templates/completion-card.md
@@ -478,6 +478,39 @@ a real transcript entry rather than the payload of a `tool_result`. Without thos
 guards one grep opens an item nothing will ever close, and every later card in
 the session is blocked.
 
+### Concept override — a /concept page is open
+
+`concept` is the sibling of `pending` for the one situation where "still
+running" is the wrong statement: a `/concept` page is open, and the turn ends
+because the loop continues **on the page**, not in chat. The bridge server, the
+keepalive pulser and the pickup waker are background Bash tasks that run for the
+whole concept and never yield a result — they are not work, they ARE the
+waiting. Counting them produced `3 Tasks laufen — ich MELDE mich` on every
+concept card, naming plumbing instead of the one true state. So:
+
+- `stop.flow.guard` ignores those three tasks (recognized by the script they
+  run — `concept-server.py`, `concept-watch.js` — or the role their launch
+  description names). Never list them under `pending`.
+- Every card rendered while the concept is open carries
+  `concept: { phase }`, and that **outranks `pending`** for the CTA:
+
+| Phase | DE | EN |
+|-------|----|----|
+| `waiting` (default) | `### 🧭 CONCEPT läuft. Warte auf deine Entscheidungen auf der Seite — ich MELDE mich` | `### 🧭 CONCEPT open. Waiting for your decisions on the page — I'll REPORT back` |
+| `iterating` | `### 🧭 CONCEPT läuft. Arbeite an der nächsten Iteration — ich MELDE mich` | `### 🧭 CONCEPT open. Working on the next iteration — I'll REPORT back` |
+| `implementing` | `### 🧭 CONCEPT läuft. Arbeite an der Implementierung — ich MELDE mich` | `### 🧭 CONCEPT open. Working on the implementation — I'll REPORT back` |
+
+Real content work — a frontend agent implementing the submission, a research
+workflow preparing the next iteration — still goes into `pending` and is folded
+into that line rather than replacing it: `Arbeite an der Implementierung mit
+Agent \`devops:frontend\`` · `… mit 1 Workflow + 2 Agenten`. The pending block
+and the dim name line render as usual, so the user still reads WHICH agents run.
+While `waiting`, open work is appended as its own clause
+(`Warte auf deine Entscheidungen auf der Seite · Agent \`x\` arbeitet`).
+
+The final card of a concept (Step 6b of the skill, after cleanup) carries no
+`concept` field — the concept is closed, and the variant's own CTA applies.
+
 ### Footer line
 
 `📌 {{version-bump}} · {{build-id}}`

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.147.0",
+  "version": "0.148.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

While a `/concept` page is open, three detached Bash tasks run for the whole session — the bridge server, the keepalive pulser and the pickup waker. They never yield a result; they *are* the waiting. The pending gate counted them anyway, so every card rendered mid-concept read "⏳ NOCH NICHT FERTIG. 3 Tasks (Start the concept bridge server on port 8840, Launch the keepalive pulser …) laufen — ich MELDE mich", naming plumbing where the only true statement was "waiting for your decisions".

## What changed

**Concept infrastructure is not pending work.** `hooks/lib/pending-tasks.js` recognizes the three tasks — by the script they run (`concept-server.py`, `concept-watch.js`) or the role their launch description names — and `scanOpenTasks` never opens them, so `stop.flow.guard` ignores them. A real agent or `npm test` launched alongside is still reported. The PostToolUse reminder says `[concept]` for these launches instead of `[pending]`, so the model is not steered into listing them.

**New card field `concept: { phase }`** — `waiting` (default), `iterating`, `implementing`. It replaces the CTA of every variant, and outranks `pending`, with "🧭 CONCEPT läuft. Warte auf deine Entscheidungen auf der Seite / Arbeite an der nächsten Iteration / Arbeite an der Implementierung — ich MELDE mich". Real content work still goes into `pending` and is folded into that line (`… mit Agent \`devops:frontend\``, `… mit 1 Workflow + 2 Agenten`); the pending block and the dim name row keep naming each item. JSON string, bare phase string and object are all accepted; an unknown phase reads as waiting.

**Docs:** completion-card template (§ Concept override), concept skill (§ Completion cards while the concept is open; final card carries no `concept`), bridge-server.md, plugin-behavior.md, card-guard block reasons.

## Tests

- 26 new tests: scanner exclusion (script-only, role-only, real work alongside, false-positive guard), hook reminder routing, `conceptWhat` wording DE/EN, card rendering incl. precedence over `pending` and JSON-string coercion.
- Full suite: 108 files, 2651 tests green. ESLint clean.
- CLI fallback render of the reported scenario: `### 🧭 CONCEPT läuft. Warte auf deine Entscheidungen auf der Seite — ich MELDE mich`.

Codex review gate: skipped (Codex usage limit reached, rc=1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)