### PR TITLE
fix(concept): isolate concept-server store dirs from test spawns

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.149.2"
+    "version": "0.149.3"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.149.2",
+      "version": "0.149.3",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.149.2",
+      "version": "0.149.3",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.149.3] — 2026-09-07
+
+### Fixed
+
+- **The concept-server test suite no longer litters the worktree with `port-<n>` stores.** A bridge started without `--html` anchors its durable store at `.claude/concepts/port-<n>/` in its cwd, and `concept-server.test.js` spawned four such servers per run — fifteen leftover directories after one afternoon, sitting next to real concept sessions where the UNPROCESSED guard and the orphan sweep are supposed to mean something. Every spawn now gets a throw-away `--store` under the OS temp dir (the same pattern `CONCEPT_BRIDGE_REGISTRY_DIR` uses for the registry), and an `afterAll` asserts the run added no `port-*` store to the cwd. The `/concept` orphan sweep names `port-*` stores explicitly as sweep-eligible. (#342)
+
 ## [0.149.2] — 2026-09-07
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.149.2**
+**Version: 0.149.3**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.149.2",
+  "version": "0.149.3",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/scripts/concept-server.test.js
+++ b/plugins/devops/scripts/concept-server.test.js
@@ -1,4 +1,4 @@
-import { describe, test, expect } from "vitest";
+import { describe, test, expect, afterAll } from "vitest";
 import { spawn, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
@@ -42,8 +42,31 @@ const PORT = 18000 + (process.pid % 1000);
 // override each run left its entries behind in the user's real registry.
 process.env.CONCEPT_BRIDGE_REGISTRY_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "concept-bridges-test-"));
 
+// Same pattern for the durable store (#342): a server started without --html
+// anchors its store at .claude/concepts/port-<n>/ in its cwd — the worktree
+// this suite runs from — and every spawn below left one behind. Point each
+// spawn at a throw-away store instead, so .claude/concepts/ only ever holds
+// real concept sessions and the UNPROCESSED guard + orphan sweep stay meaningful.
+const STORE_ROOT = fs.mkdtempSync(path.join(os.tmpdir(), "concept-store-test-"));
+const storeFor = (port) => path.join(STORE_ROOT, String(port));
+
+// Snapshot of the port-* stores that already exist in the cwd before the suite
+// runs (debris from older plugin versions is not this suite's to judge) — the
+// afterAll asserts that THIS run added none.
+const CONCEPTS_DIR = path.join(process.cwd(), ".claude", "concepts");
+const listPortStores = () => {
+  try { return fs.readdirSync(CONCEPTS_DIR).filter(d => /^port-\d+$/.test(d)).sort(); }
+  catch { return []; }
+};
+const portStoresBefore = listPortStores();
+
+afterAll(() => {
+  expect(listPortStores()).toEqual(portStoresBefore);
+  try { fs.rmSync(STORE_ROOT, { recursive: true, force: true }); } catch { /* best effort */ }
+});
+
 function startServer() {
-  const proc = spawn(PY, [SERVER, String(PORT)], { stdio: ["ignore", "pipe", "pipe"] });
+  const proc = spawn(PY, [SERVER, String(PORT), "--store", storeFor(PORT)], { stdio: ["ignore", "pipe", "pipe"] });
   return proc;
 }
 
@@ -75,7 +98,7 @@ describe.skipIf(!PY)("concept-server refuses to double-bind its port (A3)", () =
   // launch must FAIL loudly (non-zero exit) instead of silently double-binding.
   test("a second instance on the same port exits non-zero instead of sharing it", async () => {
     const BIND_PORT = PORT + 1;
-    const proc1 = spawn(PY, [SERVER, String(BIND_PORT)], { stdio: ["ignore", "pipe", "pipe"] });
+    const proc1 = spawn(PY, [SERVER, String(BIND_PORT), "--store", storeFor(BIND_PORT)], { stdio: ["ignore", "pipe", "pipe"] });
     try {
       // Wait until instance 1 actually owns the port.
       const deadline = Date.now() + 10000;
@@ -90,7 +113,7 @@ describe.skipIf(!PY)("concept-server refuses to double-bind its port (A3)", () =
       expect(up).toBe(true);
 
       // Instance 2 must fail to bind rather than silently double-bind.
-      const proc2 = spawn(PY, [SERVER, String(BIND_PORT)], { stdio: ["ignore", "pipe", "pipe"] });
+      const proc2 = spawn(PY, [SERVER, String(BIND_PORT), "--store", storeFor(BIND_PORT)], { stdio: ["ignore", "pipe", "pipe"] });
       let stderr = "";
       proc2.stderr.on("data", d => { stderr += d.toString(); });
       const exitCode = await new Promise((resolve, reject) => {
@@ -145,7 +168,7 @@ describe.skipIf(!PY)("concept-server cross-session port registry (Defect B)", ()
     const REG_PORT = PORT + 2;
     const regFile = bridgeFile(REG_PORT);
     try { fs.unlinkSync(regFile); } catch { /* not there */ }
-    const proc = spawn(PY, [SERVER, String(REG_PORT), "."], { stdio: ["ignore", "pipe", "pipe"] });
+    const proc = spawn(PY, [SERVER, String(REG_PORT), ".", "--store", storeFor(REG_PORT)], { stdio: ["ignore", "pipe", "pipe"] });
     try {
       const deadline = Date.now() + 10000;
       let up = false;

--- a/plugins/devops/skills/concept/SKILL.md
+++ b/plugins/devops/skills/concept/SKILL.md
@@ -1501,8 +1501,11 @@ Never resolve it by deleting.
 
 **Orphan sweep.** A store whose concept HTML no longer exists — the file was
 deleted manually, a worktree was wiped, an older session never ran cleanup —
-is an orphan. Sweep those whose `state.json` is older than 7 days, applying
-the same UNPROCESSED guard to each:
+is an orphan. So is a `port-<n>/` store: a bridge started without `--html`
+(older test runs did this, #342) anchors its store under that name, and no
+`docs/concepts/port-<n>.html` ever exists, so the same rule catches it. Sweep
+those whose `state.json` is older than 7 days, applying the same UNPROCESSED
+guard to each:
 
 ```bash
 for d in .claude/concepts/*/; do

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.149.2",
+  "version": "0.149.3",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
Closes #342

## Summary
- `concept-server.test.js` spawned the bridge four times without `--html`/`--store`, leaving `.claude/concepts/port-<n>/` behind in the worktree on every run.
- Every spawn now gets a throw-away `--store` under the OS temp dir (same pattern as `CONCEPT_BRIDGE_REGISTRY_DIR`); an `afterAll` asserts the run added no `port-*` store to the cwd.
- `/concept` Step 6a orphan sweep names `port-*` stores explicitly as sweep-eligible.
- The durability suites already anchor their stores in a temp root via `--html` — unchanged.

## Release
- Version 0.149.2 → 0.149.3 (patch), CHANGELOG entry added.

Shipped by /run-backlog (autonomous, lockout armed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)