### PR TITLE
docs(concept): pre-Kompass pages re-synced wholesale on next append

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.149.5"
+    "version": "0.149.6"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.149.5",
+      "version": "0.149.6",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.149.5",
+      "version": "0.149.6",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.149.6] — 2026-09-07
+
+### Changed
+
+- **A concept page from before the Kompass panel gets the new panel on its next append — deliberately, with no opt-out.** Pages generated before 0.149.0 keep the old scrolling decision panel; their next iteration append fails engine entries 56 and 59–61, and the open question was whether the drift check should convert them or leave them alone until the session closes. Decided: convert, wholesale — the panel skeleton, § Layout, § Section Navigation and § Two-Button Submit are re-synced as one block, because the anatomy spans HTML, CSS and JS and fails in halves (new JS on the old skeleton has no foot to pin; the new skeleton on the old JS never builds the tree). A carve-out would need a marker nothing else reads and a second gate path, and it would leave the one defect the anatomy removes — the call to action below the fold — exactly on the pages with the most rounds. The re-sync never touches the frozen rounds' content or answers. `validation-gate.md` § Engine drift records the policy; SKILL.md Step 5c 2.6 now lists the current engine entries. (#344)
+
 ## [0.149.5] — 2026-09-07
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.149.5**
+**Version: 0.149.6**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.149.5",
+  "version": "0.149.6",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/skills/concept/SKILL.md
+++ b/plugins/devops/skills/concept/SKILL.md
@@ -1238,10 +1238,13 @@ iteration must be live in the browser BEFORE the server signals "processed".
    not only at first generation. The page's shared engine (Attachments
    JS/CSS, § Layout CSS chrome rules, tab-switch JS) is whatever
    templates.md said on the day it was generated, and every later round
-   re-uses it. If any engine entry fails (44, 46, 47, 48, 56, tab-switch),
-   re-sync that whole block **verbatim from templates.md NOW**, before
-   appending — otherwise the new iteration inherits the old defect and the
-   user sees the same bug after updating the plugin. See
+   re-uses it. If any engine entry fails (30b, 44, 46, 47, 48, 49–53, 54,
+   56, 59–61, tab-switch), re-sync that whole block **verbatim from
+   templates.md NOW**, before appending — otherwise the new iteration
+   inherits the old defect and the user sees the same bug after updating
+   the plugin. A page from before the Kompass panel (fails 56 / 59–61) gets
+   the whole panel block — skeleton, § Layout, § Section Navigation,
+   § Two-Button Submit — on this append, no opt-out (#344). See
    `deep-knowledge/validation-gate.md` § Engine drift on iteration append.
 3. Append a new `<section data-iteration="{N+1}" data-active>` with the
    updated / next-round content (new variants, refined options, whatever

--- a/plugins/devops/skills/concept/deep-knowledge/validation-gate.md
+++ b/plugins/devops/skills/concept/deep-knowledge/validation-gate.md
@@ -254,6 +254,28 @@ halves, and a page missing one literal is a page carrying a stale copy of
 everything around it. Appending first and patching after leaves the freshly
 appended iteration wired to the old engine.
 
+**Pre-Kompass pages are converted wholesale on their next append — no
+opt-out (#344).** A page generated before the pinned-foot panel and the
+Kompass tree (0.149.0, entries 56 and 59–61) still carries the old scrolling
+decision panel. Its next append fails those entries, and the answer is the
+same as for every other engine entry: re-sync the **whole panel block** as one
+unit — the panel skeleton (`.panel-here` / `.panel-nav-scroll` /
+`.panel-status` / `.panel-cta`), § Layout (panel anatomy CSS), § Section
+Navigation (`buildSectionNav` + `buildIterationTree` + tab-bar CSS) and
+§ Two-Button Submit (split button + status line) — verbatim from templates.md,
+before the new section goes in. The anatomy spans HTML skeleton, CSS and JS
+across those sections and fails in halves; a page with the new JS on the old
+skeleton has no `.panel-cta` to pin, and a page with the new skeleton on the
+old JS never builds the tree. There is deliberately no "keep the old panel
+until this session closes" carve-out: it would need a marker nothing else
+reads, a second code path in the gate, and it would leave the one defect the
+anatomy exists to remove — the call to action below the fold — in place
+exactly on the pages that have the most rounds. A reviewer reopening an older
+concept sees the same pinned call to action as on a new one; the chips stay a
+flat `.iteration-tab` list, so the append checklist is unchanged, and the
+frozen rounds' content and answers are untouched (the re-sync never edits
+`section[data-iteration]`).
+
 **Re-syncing must never touch `section[data-iteration]` attributes.** Entry 54
 lives in the panel skeleton and the status-step JS, both of which the re-sync
 replaces wholesale; `data-reality-check` lives on the iteration sections and

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.149.5",
+  "version": "0.149.6",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
Closes #344

## Summary
- Decision recorded: a concept page generated before the Kompass panel (fails engine entries 56 / 59–61) gets the whole panel block — skeleton, § Layout, § Section Navigation, § Two-Button Submit — verbatim from `templates.md` on its next iteration append. No opt-out / carve-out.
- Rationale in `validation-gate.md` § Engine drift: the anatomy spans HTML, CSS and JS and fails in halves; a carve-out would need a marker nothing reads and would leave the below-the-fold CTA on the longest pages. Frozen rounds' content and answers are untouched.
- `SKILL.md` Step 5c 2.6 lists the current engine entries (30b, 44, 46–48, 49–53, 54, 56, 59–61, tab-switch) and points at the policy.
- Docs only; concept panel suites and the full suite green.

## Release
- Version 0.149.5 → 0.149.6 (patch), CHANGELOG entry added.

Shipped by /run-backlog (autonomous, lockout armed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)