### PR TITLE
fix(tokens): guard frees grep -q/-c/-l, curl -o and wc on large paths

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.149.3"
+    "version": "0.149.4"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.149.3",
+      "version": "0.149.4",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.149.3",
+      "version": "0.149.4",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.149.4] — 2026-09-07
+
+### Fixed
+
+- **The token guard blocked commands that only referenced a large concept page.** Any Bash command whose text contained the path of the generated concept HTML (~800 KB) was blocked with "~180,000 tokens" — the `curl -o /dev/null` 200-gate, the gate's own `grep -q` sweep, `wc -c` — although none of them bring a byte of the file into context. The grep family (`grep`, `egrep`, `fgrep`, `rg`, `ag`, `ack`) was unconditionally a reader and `curl` was unclassified, so both fell into the costly bucket. They are now classified by flag: the quiet, count and file-list forms (`-q`, `-c`, `-l`, `-L`, `--files`, `--count-matches`) are content-free, with value-taking flags and `--` honoured so a pattern that merely looks like `-q` cannot free the command (`grep -ecat f` searches for "cat"; `rg -L` is `--follow`, not a list); `curl` is content-free only with `-o`/`-O`/`--output`, and a `/dev/stdout` target still upgrades to costly; `wc` joins the passer heads. `grep -n`, bare `curl`, `cat` and `sed -n` cost exactly what they did. (#349)
+
 ## [0.149.3] — 2026-09-07
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.149.3**
+**Version: 0.149.4**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.149.3",
+  "version": "0.149.4",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/deep-knowledge/plugin-behavior.md
+++ b/plugins/devops/deep-knowledge/plugin-behavior.md
@@ -78,9 +78,12 @@ the `redteam` agent in Wave 0.
   context window (`plan-defaults`: 5% pro · 8% max_5 · 10% max_20)
 - For Bash, an expensive file only counts when a command actually READS it
   (`hooks/lib/bash-context-cost`). Passing the path as an argument — a server
-  start, `ls`, `mv`, `echo`, `git add` — is free. A command that cannot be
-  reasoned about stays costly; the one exception is a detached
-  `run_in_background` non-reader
+  start, `ls`, `mv`, `cp`, `wc`, `echo`, `git add` — is free, and so are the
+  content-free forms of known emitters: `grep -q` / `-c` / `-l` (exit code,
+  count, file names) and `curl -o <file>` / `-O` (#349). `grep -n`, bare
+  `curl`, `cat`, `sed -n` stay costly. A command that cannot be reasoned
+  about stays costly; the one exception is a detached `run_in_background`
+  non-reader
 - A block is a confirm-once gate: retrying the same operation releases it for
   30 minutes, keyed per project. Reword the description or flip
   `run_in_background` freely — neither affects the key

--- a/plugins/devops/hooks/lib/bash-context-cost.js
+++ b/plugins/devops/hooks/lib/bash-context-cost.js
@@ -5,8 +5,9 @@
  * @description Decide which large-file references inside a Bash command
  *   actually cost Claude context. Used by pre.tokens.guard to stop blocking
  *   commands that merely PASS a big file's path as an argument (server start,
- *   `ls`, `mv`, `echo`) while still blocking commands that READ the file into
- *   context (`cat`, `grep`, `jq`, `python -c`).
+ *   `ls`, `mv`, `echo`, `wc`, `grep -q`, `curl -o`) while still blocking
+ *   commands that READ the file into context (`cat`, `grep -n`, `jq`,
+ *   `python -c`, bare `curl`).
  *
  *   Three verdicts, and the difference between two of them carries the whole
  *   safety argument:
@@ -57,17 +58,39 @@ const OVERFLOW_HEAD = '__unparsed__';
 const READER_HEADS = new Set([
   OVERFLOW_HEAD,
   'cat', 'bat', 'tac', 'head', 'tail', 'less', 'more', 'nl', 'fold',
-  'grep', 'egrep', 'fgrep', 'rg', 'ag', 'ack', 'select-string', 'sls',
+  'select-string', 'sls',
   'jq', 'yq', 'xmllint', 'awk', 'gawk', 'mawk', 'sed', 'cut', 'paste',
   'sort', 'uniq', 'tr', 'column', 'diff', 'comm', 'join',
   'strings', 'od', 'xxd', 'hexdump', 'base64', 'zcat', 'gunzip',
   'type', 'get-content', 'gc', 'import-csv', 'convertfrom-json',
 ]);
 
+// The grep family prints matching LINES by default — a reader — but its
+// quiet / count / list forms print nothing of the file: `grep -q` (exit code
+// only), `-c` (a number), `-l` / `-L` (file names). Those are the gate greps
+// and 200-checks a concept session runs against its own 800 KB page, and
+// blocking them made the guard fight harmless commands (#349). Classified by
+// flag in `grepIsQuiet()`; the default stays `reader`.
+const GREP_HEADS = new Set(['grep', 'egrep', 'fgrep', 'rg', 'ag', 'ack']);
+const GREP_QUIET_LONG = /^--(quiet|silent|count|count-matches|files-with-matches|files-without-match|files)$/;
+// Short flags that take a value — the rest of a bundled token, or the next
+// token, is that value and must not be read as more flags (`grep -ecat f`
+// searches for "cat"; `grep -e -q f` searches for "-q").
+const GREP_VALUE_FLAG = /^(-e|-f|-m|-g|-t|-A|-B|-C|-d|-D|--regexp|--file|--max-count|--glob|--type|--context|--after-context|--before-context)$/;
+const GREP_VALUE_SHORT = 'efmgtABCdD';
+
+// curl prints the response body to stdout unless it is sent to a file:
+// `-o <file>` / `--output`, `-O` / `--remote-name`. The 200-gate form
+// (`curl -s -o /dev/null -w "%{http_code}" <url-with-big-path>`) never brings
+// the page into context; a bare `curl <url>` does. A `/dev/stdout` target is
+// caught by STDOUT_SINK in classifySegment (monotone upgrade to reader).
+const CURL_OUTPUT_LONG = /^--(output|remote-name|remote-name-all|output-dir)(=|$)/;
+const CURL_VALUE_SHORT = 'dHXuAbceFTKmrwxyzEUC';
+
 // Commands that only ever take a path as an operand — their output never
 // contains the file's contents.
 const PASSER_HEADS = new Set([
-  'ls', 'dir', 'stat', 'file', 'du', 'basename', 'dirname', 'realpath',
+  'ls', 'dir', 'stat', 'file', 'du', 'wc', 'basename', 'dirname', 'realpath',
   'readlink', 'pwd', 'cd', 'pushd', 'popd',
   'touch', 'mkdir', 'rmdir', 'rm', 'del', 'erase', 'cp', 'copy', 'mv',
   'move', 'ren', 'rename', 'ln', 'mklink', 'chmod', 'chown', 'attrib',
@@ -263,6 +286,53 @@ function subCommand(args) {
   return (args.find(a => !a.startsWith('-')) || '').toLowerCase();
 }
 
+/**
+ * The letters of a bundled short-flag token (`-ril` → `ril`, `-so/dev/null`
+ * → `so`), stopping at the first non-letter. `''` for anything that is not a
+ * single-dash flag.
+ */
+function shortFlagChars(token) {
+  const m = /^-([A-Za-z]+)/.exec(token);
+  return (m && !token.startsWith('--')) ? m[1] : '';
+}
+
+/**
+ * True when a grep-family command prints no file content: a quiet, count or
+ * file-list flag is present. Walks the args like the tool would — a flag
+ * that takes a value consumes the next token (or the rest of its own bundle),
+ * and `--` ends option parsing — so a pattern that merely looks like `-q`
+ * cannot free the command. `-L` lists non-matching files for grep/ag/ack but
+ * means --follow for rg, so it is quiet only outside rg.
+ */
+function grepIsQuiet(head, args) {
+  const quietShort = head === 'rg' ? 'qcl' : 'qclL';
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === '--') break;
+    if (GREP_VALUE_FLAG.test(a)) { i++; continue; }
+    if (GREP_QUIET_LONG.test(a)) return true;
+    for (const ch of shortFlagChars(a)) {
+      if (quietShort.includes(ch)) return true;
+      if (GREP_VALUE_SHORT.includes(ch)) break;   // `-ecat`: the rest is a value
+    }
+  }
+  return false;
+}
+
+/** True when curl writes the response to a file instead of stdout. */
+function curlWritesToFile(args) {
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === '--') break;
+    if (CURL_OUTPUT_LONG.test(a)) return true;
+    for (const ch of shortFlagChars(a)) {
+      if (ch === 'o' || ch === 'O') return true;
+      if (CURL_VALUE_SHORT.includes(ch)) break;   // `-dfoo`: the rest is a value
+    }
+  }
+  return false;
+}
+
 // git global flags that take a SEPARATE value, so the next token is not the
 // subcommand: `git -C dir status`, `git -c user.name=x commit`.
 const GIT_GLOBAL_WITH_VALUE = /^(-C|-c|--git-dir|--work-tree|--exec-path|--namespace|--super-prefix)$/;
@@ -317,6 +387,10 @@ function baseClassify(segment) {
   // wrapper whose real command never materialised.
   if (!head) return (strippedAssignment || strippedWrapper) ? 'reader' : 'passer';
   if (READER_HEADS.has(head)) return 'reader';
+  // Known content emitters with a content-free mode (#349). Outside that mode
+  // they are `reader`, never `unknown` — same discipline as git/gh below.
+  if (GREP_HEADS.has(head)) return grepIsQuiet(head, args) ? 'passer' : 'reader';
+  if (head === 'curl') return curlWritesToFile(args) ? 'passer' : 'reader';
   if (INTERPRETER_HEADS.has(head)) {
     return args.some(a => INLINE_CODE_FLAG.test(a)) ? 'reader' : 'unknown';
   }

--- a/plugins/devops/hooks/lib/bash-context-cost.test.js
+++ b/plugins/devops/hooks/lib/bash-context-cost.test.js
@@ -82,6 +82,57 @@ describe("classifySegment", () => {
     expect(classifySegment("timeout 30")).toBe("reader");
     expect(classifySegment("sudo -u root cat f")).toBe("reader");
   });
+
+  // #349 — the quiet / count / list forms of grep print nothing of the file.
+  describe("grep family — content-free forms are passers (#349)", () => {
+    test.each([
+      "grep -q x f", "grep --quiet x f", "grep --silent x f",
+      "grep -c x f", "grep --count x f",
+      "grep -l x dir", "grep -rl x dir", "grep -ril x dir", "grep -L x f",
+      "grep -qxF '/BACKLOG-*' f",
+      "rg -q x f", "rg -l x .", "rg --files-with-matches x .", "rg --count-matches x f", "rg --files",
+      "ag -l x .", "ack -c x f", "egrep -q x f", "fgrep -c x f",
+    ])("%s → passer", seg => expect(classifySegment(seg)).toBe("passer"));
+
+    test.each([
+      "grep x f", "grep -n x f", "grep -i x f", "grep -o x f", "grep -A3 x f", "grep -rn x dir",
+      "rg x f", "rg -n x f",
+      "grep -ecat f",          // -e takes the rest of the bundle: pattern "cat", not -c
+      "grep -e -q f",          // -e takes the next token: pattern "-q"
+      "grep -f -l f",          // -f takes the next token: pattern file "-l"
+      "grep -- -q f",          // after -- everything is an operand
+      "rg -L x f",             // rg -L is --follow, not files-without-match
+      "grep -m1 x f",          // value flag without quiet
+    ])("%s → reader", seg => expect(classifySegment(seg)).toBe("reader"));
+  });
+
+  // #349 — curl brings the body into context unless it goes to a file.
+  describe("curl — file output is a passer, stdout is a reader (#349)", () => {
+    test.each([
+      'curl -s -o /dev/null -w "%{http_code}" --max-time 3 http://localhost:8/docs/concepts/big.html',
+      "curl -so/dev/null http://x/big.html",
+      "curl -sSLo out.html http://x/big.html",
+      "curl --output out.html http://x/big.html",
+      "curl --output=out.html http://x/big.html",
+      "curl -O http://x/big.html",
+      "curl --remote-name http://x/big.html",
+    ])("%s → passer", seg => expect(classifySegment(seg)).toBe("passer"));
+
+    test.each([
+      "curl http://x/big.html",
+      "curl -s http://x/big.html",
+      "curl -sL http://x/big.html",
+      "curl -X POST -d @big.html http://x/",
+      "curl -dfoo http://x/big.html",      // -d takes the rest of the bundle
+      "curl -Hfoo http://x/big.html",
+      "curl -s -o /dev/stdout http://x/big.html",   // stdout sink upgrade
+    ])("%s → reader", seg => expect(classifySegment(seg)).toBe("reader"));
+  });
+
+  test("wc never prints content (#349)", () => {
+    expect(classifySegment("wc -c f")).toBe("passer");
+    expect(classifySegment("wc -l f")).toBe("passer");
+  });
 });
 
 describe("isFreeOfContextCost", () => {
@@ -108,6 +159,26 @@ describe("matchCostlyFiles", () => {
     expect(hits("ls -la docs/concepts/big.html")).toEqual([]);
     expect(hits('echo "wrote docs/concepts/big.html"')).toEqual([]);
     expect(hits("mv docs/concepts/big.html docs/concepts/old.html")).toEqual([]);
+  });
+
+  // #349 — the commands a concept session runs against its own 800 KB page.
+  test("quiet greps, curl -o and wc referencing the big page are free", () => {
+    expect(hits("grep -q 'panel-ready' docs/concepts/big.html")).toEqual([]);
+    expect(hits("grep -c '<style' docs/concepts/big.html")).toEqual([]);
+    expect(hits("grep -l concept-decisions docs/concepts/big.html")).toEqual([]);
+    expect(hits('curl -s -o /dev/null -w "%{http_code}" http://localhost:8840/docs/concepts/big.html')).toEqual([]);
+    expect(hits("wc -c docs/concepts/big.html")).toEqual([]);
+    expect(hits("cp docs/concepts/big.html docs/concepts/preview.html")).toEqual([]);
+    expect(hits("ls -la docs/concepts/big.html")).toEqual([]);
+  });
+
+  test("…but the content-printing forms of the same heads still cost (#349)", () => {
+    expect(hits("grep -n 'panel-ready' docs/concepts/big.html")).toEqual(["docs/concepts/big.html"]);
+    expect(hits("grep -q x other.txt; grep panel docs/concepts/big.html")).toEqual(["docs/concepts/big.html"]);
+    expect(hits("curl http://localhost:8840/docs/concepts/big.html")).toEqual(["docs/concepts/big.html"]);
+    expect(hits("curl -o /dev/stdout http://localhost:8840/docs/concepts/big.html")).toEqual(["docs/concepts/big.html"]);
+    expect(hits("grep -q x docs/concepts/big.html", { runInBackground: true })).toEqual([]);
+    expect(hits("grep x docs/concepts/big.html", { runInBackground: true })).toEqual(["docs/concepts/big.html"]);
   });
 
   test("a detached non-reader (server start) is free — the reported bug", () => {

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.149.3",
+  "version": "0.149.4",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
Closes #349

## Summary
- The grep family was unconditionally a reader and `curl` was unclassified, so the 200-gate (`curl -s -o /dev/null …`), the gate's own `grep -q` sweep and `wc -c` against an 800 KB concept page were blocked although none bring content into context.
- `grep`/`egrep`/`fgrep`/`rg`/`ag`/`ack` are now classified by flag: quiet / count / file-list forms are passers; value-taking flags (`-e`, `-f`, `-m`, `-A/-B/-C`, bundled `-ecat`) and `--` are honoured so a pattern cannot free the command; `rg -L` (follow) stays a reader.
- `curl` is a passer only with `-o`/`-O`/`--output`; a `/dev/stdout` target still upgrades to reader. `wc` joins the passer heads.
- Already on main and untouched: `cp`/`mv`/`ls` passers, retry determinism (#277).
- Tests: 30 new classification cases + 2 `matchCostlyFiles` cases; `plugin-behavior.md` updated.

## Verification
- Branch suites via `ship_build` (151 tests green). Full suite (110 files / 2762 tests) verified separately with a direct `vitest run` — `ship_build`'s own full run hit a vitest-worker RPC timeout twice with no failing test.

## Release
- Version 0.149.3 → 0.149.4 (patch), CHANGELOG entry added.

Shipped by /run-backlog (autonomous, lockout armed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)