### PR TITLE
fix(concept): design layout JS names missing markup instead of dying

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
-    "version": "0.151.0"
+    "version": "0.151.1"
   },
   "plugins": [
     {
       "name": "devops",
       "description": "Complete DevOps automation for Claude Code: hooks, skills, agents, and templates.",
-      "version": "0.151.0",
+      "version": "0.151.1",
       "author": {
         "name": "Jerry0022"
       },
@@ -20,7 +20,7 @@
     {
       "name": "local-llm",
       "description": "Local LLM integration — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens.",
-      "version": "0.151.0",
+      "version": "0.151.1",
       "author": {
         "name": "Jerry0022"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.151.1] — 2026-09-08
+
+### Fixed
+
+- **A concept page missing its dock markup lost every interaction, silently.** The shared panel-chrome block names the element it cannot find and degrades; the design layout block right below it still dereferenced `dockToggle.dataset`, `dock.dataset`, `dockClose` and `panel.classList` unguarded. That block wires everything after the dock too — screen switching, click-through, the keyboard shortcuts — so one missing element threw at boot and took all of it with it, with no visible error: a mockup that ignores every click and every arrow key, which reads as "the mockup is broken" rather than "three lines of markup are missing". The keydown handler threw once per keystroke on top of it. The dock's parts are reported once by name now, in the same shape as `missingPanelParts`, and every entry point degrades — the FAB labels, all three listener registrations, `openDock`/`closeDock` (reachable from `openPanel` through `window.closeDock?.()`, so a page with a panel and no dock still opens its panel), the four functions called from outside the block, and the keyboard shortcut. Five tests pin it, one by running the dock functions against a page that has no dock at all.
+
 ## [0.151.0] — 2026-09-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotclaude
 
-**Version: 0.151.0**
+**Version: 0.151.1**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 

--- a/plugins/devops/.claude-plugin/plugin.json
+++ b/plugins/devops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops",
-  "version": "0.151.0",
+  "version": "0.151.1",
   "description": "Complete DevOps automation for Claude Code: hooks, skills, templates, and git hygiene.",
   "author": {
     "name": "Jerry0022",

--- a/plugins/devops/skills/concept/deep-knowledge/templates.md
+++ b/plugins/devops/skills/concept/deep-knowledge/templates.md
@@ -4396,6 +4396,22 @@ change) via `harvestDockValues()`.
   const dock = document.getElementById('feedback-dock');
   const dockToggle = document.getElementById('feedback-toggle');
   const dockClose = document.getElementById('feedback-close');
+  // Same contract as the panel block's missingPanelParts: name what is
+  // missing ONCE, then degrade. Everything below used to dereference these
+  // three unguarded, so a page that shipped without the dock threw on
+  // `dockToggle.dataset` — and since this IIFE wires EVERYTHING after it too
+  // (screen switching, click-through, the keyboard shortcuts), the whole page
+  // went silent with it. The user then sees a mockup that ignores every
+  // click and arrow key, which reads as "the mockup is broken" rather than
+  // "the dock markup is missing".
+  const missingDockParts = [
+    ['feedback-dock', dock], ['feedback-toggle', dockToggle],
+    ['feedback-close', dockClose],
+  ].filter(([, el]) => !el).map(([id]) => id);
+  if (missingDockParts.length) {
+    console.error('[concept] feedback-dock markup incomplete, dock disabled — missing: '
+      + missingDockParts.join(', '));
+  }
   // The dock is a Speech-Bubble anchored to the 💬 FAB — the FAB stays
   // visible and clickable while the dock is open, so clicking it toggles
   // (open ↔ minimised). The X button is a *minimise*, not a destroy:
@@ -4408,9 +4424,10 @@ change) via `harvestDockValues()`.
   //   * on close, focus is restored to the FAB if it was inside the dock
   //     (the dock disappears via display:none, so leaving focus there
   //     would orphan it)
-  const LABEL_OPEN = dockToggle.dataset.labelOpen || dockToggle.getAttribute('aria-label');
-  const LABEL_CLOSE = dockToggle.dataset.labelClose || LABEL_OPEN;
+  const LABEL_OPEN = dockToggle?.dataset.labelOpen || dockToggle?.getAttribute('aria-label') || '';
+  const LABEL_CLOSE = dockToggle?.dataset.labelClose || LABEL_OPEN;
   function openDock() {
+    if (!dock || !dockToggle) return;
     window.closePanel?.();   // mutually exclusive overlays, see openPanel above
     dock.dataset.open = 'true';
     dockToggle.setAttribute('aria-expanded', 'true');
@@ -4424,6 +4441,9 @@ change) via `harvestDockValues()`.
   // panel instead. Every other close still restores the FAB, or focus would
   // be orphaned inside a display:none dock.
   function closeDock(handOff) {
+    // Reachable from openPanel() through `window.closeDock?.()`, so it must
+    // survive a page whose dock never existed.
+    if (!dock || !dockToggle) return;
     const focusWasInside = !handOff && dock.contains(document.activeElement);
     dock.dataset.open = 'false';
     dockToggle.setAttribute('aria-expanded', 'false');
@@ -4437,14 +4457,14 @@ change) via `harvestDockValues()`.
   // opening the dock from the FAB, or typing into it (a restored session can
   // land with the dock already open, and closeDock() is also reached by the
   // panel hand-off, which proves nothing about the dock).
-  const stopFabPulse = () => dockToggle.removeAttribute('data-untouched');
-  dockToggle.addEventListener('click', () => {
+  const stopFabPulse = () => dockToggle?.removeAttribute('data-untouched');
+  dockToggle?.addEventListener('click', () => {
     stopFabPulse();
-    if (dock.dataset.open === 'true') closeDock();
+    if (dock?.dataset.open === 'true') closeDock();
     else openDock();
   });
-  dock.addEventListener('input', stopFabPulse);
-  dockClose.addEventListener('click', closeDock);
+  dock?.addEventListener('input', stopFabPulse);
+  dockClose?.addEventListener('click', closeDock);
 
   // Maximise/restore (Work package B) — a RESIZE, never a close. Distinct
   // from minimise above: minimise flips data-open, this flips
@@ -4459,7 +4479,7 @@ change) via `harvestDockValues()`.
   // not: applyDockSize() only ever writes data-size.
   const dockMaximize = document.getElementById('feedback-maximize');
   function syncMaximizeButton() {
-    if (!dockMaximize) return;
+    if (!dockMaximize || !dock) return;
     const on = dock.dataset.userMaximized === 'true';
     dockMaximize.setAttribute('aria-pressed', String(on));
     const label = on ? '{{panel.restore_size}}' : '{{panel.maximize}}';
@@ -4467,6 +4487,7 @@ change) via `harvestDockValues()`.
     dockMaximize.title = label;
   }
   dockMaximize?.addEventListener('click', () => {
+    if (!dock) return;
     dock.dataset.userMaximized = dock.dataset.userMaximized === 'true' ? 'false' : 'true';
     applyDockSize();
     if (typeof saveState === 'function') saveState();
@@ -4498,6 +4519,9 @@ change) via `harvestDockValues()`.
     // replacing this value — so it also survives an iteration switch
     // untouched: primeDock() calls this on every switch but never clears
     // data-userMaximized itself.
+    // Exposed as window.applyDockSize and called from restoreState(), which
+    // runs on every page — including one with no dock.
+    if (!dock) return;
     const singleScreen = document.body.dataset.singleScreen === 'true';
     const singleDesign = document.body.dataset.singleDesign === 'true';
     dock.dataset.size = (singleScreen && singleDesign) ? 'compact' : 'wide';
@@ -4532,6 +4556,7 @@ change) via `harvestDockValues()`.
     try { return JSON.parse(node.textContent); } catch (e) { return null; }
   }
   function applyDockFreezeState() {
+    if (!dock) return;
     const frozen = document.body.classList.contains('viewing-frozen');
     const fields = [...document.querySelectorAll('#feedback-dock textarea')];
     if (frozen) {
@@ -4574,6 +4599,7 @@ change) via `harvestDockValues()`.
   // iteration N+1 rebuilds the dock from that empty namespace. Only editing is
   // taken away, so what is on screen cannot drift from what is in flight.
   window.markDockSubmitted = function() {
+    if (!dock) return;
     document.querySelectorAll('#feedback-dock textarea').forEach(ta => { ta.readOnly = true; });
     dock.dataset.submitted = 'true';
     if (typeof saveState === 'function') saveState();
@@ -4588,6 +4614,7 @@ change) via `harvestDockValues()`.
   // return to editable — a read-only dock under a re-armed submit button means
   // the user can see their comments and change nothing about them.
   window.unmarkDockSubmitted = function() {
+    if (!dock) return;
     if (document.body.classList.contains('viewing-frozen')) return;
     document.querySelectorAll('#feedback-dock textarea').forEach(ta => { ta.readOnly = false; });
     delete dock.dataset.submitted;
@@ -4753,7 +4780,12 @@ change) via `harvestDockValues()`.
   // Keyboard: Arrow Left/Right (and Space) jump between screens (within the
   // active design) when no textarea/input is focused and no overlay is open.
   document.addEventListener('keydown', e => {
-    if (dock.dataset.open === 'true' || panel.classList.contains('open')) return;
+    // Both optional: this handler is bound on every design page, and either
+    // overlay can be absent from the markup. Unguarded, a missing one threw
+    // on EVERY keypress — the arrow keys stopped working and the console
+    // filled with errors pointing at the keyboard shortcut rather than at
+    // the markup.
+    if (dock?.dataset.open === 'true' || panel?.classList.contains('open')) return;
     // Bailing out on textarea/input alone was too narrow: Space activates a
     // FOCUSED BUTTON, so pressing it on a mock's "Continue" advanced the
     // screen and swallowed the click at the same time. Device mode doubles

--- a/plugins/devops/skills/concept/fab-labels.test.js
+++ b/plugins/devops/skills/concept/fab-labels.test.js
@@ -172,10 +172,10 @@ describe("the one-shot attention pulse", () => {
   test("the JS clears data-untouched on FAB click and on dock input", () => {
     const clear = /removeAttribute\('data-untouched'\)/;
     expect(jsSource, "the clear itself").toMatch(clear);
-    const click = slice(jsSource, "dockToggle.addEventListener('click'");
+    const click = slice(jsSource, "dockToggle?.addEventListener('click'");
     expect(click, "first dock open ends the pulse").toMatch(/stopFabPulse\(\)|removeAttribute\('data-untouched'\)/);
     expect(jsSource, "and so does the first keystroke inside the dock")
-      .toMatch(/dock\.addEventListener\('input',\s*stopFabPulse\)/);
+      .toMatch(/dock\?\.addEventListener\('input',\s*stopFabPulse\)/);
   });
 });
 

--- a/plugins/devops/skills/concept/panel-chrome.test.js
+++ b/plugins/devops/skills/concept/panel-chrome.test.js
@@ -458,7 +458,7 @@ describe("panel and dock are mutually exclusive overlays", () => {
     expect(jsSource, "☰ bound to openPanel")
       .toMatch(/panelToggle\?\.addEventListener\('click',\s*openPanel\)/);
     expect(jsSource, "💬 toggles the dock")
-      .toMatch(/dockToggle\.addEventListener\('click',[\s\S]{0,160}?closeDock\(\)[\s\S]{0,80}?openDock\(\)/);
+      .toMatch(/dockToggle\?\.addEventListener\('click',[\s\S]{0,160}?closeDock\(\)[\s\S]{0,80}?openDock\(\)/);
   });
 
   test("a hand-off close does not park focus on the dock FAB", () => {
@@ -649,5 +649,104 @@ describe("exactly one design / screen / view paints", () => {
     expect(view, "showView writes body[data-view-active]").toMatch(/body\.dataset\.viewActive\s*=\s*'true'/);
     expect(slice(jsSource, "window.showDesign = function("), "showDesign clears it again")
       .toMatch(/body\.dataset\.viewActive\s*=\s*'false'/);
+  });
+});
+
+// The design layout IIFE wires the dock AND everything after it: screen
+// switching, click-through, the keyboard shortcuts. It used to dereference
+// #feedback-dock / #feedback-toggle / #feedback-close and #decision-panel
+// unguarded, so a page that shipped without one of them threw at boot — and
+// took every listener below the throw with it, silently. The user then sees a
+// mockup that ignores every click and arrow key and reasonably blames the
+// mockup. The shared panel-chrome block already names what is missing and
+// degrades (missingPanelParts); this pins the same contract for the dock.
+describe("the design layout JS degrades instead of dying", () => {
+  test("the missing parts are named once, the way the panel block names its own", () => {
+    const report = slice(jsSource, "const missingDockParts = [");
+    for (const id of ["feedback-dock", "feedback-toggle", "feedback-close"]) {
+      expect(report, id).toContain(`'${id}'`);
+    }
+    expect(jsSource, "one console.error, naming them")
+      .toMatch(/console\.error\('\[concept\] feedback-dock markup incomplete[^']*'\s*\n?\s*\+ missingDockParts\.join/);
+  });
+
+  test("every listener the dock registers is registered optionally", () => {
+    for (const call of [
+      /dockToggle\?\.addEventListener\('click'/,
+      /dock\?\.addEventListener\('input'/,
+      /dockClose\?\.addEventListener\('click'/,
+    ]) {
+      expect(jsSource, String(call)).toMatch(call);
+    }
+    // …and the labels the FAB swaps are read optionally too — this was the
+    // exact line that threw: `dockToggle.dataset.labelOpen`.
+    expect(jsSource).toMatch(/const LABEL_OPEN = dockToggle\?\.dataset\.labelOpen/);
+  });
+
+  test("openDock/closeDock are no-ops without a dock, and openPanel still works", () => {
+    // Executed, not pattern-matched: closeDock is reachable from openPanel
+    // through `window.closeDock?.()`, so a page with a panel and no dock must
+    // still be able to open its panel.
+    const focusLog = [];
+    const el = (name) => {
+      const cls = new Set();
+      const node = {
+        name,
+        classList: { add: (c) => cls.add(c), remove: (c) => cls.delete(c), contains: (c) => cls.has(c) },
+        dataset: {},
+        setAttribute() {}, getAttribute() { return null; },
+        holds: false,
+        contains() { return node.holds; },
+        focus() { focusLog.push(name); },
+      };
+      return node;
+    };
+    const src = [
+      slice(jsSource, "window.openPanel ="),
+      slice(jsSource, "window.closePanel ="),
+      slice(jsSource, "function openDock("),
+      slice(jsSource, "function closeDock("),
+      "window.closeDock = closeDock",
+    ].join(";\n");
+    const make = new Function("panel", "panelToggle", "panelCloseBtn", "backdrop",
+      "dock", "dockToggle", "document", "window", "LABEL_OPEN", "LABEL_CLOSE",
+      src + "; return { openPanel: window.openPanel, closePanel: window.closePanel,"
+          + " openDock, closeDock };");
+    const panel = el("panel"), panelToggle = el("panelToggle"),
+      panelCloseBtn = el("panelCloseBtn"), backdrop = el("backdrop");
+    const doc = { body: el("body"), activeElement: null, getElementById: () => null };
+    // The dock is simply not there.
+    const api = make(panel, panelToggle, panelCloseBtn, backdrop, null, null,
+      doc, {}, "open", "close");
+
+    expect(() => api.openDock()).not.toThrow();
+    expect(() => api.closeDock()).not.toThrow();
+    expect(() => api.openPanel()).not.toThrow();
+    expect(panel.classList.contains("open"), "the panel still opens").toBe(true);
+    expect(() => api.closePanel()).not.toThrow();
+    expect(panel.classList.contains("open")).toBe(false);
+  });
+
+  test("the keyboard shortcuts read both overlays optionally", () => {
+    // Bound on every design page and fired on EVERY keypress: unguarded, a
+    // missing overlay threw once per keystroke and killed arrow-key
+    // navigation while pointing at the wrong component.
+    expect(jsSource).toMatch(
+      /if \(dock\?\.dataset\.open === 'true' \|\| panel\?\.classList\.contains\('open'\)\) return;/
+    );
+  });
+
+  test("every dock function callable from outside checks for the dock first", () => {
+    // These four are reached from restoreState(), showIteration() and the
+    // submit path — code that runs on pages with no dock at all.
+    for (const [name, marker] of [
+      ["applyDockSize", "function applyDockSize()"],
+      ["applyDockFreezeState", "function applyDockFreezeState()"],
+      ["markDockSubmitted", "window.markDockSubmitted = function()"],
+      ["unmarkDockSubmitted", "window.unmarkDockSubmitted = function()"],
+    ]) {
+      const fn = slice(jsSource, marker);
+      expect(fn, name).toMatch(/if \(!dock\) return;/);
+    }
   });
 });

--- a/plugins/local-llm/.claude-plugin/plugin.json
+++ b/plugins/local-llm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "local-llm",
-  "version": "0.151.0",
+  "version": "0.151.1",
   "description": "Local LLM integration for Claude Code — delegates mechanical coding tasks to a local AnythingLLM Desktop workspace to save tokens without sacrificing quality.",
   "author": {
     "name": "Jerry0022",


### PR DESCRIPTION
## Summary

The shared panel-chrome block guards all four of its elements and logs which one is absent. The design layout block right below it still dereferenced `dockToggle.dataset`, `dock.dataset`, `dockClose` and `panel.classList` unguarded — and that block wires everything after the dock too: screen switching, click-through, the keyboard shortcuts.

So a page generated without the dock markup threw at boot and took all of it down with no visible error. What the user sees is a mockup that ignores every click and every arrow key — which reads as "the mockup is broken", not "three lines of markup are missing". The keydown handler threw once per keystroke on top.

## What changed

- `missingDockParts` reports the absent ids **once**, in the same shape as `missingPanelParts`.
- Entry points degrade: FAB labels via `?.`, all three listener registrations optional, `openDock`/`closeDock` return early — `closeDock` is reachable from `openPanel` through `window.closeDock?.()`, so a page with a panel and no dock still opens its panel.
- The four functions called from **outside** the block — `applyDockSize`, `applyDockFreezeState`, `markDockSubmitted`, `unmarkDockSubmitted` (reached from `restoreState()`, `showIteration()` and the submit path) — check for the dock first.
- The keyboard shortcut reads both overlays optionally.

## Verification

- Five new tests in `panel-chrome.test.js`; one runs `openDock`/`closeDock`/`openPanel` against a page with no dock at all. Verified failing with the guard removed, then restored.
- `npm run lint` clean; full suite 112 files / 2808 tests green (ship gate ran the 18-file concept suite, 393 tests).
- Codex gate skipped — the CLI is at its usage limit until 2026-09-10.

Pre-existing; found during the red-team pass on #360 and deliberately left out of that commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)