### PR TITLE
fix(concept): Kompass panel verified live, five foot/boot defects

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.150.0"
+    "version": "0.150.1"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.150.0",
+      "version": "0.150.1",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.150.0",
+      "version": "0.150.1",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.150.1] — 2026-09-07
+
+### Fixed
+
+- **The Kompass decision panel has now been looked at in a real browser — and five things the jsdom suites could not see are fixed.** `scripts/build-concept-fixture.js` assembles a standalone page from the reference blocks in `templates.md` — N rounds, M entries, decision or design template, the design skeleton completed with the foot states it tells the author to copy — so the panel can be opened where layout and paint exist. The first run (8 rounds, 14 entries) confirmed what the tests promised: the archive folds seven earlier rounds and opens itself on a frozen tab, the table of contents groups into Kontext / Varianten past twelve entries, the split button opens its menu and closes on Escape, the six status-line states render in six colours, the mobile bottom bar caps at 60vh, the design-mode foot keeps the 💬 FAB's row free. It also found: the frozen block was 157px in a 120px foot with its "back to the live round" button clipped below the cap (its hint paragraph no longer renders in the foot — the status line and the frozen bar already say it — and `.panel-cta` scrolls as a safety net); the submitted block overran the cap by 3px (compact indicator); the mobile head-fold never applied because a later `.panel-here { display: flex }` won the cascade; a design page threw at boot on the unguarded `#theme-toggle` listener, so the tab-switch wiring never ran and the "you are here" head stayed empty; and after a submit, a detour into a past tab and back re-showed the ready block with live submit buttons under the "übermittelt" indicator. Each fix is pinned by a test, and the reference suite now holds every boot-time `getElementById(...).call` to ids that exist in every skeleton. The #346 computed-token probe moves from `--bg-color` to `--accent-color`: the reference CSS defines no tokens itself, and generated pages differ on `--bg` vs `--bg-color`. (#341)
+
 ## [0.150.0] — 2026-09-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.150.0**
+**Version: 0.150.1**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.150.0",
+  "version": "0.150.1",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/hooks/lib/concept-gate.js
+++ b/plugins/devops/hooks/lib/concept-gate.js
@@ -174,7 +174,7 @@ function buildBlockReason(filePath, missing, forbidden, structural) {
     structural.forEach(s => lines.push(`  - ${s.kind}: ${s.why}`));
     lines.push('  Typical cause: the opening <style> line of an older page was pasted INSIDE the new style block.');
     lines.push('  Fix: exactly one <style> per block, closed before the next tag; then verify in the browser that');
-    lines.push("  getComputedStyle(document.documentElement).getPropertyValue('--bg-color') is non-empty.");
+    lines.push("  getComputedStyle(document.documentElement).getPropertyValue('--accent-color') is non-empty.");
     lines.push('');
   }
   if (forbidden.length) {

--- a/plugins/devops/hooks/lib/concept-gate.test.js
+++ b/plugins/devops/hooks/lib/concept-gate.test.js
@@ -184,7 +184,7 @@ body { background: var(--bg-color); }
     const reason = buildBlockReason("docs/concepts/2026-09-07-broken.html", r.missing, r.forbidden, r.structural);
     expect(reason).toMatch(/Broken <style> \/ <script> structure/);
     expect(reason).toMatch(/nested-style/);
-    expect(reason).toMatch(/--bg-color/);
+    expect(reason).toMatch(/--accent-color/);
   });
 
   test("buildBlockReason without the structural argument still works (older callers)", () => {

--- a/plugins/devops/scripts/build-concept-fixture.js
+++ b/plugins/devops/scripts/build-concept-fixture.js
@@ -1,0 +1,268 @@
+#!/usr/bin/env node
+/**
+ * @script build-concept-fixture
+ * @version 0.1.0
+ * @plugin devops
+ * @description Assemble a standalone concept page from the reference blocks in
+ *   `skills/concept/deep-knowledge/templates.md` — the same fenced HTML / CSS
+ *   / JS a generated page is copied from — with a synthetic history of N
+ *   rounds, so the Kompass decision panel (archive fold, TOC groups, the six
+ *   status-line states, the split button, the mobile bottom bar, the FAB
+ *   gutter in design mode) can be opened in a REAL browser and looked at
+ *   (#341). The jsdom suites (section-nav, panel-anatomy, panel-chrome) run
+ *   the same engine without layout or paint; this is the fixture for the
+ *   half they cannot see.
+ *
+ *   Usage:
+ *     node build-concept-fixture.js --out <file.html> [--rounds 8] [--entries 14]
+ *                                   [--mode decision|design] [--locale en|de]
+ *
+ *   No bridge is involved: the page's heartbeat / draft fetches fail and the
+ *   status line settles on "local-only", which is itself one of the states to
+ *   verify. Open it via file:// in an isolated browser profile (never the
+ *   user's Edge window — SKILL.md Step 3, #347).
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const TEMPLATES = path.join(__dirname, '..', 'skills', 'concept', 'deep-knowledge', 'templates.md');
+
+function parseArgs(argv) {
+  const out = { out: '', rounds: 8, entries: 14, mode: 'decision', locale: 'en' };
+  for (let i = 0; i < argv.length; i++) {
+    const key = argv[i].startsWith('--') ? argv[i].slice(2) : null;
+    if (!key || !Object.prototype.hasOwnProperty.call(out, key)) continue;
+    const raw = argv[i + 1];
+    if (raw === undefined || raw.startsWith('--')) continue;
+    i++;
+    out[key] = typeof out[key] === 'number' ? Number(raw) : raw;
+  }
+  return out;
+}
+
+/** Fenced blocks of a markdown file, same walk as the concept test suites. */
+function scanBlocks(src) {
+  const lines = src.split('\n');
+  const out = [];
+  let open = null, body = [];
+  for (let i = 0; i < lines.length; i++) {
+    const m = /^```(.*)$/.exec(lines[i]);
+    if (m) {
+      if (open === null) { open = { info: m[1].trim(), start: i + 2 }; body = []; }
+      else { out.push({ info: open.info, line: open.start, code: body.join('\n') }); open = null; }
+      continue;
+    }
+    if (open) body.push(lines[i]);
+  }
+  return out;
+}
+
+/** `{{key}}` → the locale table's column, key itself when the row is missing. */
+function localeMap(md, locale) {
+  const map = new Map();
+  const header = md.match(/^\| Key \| (.+) \|$/m);
+  const cols = header ? header[1].split('|').map(s => s.trim()) : ['en', 'de'];
+  const idx = Math.max(0, cols.indexOf(locale));
+  const rowRe = /^\| `([a-z_.]+)`\s*\|(.+)\|$/gm;
+  let m;
+  while ((m = rowRe.exec(md))) {
+    const cells = m[2].split('|').map(s => s.trim());
+    if (cells[idx]) map.set(m[1], cells[idx]);
+  }
+  return map;
+}
+
+function esc(s) {
+  return String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+const LOREM = [
+  'The reviewer reads this section and decides whether the direction holds.',
+  'A second paragraph keeps the section tall enough that the scroll spy has something to track.',
+  'Nothing here is real product copy; the fixture only needs the shape of a long round.',
+];
+
+/** One plain context section (TOC entry, scroll only). */
+function plainSection(id, label) {
+  return [
+    `<section id="${id}" data-nav-label="${esc(label)}">`,
+    `  <h2>${esc(label)}</h2>`,
+    ...LOREM.map(p => `  <p>${p}</p>`),
+    '</section>',
+  ].join('\n');
+}
+
+/** One variant card with the mandatory bi-state selector + note slot. */
+function variantSection(id, label, { discard = false, disabled = false } = {}) {
+  const dis = disabled ? ' disabled' : '';
+  return [
+    `<section id="${id}" class="variant-card" data-nav-label="${esc(label)}">`,
+    `  <h2>${esc(label)}</h2>`,
+    `  <p>${LOREM[0]}</p>`,
+    `  <ul><li>Pro: ${LOREM[1]}</li><li>Con: ${LOREM[2]}</li></ul>`,
+    `  <div class="variant-evaluation" data-decision="${id}" data-label="${esc(label)}">`,
+    '    <div class="eval-group">',
+    `      <label class="eval-option"><input type="radio" name="eval-${id}" value="discard"${discard ? ' checked' : ''}${dis}><span class="eval-label">{{variant.discard}}</span></label>`,
+    `      <label class="eval-option"><input type="radio" name="eval-${id}" value="include"${discard ? '' : ' checked'}${dis}><span class="eval-label">{{variant.include}}</span></label>`,
+    '    </div>',
+    '    <div class="field-row decision-comment-row">',
+    `      <label for="${id}-note">{{decision.comment_label}}</label>`,
+    `      <textarea id="${id}-note" data-comment="${id}-note" data-attachable placeholder="{{decision.comment_placeholder}}" rows="2"${dis}${disabled ? ' readonly' : ''}></textarea>`,
+    '    </div>',
+    '  </div>',
+    '</section>',
+  ].join('\n');
+}
+
+/**
+ * A decision round. `entries` sections, the first `plain` of them context
+ * sections and the rest variant cards — two kinds, so the live round groups
+ * once it exceeds NAV_GROUP_OVER_ENTRIES.
+ */
+function decisionRound(n, { live, entries, plain, discard = 0 }) {
+  const parts = [];
+  parts.push(`<section id="iter-${n}" data-iteration="${n}" data-iteration-template="decision"${live ? ' data-active' : ' hidden'}>`);
+  parts.push('  <div class="iteration-intro">');
+  parts.push(`    <h2>Iteration ${n} · ${live ? 'live round' : 'frozen round'}</h2>`);
+  parts.push(`    <p>Synthetic round ${n} of the Kompass fixture — ${entries} sections, ${plain} of them context.</p>`);
+  parts.push('  </div>');
+  for (let i = 0; i < entries; i++) {
+    const id = `r${n}-s${i}`;
+    if (i < plain) parts.push(plainSection(id, `Context ${i + 1} — round ${n}`));
+    else parts.push(variantSection(id, `Variant ${String.fromCharCode(65 + i - plain)} — round ${n}`, { discard: i - plain < discard, disabled: !live }));
+  }
+  parts.push('</section>');
+  return parts.join('\n');
+}
+
+/** A design round: one design with three wired screens, no views. */
+function designRound(n, { live }) {
+  const screen = (id, label, next, active) => [
+    `<section id="${id}" data-screen data-nav-label="${esc(label)}"${active ? ' data-screen-active="true"' : ' hidden'}>`,
+    '  <div class="device-frame">',
+    `    <div style="padding:2rem;font-family:system-ui"><h1 style="margin:0 0 1rem">${esc(label)}</h1>`,
+    `    <p>${LOREM[0]}</p>`,
+    next ? `    <button type="button" data-screen-link="${next}">Continue →</button>` : '    <p><strong>Done.</strong></p>',
+    '    </div>',
+    '  </div>',
+    '</section>',
+  ].join('\n');
+  return [
+    `<section id="iter-${n}" data-iteration="${n}" data-iteration-template="design"${live ? ' data-active' : ' hidden'}>`,
+    `  <section data-design="d${n}" data-nav-label="Design ${n}" data-design-active="true">`,
+    screen(`d${n}-s1`, 'Welcome', `d${n}-s2`, true),
+    screen(`d${n}-s2`, 'Credentials', `d${n}-s3`, false),
+    screen(`d${n}-s3`, 'Success', null, false),
+    '  </section>',
+    '</section>',
+  ].join('\n');
+}
+
+function tabs(rounds, live) {
+  return rounds.map(n =>
+    `<button class="iteration-tab" role="tab" data-iteration="${n}" aria-selected="${n === live ? 'true' : 'false'}">Iteration ${n}${n === live ? ' {{iteration.active_suffix}}' : ''}</button>`
+  ).join('\n');
+}
+
+// The reference CSS consumes design tokens (`var(--panel-bg)`, `var(--accent-color)`,
+// …) but defines none — every generated page carries its own `:root` block,
+// written by Claude per project (SKILL.md Step 2 § Design). The fixture needs
+// one too, or every state colour collapses to the browser default. This set
+// mirrors the newest sample page in docs/concepts/ plus the names the
+// reference CSS additionally reads (both the `--bg` and the `--bg-color`
+// family are in use across pages).
+const TOKENS = `
+:root {
+  --bg: #0d1117; --bg-color: #0d1117; --bg-secondary: #161b22; --bg-subtle: #1c2128; --surface-2: #1c2128;
+  --text: #c9d1d9; --text-color: #c9d1d9; --text-primary: #c9d1d9; --text-secondary: #8b949e;
+  --text-muted: #8b949e; --text-tertiary: #6e7681;
+  --panel-bg: #161b22; --border-color: #30363d; --input-bg: #0d1117; --code-bg: #1c2128;
+  --accent-color: #58a6ff; --success-color: #3fb950; --warning-color: #d29922; --danger-color: #f85149;
+  --chrome-safe-top: 0px; --chrome-safe-bottom: 0px;
+}
+html[data-theme="light"] {
+  --bg: #ffffff; --bg-color: #ffffff; --bg-secondary: #f6f8fa; --bg-subtle: #f6f8fa; --surface-2: #eaeef2;
+  --text: #1f2328; --text-color: #1f2328; --text-primary: #1f2328; --text-secondary: #59636e;
+  --text-muted: #59636e; --text-tertiary: #818b98;
+  --panel-bg: #f6f8fa; --border-color: #d1d9e0; --input-bg: #ffffff; --code-bg: #f6f8fa;
+  --accent-color: #0969da; --success-color: #1a7f37; --warning-color: #9a6700; --danger-color: #d1242f;
+}
+body { margin: 0; background: var(--bg); color: var(--text); font-family: system-ui, -apple-system, "Segoe UI", sans-serif; line-height: 1.5; }
+.concept-content { padding: 2rem; }
+.variant-card { border: 1px solid var(--border-color); border-radius: 8px; padding: 1rem 1.25rem; margin: 1rem 0; background: var(--panel-bg); }
+`;
+
+function build(opts, md = fs.readFileSync(TEMPLATES, 'utf8')) {
+  const blocks = scanBlocks(md);
+  const html = blocks.filter(b => b.info === 'html');
+  const css = blocks.filter(b => b.info === 'css').map(b => b.code).join('\n\n');
+  const js = blocks.filter(b => /^(javascript|js)$/.test(b.info)).map(b => b.code).join('\n\n');
+  const locale = localeMap(md, opts.locale);
+  const subst = s => s.replace(/\{\{([a-z_.]+)\}\}/g, (_, k) => locale.get(k) || k);
+
+  const rounds = Array.from({ length: opts.rounds }, (_, i) => i + 1);
+  const live = opts.rounds;
+  const sections = rounds.map(n => {
+    if (n === live) {
+      return opts.mode === 'design'
+        ? designRound(n, { live: true })
+        : decisionRound(n, { live: true, entries: opts.entries, plain: Math.max(2, Math.floor(opts.entries / 3)) });
+    }
+    // Frozen history: varying sizes, a few discards, so the chip summaries differ.
+    return decisionRound(n, { live: false, entries: 3 + (n % 4), plain: 1, discard: n % 3 });
+  }).join('\n\n');
+
+  const stamp = new Date().toISOString().replace(/\.\d{3}Z$/, '');
+  const title = `Kompass fixture — ${opts.rounds} rounds, ${opts.entries} entries (${opts.mode})`;
+  let page;
+
+  if (opts.mode === 'design') {
+    const skel = html.find(b => b.code.includes('class="concept-layout design fullscreen"'));
+    if (!skel) throw new Error('design skeleton not found in templates.md');
+    // The design skeleton ships only #panel-ready and #panel-submitted and
+    // tells the author to copy #panel-frozen + #panel-final-report verbatim
+    // from the Common Structure — do exactly that, in place of its comment.
+    const common = html.find(b => b.code.startsWith('<!DOCTYPE html>'));
+    if (!common) throw new Error('common structure skeleton not found in templates.md');
+    const foot = common.code.slice(common.code.indexOf('<div id="panel-frozen"'), common.code.indexOf('<!-- /.panel-cta -->'));
+    const restStates = foot.slice(0, foot.lastIndexOf('</div>'));   // drop the .panel-cta closer itself
+    page = skel.code
+      .replace(/<!-- The remaining two panel states[\s\S]*?-->/, restStates)
+      .replace(/^<html data-template="design">/m,
+        `<!DOCTYPE html>\n<html lang="${opts.locale}" data-theme="dark" data-page-version="${stamp}" data-template="design">\n<head>\n<meta charset="UTF-8">\n<meta name="viewport" content="width=device-width, initial-scale=1.0">\n<title>${esc(title)}</title>\n<style>\n${TOKENS}\n${css}\n</style>\n</head>`)
+      .replace(/<main>[\s\S]*?<\/main>/, `<main>\n${sections}\n</main>`)
+      .replace(/<\/body>\s*<\/html>\s*$/, `<script type="application/json" id="concept-decisions">\n{"submitted": false, "decisions": [], "comments": []}\n</script>\n<script>\n${js}\n</script>\n</body>\n</html>\n`);
+  } else {
+    const skel = html.find(b => b.code.startsWith('<!DOCTYPE html>'));
+    if (!skel) throw new Error('common structure skeleton not found in templates.md');
+    page = skel.code
+      .replace(/<html lang="en"[^>]*>/, `<html lang="${opts.locale}" data-theme="dark" data-page-version="${stamp}" data-template="decision">`)
+      .replace(/<title>[^<]*<\/title>/, `<title>${esc(title)}</title>`)
+      .replace(/<style>\/\* all CSS inline \*\/<\/style>/, `<style>\n${TOKENS}\n${css}\n</style>`)
+      .replace(/<h1>\{title\}<\/h1>\s*<p class="subtitle">[^<]*<\/p>/, `<h1>${esc(title)}</h1>\n        <p class="subtitle">Generated by scripts/build-concept-fixture.js — no bridge, no real content.</p>`)
+      .replace(/<main>[\s\S]*?<\/main>/, `<main>\n${sections}\n</main>`)
+      .replace(/<script>\/\* all JS inline \*\/<\/script>/, `<script>\n${js}\n</script>`);
+  }
+
+  // Tabs go into the (first) iteration-tabs nav of whichever skeleton was used.
+  page = page.replace(/(<nav class="iteration-tabs"[^>]*>)[\s\S]*?(<\/nav>)/, `$1\n${tabs(rounds, live)}\n$2`);
+  page = subst(page);
+  // Anything the skeleton left as a {placeholder} for Claude to fill.
+  page = page.replace(/\{generation-timestamp\}/g, stamp);
+  return page;
+}
+
+module.exports = { parseArgs, scanBlocks, localeMap, build, TEMPLATES };
+
+if (require.main === module) {
+  const opts = parseArgs(process.argv.slice(2));
+  if (!opts.out) {
+    process.stderr.write('usage: build-concept-fixture.js --out <file.html> [--rounds 8] [--entries 14] [--mode decision|design] [--locale en|de]\n');
+    process.exit(2);
+  }
+  const page = build(opts);
+  fs.mkdirSync(path.dirname(path.resolve(opts.out)), { recursive: true });
+  fs.writeFileSync(opts.out, page);
+  process.stdout.write(`${path.resolve(opts.out)} (${page.length} bytes, ${opts.rounds} rounds, mode ${opts.mode})\n`);
+}

--- a/plugins/devops/skills/concept/SKILL.md
+++ b/plugins/devops/skills/concept/SKILL.md
@@ -727,14 +727,19 @@ read of the rendered CSS, no bridge interaction) and evaluate:
 > ends.
 
 ```js
-getComputedStyle(document.documentElement).getPropertyValue('--bg-color').trim()
+getComputedStyle(document.documentElement).getPropertyValue('--accent-color').trim()
 ```
 
-Non-empty → proceed to `start`. Empty → do NOT open the tab; regenerate the
-`<style>` block from `templates.md` § Layout (exactly one `<style>` opener,
-closed before the next tag), re-run the gate, re-check. Skip the check only
-when no browser tool is reachable at all — then say so in the completion card's
-`userFinalTest` so the user knows the theme was not verified.
+`--accent-color` is the token every page defines and the panel's split button,
+chips and status line consume; the reference CSS itself defines no tokens, and
+pages differ on `--bg` vs `--bg-color`, so those are not reliable probes. (A
+page that uses a different accent name is one you authored — probe the token
+your `:root` block defines.) Non-empty → proceed to `start`. Empty → do NOT
+open the tab; regenerate the `<style>` block from `templates.md` § Layout
+(exactly one `<style>` opener, closed before the next tag), re-run the gate,
+re-check. Skip the check only when no browser tool is reachable at all — then
+say so in the completion card's `userFinalTest` so the user knows the theme
+was not verified.
 
 **If the `start "" msedge …` command errors** (Edge not installed, not in
 PATH), do NOT silently fall back to the preview MCP. Tell the user the

--- a/plugins/devops/skills/concept/deep-knowledge/templates.md
+++ b/plugins/devops/skills/concept/deep-knowledge/templates.md
@@ -5945,6 +5945,14 @@ document.addEventListener('DOMContentLoaded', buildSectionNav);
 .panel-here-back { margin: 0 0 0 auto; }
 .panel-here-section[hidden],
 .panel-here-back[hidden] { display: none; }
+/* Mobile: the head folds into the status line (§ Layout — Sidebar's media
+   block says so too, but it sits EARLIER in the source than the `display:
+   flex` above, and equal specificity means the later rule wins — the first
+   live check (#341) showed the head taking 51px of a 487px bottom bar). This
+   copy comes after the layout rule, so the fold actually applies. */
+@media (max-width: 768px) {
+  .panel-here { display: none; }
+}
 .panel-nav-scroll {
   flex: 1 1 auto;
   min-height: 0;
@@ -5966,6 +5974,14 @@ document.addEventListener('DOMContentLoaded', buildSectionNav);
   position: relative;
   max-height: 120px;
   padding-top: 0.6rem;
+  /* Safety net, never the plan: the cap is what keeps the call to action on
+     screen, so a foot whose content outgrows it scrolls inside the foot
+     instead of clipping — the first live check (#341) found the frozen block
+     at 157px with its "back to the live round" button cut off below the cap.
+     The scrollbar rules above already cover .panel-cta. Every foot state is
+     sized to fit WITHOUT scrolling (see #panel-frozen .hint and
+     .submitted-indicator below); this only catches the next overflow. */
+  overflow-y: auto;
 }
 /* The close-out wizard is the one legitimate exception: a multi-step form,
    not a call to action. On the final-report tab the foot may grow and scroll
@@ -6153,13 +6169,15 @@ html[data-template="design"] .frozen-bar {
 }
 
 /* Submitted state — compact: it shares the ≤120px foot with the frozen block
-   and the split button, and the progress itself lives in the status line. */
+   and the split button, and the progress itself lives in the status line.
+   Measured at panel width (#341): indicator 63px + hint 54px overran the cap
+   by 3px, so the indicator lost a little padding — 58 + 54 = 112, no scroll. */
 .submitted-indicator {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  padding: 0.55rem 0.75rem;
-  margin-bottom: 0.4rem;
+  padding: 0.4rem 0.75rem;
+  margin-bottom: 0.3rem;
   border-radius: 8px;
   background: color-mix(in srgb, var(--success-color, #3fb950) 15%, transparent);
   border: 1px solid var(--success-color, #3fb950);
@@ -6192,7 +6210,13 @@ html[data-template="design"] .frozen-bar {
   font-size: 0.9rem;
 }
 .frozen-indicator .frozen-icon { font-size: 1.1rem; }
-#panel-frozen .hint { font-size: 0.78rem; line-height: 1.35; margin: 0; }
+/* The hint paragraph does not render in the foot (#341): at panel width it
+   wraps to three lines (67px) and pushes the frozen block to 157px — past the
+   120px cap, with the back button clipped below it. The same sentence is
+   already on screen twice: the status line ("🕘 Iteration N · nur lesen") and
+   the frozen bar over the content. The markup stays (screen readers, older
+   pages) — the foot is indicator + back button, ≈85px. */
+#panel-frozen .hint { display: none; font-size: 0.78rem; line-height: 1.35; margin: 0; }
 #panel-frozen .link-btn { margin-top: 0.3rem; }
 
 /* Progress steps under the status line.
@@ -9106,7 +9130,11 @@ function updateStatusSteps(data) {
 ## Theme Toggle
 
 ```javascript
-document.getElementById('theme-toggle').addEventListener('click', () => {
+// Null-guarded (#341): the design skeleton carries no #theme-toggle, and an
+// unguarded dereference here threw at boot and took the rest of the script
+// with it — the tab-switch boot never ran, so the "you are here" head stayed
+// empty on every design page until the first manual tab click.
+document.getElementById('theme-toggle')?.addEventListener('click', () => {
   const html = document.documentElement;
   const current = html.getAttribute('data-theme');
   html.setAttribute('data-theme', current === 'dark' ? 'light' : 'dark');
@@ -9612,9 +9640,13 @@ function showIteration(n) {
   const panelSubmitted = document.getElementById('panel-submitted');
   const panelFrozen = document.getElementById('panel-frozen');
   const panelFinal = document.getElementById('panel-final-report');
-  if (panelReady) panelReady.style.display = (isLive && !isFinal) ? 'block' : 'none';
+  // ready and submitted are mutually exclusive (#341): submitWithAction hides
+  // the ready block, and a detour into a past tab and back must not bring
+  // it back under the submitted indicator — that showed both blocks at once
+  // (126px in a 120px foot) with live submit buttons under "übermittelt".
+  const submitted = document.body.classList.contains('concept-submitted');
+  if (panelReady) panelReady.style.display = (isLive && !isFinal && !submitted) ? 'block' : 'none';
   if (panelSubmitted) {
-    const submitted = document.body.classList.contains('concept-submitted');
     panelSubmitted.style.display = (isLive && !isFinal && submitted) ? 'block' : 'none';
   }
   if (panelFinal) panelFinal.style.display = isFinal ? 'block' : 'none';

--- a/plugins/devops/skills/concept/deep-knowledge/validation-gate.md
+++ b/plugins/devops/skills/concept/deep-knowledge/validation-gate.md
@@ -72,11 +72,13 @@ offsets. A `<style` token inside an open `<script>` block is JS string content
 
 **Then confirm the tokens actually applied — in the browser, before the page is
 shown (SKILL.md Step 3).** Evaluate
-`getComputedStyle(document.documentElement).getPropertyValue('--bg-color')` on
-the loaded page; it MUST be non-empty. An empty value means the design-token
-block was swallowed even though the file looks balanced (a stray `{`, an
-unterminated comment) — regenerate the block from `templates.md` § Layout
-before opening the tab.
+`getComputedStyle(document.documentElement).getPropertyValue('--accent-color')`
+on the loaded page; it MUST be non-empty. `--accent-color` is the one token
+every page defines and the panel chrome consumes (the reference CSS defines no
+tokens itself, and pages differ on `--bg` vs `--bg-color`, so probe the accent).
+An empty value means the design-token block was swallowed even though the file
+looks balanced (a stray `{`, an unterminated comment) — regenerate the block
+from `templates.md` § Layout before opening the tab.
 
 ## Phase 1 — Shared patterns (ALL templates)
 

--- a/plugins/devops/skills/concept/frozen-veil-bar.test.js
+++ b/plugins/devops/skills/concept/frozen-veil-bar.test.js
@@ -173,7 +173,12 @@ function makeStub() {
   const title = mkEl();
   const bar = mkEl(); bar.hidden = true;
   bar.querySelector = (sel) => (sel === "[data-frozen-bar-title]" ? title : null);
-  const byId = { "content-dimmer": dimmer, "frozen-bar": bar };
+  // The four foot states showIteration() switches (#341 pins ready/submitted).
+  const ready = mkEl(); const submitted = mkEl(); const frozen = mkEl(); const final = mkEl();
+  const byId = {
+    "content-dimmer": dimmer, "frozen-bar": bar,
+    "panel-ready": ready, "panel-submitted": submitted, "panel-frozen": frozen, "panel-final-report": final,
+  };
   const body = mkEl();
   const documentElement = mkEl();
   const document = {
@@ -189,7 +194,7 @@ function makeStub() {
     dispatchEvent: () => true,
     addEventListener: () => {},
   };
-  return { document, sections, tabs, dimmer, bar, title, body };
+  return { document, sections, tabs, dimmer, bar, title, body, ready, submitted, frozen, final };
 }
 
 function loadRuntime() {
@@ -266,5 +271,30 @@ describe("frozen veil + floating bar — behaviour (reference JS on a DOM stub)"
     expect(r.body.classList.contains("viewing-final")).toBe(true);
     expect(veiled(r)).toBe(false);
     expect(r.bar.hidden).toBe(true);
+  });
+
+  // #341 — found in the first real-browser run: after a submit, a detour into
+  // a past tab and back re-showed #panel-ready UNDER the submitted indicator
+  // (126px in a 120px foot, live submit buttons under "übermittelt").
+  test("ready and submitted are mutually exclusive across tab switches", () => {
+    const r = loadRuntime();
+    r.showIteration("3");
+    expect(r.ready.style.display).toBe("block");
+    expect(r.submitted.style.display).toBe("none");
+    // submitWithAction() adds the class and hides ready; a round trip must keep it hidden.
+    r.body.classList.add("concept-submitted");
+    r.showIteration("1");
+    expect(r.ready.style.display).toBe("none");
+    expect(r.submitted.style.display).toBe("none");
+    expect(r.frozen.style.display).toBe("block");
+    r.showIteration("3");
+    expect(r.ready.style.display).toBe("none");
+    expect(r.submitted.style.display).toBe("block");
+    expect(r.frozen.style.display).toBe("none");
+    // restorePanelToReady() removes the class → ready is back, submitted gone.
+    r.body.classList.remove("concept-submitted");
+    r.showIteration("3");
+    expect(r.ready.style.display).toBe("block");
+    expect(r.submitted.style.display).toBe("none");
   });
 });

--- a/plugins/devops/skills/concept/panel-anatomy.test.js
+++ b/plugins/devops/skills/concept/panel-anatomy.test.js
@@ -251,6 +251,46 @@ describe("panel anatomy — CSS", () => {
     expect(media[1]).toMatch(/\.panel-here \{ display: none; \}/);
   });
 
+  // #341 — the first live check in a real browser (scripts/build-concept-fixture.js,
+  // 8 rounds, 14 entries) found three things the jsdom suites cannot see:
+  // the frozen block overran the 120px cap with its back button clipped, the
+  // submitted block overran it by 3px, and the mobile head-fold never applied
+  // because a later `.panel-here { display: flex }` won the cascade.
+  test("the foot scrolls instead of clipping when a state outgrows the cap (#341)", () => {
+    const cta = rulesFor(/^\.panel-cta$/).find((r) => /max-height/.test(r.body));
+    expect(cta.body).toMatch(/overflow-y:\s*auto/);
+  });
+
+  test("the frozen block fits the cap: its hint paragraph does not render in the foot (#341)", () => {
+    const hint = rulesFor(/^#panel-frozen \.hint$/)[0];
+    expect(hint, "#panel-frozen .hint").toBeTruthy();
+    expect(hint.body).toMatch(/display:\s*none/);
+    // The sentence stays on screen elsewhere — status line + frozen bar.
+    expect(rulesFor(/^\.panel-status\[data-status="frozen"\] \.status-line$/).length).toBeGreaterThan(0);
+    expect(cssSource).toContain(".frozen-bar");
+  });
+
+  test("the submitted block fits the cap: compact indicator padding (#341)", () => {
+    const ind = rulesFor(/^\.submitted-indicator$/)[0];
+    expect(ind, ".submitted-indicator").toBeTruthy();
+    const pad = /padding:\s*([\d.]+)rem/.exec(ind.body);
+    expect(pad, "vertical padding in rem").toBeTruthy();
+    expect(Number(pad[1])).toBeLessThanOrEqual(0.4);
+  });
+
+  test("the mobile head-fold comes AFTER the layout rule, so it wins the cascade (#341)", () => {
+    const src = stripComments(cssSource);
+    const layout = src.search(/\.panel-here \{[^}]*display:\s*flex/);
+    expect(layout, ".panel-here layout rule").toBeGreaterThan(-1);
+    const fold = src.lastIndexOf(".panel-here { display: none; }");
+    expect(fold, "mobile fold").toBeGreaterThan(-1);
+    expect(fold, "a fold before the layout rule is overridden by it").toBeGreaterThan(layout);
+    // …and it is inside a max-width media block, not unconditional.
+    const tail = src.slice(0, fold);
+    const lastMedia = tail.lastIndexOf("@media (max-width: 768px)");
+    expect(lastMedia).toBeGreaterThan(layout);
+  });
+
   test("the six states are styled and 'local-only' is the one with a background", () => {
     for (const s of ["saved", "saving", "connecting", "local-only", "submitted", "frozen"]) {
       expect(rulesFor(new RegExp(`^\\.panel-status\\[data-status="${s}"\\] \\.status-line$`)).length, s).toBeGreaterThan(0);

--- a/plugins/devops/skills/concept/templates-reference.test.js
+++ b/plugins/devops/skills/concept/templates-reference.test.js
@@ -211,3 +211,42 @@ describe("attachment tooltip locale (#343)", () => {
     expect(tableKeys.has("error_quota")).toBe(false);
   });
 });
+
+// #341 — the first real-browser run of a design-template page threw at boot:
+// `getElementById('theme-toggle').addEventListener(...)` on a skeleton that
+// has no theme toggle. A top-level throw ends the whole <script>, so every
+// wiring after it (tab switch, "you are here" head, back links) never ran.
+// The undeclared-id test above accepts an id that exists in ANY html block;
+// this one holds every direct `getElementById(x).<call>` chain to the ids
+// that exist in EVERY full-page skeleton, or requires the optional chain.
+describe("boot-time dereferences survive every skeleton (#341)", () => {
+  const common = htmlBlocks.find((b) => b.code.startsWith("<!DOCTYPE html>"))?.code || "";
+  const design = htmlBlocks.find((b) => b.code.includes('class="concept-layout design fullscreen"'))?.code || "";
+  // The design skeleton deliberately omits #panel-frozen and
+  // #panel-final-report and tells the author to copy them verbatim from the
+  // Common Structure's .panel-cta — so a design page is the design skeleton
+  // PLUS that foot. Everything else (the header's #theme-toggle, say) is not
+  // part of the copy rule and must be null-guarded.
+  const commonFoot = common.slice(common.indexOf('<div class="panel-cta">'), common.indexOf("<!-- /.panel-cta -->"));
+  const skeletons = [common, design + commonFoot];
+
+  test("both full-page skeletons are found", () => {
+    expect(common.length).toBeGreaterThan(0);
+    expect(design.length).toBeGreaterThan(0);
+    expect(commonFoot).toContain('id="panel-frozen"');
+    expect(commonFoot).toContain('id="panel-final-report"');
+  });
+
+  test("no unguarded getElementById(...).call on an id a skeleton lacks", () => {
+    const js = jsBlocks.map((b) => b.code).join("\n");
+    const re = /getElementById\('([A-Za-z0-9_-]+)'\)\.(addEventListener|classList|dataset|style|textContent|hidden|value)/g;
+    const offenders = [];
+    let m;
+    while ((m = re.exec(js))) {
+      const id = m[1];
+      const missing = skeletons.filter((s) => !s.includes(`id="${id}"`));
+      if (missing.length) offenders.push(`${id} (missing in ${missing.length} skeleton${missing.length > 1 ? "s" : ""})`);
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.150.0",
+  "version": "0.150.1",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
Closes #341

## Summary
- **New:** `scripts/build-concept-fixture.js` assembles a standalone page from the reference blocks in `templates.md` (N rounds, M entries, decision or design; the design skeleton completed with the foot states it tells the author to copy) so the panel can be verified in a real browser.
- **Verified live** (Claude browser pane, 8 rounds / 14 entries): archive fold (7 rounds, auto-open on a frozen tab), TOC groups Kontext 4 / Varianten 10, split-button menu + Escape, six status-line states in six colours, mobile bottom bar at the 60vh cap, design-mode FAB gutter (92px, no overlap).
- **Defects found and fixed in `templates.md`:**
  1. frozen block 157px in a 120px foot, back button clipped → hint no longer renders in the foot (status line + frozen bar carry it), `.panel-cta { overflow-y: auto }` as safety net
  2. submitted block 123px → compact indicator (112px)
  3. mobile `.panel-here` fold overridden by the later layout rule → re-declared after it
  4. unguarded `#theme-toggle` listener threw at boot on design pages → tab-switch wiring never ran, "you are here" empty → optional chain
  5. after a submit, a tab round trip re-showed `#panel-ready` under `#panel-submitted` → `showIteration` keeps them exclusive
- #346 probe: `--bg-color` → `--accent-color` (the reference CSS defines no tokens; pages differ on `--bg` vs `--bg-color`).
- Tests: panel-anatomy (4 new), frozen-veil-bar (ready/submitted exclusivity), templates-reference (boot-time dereferences vs every skeleton), concept-gate reason text.

## Verification
- `ship_build` with the concept suites + gate: 17 files / 361 tests green.
- Full suite run directly: 107/110 files green; `git-sync.*` (3 files, untouched by this branch, green in the #348 build 30 min earlier) timed out at 60 s under 97 % CPU (Windows Defender + other sessions' bridges). Re-run when the machine is idle.

## Release
- Version 0.150.0 → 0.150.1 (patch), CHANGELOG entry added.

Shipped by /run-backlog (autonomous, lockout armed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)