### PR TITLE
fix(concept): gate blocks nested or unbalanced style/script blocks

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.149.1"
+    "version": "0.149.2"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.149.1",
+      "version": "0.149.2",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.149.1",
+      "version": "0.149.2",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.149.2] — 2026-09-07
+
+### Fixed
+
+- **The concept gate passed a page whose style block was nested and unstyled.** When the shared engine CSS was carried over from an earlier concept page, the opening `<style>` line landed *inside* the new style block; the CSS parser swallowed the whole `:root` design-token block, the page rendered white with no dark theme — and every gate grep still passed, because all marker strings were present. `post.concept.gate` now walks the `<style>`/`<script>` tag stream and blocks on a nested opener, a stray closer, an unclosed block or an open/close count mismatch, naming the offsets; a `<style` token inside an open `<script>` is treated as JS string content, so the templates' own markup-building strings do not trip it. `validation-gate.md` gained the same rule as Phase 0b, and the concept skill now evaluates `getComputedStyle(document.documentElement).getPropertyValue('--bg-color')` in a browser between the 200 gate and the `start` — an empty value means the tokens were swallowed by something only a CSS parser sees, and the tab is not opened. (#346)
+
 ## [0.149.1] — 2026-09-07
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.149.1**
+**Version: 0.149.2**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.149.1",
+  "version": "0.149.2",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/hooks/lib/concept-gate.js
+++ b/plugins/devops/hooks/lib/concept-gate.js
@@ -79,23 +79,104 @@ function findForbidden(html) {
 }
 
 /**
+ * Structural integrity of the `<style>` / `<script>` blocks (#346).
+ *
+ * Every marker grep passes on a page whose opening `<style>` line was copied
+ * INSIDE the new style block (engine CSS carried over from an older page):
+ * the CSS parser swallows the whole `:root` token block and the page renders
+ * white and unthemed — "das ganze Konzept kaputt dargestellt" — while all the
+ * required tokens are still present. So the gate walks the tag stream and
+ * reports: a `<style` or `<script` that opens while a block of that kind is
+ * already open, a closing tag with no open block, an open block that never
+ * closes, and an open/close count mismatch per kind. A `<style` token seen
+ * while a `<script>` block is open is ignored — that is a string inside JS,
+ * not markup — and only the tag-open form (`<style>` / `<style ...>`) counts,
+ * never a bare mention in prose or a comment.
+ *
+ * @returns {Array<{kind:string, why:string, at:number}>} — empty when sound.
+ */
+function findStructural(html) {
+  const body = html || '';
+  const issues = [];
+  const re = /<(\/?)(style|script)(?=[\s>])/gi;
+  const open = { style: null, script: null };
+  const counts = { style: { open: 0, close: 0 }, script: { open: 0, close: 0 } };
+  let m;
+  while ((m = re.exec(body)) !== null) {
+    const closing = m[1] === '/';
+    const kind = m[2].toLowerCase();
+    const at = m.index;
+    // Inside an open <script>, a "<style" / "<script" token is JS string
+    // content (template literals building markup), not a tag.
+    if (open.script !== null && !(closing && kind === 'script')) continue;
+    if (closing) {
+      counts[kind].close += 1;
+      if (open[kind] === null) {
+        issues.push({ kind: `stray-close-${kind}`, why: `</${kind}> at offset ${at} closes nothing — no open <${kind}> block`, at });
+      } else {
+        open[kind] = null;
+      }
+      continue;
+    }
+    counts[kind].open += 1;
+    if (open[kind] !== null) {
+      issues.push({ kind: `nested-${kind}`, why: `<${kind}> at offset ${at} opens inside the <${kind}> block that opened at offset ${open[kind]} — the parser swallows everything up to the next </${kind}>`, at });
+      continue; // keep the outer block as the open one
+    }
+    if (kind === 'script' && open.style !== null) {
+      issues.push({ kind: 'script-in-style', why: `<script> at offset ${at} opens inside the <style> block that opened at offset ${open.style}`, at });
+      continue;
+    }
+    open[kind] = at;
+  }
+  for (const kind of ['style', 'script']) {
+    if (open[kind] !== null) {
+      issues.push({ kind: `unclosed-${kind}`, why: `<${kind}> at offset ${open[kind]} is never closed`, at: open[kind] });
+    }
+    const c = counts[kind];
+    if (c.open !== c.close) {
+      issues.push({ kind: `unbalanced-${kind}`, why: `${c.open} <${kind}> vs ${c.close} </${kind}> tags`, at: -1 });
+    }
+  }
+  return issues;
+}
+
+/**
  * Full evaluation for a written file.
- * @returns {{applicable:boolean, ok:boolean, missing:Array, forbidden:Array}}
+ * @returns {{applicable:boolean, ok:boolean, missing:Array, forbidden:Array, structural:Array}}
  */
 function evaluate(filePath, html) {
   if (!isConceptHtml(filePath, html)) {
-    return { applicable: false, ok: true, missing: [], forbidden: [] };
+    return { applicable: false, ok: true, missing: [], forbidden: [], structural: [] };
   }
   const missing = findMissing(html);
   const forbidden = findForbidden(html);
-  return { applicable: true, ok: missing.length === 0 && forbidden.length === 0, missing, forbidden };
+  const structural = findStructural(html);
+  return {
+    applicable: true,
+    ok: missing.length === 0 && forbidden.length === 0 && structural.length === 0,
+    missing,
+    forbidden,
+    structural,
+  };
 }
 
 /** Build the blocking feedback shown to Claude (stderr, exit 2). */
-function buildBlockReason(filePath, missing, forbidden) {
+function buildBlockReason(filePath, missing, forbidden, structural) {
+  missing = missing || [];
+  forbidden = forbidden || [];
+  structural = structural || [];
   const lines = [];
   lines.push(`BLOCKED: "${path.basename(filePath || 'concept.html')}" is not a valid live-bridge concept page.`);
   lines.push('');
+  if (structural.length) {
+    lines.push('Broken <style> / <script> structure — the page renders unstyled (white, no theme) even though every marker is present:');
+    structural.forEach(s => lines.push(`  - ${s.kind}: ${s.why}`));
+    lines.push('  Typical cause: the opening <style> line of an older page was pasted INSIDE the new style block.');
+    lines.push('  Fix: exactly one <style> per block, closed before the next tag; then verify in the browser that');
+    lines.push("  getComputedStyle(document.documentElement).getPropertyValue('--bg-color') is non-empty.");
+    lines.push('');
+  }
   if (forbidden.length) {
     lines.push('Forbidden clipboard / paste-into-chat submit detected:');
     forbidden.forEach(f => lines.push(`  - ${f.why}`));
@@ -127,6 +208,7 @@ module.exports = {
   isConceptHtml,
   findMissing,
   findForbidden,
+  findStructural,
   evaluate,
   buildBlockReason,
 };

--- a/plugins/devops/hooks/lib/concept-gate.test.js
+++ b/plugins/devops/hooks/lib/concept-gate.test.js
@@ -4,6 +4,7 @@ import {
   isConceptHtml,
   findMissing,
   findForbidden,
+  findStructural,
   evaluate,
   buildBlockReason,
 } from "./concept-gate.js";
@@ -114,6 +115,81 @@ describe("findForbidden", () => {
     </script>`;
     expect(findForbidden(PASTE_HANDLER)).toEqual([]);
     expect(findForbidden(VALID + PASTE_HANDLER)).toEqual([]);
+  });
+});
+
+// #346 — the reported regression: the opening <style> line of an older page
+// was pasted INSIDE the new style block. Every marker grep passes, the CSS
+// parser swallows the :root token block, the page renders white.
+describe("findStructural (#346)", () => {
+  const STYLED = `<!doctype html><html><head>
+<style>
+:root { --bg-color: #111; }
+body { background: var(--bg-color); }
+</style>
+</head><body>
+<script>const a = 1;</script>
+<script type="application/json" id="concept-decisions">{}</script>
+</body></html>`;
+
+  test("a page with balanced, non-nested blocks is sound", () => {
+    expect(findStructural(STYLED)).toEqual([]);
+    expect(findStructural(VALID)).toEqual([]);
+  });
+
+  test("a <style> opened inside an open <style> block is reported as nested", () => {
+    const nested = STYLED.replace(":root {", "<style>\n:root {");
+    const kinds = findStructural(nested).map(s => s.kind);
+    expect(kinds).toContain("nested-style");
+    expect(kinds).toContain("unbalanced-style");
+  });
+
+  test("an unclosed <script> is reported as unclosed and unbalanced", () => {
+    const unclosed = STYLED.replace(/<script>const a = 1;<\/script>[\s\S]*$/, "<script>const a = 1;\n");
+    const kinds = findStructural(unclosed).map(s => s.kind);
+    expect(kinds).toContain("unclosed-script");
+    expect(kinds).toContain("unbalanced-script");
+  });
+
+  test("a <script> that opens inside an open <style> block is reported", () => {
+    const kinds = findStructural("<style>:root{}<script>x()</script></style>").map(s => s.kind);
+    expect(kinds).toContain("script-in-style");
+  });
+
+  test("a stray </style> with no open block is reported", () => {
+    const kinds = findStructural("<html><body></style><p>x</p></body></html>").map(s => s.kind);
+    expect(kinds).toContain("stray-close-style");
+  });
+
+  test("'<style' inside a JS string is not a tag (no false positive)", () => {
+    const js = `<style>:root{--bg-color:#000}</style>
+<script>
+  const frame = '<style>' + css + '</style>';
+  const tpl = \`<div>\${'<script'}</div>\`;
+</script>`;
+    expect(findStructural(js)).toEqual([]);
+  });
+
+  test("the bare word 'style' in prose or attributes is not a tag", () => {
+    expect(findStructural(`<style>a{}</style><p style="color:red">style guide, restyle</p>`)).toEqual([]);
+  });
+
+  test("evaluate surfaces structural issues as their own category and fails the page", () => {
+    const nestedValid = VALID.replace("<body>", "<style>\n<style>\n:root{--bg-color:#000}\n</style>\n<body>");
+    const r = evaluate("docs/concepts/2026-09-07-broken.html", nestedValid);
+    expect(r.ok).toBe(false);
+    expect(r.missing).toEqual([]);
+    expect(r.forbidden).toEqual([]);
+    expect(r.structural.map(s => s.kind)).toContain("nested-style");
+    const reason = buildBlockReason("docs/concepts/2026-09-07-broken.html", r.missing, r.forbidden, r.structural);
+    expect(reason).toMatch(/Broken <style> \/ <script> structure/);
+    expect(reason).toMatch(/nested-style/);
+    expect(reason).toMatch(/--bg-color/);
+  });
+
+  test("buildBlockReason without the structural argument still works (older callers)", () => {
+    const r = evaluate("docs/concepts/2026-06-07-haushalt.html", CLIPBOARD_FALLBACK);
+    expect(() => buildBlockReason("x.html", r.missing, r.forbidden)).not.toThrow();
   });
 });
 

--- a/plugins/devops/hooks/post-tool-use/post.concept.gate.js
+++ b/plugins/devops/hooks/post-tool-use/post.concept.gate.js
@@ -7,10 +7,12 @@
  * @matcher Write|Edit|NotebookEdit
  * @description Deterministic backstop for concept pages. After a
  *   concept HTML is written, verify it carries the live decision panel +
- *   bridge-submit markers and contains NO clipboard / paste-into-chat
- *   fallback. Blocks (exit 2) with actionable feedback when the page is
- *   invalid, so the regression survives only until the next regenerate —
- *   never until the user has to copy a JSON by hand.
+ *   bridge-submit markers, contains NO clipboard / paste-into-chat
+ *   fallback, and has sound <style>/<script> structure (no nested or
+ *   unclosed block — the "white, unthemed page" regression, #346). Blocks
+ *   (exit 2) with actionable feedback when the page is invalid, so the
+ *   regression survives only until the next regenerate — never until the
+ *   user has to copy a JSON by hand.
  *
  *   Scope: only fires on concept HTML (the `docs/concepts/` path or a concept
  *   content signature). Non-concept files pass through untouched. This is a
@@ -52,9 +54,9 @@ process.stdin.on('end', () => {
 
   if (!isConceptHtml(file, html)) process.exit(0);
 
-  const { ok, missing, forbidden } = evaluate(file, html);
+  const { ok, missing, forbidden, structural } = evaluate(file, html);
   if (ok) process.exit(0);
 
-  process.stderr.write(buildBlockReason(file, missing, forbidden) + '\n');
+  process.stderr.write(buildBlockReason(file, missing, forbidden, structural) + '\n');
   process.exit(2);
 });

--- a/plugins/devops/skills/concept/SKILL.md
+++ b/plugins/devops/skills/concept/SKILL.md
@@ -707,6 +707,25 @@ microsoft-edge "$URL" &
 The empty `""` on Windows is required — without it, `cmd.exe` interprets
 the first quoted argument as a window title.
 
+**Computed-token check — between the 200 gate and the `start` (#346).** A
+page can pass every grep and still open white: the design-token block is
+swallowed when a `<style>` opens inside a `<style>` (engine CSS carried over
+from an older page) or a stray brace ends `:root` early. `post.concept.gate`
+and `validation-gate.md` § Phase 0b catch the tag structure; this step catches
+what only a CSS parser sees. Load `$URL` in a headless browser context (the
+Claude browser pane / Playwright — NOT the tab the user will get; this is a
+read of the rendered CSS, no bridge interaction) and evaluate:
+
+```js
+getComputedStyle(document.documentElement).getPropertyValue('--bg-color').trim()
+```
+
+Non-empty → proceed to `start`. Empty → do NOT open the tab; regenerate the
+`<style>` block from `templates.md` § Layout (exactly one `<style>` opener,
+closed before the next tag), re-run the gate, re-check. Skip the check only
+when no browser tool is reachable at all — then say so in the completion card's
+`userFinalTest` so the user knows the theme was not verified.
+
 **If the `start "" msedge …` command errors** (Edge not installed, not in
 PATH), do NOT silently fall back to the preview MCP. Tell the user the
 exact error and ask whether to try the Edge protocol handler

--- a/plugins/devops/skills/concept/deep-knowledge/validation-gate.md
+++ b/plugins/devops/skills/concept/deep-knowledge/validation-gate.md
@@ -44,6 +44,40 @@ reference contains it. Grep for the copy-out forms above, never for a bare
 `clipboard`; `post.concept.gate` (`hooks/lib/concept-gate.js`) uses the same
 narrowed pattern.
 
+## Phase 0b — Structural integrity (hard fail, #346)
+
+Every grep in Phase 1 and 2 passes on a page whose `<style>` block is broken:
+when the shared engine CSS was carried over from an earlier concept page, the
+opening `<style>` line was copied *inside* the new style block. The CSS parser
+then swallowed the whole `:root` design-token block, the page rendered white
+and unthemed in design mode with no dark theme — and every marker string was
+still present. So before the pattern sweep, check the tag structure:
+
+| Check | Rule |
+|---|---|
+| Balance | count of `<style` equals `</style>`; count of `<script` equals `</script>` (tag-open form only — `<style>` / `<style …>` — never the bare word in prose or a `style="…"` attribute) |
+| No nesting | no `<style` opens while a `<style>` block is open; no `<script` opens while a `<script>` or `<style>` block is open |
+| No strays | no `</style>` / `</script>` without an open block; no block left open at end of file |
+
+```bash
+# quick balance check — must print two equal pairs
+grep -oiE '<style[[:space:]>]' "$HTML" | wc -l; grep -oi '</style>' "$HTML" | wc -l
+grep -oiE '<script[[:space:]>]' "$HTML" | wc -l; grep -oi '</script>' "$HTML" | wc -l
+```
+
+`post.concept.gate` runs the same walk (`findStructural()` in
+`hooks/lib/concept-gate.js`) on every write and blocks with the offending
+offsets. A `<style` token inside an open `<script>` block is JS string content
+(template literals that build markup) and is ignored.
+
+**Then confirm the tokens actually applied — in the browser, before the page is
+shown (SKILL.md Step 3).** Evaluate
+`getComputedStyle(document.documentElement).getPropertyValue('--bg-color')` on
+the loaded page; it MUST be non-empty. An empty value means the design-token
+block was swallowed even though the file looks balanced (a stray `{`, an
+unterminated comment) — regenerate the block from `templates.md` § Layout
+before opening the tab.
+
 ## Phase 1 — Shared patterns (ALL templates)
 
 Every concept page must contain these 66 patterns, regardless of template

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.149.1",
+  "version": "0.149.2",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
Closes #346

## Summary
- A page whose opening `<style>` line was pasted inside the new style block passed every marker grep and rendered white and unthemed.
- `post.concept.gate` now walks the `<style>`/`<script>` tag stream and blocks on a nested opener, stray closer, unclosed block or count mismatch (own failure category, offsets named). A `<style` token inside an open `<script>` is treated as JS string content.
- `validation-gate.md` Phase 0b documents the rule; the concept skill now evaluates `--bg-color` via `getComputedStyle` in a browser between the 200 gate and the `start`.
- Verified `findStructural()` against the 7 sample pages in `docs/concepts/` (0 issues); 9 new tests.

## Release
- Version 0.149.1 → 0.149.2 (patch), CHANGELOG entry added.

Shipped by /run-backlog (autonomous, lockout armed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)