### PR TITLE
fix(usage): verify PID ownership before killing the scraper, drop /T

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.149.4"
+    "version": "0.149.5"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.149.4",
+      "version": "0.149.5",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.149.4",
+      "version": "0.149.5",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.149.5] — 2026-09-07
+
+### Fixed
+
+- **Rendering a completion card could close the user's own Edge window.** `refresh-usage-headless` kills its hidden scraper instance before every cold relaunch with `taskkill /F /PID <pid> /T` on the pid from `~/.claude/edge-usage-scraper.pid`. That file is written once at launch and nothing observes the child's exit — the launcher spawns Edge detached and the Node process is gone seconds later — so it goes stale the moment the scraper quits, and Windows hands the number to the next process within hours. Observed on 2026-09-04: the file was three hours old, the pid had been reused by the user's main `msedge.exe`, and `/T` took the whole tree down right after a card rendered. The kill path now asks the OS who owns the pid (`Get-CimInstance Win32_Process`) and requires both the image name and the scraper's unique profile directory on the live command line; anything else — a foreign process, a gone pid, a query that timed out — is not killed and the stale file is simply deleted. `/T` is gone; the existing reap by command line already catches children and the real singleton. The exit-hook variant the issue proposed is not possible with a detached launcher and is documented as such. (#328)
+
 ## [0.149.4] — 2026-09-07
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.149.4**
+**Version: 0.149.5**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.149.4",
+  "version": "0.149.5",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/scripts/refresh-usage-headless.js
+++ b/plugins/devops/scripts/refresh-usage-headless.js
@@ -296,20 +296,67 @@ function reapScraperInstances() {
 }
 
 /**
- * Kill the scraper instance. Fast PID-file path first (bounded by a timeout so a
- * wedged taskkill can't hang the whole refresh under the MCP's 60s budget), then
- * the reliable command-line reap that catches the real browser the stale PID
- * missed. Never touches the user's main Edge.
+ * Who owns <pid> right now? (#328)
+ *
+ * The PID file is written once at launch and nothing observes the child's
+ * exit — the launcher spawns Edge detached + unref'd and this process exits
+ * seconds later — so the file goes stale the moment the scraper quits, and
+ * Windows reuses PIDs within hours. A blind `taskkill /PID <stale> /T` then
+ * kills whatever owns that number today; observed: the user's MAIN Edge tree,
+ * right after a completion card rendered. So before any kill, ask the OS who
+ * holds the pid and require BOTH the image name and our unique profile dir on
+ * the live command line.
+ *
+ * @returns {'ours'|'foreign'|'gone'|'unknown'} — only `ours` may be killed.
+ *   `unknown` (query failed / timed out) is deliberately not killable: a
+ *   scraper we cannot verify is caught by the command-line reap anyway.
  */
-function killScraperInstance() {
+function classifyScraperPid(pid, { exec = execSync, needle = path.basename(SCRAPER_PROFILE_DIR) } = {}) {
+  if (!(pid > 0)) return 'gone';
+  const ps =
+    `$p = Get-CimInstance Win32_Process -Filter 'ProcessId=${pid}'; ` +
+    "if ($p) { $p.Name + '|' + $p.CommandLine }";
+  let out;
   try {
-    const pid = parseInt(fs.readFileSync(SCRAPER_PID_FILE, 'utf8').trim(), 10);
-    if (pid > 0) {
-      try { execSync(`taskkill /F /PID ${pid} /T`, { stdio: 'ignore', timeout: 5000 }); } catch {}
+    out = exec(`powershell -NoProfile -NonInteractive -Command "${ps}"`, {
+      encoding: 'utf8', timeout: 8000, stdio: ['ignore', 'pipe', 'ignore'],
+    });
+  } catch {
+    return 'unknown';
+  }
+  const line = String(out || '').trim();
+  if (!line) return 'gone';
+  const sep = line.indexOf('|');
+  const name = (sep === -1 ? line : line.slice(0, sep)).trim().toLowerCase();
+  const cmdline = sep === -1 ? '' : line.slice(sep + 1);
+  return (name === 'msedge.exe' && cmdline.includes(needle)) ? 'ours' : 'foreign';
+}
+
+/**
+ * Kill the scraper instance. PID-file path first — but only after
+ * `classifyScraperPid()` has confirmed the pid still belongs to OUR scraper
+ * (#328); a stale file pointing at a foreign process is just deleted. No `/T`:
+ * the command-line reap below already catches children and the real singleton
+ * the short-lived launcher pid missed. Bounded by timeouts so a wedged query or
+ * taskkill can't hang the whole refresh under the MCP's 60s budget. Never
+ * touches the user's main Edge.
+ *
+ * Dependencies are injectable for the unit tests only; production callers pass
+ * nothing.
+ */
+function killScraperInstance({ exec = execSync, pidFile = SCRAPER_PID_FILE, reap = reapScraperInstances, classify = classifyScraperPid } = {}) {
+  let pid = 0;
+  try { pid = parseInt(fs.readFileSync(pidFile, 'utf8').trim(), 10); } catch {}
+  if (pid > 0) {
+    const owner = classify(pid, { exec });
+    if (owner === 'ours') {
+      try { exec(`taskkill /F /PID ${pid}`, { stdio: 'ignore', timeout: 5000 }); } catch {}
+    } else {
+      log(`Scraper PID file is stale (pid ${pid} is ${owner}) — not killing, dropping the file`);
     }
-  } catch {}
-  try { fs.unlinkSync(SCRAPER_PID_FILE); } catch {}
-  reapScraperInstances();
+  }
+  try { fs.unlinkSync(pidFile); } catch {}
+  reap();
 }
 
 /** Age of a lock file in ms, or Infinity if absent/unreadable. */
@@ -890,6 +937,8 @@ module.exports = {
   shouldOpenLoginWindow,
   loginPending,
   reapScraperInstances,
+  classifyScraperPid,
+  killScraperInstance,
   LOGIN_RETRY_AFTER_MS,
   FRESH_CACHE_MAX_AGE_SECONDS,
 };

--- a/plugins/devops/scripts/refresh-usage-headless.test.js
+++ b/plugins/devops/scripts/refresh-usage-headless.test.js
@@ -9,8 +9,102 @@ import {
   writeJsonAtomic,
   isMarkerPending,
   shouldOpenLoginWindow,
+  classifyScraperPid,
+  killScraperInstance,
   LOGIN_RETRY_AFTER_MS,
 } from "./refresh-usage-headless.js";
+
+// #328 — a stale PID file + `taskkill /F /PID <pid> /T` killed the user's main
+// Edge tree once the OS had reused the pid. The kill path must verify ownership
+// first and never use /T.
+describe("killScraperInstance — ownership check before any kill (#328)", () => {
+  let dir;
+  afterEach(() => {
+    if (dir) { try { rmSync(dir, { recursive: true, force: true }); } catch {} dir = null; }
+  });
+
+  // A fake execSync: answers the CIM query with `cimLine`, records every call.
+  function fakeExec(cimLine, { throwOnCim = false } = {}) {
+    const calls = [];
+    const exec = vi.fn((cmd) => {
+      calls.push(cmd);
+      if (/Get-CimInstance/.test(cmd)) {
+        if (throwOnCim) throw new Error("powershell timed out");
+        return cimLine;
+      }
+      return "";
+    });
+    exec.calls = calls;
+    exec.kills = () => calls.filter(c => /^taskkill/.test(c));
+    return exec;
+  }
+
+  function pidFileWith(content) {
+    dir = mkdtempSync(join(tmpdir(), "usage-pid-test-"));
+    const pidFile = join(dir, "edge-usage-scraper.pid");
+    fs.writeFileSync(pidFile, content);
+    return pidFile;
+  }
+
+  test("classifyScraperPid: our scraper = msedge.exe + the profile dir on its command line", () => {
+    const ours = fakeExec("msedge.exe|\"C:\\Program Files\\Microsoft\\Edge\\Application\\msedge.exe\" --user-data-dir=C:\\Users\\x\\.claude\\edge-usage-profile --remote-debugging-port=9223");
+    expect(classifyScraperPid(28664, { exec: ours })).toBe("ours");
+    // Same image, the USER's profile → foreign. This is the exact #328 case.
+    const mainEdge = fakeExec("msedge.exe|\"C:\\Program Files\\Microsoft\\Edge\\Application\\msedge.exe\" --profile-directory=Default");
+    expect(classifyScraperPid(28664, { exec: mainEdge })).toBe("foreign");
+    expect(classifyScraperPid(28664, { exec: fakeExec("notepad.exe|notepad.exe") })).toBe("foreign");
+    expect(classifyScraperPid(28664, { exec: fakeExec("") })).toBe("gone");
+    expect(classifyScraperPid(28664, { exec: fakeExec("", { throwOnCim: true }) })).toBe("unknown");
+    expect(classifyScraperPid(0, { exec: fakeExec("x") })).toBe("gone");
+  });
+
+  test("PID file pointing at the user's main Edge → no taskkill, file removed, reap still runs", () => {
+    const pidFile = pidFileWith("28664");
+    const exec = fakeExec("msedge.exe|msedge.exe --profile-directory=Default");
+    const reap = vi.fn();
+    killScraperInstance({ exec, pidFile, reap });
+    expect(exec.kills()).toEqual([]);
+    expect(fs.existsSync(pidFile)).toBe(false);
+    expect(reap).toHaveBeenCalledTimes(1);
+  });
+
+  test("PID file pointing at a non-Edge process → no taskkill", () => {
+    const pidFile = pidFileWith("4242");
+    const exec = fakeExec("notepad.exe|notepad.exe");
+    killScraperInstance({ exec, pidFile, reap: () => {} });
+    expect(exec.kills()).toEqual([]);
+    expect(fs.existsSync(pidFile)).toBe(false);
+  });
+
+  test("PID file pointing at our scraper → taskkill on that pid, WITHOUT /T", () => {
+    const pidFile = pidFileWith("31337");
+    const exec = fakeExec("msedge.exe|msedge.exe --user-data-dir=C:\\u\\.claude\\edge-usage-profile --remote-debugging-port=9223");
+    killScraperInstance({ exec, pidFile, reap: () => {} });
+    expect(exec.kills()).toEqual(["taskkill /F /PID 31337"]);
+    expect(fs.existsSync(pidFile)).toBe(false);
+  });
+
+  test("ownership query fails (timeout) → treated as unknown, no kill", () => {
+    const pidFile = pidFileWith("777");
+    const exec = fakeExec("", { throwOnCim: true });
+    killScraperInstance({ exec, pidFile, reap: () => {} });
+    expect(exec.kills()).toEqual([]);
+    expect(fs.existsSync(pidFile)).toBe(false);
+  });
+
+  test("pid already gone → no kill; no PID file → no query at all", () => {
+    const pidFile = pidFileWith("9");
+    const exec = fakeExec("");
+    killScraperInstance({ exec, pidFile, reap: () => {} });
+    expect(exec.kills()).toEqual([]);
+
+    const exec2 = fakeExec("x");
+    const reap = vi.fn();
+    killScraperInstance({ exec: exec2, pidFile: join(dir, "missing.pid"), reap });
+    expect(exec2).not.toHaveBeenCalled();
+    expect(reap).toHaveBeenCalledTimes(1);
+  });
+});
 
 // Fixed "now" so the age math is deterministic.
 const NOW = Date.parse("2026-06-18T12:00:00.000Z");

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.149.4",
+  "version": "0.149.5",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
Closes #328

## Summary
- `killScraperInstance()` ran `taskkill /F /PID <pid> /T` on whatever pid the stale PID file held; Windows reuses pids within hours, and the observed victim was the user's main Edge tree right after a completion card rendered.
- The pid is now classified via `Get-CimInstance Win32_Process` — `msedge.exe` AND the scraper profile dir on the live command line → `ours`; a foreign process, a gone pid or a failed/timed-out query is never killed and the stale file is deleted instead. `/T` is dropped; the existing command-line reap still catches children and the real singleton.
- Dependencies are injectable for tests only; 6 new tests cover main-Edge pid, non-Edge pid, our scraper (kill without `/T`), timeout, gone, and missing PID file. Real-OS sanity: own node pid / System → `foreign`, pid 999999 → `gone`.
- Deviation from the proposal: the "delete PID file on child exit" item is infeasible (detached + unref'd launcher, process exits immediately) and is documented in the code.

## Verification
- Branch suite via `ship_build` (36 tests green); full suite (110 files) verified separately with a direct `vitest run`.

## Release
- Version 0.149.4 → 0.149.5 (patch), CHANGELOG entry added.

Shipped by /run-backlog (autonomous, lockout armed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)