### PR TITLE
fix(concept): gate matches copy-out clipboard API, not the bare word

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.149.0"
+    "version": "0.149.1"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.149.0",
+      "version": "0.149.1",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.149.0",
+      "version": "0.149.1",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.149.1] — 2026-09-07
+
+### Fixed
+
+- **The concept gate blocked every page that carried the templates' own paste handler.** `post.concept.gate` forbade the bare word `clipboard`, meant to catch the "copy the decisions JSON and paste it into chat" fallback. The attachment engine that every page inherits from the reference reads `ev.clipboardData` for Ctrl/Cmd+V file paste — a paste *into* the page, the opposite direction — so a page generated verbatim from `templates.md` failed its own gate on the next Edit, and the workaround was to obfuscate the property name and re-apply it after every engine re-sync. The gate (and the Phase 0 grep in `validation-gate.md`) now match the copy-out forms only: `navigator.clipboard`, `clipboard.writeText` / `readText`, "copy to clipboard"; `Zwischenablage` and the paste-into-chat wording are unchanged. (#330)
+
 ## [0.149.0] — 2026-09-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.149.0**
+**Version: 0.149.1**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.149.0",
+  "version": "0.149.1",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/hooks/lib/concept-gate.js
+++ b/plugins/devops/hooks/lib/concept-gate.js
@@ -33,8 +33,14 @@ const REQUIRED = [
 // Clipboard / paste-into-chat submit anti-patterns. A valid live-bridge
 // concept page never copies anything to the clipboard, so any match here is
 // the exact regression the user reported.
+//
+// The clipboard pattern matches the copy-out API and the copy-out UI wording
+// only — NOT the bare word. The templates' own attachment engine legitimately
+// reads `ev.clipboardData` for Ctrl/Cmd+V file paste (templates.md
+// § Attachments), and a bare /clipboard/ blocked every page generated verbatim
+// from the reference (#330).
 const FORBIDDEN = [
-  { re: /clipboard/i, why: 'clipboard copy (navigator.clipboard / "copy to clipboard")' },
+  { re: /navigator\.clipboard|clipboard\.(write|read)(Text)?\(|copy (to|into) (the )?clipboard/i, why: 'clipboard copy (navigator.clipboard / clipboard.writeText / "copy to clipboard")' },
   { re: /zwischenablage/i, why: '"Zwischenablage kopieren" copy UI' },
   { re: /in den chat (ein|einf)/i, why: '"in den Chat einfügen" paste instruction' },
   { re: /paste[^.\n]{0,24}chat/i, why: '"paste … into chat" instruction' },

--- a/plugins/devops/hooks/lib/concept-gate.test.js
+++ b/plugins/devops/hooks/lib/concept-gate.test.js
@@ -91,6 +91,30 @@ describe("findForbidden", () => {
     expect(findForbidden("<button onclick='navigator.clipboard.writeText(x)'>copy</button>").length)
       .toBeGreaterThan(0);
   });
+
+  test("catches a detached clipboard.writeText / 'copy to clipboard' UI", () => {
+    expect(findForbidden("<script>const c = navigator.clipboard; c.writeText(md);</script>").length)
+      .toBeGreaterThan(0);
+    expect(findForbidden("<script>clip.writeText(md)</script><button>Copy to clipboard</button>").length)
+      .toBeGreaterThan(0);
+  });
+
+  // #330 — the templates' own Ctrl/Cmd+V attachment handler reads
+  // ev.clipboardData. That is a paste INTO the page, not a copy OUT of it, and
+  // a page generated verbatim from the reference must pass its own gate.
+  test("does NOT flag the sanctioned ev.clipboardData paste handler (#330)", () => {
+    const PASTE_HANDLER = `<script>
+      function initCommentAttachments(ta) {
+        ta.addEventListener('paste', function (ev) {
+          const dt = ev.clipboardData || {};
+          const files = Array.from(dt.files || []);
+          if (files.length) { ev.preventDefault(); files.forEach(f => uploadAttachment(f)); }
+        });
+      }
+    </script>`;
+    expect(findForbidden(PASTE_HANDLER)).toEqual([]);
+    expect(findForbidden(VALID + PASTE_HANDLER)).toEqual([]);
+  });
 });
 
 describe("evaluate", () => {

--- a/plugins/devops/skills/concept/deep-knowledge/validation-gate.md
+++ b/plugins/devops/skills/concept/deep-knowledge/validation-gate.md
@@ -27,13 +27,22 @@ and regenerate with the live submit, exactly like a missing required pattern.
 
 | Forbidden grep (case-insensitive) | Why it's banned |
 |---|---|
-| `clipboard` (`navigator.clipboard`, "copy to clipboard") | A "copy the decisions JSON" button is the regression this gate exists to kill — the live bridge already delivers decisions. |
+| `navigator.clipboard` / `clipboard.writeText` / `clipboard.readText` / "copy to clipboard" | A "copy the decisions JSON" button is the regression this gate exists to kill — the live bridge already delivers decisions. |
 | `zwischenablage` | German variant of the same clipboard-copy fallback. |
 | `in den chat ein` / "paste … into chat" | Instructing the user to paste anything into chat means the live submit was never wired. |
 
-A valid live-bridge page never copies anything to the clipboard, so there are
-no legitimate matches — do not "keep it as a convenience". The decision panel
-+ live submit is the only sanctioned mechanism, and it may never be omitted.
+A valid live-bridge page never copies anything **out** to the clipboard, so
+there are no legitimate matches for the copy-out API or wording — do not "keep
+it as a convenience". The decision panel + live submit is the only sanctioned
+mechanism, and it may never be omitted.
+
+**Not forbidden — the bare word is not the pattern (#330).** The attachment
+engine (`templates.md` § Attachments, `initCommentAttachments()`) reads
+`ev.clipboardData` in its Ctrl/Cmd+V paste handler. That is a paste *into* the
+page, the opposite direction, and every page generated verbatim from the
+reference contains it. Grep for the copy-out forms above, never for a bare
+`clipboard`; `post.concept.gate` (`hooks/lib/concept-gate.js`) uses the same
+narrowed pattern.
 
 ## Phase 1 — Shared patterns (ALL templates)
 

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.149.0",
+  "version": "0.149.1",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
Closes #330

## Summary
- `post.concept.gate` forbade the bare word `clipboard`, which blocked every page carrying the templates' own Ctrl/Cmd+V attachment handler (`ev.clipboardData`).
- The forbidden pattern now matches copy-out forms only: `navigator.clipboard`, `clipboard.writeText` / `readText`, "copy to clipboard". `Zwischenablage` and paste-into-chat wording unchanged.
- `validation-gate.md` Phase 0 documents the same narrowing and the sanctioned `clipboardData` read.
- Tests: sanctioned paste handler passes; detached `writeText` / "Copy to clipboard" UI still blocked.

## Release
- Version 0.149.0 → 0.149.1 (patch), CHANGELOG entry added.

Shipped by /run-backlog (autonomous, lockout armed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)