### PR TITLE
feat(concept): relaunch a dead bridge automatically (#348)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.149.8"
+    "version": "0.150.0"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.149.8",
+      "version": "0.150.0",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.149.8",
+      "version": "0.150.0",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.150.0] — 2026-09-07
+
+### Added
+
+- **A concept page stays connected across Claude restarts — the bridge comes back on its own.** The bridge server, the keepalive pulser and the pickup waker are background Bash tasks and die with every Claude session restart (observed three times during one concept); the page then showed "Claude nicht verbunden" and, after three failed autosaves, the "Notizen liegen nur in diesem Browser" strip — which reads as "my notes are at risk" — until someone noticed and relaunched all three by hand on the same port. Two paths now do that unattended. At SessionStart, `ss.concept.resume` no longer exits silently when the bridge is dead and nothing is pending: it hands the new session a relaunch mandate — same port, same `--html`, a verified heartbeat round-trip, pulser, waker and the backup cron — and only prunes a state file older than 24 h. And the backup cron's `concept-tick` recovers a bridge that dies *without* a restart (a crash, a manual kill, the watchdog): after two consecutive heartbeat misses it prints the relaunch instruction exactly once, edge-triggered through `tick_heartbeat_failures` / `relaunch_requested_at` in the state file, and the next successful heartbeat re-arms it — a single transient miss never fires, and a dying bridge never spams the transcript once a minute. Both instructions say what to do when the port is already bound (another session brought the bridge back): skip the relaunch, re-arm the watchers. The page reconnects on its own once the heartbeat is back. (#348)
+
 ## [0.149.8] — 2026-09-07
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.149.8**
+**Version: 0.150.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.149.8",
+  "version": "0.150.0",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/hooks/session-start/ss.concept.resume.js
+++ b/plugins/devops/hooks/session-start/ss.concept.resume.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * @hook ss.concept.resume
- * @version 0.4.0
+ * @version 0.5.0
  * @event SessionStart
  * @plugin devops
  * @description Recover an open concept session after a Claude restart.
@@ -13,7 +13,10 @@
  *   die with the prior session; re-arming only the cron left the resumed
  *   session watching on a path that fires just while the REPL is idle, so a
  *   submission could rot in the bridge while the page still showed a green
- *   indicator (issue #276).
+ *   indicator (issue #276). A bridge that died with the session is relaunched
+ *   on the same port whether or not a submission is pending (#348) — the
+ *   server is a background Bash task too, and it used to stay dead until
+ *   someone noticed the red indicator.
  *
  *   Trust model: `.claude/concept-active.json` is treated as a per-project
  *   state file, NOT as authenticated control input. We accept that anyone
@@ -448,6 +451,35 @@ function buildDeadBridgeRecovery(state, store) {
   ].join(' ');
 }
 
+/**
+ * A dead bridge with NOTHING pending (#348). The bridge server, the keepalive
+ * pulser and the pickup waker are all session-scoped and die with every
+ * Claude restart — observed three times in one concept. The page then shows
+ * "Claude nicht verbunden" until someone notices and relaunches all three by
+ * hand on the same port. This branch used to exit silently unless a
+ * submission was on disk; now the resumed session relaunches the bridge on
+ * the recorded port whether or not anything is pending, so the page
+ * reconnects on its own.
+ */
+function buildDeadBridgeRelaunch(state, statePath = STATE_PATH) {
+  const server = path.join(__dirname, '..', '..', 'scripts', 'concept-server.py');
+  const bg = buildBackgroundTasks(state.port, statePath);
+  return [
+    `An open /concept session was found in this project (port ${state.port}, html_path ${state.html_path}, ` +
+    `slug ${state.slug || '?'}), but the bridge does not answer /heartbeat — the previous Claude session took ` +
+    `the server and both watchers with it. Nothing is pending on disk. Relaunch the bridge now, on the SAME ` +
+    `port so the open tab and the state file stay valid: ` +
+    `\`python "${server}" ${state.port} "${cwd}" --html "${state.html_path}"\` ` +
+    `(Bash tool, run_in_background: true — no trailing &, no nohup). If it exits because the port is already ` +
+    `bound, another session brought the bridge back — skip the relaunch and only re-arm the watchers.`,
+    `Then verify the heartbeat round-trips (POST /heartbeat, then GET /heartbeat must return a non-zero ` +
+    `claude_ts), re-arm the keepalive pulser (${bg.pulser}) and the pickup waker (${bg.waker}) as background ` +
+    `Bash tasks (run_in_background: true), and re-arm the backup cron: CronCreate with cron "* * * * *" ` +
+    `(recurring: true) and prompt: '${buildCronBody(state.port, statePath)}'. The page reconnects on its own ` +
+    `once the heartbeat is back — the user does not have to reload.`,
+  ].join(' ');
+}
+
 module.exports = {
   isValidHtmlPath,
   isStale,
@@ -459,6 +491,7 @@ module.exports = {
   readStore,
   buildVerificationMandate,
   buildDeadBridgeRecovery,
+  buildDeadBridgeRelaunch,
 };
 
 if (require.main === module) {
@@ -508,9 +541,14 @@ if (require.main === module) {
         process.stdout.write(buildDeadBridgeRecovery(state, store) + '\n');
         process.exit(0);
       }
-      // Nothing pending. If the state file is also stale, prune it; otherwise
-      // leave it — the user might be restarting the server in another terminal.
-      if (isStale(state)) deleteState();
+      // Nothing pending. A stale state file (>24 h) is an abandoned concept —
+      // prune it. Otherwise the bridge died with the previous session (#348):
+      // relaunch it on the same port instead of leaving the page disconnected
+      // until someone notices the red indicator. A server the user is already
+      // restarting in another terminal makes the relaunch fail on the bound
+      // port, which the mandate treats as "already back".
+      if (isStale(state)) { deleteState(); process.exit(0); }
+      process.stdout.write(buildDeadBridgeRelaunch(state, STATE_PATH) + '\n');
       process.exit(0);
     }
 

--- a/plugins/devops/hooks/session-start/ss.concept.resume.recovery.test.js
+++ b/plugins/devops/hooks/session-start/ss.concept.resume.recovery.test.js
@@ -7,6 +7,7 @@ import {
   readStore,
   buildVerificationMandate,
   buildDeadBridgeRecovery,
+  buildDeadBridgeRelaunch,
   buildResumeInstructions,
 } from "./ss.concept.resume.js";
 
@@ -167,6 +168,40 @@ describe("a dead bridge is relaunched, not written off", () => {
     );
     expect(text).toContain("--mode pulse");
     expect(text).toContain("--mode watch");
+  });
+});
+
+// #348 — the server is a background Bash task like the watchers and dies with
+// every restart. With nothing pending the hook used to exit silently, and the
+// page stayed on "Claude nicht verbunden" until someone relaunched by hand.
+describe("a dead bridge with nothing pending is relaunched too (#348)", () => {
+  const state = { port: 8748, html_path: "docs/concepts/2026-08-16-x.html", slug: "x" };
+  const text = buildDeadBridgeRelaunch(state, "C:/p/.claude/concept-active.json");
+
+  test("relaunches the server on the SAME port with the recorded --html", () => {
+    expect(text).toContain("concept-server.py");
+    expect(text).toContain("8748");
+    expect(text).toContain('--html "docs/concepts/2026-08-16-x.html"');
+    expect(text).toMatch(/SAME port/i);
+    expect(text).toContain("run_in_background: true");
+  });
+
+  test("re-arms all three watchers — pulser, waker and the backup cron", () => {
+    expect(text).toContain("--mode pulse");
+    expect(text).toContain("--mode watch");
+    expect(text).toContain("concept-tick.js");
+    expect(text).toContain("CronCreate");
+    expect(text).toContain('"C:/p/.claude/concept-active.json"');
+  });
+
+  test("verifies the heartbeat round-trip and tolerates a port already re-bound", () => {
+    expect(text).toContain("claude_ts");
+    expect(text).toMatch(/already bound/i);
+  });
+
+  test("carries no store-verification ceremony — nothing was submitted", () => {
+    expect(text).not.toContain("VERIFY BEFORE YOU ACT");
+    expect(text).not.toContain("/recovery");
   });
 });
 

--- a/plugins/devops/scripts/concept-tick.js
+++ b/plugins/devops/scripts/concept-tick.js
@@ -38,8 +38,10 @@
  *   Exit code is 0 for every tick outcome, including an unreachable bridge:
  *   a non-zero exit would surface as a failed Bash call in the transcript on
  *   every tick of a dying bridge. Bridge liveness is owned by the pulser and
- *   the server-side `--html` watchdog, not by this script. Only invalid
- *   arguments exit 2.
+ *   the server-side `--html` watchdog, not by this script — with one
+ *   edge-triggered exception (#348): after RELAUNCH_AFTER_FAILURES consecutive
+ *   heartbeat misses the tick prints the relaunch instruction ONCE and then
+ *   stays silent until the bridge answers again. Only invalid arguments exit 2.
  */
 
 const fs = require('fs');
@@ -140,6 +142,91 @@ function request(port, pathname, method, timeoutSec) {
   });
 }
 
+// (#348) A bridge that dies WITHOUT a session restart — a crash, a manual
+// kill, the server-side watchdog — has nobody to bring it back: the pulser
+// only notices while its own session is alive, and this cron used to log the
+// failure to stderr forever. So the tick relaunches, but edge-triggered: the
+// consecutive-failure count and a one-shot marker live in the state file, the
+// instruction is printed exactly once after RELAUNCH_AFTER_FAILURES misses,
+// and the next successful heartbeat re-arms the edge. One transient miss
+// (a slow /heartbeat under load) never fires it.
+const RELAUNCH_AFTER_FAILURES = 2;
+
+function readStateJson(statePath) {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(statePath, 'utf8'));
+    return parsed && typeof parsed === 'object' ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+// Atomic where the platform allows it; a direct write is the fallback for the
+// Windows EPERM-on-rename case (another process holds the file open).
+function writeStateJson(statePath, obj) {
+  const data = JSON.stringify(obj, null, 2);
+  const tmp = `${statePath}.tmp-${process.pid}`;
+  try {
+    fs.writeFileSync(tmp, data);
+    fs.renameSync(tmp, statePath);
+  } catch {
+    try { fs.unlinkSync(tmp); } catch { /* never existed */ }
+    fs.writeFileSync(statePath, data);
+  }
+}
+
+/**
+ * Record one heartbeat outcome in the state file.
+ * @returns {{relaunch:boolean, failures:number}} — `relaunch` is true on the
+ *   ONE tick that crosses the threshold with no relaunch already requested.
+ */
+function noteHeartbeat(statePath, ok) {
+  const state = readStateJson(statePath);
+  if (!state) return { relaunch: false, failures: 0 };
+  if (ok) {
+    if (!state.tick_heartbeat_failures && !state.relaunch_requested_at) return { relaunch: false, failures: 0 };
+    delete state.tick_heartbeat_failures;
+    delete state.relaunch_requested_at;
+    try { writeStateJson(statePath, state); } catch { /* next success retries */ }
+    return { relaunch: false, failures: 0 };
+  }
+  const prior = Number.isInteger(state.tick_heartbeat_failures) ? state.tick_heartbeat_failures : 0;
+  const failures = prior + 1;
+  state.tick_heartbeat_failures = failures;
+  let relaunch = false;
+  if (failures >= RELAUNCH_AFTER_FAILURES && !state.relaunch_requested_at) {
+    state.relaunch_requested_at = new Date().toISOString();
+    relaunch = true;
+  }
+  // If the marker cannot be persisted, do not fire: without it every later
+  // tick would fire again, which is the per-minute spam this design avoids.
+  try { writeStateJson(statePath, state); } catch { return { relaunch: false, failures }; }
+  return { relaunch, failures };
+}
+
+/**
+ * The relaunch instruction (#348). Mirrors the SessionStart hook's dead-bridge
+ * mandate: same port, --html, both watchers — the pieces a restart or a crash
+ * takes away together.
+ */
+function relaunchInstruction(port, statePath, htmlPath) {
+  const root = path.dirname(path.dirname(statePath));
+  const server = path.join(__dirname, 'concept-server.py');
+  const watch = path.join(__dirname, 'concept-watch.js');
+  return (
+    `The concept bridge on port ${port} has not answered /heartbeat for ${RELAUNCH_AFTER_FAILURES} consecutive ` +
+    `ticks — the server process is gone (a Claude restart or a crash takes it and both watchers with it). ` +
+    `Relaunch it on the SAME port so the open tab and the state file stay valid: ` +
+    `\`python "${server}" ${port} "${root}" --html "${htmlPath}"\` ` +
+    `(Bash tool, run_in_background: true — no trailing &, no nohup). If it exits because the port is already ` +
+    `bound, another session brought the bridge back — skip the relaunch. ` +
+    `Then re-arm the keepalive pulser: node "${watch}" --mode pulse --port ${port} --state "${statePath}" ` +
+    `and the pickup waker: node "${watch}" --mode watch --port ${port} --state "${statePath}" ` +
+    `(both background Bash tasks, run_in_background: true). The page reconnects on its own once the ` +
+    `heartbeat is back. This instruction is printed once; later ticks stay silent until the bridge answers again.`
+  );
+}
+
 /**
  * The cleanup instruction. CronDelete is a tool, so this one step cannot move
  * into the script — but the *text* can, and it only ever reaches Claude on the
@@ -187,7 +274,7 @@ function pendingInstruction(port, version) {
  *   silent tick. Returned rather than written so the tests can assert on it.
  */
 async function tick(opts, deps = {}) {
-  const io = { request, inspectState, exists: fs.existsSync, ...deps };
+  const io = { request, inspectState, noteHeartbeat, exists: fs.existsSync, ...deps };
 
   // (0) Self-cleanup gate — FIRST step every tick, before any bridge traffic.
   const state = io.inspectState(opts.state, opts.port, io.exists);
@@ -197,13 +284,21 @@ async function tick(opts, deps = {}) {
   }
 
   // (1) Heartbeat POST — what keeps the page's indicator green when the pulser
-  // is gone. Its failure is not reported: the pulser and the server-side
-  // watchdog own bridge liveness, and a per-tick complaint about a dying
-  // bridge would spam the transcript once a minute.
+  // is gone. A single failure is stderr only: a per-tick complaint about a
+  // dying bridge would spam the transcript once a minute. The SECOND
+  // consecutive failure prints the relaunch instruction exactly once (#348);
+  // the state file carries the edge so later ticks stay silent until the
+  // bridge answers again.
   const beat = await io.request(opts.port, '/heartbeat', 'POST', opts.timeout);
   if (!beat.ok) {
+    const note = io.noteHeartbeat(opts.state, false);
+    if (note.relaunch) {
+      const st = readStateJson(opts.state) || {};
+      return { stdout: relaunchInstruction(opts.port, opts.state, String(st.html_path || '')), stderr: '' };
+    }
     return { stdout: '', stderr: `concept-tick: bridge on port ${opts.port} did not answer /heartbeat\n` };
   }
+  io.noteHeartbeat(opts.state, true);
 
   // (2) Pending check via /pending — a strict `{"pending": bool, "version": N}`,
   // never a substring match on /decisions.
@@ -228,10 +323,13 @@ module.exports = {
   parseArgs,
   validate,
   inspectState,
+  noteHeartbeat,
   cleanupInstruction,
   pendingInstruction,
+  relaunchInstruction,
   tick,
   DEFAULTS,
+  RELAUNCH_AFTER_FAILURES,
 };
 
 if (require.main === module) {

--- a/plugins/devops/scripts/concept-tick.test.js
+++ b/plugins/devops/scripts/concept-tick.test.js
@@ -220,6 +220,102 @@ describe("tick", () => {
     expect(spy.calls).toEqual(["/heartbeat"]);
   });
 
+  // #348 — a bridge that dies without a session restart had nobody to bring
+  // it back. The tick relaunches, edge-triggered: once, after two consecutive
+  // misses, re-armed by the next successful heartbeat.
+  describe("heartbeat failure → edge-triggered relaunch (#348)", () => {
+    const readState = () => JSON.parse(fs.readFileSync(statePath, "utf8"));
+    const run = (spy) => tick({ port: PORT, state: statePath, timeout: 8 }, { request: spy.request });
+
+    test("the first miss is stderr only and only counts", async () => {
+      writeState({ ...LIVE, baseline_sha: "abc123" });
+      writeHtml(LIVE.html_path);
+      const res = await run(spyRequest({}));
+      expect(res.stdout).toBe("");
+      expect(res.stderr).toContain("/heartbeat");
+      const st = readState();
+      expect(st.tick_heartbeat_failures).toBe(1);
+      expect(st.relaunch_requested_at).toBeUndefined();
+      expect(st.baseline_sha).toBe("abc123"); // other fields survive the rewrite
+    });
+
+    test("the second consecutive miss prints the relaunch instruction once", async () => {
+      writeState(LIVE);
+      writeHtml(LIVE.html_path);
+      await run(spyRequest({}));
+      const res = await run(spyRequest({}));
+      expect(res.stderr).toBe("");
+      expect(res.stdout).toContain("concept-server.py");
+      expect(res.stdout).toContain(`${PORT}`);
+      expect(res.stdout).toContain(`--html "${LIVE.html_path}"`);
+      expect(res.stdout).toContain(`"${root}"`); // project root, not the cron's cwd
+      expect(res.stdout).toContain("--mode pulse");
+      expect(res.stdout).toContain("--mode watch");
+      expect(res.stdout).toContain(statePath);
+      expect(res.stdout).toContain("run_in_background");
+      expect(res.stdout).toMatch(/SAME port/i);
+      const st = readState();
+      expect(st.tick_heartbeat_failures).toBe(2);
+      expect(typeof st.relaunch_requested_at).toBe("string");
+    });
+
+    test("the third and every later miss is silent again — no per-minute spam", async () => {
+      writeState(LIVE);
+      writeHtml(LIVE.html_path);
+      await run(spyRequest({}));
+      await run(spyRequest({}));
+      for (let i = 0; i < 3; i++) {
+        const res = await run(spyRequest({}));
+        expect(res.stdout).toBe("");
+        expect(res.stderr).toContain("/heartbeat");
+      }
+      expect(readState().tick_heartbeat_failures).toBe(5);
+    });
+
+    test("a successful heartbeat clears the counter and re-arms the edge", async () => {
+      writeState(LIVE);
+      writeHtml(LIVE.html_path);
+      await run(spyRequest({}));
+      await run(spyRequest({}));
+      const alive = spyRequest({ "/heartbeat": ok(""), "/pending": ok(JSON.stringify({ pending: false })) });
+      expect(await run(alive)).toEqual({ stdout: "", stderr: "" });
+      const st = readState();
+      expect(st.tick_heartbeat_failures).toBeUndefined();
+      expect(st.relaunch_requested_at).toBeUndefined();
+      // The bridge dies again later → the instruction fires again, once.
+      await run(spyRequest({}));
+      expect((await run(spyRequest({}))).stdout).toContain("concept-server.py");
+      expect((await run(spyRequest({}))).stdout).toBe("");
+    });
+
+    test("a single transient miss between good ticks never fires", async () => {
+      writeState(LIVE);
+      writeHtml(LIVE.html_path);
+      const alive = spyRequest({ "/heartbeat": ok(""), "/pending": ok(JSON.stringify({ pending: false })) });
+      for (let i = 0; i < 3; i++) {
+        expect((await run(spyRequest({}))).stdout).toBe("");
+        await run(alive);
+      }
+      expect(readState().tick_heartbeat_failures).toBeUndefined();
+    });
+
+    test("a healthy tick does not rewrite the state file at all", async () => {
+      writeState(LIVE);
+      writeHtml(LIVE.html_path);
+      const before = fs.statSync(statePath).mtimeMs;
+      const raw = fs.readFileSync(statePath, "utf8");
+      await run(spyRequest({ "/heartbeat": ok(""), "/pending": ok(JSON.stringify({ pending: false })) }));
+      expect(fs.readFileSync(statePath, "utf8")).toBe(raw);
+      expect(fs.statSync(statePath).mtimeMs).toBe(before);
+    });
+
+    test("a half-written state file is neither a dead concept nor a relaunch", async () => {
+      writeState('{"port": 8883, "html_pa');
+      const res = await run(spyRequest({}));
+      expect(res.stdout).toBe("");
+    });
+  });
+
   test("unparseable /pending JSON is a silent tick, not a guess", async () => {
     writeState(LIVE);
     writeHtml(LIVE.html_path);

--- a/plugins/devops/skills/concept/deep-knowledge/bridge-server.md
+++ b/plugins/devops/skills/concept/deep-knowledge/bridge-server.md
@@ -245,10 +245,23 @@ AND provides HTTP endpoints for heartbeat and decision exchange.
        unrecoverable; sweeping by-port catches the orphan even when the id is
        lost). Steps 1 and 2 are skipped.
 
-   (1) **Heartbeat POST** to `/heartbeat`. A failure here is reported on
-       stderr only, never as an instruction: bridge liveness is owned by the
-       keepalive pulser and the server-side `--html` watchdog, and a per-tick
-       complaint about a dying bridge would spam the transcript once a minute.
+   (1) **Heartbeat POST** to `/heartbeat`. A single failure is reported on
+       stderr only: bridge liveness is owned by the keepalive pulser and the
+       server-side `--html` watchdog, and a per-tick complaint about a dying
+       bridge would spam the transcript once a minute. **The second
+       consecutive failure prints the relaunch instruction — once (#348).**
+       A bridge that dies *without* a session restart (a crash, a manual
+       kill, the watchdog) had nobody to bring it back: the pulser only
+       notices while its own session is alive. The tick therefore keeps a
+       consecutive-miss counter (`tick_heartbeat_failures`) and a one-shot
+       marker (`relaunch_requested_at`) in the state file; the instruction
+       — relaunch on the SAME port with the recorded `--html`, re-arm pulser
+       and waker — fires on the tick that crosses two misses with no marker
+       set, every later miss is silent again, and the next successful
+       heartbeat clears both fields so a later death fires it again. One
+       transient miss between good ticks never fires. The instruction says
+       what to do when the port is already bound (another session brought
+       the bridge back): skip the relaunch, only re-arm the watchers.
 
    (2) **Pending check** against the deterministic `/pending` endpoint — a
        strict `{"pending": true|false, "version": N}` with no free-form
@@ -472,6 +485,24 @@ AND provides HTTP endpoints for heartbeat and decision exchange.
      while this file lives at the project root. Absent in a repo with no remote
      (and on pages generated before the gate existed) — the implement gate then
      skips silently rather than blocking. See `reality-check.md` § Baseline.
+   - `tick_heartbeat_failures` / `relaunch_requested_at` — written by
+     `concept-tick.js` only (#348): the consecutive heartbeat-miss count and
+     the one-shot marker that makes the relaunch instruction fire once. Both
+     are removed by the next successful heartbeat; nothing else reads them.
+
+   **What survives a Claude restart, and how it comes back (#348).** The
+   bridge server, the keepalive pulser and the pickup waker are all
+   background Bash tasks and die with the session — the cron too. At the next
+   SessionStart the `ss.concept.resume` hook reads this file, probes
+   `/heartbeat`, and hands the new session one of three mandates: a live
+   bridge → re-arm the three watchers (and process a pending submission
+   first); a dead bridge with an unprocessed submission on disk → the
+   recovery mandate (relaunch on the same port, verify the store, process);
+   a dead bridge with nothing pending → the relaunch mandate (same port,
+   same `--html`, verified heartbeat round-trip, all three watchers). Only a
+   state file older than 24 h is pruned instead. The page reconnects on its
+   own once the heartbeat is back; the reviewer never has to reload or wait
+   for someone to notice the red indicator.
 
    Path: ALWAYS `<project-cwd>/.claude/concept-active.json` (NOT a worktree
    subpath, NOT under `docs/`). The hook reads this exact path and silently

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.149.8",
+  "version": "0.150.0",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
Closes #348

## Summary
Option B as decided at the gate — both paths:
- **Resume hook** (`ss.concept.resume`): a dead bridge with nothing pending gets a relaunch mandate at SessionStart — same port, same `--html`, verified heartbeat round-trip, pulser + waker + backup cron — instead of a silent exit. Only a state file older than 24 h is pruned. The mandate says what to do when the port is already bound (skip the relaunch, re-arm the watchers).
- **Tick script** (`concept-tick`): after two consecutive heartbeat misses it prints the relaunch instruction once, edge-triggered via `tick_heartbeat_failures` / `relaunch_requested_at` in `concept-active.json`; the next successful heartbeat clears both. A single transient miss never fires; later misses stay silent (no per-minute spam). A healthy tick never rewrites the state file.
- `bridge-server.md` § step 3 (1) and § step 4 document the behaviour and the two state fields.
- 11 new tests; the hook's main path verified end to end against a temp project (dead bridge → mandate; stale state → pruned).
- Not included (follow-up): the friendlier "verbindet neu…" strip wording with a retry countdown from the 2026-09-07 comment.

## Verification
- `ship_build` full suite: 110 files / 2784 tests green.

## Release
- Version 0.149.8 → 0.150.0 (minor — new behaviour), CHANGELOG entry added.

Shipped by /run-backlog (autonomous, lockout armed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)