### PR TITLE
fix(concept): draft mirror hydrates text: keys only, never navigation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.149.7"
+    "version": "0.149.8"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.149.7",
+      "version": "0.149.8",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.149.7",
+      "version": "0.149.8",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.149.8] — 2026-09-07
+
+### Fixed
+
+- **The draft mirror can no longer steer a second browser onto the user's view.** `hydrateDraftFromBridge()` merged every string in the bridge's `recovered` draft into the local blob. The bridge has limited `recovered` to `text:` keys since 0.143.0, so on a current bridge nothing else ever arrived — but nothing on the page enforced that, and an older bridge, or a key the server lets through later, would have pulled Claude's screenshot-verification tab onto whatever screen the user was reading seconds after load. The client now skips every non-`text:` key (`_activeView`, `_activeScreen*`, `_viewportMode`, the `input:` selections) as defense in depth, and the reported symptom is named for what it is: two tabs of the same browser profile share `localStorage`, so a verification tab opened in the user's Edge profile inherits — and writes back — the user's position. The concept skill now states that verification tabs run in their own profile (Playwright, the Claude browser pane), never in the user's window. (#347)
+
 ## [0.149.7] — 2026-09-07
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.149.7**
+**Version: 0.149.8**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.149.7",
+  "version": "0.149.8",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/skills/concept/SKILL.md
+++ b/plugins/devops/skills/concept/SKILL.md
@@ -716,6 +716,16 @@ what only a CSS parser sees. Load `$URL` in a headless browser context (the
 Claude browser pane / Playwright — NOT the tab the user will get; this is a
 read of the rendered CSS, no bridge interaction) and evaluate:
 
+> **Verification tabs use their own browser profile — always.** Two tabs of
+> the same profile share `localStorage`, and the page keeps its navigation
+> state (`_activeView`, `_activeScreen*`, `_viewportMode`) there. A
+> verification tab opened in the user's Edge profile therefore lands on
+> whatever view the user is reading, and its own autosaves write its
+> position back over theirs (#347). Playwright and the Claude browser pane
+> run an isolated profile; a tab in the user's window does not. The bridge
+> mirror is not the leak — `recovered` carries `text:` keys only, on both
+> ends.
+
 ```js
 getComputedStyle(document.documentElement).getPropertyValue('--bg-color').trim()
 ```

--- a/plugins/devops/skills/concept/comment-durability.test.js
+++ b/plugins/devops/skills/concept/comment-durability.test.js
@@ -333,6 +333,31 @@ describe("comment durability — the bridge mirror", () => {
     expect(live.value).toBe("das Neueste, gerade getippt");
   });
 
+  // #347 — the mirror exists for typed text. A second browser on the same page
+  // (Claude's screenshot-verification tab) must never be pulled onto the view
+  // the user is reading: navigation / preference keys never hydrate, even
+  // when an older bridge lets them through in `recovered`.
+  test("hydrates text: keys only — navigation state from the bridge never lands (#347)", async () => {
+    const { window, setDraft } = buildDom();
+    setDraft({
+      ok: true, found: true, rev: 9, state: {},
+      recovered: {
+        "text:i2:d-auth-note": "vom anderen Browser",
+        "_activeView": "view-b",
+        "_activeScreen:d1": "s3",
+        "_viewportMode": "phone",
+        "input:choice:yes": "on",
+      },
+    });
+    await window.hydrateDraftFromBridge();
+    const blob = readBlob(window);
+    expect(blob["text:i2:d-auth-note"]).toBe("vom anderen Browser");
+    expect(blob["_activeView"]).toBeUndefined();
+    expect(blob["_activeScreen:d1"]).toBeUndefined();
+    expect(blob["_viewportMode"]).toBeUndefined();
+    expect(blob["input:choice:yes"]).toBeUndefined();
+  });
+
   test("fills a field the local blob has EMPTY — the shape of every past bug", async () => {
     const { window, setDraft } = buildDom({
       storage: { _pageVersion: PAGE_VERSION, "text:i2:d-auth-note": "" },

--- a/plugins/devops/skills/concept/deep-knowledge/templates.md
+++ b/plugins/devops/skills/concept/deep-knowledge/templates.md
@@ -6825,6 +6825,14 @@ async function hydrateDraftFromBridge() {
   const local = _readStoredState();
   let changed = false;
   Object.entries(data.recovered || {}).forEach(([k, v]) => {
+    // Only typed text is mirrored back (#347). The bridge already limits
+    // `recovered` to `text:` keys, but an older bridge — or any future key
+    // the server lets through — must never steer THIS browser: `_activeView`,
+    // `_activeScreen*`, `_viewportMode` and every other `_`-prefixed
+    // navigation / preference key belong to the tab that wrote them. A
+    // second browser on the same page (a screenshot-verification tab) would
+    // otherwise be pulled onto whatever the user is reading.
+    if (typeof k !== 'string' || !k.startsWith('text:')) return;
     if (typeof v !== 'string' || !v) return;
     if (typeof local[k] === 'string' && local[k] !== '') return;
     local[k] = v;

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.149.7",
+  "version": "0.149.8",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
Closes #347

## Summary
- `hydrateDraftFromBridge()` merged every string in the bridge's `recovered` draft. The bridge has limited `recovered` to `text:` keys since 0.143.0 (`DRAFT_RECOVER_PREFIX`, pinned by `draft-durability.test.js`), so on a current bridge the mirror could not steer a second browser — the reported symptom is two tabs of one browser profile sharing `localStorage`.
- Client guard added as defense in depth: every non-`text:` key (`_activeView`, `_activeScreen*`, `_viewportMode`, `input:` selections) is skipped, so an older bridge or a future server change can never pull a verification tab onto the user's view.
- Concept skill Step 3: verification tabs run in their own browser profile (Playwright / Claude browser pane), never in the user's Edge window.
- `comment-durability.test.js`: a `recovered` blob carrying navigation keys hydrates the text and nothing else.
- Reproduction outcome (plan A): the bridge path is ruled out by the existing server-level test; no live two-browser repro was needed.

## Verification
- `ship_build` full suite: 110 files / 2773 tests green.

## Release
- Version 0.149.7 → 0.149.8 (patch), CHANGELOG entry added.

Shipped by /run-backlog (autonomous, lockout armed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)